### PR TITLE
fix: update release checklist for branch protection

### DIFF
--- a/.atdd/config.yaml
+++ b/.atdd/config.yaml
@@ -6,7 +6,7 @@ sync:
   agents:
   - claude
 toolkit:
-  last_version: 1.2.2
+  last_version: 1.3.5
 github:
   repo: afokapu/atdd
   project_number: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.3.6"
+version = "1.3.7"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/templates/ATDD.md
+++ b/src/atdd/coach/templates/ATDD.md
@@ -254,10 +254,10 @@ release:
   workflow:
     - "Determine change class"
     - "Bump version in version file"
-    - "Commit: 'Bump version to {version}'"
-    - "Create tag: git tag v{version}"
-    - "Push with tags: git push origin {branch} --tags"
-    - "Record in Session Log: 'Released: v{version}'"
+    - "Commit: 'Bump version to {version}' (last commit in PR branch)"
+    - "Push branch and merge PR (version bump is part of the PR)"
+    - "After merge: git tag v{version} on the merge commit, then git push origin --tags"
+    - "Record in Activity Log: 'Released: v{version}'"
 
   # Config (required in .atdd/config.yaml):
   # release:

--- a/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
+++ b/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
@@ -151,9 +151,9 @@
 
 - [ ] Determine change class: PATCH / MINOR / MAJOR
 - [ ] Bump version in version file
-- [ ] Commit: "Bump version to {{version}}"
-- [ ] Create tag: `git tag v{{version}}`
-- [ ] Push with tags: `git push origin {{branch}} --tags`
+- [ ] Commit: "Bump version to {{version}}" (last commit in PR branch)
+- [ ] Merge PR (version bump included in the PR)
+- [ ] After merge: `git tag v{{version}}` on merge commit, then `git push origin --tags`
 - [ ] Record tag in Activity Log: "Released: v{{version}}"
 
 ---


### PR DESCRIPTION
## Summary

- Updates release workflow in `ATDD.md` and `PARENT-ISSUE-TEMPLATE.md` to account for branch protection
- Version bump is now the last commit in the PR branch (not a post-merge direct push)
- Tag is created on the merge commit after PR merge

## Test plan

- [ ] `atdd new` generates issue with corrected Release Gate checklist
- [ ] `atdd sync` propagates updated workflow to CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)