### PR TITLE
chore(init): enforce branch protection for admins

### DIFF
--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -645,7 +645,7 @@ jobs:
                     "strict": True,
                     "contexts": [],
                 },
-                "enforce_admins": False,
+                "enforce_admins": True,
                 "required_pull_request_reviews": {
                     "required_approving_review_count": 0,
                 },
@@ -660,7 +660,7 @@ jobs:
                 capture_output=True, text=True, timeout=15,
             )
             if result.returncode == 0:
-                print("  Branch protection: main (require up-to-date, require PR)")
+                print("  Branch protection: main (require up-to-date, require PR, enforce admins)")
                 return True
             else:
                 stderr = result.stderr.strip()


### PR DESCRIPTION
## Summary
- Set `enforce_admins: true` in branch protection so main requires PRs for everyone, including repo admins
- No more direct pushes to main — all changes go through PRs

## Test plan
- [x] `atdd init --force` applies branch protection with enforce_admins
- [ ] Verify direct push to main is blocked after merge

Closes #46