### PR TITLE
feat: generate VS Code workspace file for worktree layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,38 @@ Also sets up on GitHub:
 - Labels: `atdd-issue`, `atdd-wmbt`, `atdd:RED`, `atdd:GREEN`, `atdd:REFACTOR`, archetype labels
 - Project v2 custom fields: `ATDD:Status`, `ATDD:Train`, `ATDD:Archetypes`, etc.
 
+### Worktree Layout
+
+Migrate your repo to a flat-sibling worktree layout where each branch lives alongside `main/`:
+
+```bash
+atdd init --worktree-layout         # Migrate repo into main/ subdirectory
+atdd init --worktree-layout --force # Non-interactive
+```
+
+Resulting structure:
+```
+your-project/
+├── your-project.code-workspace   # VS Code multi-root workspace (auto-generated)
+├── main/                         # Primary checkout
+├── feat-some-feature/            # git worktree: feat/some-feature
+└── fix-login-bug/                # git worktree: fix/login-bug
+```
+
+Creating and removing worktrees:
+```bash
+cd main
+git worktree add ../feat-my-feature -b feat/my-feature   # New branch
+git worktree remove ../feat-my-feature                    # After merge
+```
+
+After adding or removing worktrees, run `atdd sync` to refresh the workspace file:
+```bash
+atdd sync   # Regenerates .code-workspace with current worktrees
+```
+
+Open the `.code-workspace` file in VS Code ("Open Workspace from File") for multi-root, branch-aware editing — each folder shows its active branch in the status bar.
+
 ### Issue Management
 
 Issues are the source of truth, backed by GitHub Issues with Project v2 custom fields.

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -76,6 +76,59 @@ class ProjectInitializer:
                     break
         return worktrees
 
+    # Known branch prefixes for slug → branch name mapping
+    _BRANCH_PREFIXES = ("feat", "fix", "refactor", "chore", "docs", "devops")
+
+    def _slug_to_branch_name(self, slug: str) -> str:
+        """Convert worktree directory slug to branch-style name.
+
+        Maps the first hyphen after a known prefix back to '/':
+            feat-some-feature → feat/some-feature
+            fix-typo          → fix/typo
+            main              → main  (no prefix match)
+        """
+        for prefix in self._BRANCH_PREFIXES:
+            if slug.startswith(prefix + "-"):
+                return prefix + "/" + slug[len(prefix) + 1:]
+        return slug
+
+    def _write_workspace(self) -> None:
+        """Write a VS Code .code-workspace file in the parent directory.
+
+        Scans sibling directories for git worktrees and generates a multi-root
+        workspace so VS Code shows branch info per folder.
+        """
+        parent = self.target_dir.parent
+        workspace_name = parent.name
+        workspace_path = parent / f"{workspace_name}.code-workspace"
+
+        folders = []
+        for child in sorted(parent.iterdir()):
+            if not child.is_dir():
+                continue
+            if child.name.startswith("."):
+                continue
+            git_marker = child / ".git"
+            if not (git_marker.is_file() or git_marker.is_dir()):
+                continue
+            folders.append({
+                "path": child.name,
+                "name": self._slug_to_branch_name(child.name),
+            })
+
+        # Ensure main is listed first
+        main_entry = next((f for f in folders if f["path"] == "main"), None)
+        if main_entry:
+            folders.remove(main_entry)
+            folders.insert(0, main_entry)
+
+        workspace = {"folders": folders, "settings": {}}
+
+        workspace_path.write_text(
+            json.dumps(workspace, indent=2) + "\n"
+        )
+        print(f"Wrote: {workspace_path}")
+
     def _migrate_to_worktree_layout(self) -> Path:
         """
         Move all repo contents into a main/ subdirectory.
@@ -144,6 +197,7 @@ class ProjectInitializer:
         if worktree_layout:
             if layout == "worktree-ready":
                 print("Already in worktree-ready layout (repo root is main/).")
+                self._write_workspace()
             elif layout == "worktree":
                 print("Error: You are inside a linked worktree.")
                 print("Run this command from the main checkout instead.")
@@ -190,6 +244,7 @@ class ProjectInitializer:
                     new_root = self._migrate_to_worktree_layout()
                     self._update_target_dir(new_root)
                     print(f"Migrated to worktree layout: {new_root}")
+                    self._write_workspace()
                     print(f"\n  ** After init completes, run: cd main **\n")
                 except RuntimeError as e:
                     print(f"Error: {e}")

--- a/src/atdd/coach/commands/sync.py
+++ b/src/atdd/coach/commands/sync.py
@@ -116,6 +116,13 @@ class AgentConfigSync:
 
         print(f"\nSync complete: {synced_count} updated, {unchanged_count} unchanged")
 
+        # Refresh VS Code workspace file if in worktree layout
+        from atdd.coach.utils.repo import detect_worktree_layout
+        if detect_worktree_layout(self.target_dir) == "worktree-ready":
+            from atdd.coach.commands.initializer import ProjectInitializer
+            initializer = ProjectInitializer(self.target_dir)
+            initializer._write_workspace()
+
         # Apply branch protection if upgrading
         self._apply_branch_protection_on_upgrade()
 


### PR DESCRIPTION
## Summary
- Add `_write_workspace()` to `ProjectInitializer` — scans parent dir for git worktree siblings, writes `{name}.code-workspace` with `main` first, others sorted alphabetically
- Slug-to-branch mapping (`feat-foo` → `feat/foo`) for readable folder names in VS Code
- Called from `init --worktree-layout` (both fresh migration and already-ready paths) and from `sync` to refresh after worktree add/remove
- README updated with Worktree Layout documentation

## Test plan
- [x] `PYTHONPATH=src python3 -c "from atdd.coach.commands.initializer import ProjectInitializer; ..."` — imports clean
- [x] `_write_workspace()` produces valid JSON with `main` first
- [x] `_slug_to_branch_name()` maps all 6 prefixes correctly, passes through unknown slugs