### PR TITLE
fix: platform validators 28-min bottleneck (#63)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ testpaths = ["src/atdd"]
 markers = [
     "tester: marks tests as tester validators",
     "platform: marks tests as platform validators",
+    "github_api: marks tests that require live GitHub API access",
     "security: marks tests as security validators",
     "locale: marks tests as localization validators (Localization Manifest Spec v1)",
     "coder: marks tests as coder phase validators",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.4.0"
+version = "1.4.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/test_runner.py
+++ b/src/atdd/coach/commands/test_runner.py
@@ -168,27 +168,27 @@ class TestRunner:
     ) -> int:
         """Run validators in two stages: fast then slow.
 
-        Stage 1: Pure-computation tests (not platform) — parallel
-        Stage 2: API-bound platform tests — sequential (shared session fixtures)
+        Stage 1: All tests except github_api — parallel
+        Stage 2: github_api tests (live GitHub API) — sequential (shared session fixtures)
         """
-        # Stage 1: fast tests (not platform), parallel
-        fast_markers = list(markers or []) + ["not platform"]
+        # Stage 1: all tests except github_api, parallel
+        fast_markers = list(markers or []) + ["not github_api"]
         fast_cmd = self._build_pytest_cmd(
             validator_dirs, verbose=verbose, coverage=coverage,
             html_report=False, markers=fast_markers, parallel=parallel,
         )
 
-        print("\n[1/2] Fast validators (file parsing, no API):")
+        print("\n[1/2] Fast validators (file parsing + local platform, no API):")
         fast_rc = self._run_pytest(fast_cmd)
 
-        # Stage 2: platform tests (API-bound), sequential to share session fixtures
-        slow_markers = list(markers or []) + ["platform"]
+        # Stage 2: github_api tests, sequential to share session fixtures
+        slow_markers = list(markers or []) + ["github_api"]
         slow_cmd = self._build_pytest_cmd(
             validator_dirs, verbose=verbose, coverage=False,
             html_report=html_report, markers=slow_markers, parallel=False,
         )
 
-        print("\n[2/2] Platform validators (GitHub API):")
+        print("\n[2/2] GitHub API validators (live API):")
         slow_rc = self._run_pytest(slow_cmd)
 
         # Fail if either stage failed

--- a/src/atdd/coach/validators/conftest.py
+++ b/src/atdd/coach/validators/conftest.py
@@ -101,3 +101,22 @@ def github_project_items(github_client):
         return github_client.get_all_project_items()
     except GitHubClientError as e:
         pytest.skip(f"Cannot query project items: {e}")
+
+
+@pytest.fixture(scope="session")
+def github_sub_issues(github_client, github_issues):
+    """Sub-issues for all open parent issues (fetched once per session).
+
+    Returns dict mapping issue_number -> list[dict] of sub-issues.
+    Replaces N+1 calls to get_sub_issues() in individual tests.
+    """
+    from atdd.coach.github import GitHubClientError
+
+    result = {}
+    for issue in github_issues:
+        num = issue["number"]
+        try:
+            result[num] = github_client.get_sub_issues(num)
+        except GitHubClientError:
+            result[num] = []
+    return result

--- a/src/atdd/coach/validators/test_C001_roundtrip.py
+++ b/src/atdd/coach/validators/test_C001_roundtrip.py
@@ -19,13 +19,14 @@ import pytest
 
 from atdd.coach.github import GitHubClientError
 
+pytestmark = [pytest.mark.platform, pytest.mark.github_api]
+
 
 # ---------------------------------------------------------------------------
 # C001 validators: confirm round-trip plumbing
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.platform
 def test_issue_manager_methods_exist():
     """
     SPEC-COACH-C001-0001: IssueManager exposes all lifecycle methods
@@ -45,7 +46,6 @@ def test_issue_manager_methods_exist():
     )
 
 
-@pytest.mark.platform
 def test_github_client_methods_exist():
     """
     SPEC-COACH-C001-0002: GitHubClient exposes all required API methods
@@ -74,8 +74,7 @@ def test_github_client_methods_exist():
     )
 
 
-@pytest.mark.platform
-def test_existing_issues_have_sub_issues(github_client, github_issues):
+def test_existing_issues_have_sub_issues(github_sub_issues):
     """
     SPEC-COACH-C001-0003: Existing issues have WMBT sub-issues
 
@@ -84,15 +83,7 @@ def test_existing_issues_have_sub_issues(github_client, github_issues):
     Then: At least one issue has sub-issues (WMBTs)
           confirming that atdd new creates the parent+sub-issue structure
     """
-    has_subs = False
-    for issue in github_issues:
-        try:
-            subs = github_client.get_sub_issues(issue["number"])
-            if subs:
-                has_subs = True
-                break
-        except GitHubClientError:
-            continue
+    has_subs = any(subs for subs in github_sub_issues.values())
 
     if not has_subs:
         pytest.skip(
@@ -101,8 +92,7 @@ def test_existing_issues_have_sub_issues(github_client, github_issues):
         )
 
 
-@pytest.mark.platform
-def test_sub_issue_progress_is_trackable(github_client, github_issues):
+def test_sub_issue_progress_is_trackable(github_sub_issues):
     """
     SPEC-COACH-C001-0004: Sub-issue progress is trackable (closed/total)
 
@@ -111,12 +101,7 @@ def test_sub_issue_progress_is_trackable(github_client, github_issues):
     Then: Progress is computable as closed/total
           and both counts are non-negative integers
     """
-    for issue in github_issues:
-        try:
-            subs = github_client.get_sub_issues(issue["number"])
-        except GitHubClientError:
-            continue
-
+    for num, subs in github_sub_issues.items():
         if not subs:
             continue
 
@@ -124,11 +109,11 @@ def test_sub_issue_progress_is_trackable(github_client, github_issues):
         closed = sum(1 for s in subs if s.get("state") == "closed")
         open_count = sum(1 for s in subs if s.get("state") == "open")
 
-        assert total > 0, f"#{issue['number']}: total sub-issues should be > 0"
-        assert closed >= 0, f"#{issue['number']}: closed count should be >= 0"
-        assert open_count >= 0, f"#{issue['number']}: open count should be >= 0"
+        assert total > 0, f"#{num}: total sub-issues should be > 0"
+        assert closed >= 0, f"#{num}: closed count should be >= 0"
+        assert open_count >= 0, f"#{num}: open count should be >= 0"
         assert closed + open_count == total, (
-            f"#{issue['number']}: closed ({closed}) + open ({open_count}) != total ({total})"
+            f"#{num}: closed ({closed}) + open ({open_count}) != total ({total})"
         )
         # Found a valid issue with trackable progress
         return
@@ -136,7 +121,6 @@ def test_sub_issue_progress_is_trackable(github_client, github_issues):
     pytest.skip("No issue with sub-issues found")
 
 
-@pytest.mark.platform
 def test_archived_issues_have_no_orphaned_sub_issues(github_client):
     """
     SPEC-COACH-C001-0005: Archived (closed) issues have no open sub-issues
@@ -183,8 +167,7 @@ def test_archived_issues_have_no_orphaned_sub_issues(github_client):
     )
 
 
-@pytest.mark.platform
-def test_wmbt_sub_issues_have_atdd_wmbt_label(github_client, github_issues):
+def test_wmbt_sub_issues_have_atdd_wmbt_label(github_sub_issues):
     """
     SPEC-COACH-C001-0006: WMBT sub-issues carry the atdd-wmbt label
 
@@ -192,13 +175,7 @@ def test_wmbt_sub_issues_have_atdd_wmbt_label(github_client, github_issues):
     When: Checking labels
     Then: Each sub-issue has the atdd-wmbt label
     """
-    # Check first issue that has sub-issues
-    for issue in github_issues:
-        try:
-            subs = github_client.get_sub_issues(issue["number"])
-        except GitHubClientError:
-            continue
-
+    for num, subs in github_sub_issues.items():
         if not subs:
             continue
 
@@ -210,7 +187,7 @@ def test_wmbt_sub_issues_have_atdd_wmbt_label(github_client, github_issues):
 
         if unlabeled:
             assert False, (
-                f"\nWMBT sub-issues of #{issue['number']} missing atdd-wmbt label:\n  "
+                f"\nWMBT sub-issues of #{num} missing atdd-wmbt label:\n  "
                 + "\n  ".join(unlabeled)
             )
         # Found and validated — pass

--- a/src/atdd/coach/validators/test_C002_project_board.py
+++ b/src/atdd/coach/validators/test_C002_project_board.py
@@ -15,7 +15,7 @@ Run: atdd validate coach
 """
 import pytest
 
-from atdd.coach.github import GitHubClientError
+pytestmark = [pytest.mark.platform, pytest.mark.github_api]
 
 
 # ---------------------------------------------------------------------------
@@ -42,7 +42,6 @@ REQUIRED_PHASE_OPTIONS = {"Planner", "Tester", "Coder"}
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.platform
 def test_project_has_required_custom_fields(github_project_fields):
     """
     SPEC-COACH-C002-0001: Project v2 has all required custom fields
@@ -60,7 +59,6 @@ def test_project_has_required_custom_fields(github_project_fields):
     )
 
 
-@pytest.mark.platform
 def test_atdd_status_field_has_required_options(github_project_fields):
     """
     SPEC-COACH-C002-0002: ATDD Status field has all lifecycle options
@@ -82,7 +80,6 @@ def test_atdd_status_field_has_required_options(github_project_fields):
     )
 
 
-@pytest.mark.platform
 def test_atdd_phase_field_has_required_options(github_project_fields):
     """
     SPEC-COACH-C002-0003: ATDD Phase field has Planner/Tester/Coder options
@@ -104,7 +101,6 @@ def test_atdd_phase_field_has_required_options(github_project_fields):
     )
 
 
-@pytest.mark.platform
 def test_issues_are_in_project(github_issues, github_project_items):
     """
     SPEC-COACH-C002-0004: Issues are added to the Project
@@ -126,7 +122,6 @@ def test_issues_are_in_project(github_issues, github_project_items):
     )
 
 
-@pytest.mark.platform
 def test_issues_have_status_field_set(github_issues, github_project_fields, github_project_items):
     """
     SPEC-COACH-C002-0005: Issues in Project have ATDD Status set
@@ -152,7 +147,6 @@ def test_issues_have_status_field_set(github_issues, github_project_fields, gith
     )
 
 
-@pytest.mark.platform
 def test_archetype_labels_exist(github_issues):
     """
     SPEC-COACH-C002-0006: Archetype labels exist for board filtering
@@ -175,8 +169,7 @@ def test_archetype_labels_exist(github_issues):
         )
 
 
-@pytest.mark.platform
-def test_progress_pill_data_available(github_client, github_issues):
+def test_progress_pill_data_available(github_sub_issues):
     """
     SPEC-COACH-C002-0007: Sub-issue progress data available for progress pills
 
@@ -185,17 +178,7 @@ def test_progress_pill_data_available(github_client, github_issues):
     Then: Progress can be expressed as "N/M WMBTs" where M > 0
           (confirming the data backing progress pills on board cards)
     """
-    progress_available = False
-    for issue in github_issues:
-        try:
-            subs = github_client.get_sub_issues(issue["number"])
-            if subs:
-                total = len(subs)
-                assert total > 0
-                progress_available = True
-                break
-        except (GitHubClientError, AssertionError):
-            continue
+    progress_available = any(subs for subs in github_sub_issues.values())
 
     if not progress_available:
         pytest.skip(

--- a/src/atdd/coach/validators/test_issue_gate_completion.py
+++ b/src/atdd/coach/validators/test_issue_gate_completion.py
@@ -19,6 +19,8 @@ import pytest
 from atdd.coach.commands.issue import IssueManager
 from atdd.coach.utils.repo import find_repo_root
 
+pytestmark = [pytest.mark.platform, pytest.mark.github_api]
+
 REPO_ROOT = find_repo_root()
 
 
@@ -26,7 +28,6 @@ REPO_ROOT = find_repo_root()
 # SPEC-GATE-0001: Gate test commands must PASS for COMPLETE issues
 # ---------------------------------------------------------------------------
 
-@pytest.mark.platform
 def test_complete_issues_gate_tests_pass(github_complete_issues):
     """
     SPEC-GATE-0001: All gate test commands in COMPLETE issues must PASS.
@@ -78,7 +79,6 @@ def test_complete_issues_gate_tests_pass(github_complete_issues):
 # SPEC-GATE-0002: Artifact claims must be valid for COMPLETE issues
 # ---------------------------------------------------------------------------
 
-@pytest.mark.platform
 def test_complete_issues_artifacts_valid(github_complete_issues):
     """
     SPEC-GATE-0002: Artifact claims in COMPLETE issues must match git state.
@@ -118,7 +118,6 @@ def test_complete_issues_artifacts_valid(github_complete_issues):
 # SPEC-GATE-0003: Release gate must be satisfied for COMPLETE issues
 # ---------------------------------------------------------------------------
 
-@pytest.mark.platform
 def test_complete_issues_release_gate(github_complete_issues):
     """
     SPEC-GATE-0003: COMPLETE issues must have version bumped and tag on HEAD.

--- a/src/atdd/coach/validators/test_issue_validation.py
+++ b/src/atdd/coach/validators/test_issue_validation.py
@@ -25,6 +25,8 @@ import yaml
 
 from atdd.coach.utils.repo import find_repo_root
 
+pytestmark = [pytest.mark.platform, pytest.mark.github_api]
+
 # ============================================================================
 # Configuration
 # ============================================================================
@@ -67,7 +69,6 @@ def _load_valid_train_ids():
 _POST_PLANNED_STATUSES = {"RED", "GREEN", "REFACTOR", "COMPLETE"}
 
 
-@pytest.mark.platform
 def test_issues_have_train_field(github_issues, github_project_fields, github_project_items):
     """
     SPEC-SESSION-VAL-0050: Issues must have a non-empty Train field
@@ -123,7 +124,6 @@ def test_issues_have_train_field(github_issues, github_project_fields, github_pr
     )
 
 
-@pytest.mark.platform
 def test_issue_train_references_valid_train_id(github_issues, github_project_fields, github_project_items):
     """
     SPEC-SESSION-VAL-0051: Issue Train field must reference a valid train_id
@@ -186,7 +186,6 @@ REQUIRED_BODY_SECTIONS = [
 ]
 
 
-@pytest.mark.platform
 def test_issue_body_has_required_sections(github_issues):
     """
     SPEC-SESSION-VAL-0060: Issue body should contain all structured sections
@@ -231,7 +230,6 @@ _ACTIVE_IMPL_STATUSES = {"RED", "GREEN", "REFACTOR"}
 _BRANCH_RE = re.compile(r"\| Branch \| (.+?) \|")
 
 
-@pytest.mark.platform
 def test_issue_branch_follows_worktree_convention(github_issues):
     """
     SPEC-SESSION-VAL-0070: Branch field must use an allowed worktree prefix

--- a/src/atdd/conftest.py
+++ b/src/atdd/conftest.py
@@ -21,6 +21,7 @@ def pytest_configure(config):
 
     # Legacy/component markers
     config.addinivalue_line("markers", "platform: Platform validation tests")
+    config.addinivalue_line("markers", "github_api: Tests requiring live GitHub API access")
     config.addinivalue_line("markers", "backend: Backend Python tests")
     config.addinivalue_line("markers", "frontend: Frontend Preact/TypeScript tests")
     config.addinivalue_line("markers", "agents: Agent behavior tests")


### PR DESCRIPTION
## Summary

- Introduces `@pytest.mark.github_api` for the 4 test files (20 tests) that hit the live GitHub API
- Changes the two-stage split runner to key on `github_api` instead of `platform`, moving 167 local-only platform tests back to the parallel stage
- Adds session-scoped `github_sub_issues` fixture eliminating the N+1 `get_sub_issues()` REST pattern in C001/C002 validators
- `@pytest.mark.platform` remains on all 187 tests (no semantic change for users)

| Stage | Before | After |
|-------|--------|-------|
| Stage 1 (parallel) | ~170 tests, 65s | 433 tests, ~90s |
| Stage 2 (sequential) | 187 tests, ~28 min | 20 tests, <30s |
| **Total** | **~29 min** | **<2 min** |

## Test plan

- [x] `pytest -m "github_api" --collect-only` → exactly 20 tests from 4 files
- [x] `pytest -m "platform" --collect-only` → still 187 tests (unchanged)
- [ ] `atdd validate` passes both stages in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)