### PR TITLE
fix: move pytest to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"
 license = {text = "MIT"}
-dependencies = ["pyyaml"]
+dependencies = ["pyyaml", "pytest>=7.0", "pytest-xdist", "jsonschema", "pytest-html"]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-xdist"]
+dev = []
 viz = ["streamlit", "st-link-analysis"]
 
 [project.scripts]

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -610,7 +610,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install ATDD toolkit
-        run: pip3 install atdd pytest jsonschema pytest-html
+        run: pip3 install atdd
 
       - name: Run ATDD validators
         run: atdd validate


### PR DESCRIPTION
## Summary

- Moves `pytest>=7.0`, `pytest-xdist`, `jsonschema`, and `pytest-html` from dev extras to core `[project.dependencies]` in `pyproject.toml`
- Simplifies the consumer CI workflow template in `initializer.py` from `pip3 install atdd pytest jsonschema pytest-html` to `pip3 install atdd`
- These are runtime dependencies — `atdd validate` invokes pytest programmatically to run validators

## Test plan

- [ ] `pip install atdd` installs pytest, pytest-xdist, jsonschema, pytest-html automatically
- [ ] `atdd validate` works without manual dependency installation
- [ ] `atdd init` generates simplified CI workflow with just `pip3 install atdd`
- [ ] Existing CI passes with the new dependency layout

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)