### PR TITLE
Bump version to 1.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.3.5"
+version = "1.3.6"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- PATCH version bump for fix: move pytest to core dependencies (#56)

## Test plan

- [ ] CI passes
- [ ] Tag v1.3.6 created after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)