### PR TITLE
feat: worktree layout detection & migration in atdd init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.3.8"
+version = "1.4.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -368,6 +368,11 @@ Phase descriptions:
         action="store_true",
         help="Overwrite existing files"
     )
+    init_parser.add_argument(
+        "--worktree-layout",
+        action="store_true",
+        help="Migrate repo to flat-sibling worktree layout (moves contents into main/)"
+    )
 
     # ----- atdd new <slug> -----
     new_parser = subparsers.add_parser(
@@ -802,7 +807,7 @@ Phase descriptions:
     # atdd init
     elif args.command == "init":
         initializer = ProjectInitializer()
-        return initializer.init(force=args.force)
+        return initializer.init(force=args.force, worktree_layout=args.worktree_layout)
 
     # atdd new <slug>
     elif args.command == "new":

--- a/src/atdd/coach/commands/gate.py
+++ b/src/atdd/coach/commands/gate.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from atdd.coach.commands.sync import AgentConfigSync
+from atdd.coach.utils.repo import detect_worktree_layout
 
 
 class ATDDGate:
@@ -120,13 +121,17 @@ class ATDDGate:
             return 1
 
         issue_convention = self._load_issue_convention()
+        layout = detect_worktree_layout(self.target_dir)
 
         if json:
             output = {
                 "files": files,
                 "constraints": self.KEY_CONSTRAINTS,
                 "issue_convention": issue_convention,
+                "worktree_layout": layout,
             }
+            if layout == "flat":
+                output["worktree_advisory"] = "Run: atdd init --worktree-layout"
             print(json_module.dumps(output, indent=2))
             return 0
 
@@ -143,6 +148,10 @@ class ATDDGate:
                 print(f"  - {info['file']} (no managed block)")
             else:
                 print(f"  - {info['file']} (missing)")
+
+        if layout == "flat":
+            print("\n  Advisory: Repo uses flat layout (not worktree-ready).")
+            print("  Run: atdd init --worktree-layout")
 
         print("\nKey constraints:")
         for i, constraint in enumerate(self.KEY_CONSTRAINTS, 1):

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -22,6 +22,7 @@ Convention: src/atdd/coach/conventions/issue.convention.yaml
 """
 import json
 import logging
+import shutil
 import subprocess
 from datetime import date
 from pathlib import Path
@@ -50,16 +51,154 @@ class ProjectInitializer:
         # Package template location
         self.package_root = Path(__file__).parent.parent  # src/atdd/coach
 
-    def init(self, force: bool = False) -> int:
+    def _has_linked_worktrees(self) -> list:
+        """Return paths of linked worktrees (excludes the main checkout)."""
+        try:
+            result = subprocess.run(
+                ["git", "worktree", "list", "--porcelain"],
+                capture_output=True, text=True, timeout=10,
+                cwd=self.target_dir,
+            )
+            if result.returncode != 0:
+                return []
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return []
+
+        # Porcelain format: blocks separated by blank lines, first block is main checkout
+        worktrees = []
+        blocks = result.stdout.strip().split("\n\n")
+        for i, block in enumerate(blocks):
+            if i == 0:
+                continue  # Skip main checkout (first entry)
+            for line in block.splitlines():
+                if line.startswith("worktree "):
+                    worktrees.append(line[len("worktree "):])
+                    break
+        return worktrees
+
+    def _migrate_to_worktree_layout(self) -> Path:
+        """
+        Move all repo contents into a main/ subdirectory.
+
+        Returns:
+            Path to the new repo root (main/).
+
+        Raises:
+            RuntimeError: If migration fails (with rollback).
+        """
+        main_dir = self.target_dir / "main"
+
+        if main_dir.exists():
+            raise RuntimeError(
+                f"Directory already exists: {main_dir}\n"
+                "Cannot migrate — 'main/' would conflict."
+            )
+
+        main_dir.mkdir()
+        moved_items = []
+
+        try:
+            for item in sorted(self.target_dir.iterdir()):
+                if item.name == "main":
+                    continue
+                dest = main_dir / item.name
+                shutil.move(str(item), str(dest))
+                moved_items.append((dest, item))
+        except Exception as e:
+            # Rollback: move items back
+            for dest, original in reversed(moved_items):
+                try:
+                    shutil.move(str(dest), str(original))
+                except Exception:
+                    pass
+            try:
+                main_dir.rmdir()
+            except Exception:
+                pass
+            raise RuntimeError(f"Migration failed (rolled back): {e}") from e
+
+        return main_dir
+
+    def _update_target_dir(self, new_root: Path) -> None:
+        """Repoint all paths to the new repo root after migration."""
+        self.target_dir = new_root
+        self.atdd_config_dir = new_root / ".atdd"
+        self.manifest_file = self.atdd_config_dir / "manifest.yaml"
+        self.config_file = self.atdd_config_dir / "config.yaml"
+
+    def init(self, force: bool = False, worktree_layout: bool = False) -> int:
         """
         Bootstrap .atdd/ config and GitHub infrastructure.
 
         Args:
             force: If True, overwrite existing files.
+            worktree_layout: If True, migrate repo to flat-sibling worktree layout.
 
         Returns:
             0 on success, 1 on error.
         """
+        from atdd.coach.utils.repo import detect_worktree_layout, find_repo_root
+
+        layout = detect_worktree_layout(self.target_dir)
+
+        if worktree_layout:
+            if layout == "worktree-ready":
+                print("Already in worktree-ready layout (repo root is main/).")
+            elif layout == "worktree":
+                print("Error: You are inside a linked worktree.")
+                print("Run this command from the main checkout instead.")
+                return 1
+            elif layout == "no-git":
+                print("Error: No git repository found.")
+                print("Initialize git first: git init")
+                return 1
+            elif layout == "flat":
+                # Safety: must be at repo root, not a subdirectory
+                try:
+                    repo_root = find_repo_root(self.target_dir)
+                    if repo_root.resolve() != self.target_dir.resolve():
+                        print("Error: Not at repository root.")
+                        print(f"Run from: {repo_root}")
+                        return 1
+                except RuntimeError:
+                    pass
+
+                # Safety: no linked worktrees (their .git files would break)
+                linked = self._has_linked_worktrees()
+                if linked:
+                    print("Error: Existing linked worktrees would break after migration.")
+                    print("Remove them first:")
+                    for wt in linked:
+                        print(f"  git worktree remove {wt}")
+                    return 1
+
+                # Confirm before migrating
+                items = [i.name for i in self.target_dir.iterdir()]
+                print(f"This will move all {len(items)} items into {self.target_dir / 'main'}:")
+                for name in sorted(items)[:10]:
+                    print(f"  {name}")
+                if len(items) > 10:
+                    print(f"  ... and {len(items) - 10} more")
+                if not force:
+                    answer = input("\nProceed? [y/N] ").strip().lower()
+                    if answer not in ("y", "yes"):
+                        print("Aborted.")
+                        return 1
+
+                # Migrate
+                try:
+                    new_root = self._migrate_to_worktree_layout()
+                    self._update_target_dir(new_root)
+                    print(f"Migrated to worktree layout: {new_root}")
+                    print(f"\n  ** After init completes, run: cd main **\n")
+                except RuntimeError as e:
+                    print(f"Error: {e}")
+                    return 1
+        else:
+            if layout == "flat":
+                print("Advisory: Repo uses flat layout (not worktree-ready).")
+                print("  Run: atdd init --worktree-layout\n")
+
         # Check if already initialized
         if self.atdd_config_dir.exists() and not force:
             print(f"ATDD already initialized at {self.target_dir}")

--- a/src/atdd/coach/utils/repo.py
+++ b/src/atdd/coach/utils/repo.py
@@ -75,6 +75,32 @@ def find_repo_root(start: Optional[Path] = None) -> Path:
     return start.resolve() if start else Path.cwd().resolve()
 
 
+def detect_worktree_layout(start: Optional[Path] = None) -> str:
+    """
+    Detect the worktree layout of a repository.
+
+    Returns:
+        "worktree-ready" - .git is a dir and parent dir is named "main"
+        "worktree"       - .git is a file (linked worktree)
+        "flat"           - .git is a dir but parent dir is not "main"
+        "no-git"         - no .git found
+    """
+    root = start or Path.cwd()
+    root = root.resolve()
+
+    git_path = root / ".git"
+
+    if git_path.is_file():
+        return "worktree"
+
+    if git_path.is_dir():
+        if root.name == "main":
+            return "worktree-ready"
+        return "flat"
+
+    return "no-git"
+
+
 def require_repo_root(start: Optional[Path] = None) -> Path:
     """
     Find repo root, raising RuntimeError if no markers found.


### PR DESCRIPTION
## Summary
- Add `detect_worktree_layout()` utility to `repo.py` — returns `worktree-ready`, `worktree`, `flat`, or `no-git`
- Add `--worktree-layout` flag to `atdd init` that migrates flat checkouts to the flat-sibling worktree layout (moves all contents into `main/`)
- Safety checks: linked worktree detection, `main/` conflict guard, repo-root verification, rollback on failure, interactive `y/N` confirmation (bypass with `--force`)
- Surface layout advisory in `atdd gate` output (both human-readable and JSON)

## Test plan
- [ ] `atdd init --help` shows `--worktree-layout` flag
- [ ] `atdd gate` in flat repo shows advisory
- [ ] `atdd init` (without flag) in flat repo prints advisory
- [ ] `atdd init --worktree-layout` in already-migrated repo says "already worktree-ready"
- [ ] `atdd init --worktree-layout` in flat repo with linked worktrees aborts with removal instructions
- [ ] `atdd init --worktree-layout` in scratch repo migrates contents into `main/`, prompts for confirmation
- [ ] Existing coach validators pass (pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)