### PR TITLE
fix: escape {prefix} in parent issue template

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.3.7"
+version = "1.3.8"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
+++ b/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
@@ -5,7 +5,7 @@
 | Date | `{today}` |
 | Status | `INIT` |
 | Type | `{issue_type}` |
-| Branch | TBD <!-- fmt: {prefix}/{slug} e.g. feat/my-feature --> |
+| Branch | TBD <!-- fmt: {{prefix}}/{slug} e.g. feat/my-feature --> |
 | Archetypes | {archetypes_display} |
 | Train | {train_display} |
 | Feature | TBD |


### PR DESCRIPTION
## Summary

- Escapes `{prefix}` to `{{prefix}}` in `PARENT-ISSUE-TEMPLATE.md` so Python's `str.format()` doesn't crash with `KeyError: 'prefix'`
- This is the root cause of `atdd new` failing on 1.3.7

## Test plan

- [ ] `atdd new smoke-test --type analysis` succeeds without `KeyError`
- [ ] Generated issue body shows `{prefix}` as literal text in the Branch comment

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)