### PR TITLE
feat: add `atdd branch` command and fix `atdd new` title prefix

### DIFF
--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -8,7 +8,7 @@ The coach orchestrates all ATDD lifecycle operations:
 - status: Show platform status
 - registry: Update registries from source files
 - init: Initialize ATDD structure in consumer repos
-- new/list/update/archive/close-wmbt: Manage GitHub Issues
+- new/list/update/archive/close-wmbt/branch: Manage GitHub Issues
 - sync: Sync ATDD rules to agent config files
 - gate: Verify agents loaded ATDD rules
 
@@ -237,6 +237,8 @@ Examples:
   %(prog)s update 11 --status RED         Update issue fields
   %(prog)s archive 11                     Archive issue
   %(prog)s close-wmbt 11 D005             Close WMBT sub-issue
+  %(prog)s branch 69                      Create worktree from issue #69
+  %(prog)s branch 69 --prefix fix         Override branch prefix
 
   # Agent config sync
   %(prog)s sync                           Sync ATDD rules to agent configs
@@ -432,6 +434,19 @@ Phase descriptions:
     update_top_parser.add_argument("--archetypes", type=str, help="ATDD: Archetypes (comma-separated)")
     update_top_parser.add_argument("--complexity", type=str, help="ATDD: Complexity (e.g., 4-High)")
     update_top_parser.add_argument("--force", "-f", action="store_true", help="Bypass gate/body checks on COMPLETE (train still enforced)")
+
+    # ----- atdd branch <issue_number> -----
+    branch_parser = subparsers.add_parser(
+        "branch",
+        help="Create worktree branch from issue metadata",
+        description="Create a git worktree with the correct prefix/slug naming derived from issue metadata"
+    )
+    branch_parser.add_argument("issue_number", type=int, help="Issue number")
+    branch_parser.add_argument(
+        "--prefix",
+        type=str,
+        help="Override branch prefix (feat, fix, refactor, chore, docs, devops)"
+    )
 
     # ----- atdd close-wmbt <issue_number> <wmbt_id> -----
     close_wmbt_top_parser = subparsers.add_parser(
@@ -840,6 +855,15 @@ Phase descriptions:
             archetypes=getattr(args, 'archetypes', None),
             complexity=getattr(args, 'complexity', None),
             force=getattr(args, 'force', False),
+        )
+
+    # atdd branch <issue_number>
+    elif args.command == "branch":
+        from atdd.coach.commands.branch import BranchManager
+        manager = BranchManager()
+        return manager.branch(
+            issue_number=args.issue_number,
+            prefix=getattr(args, 'prefix', None),
         )
 
     # atdd close-wmbt <issue_id> <wmbt_id> (top-level shorthand)

--- a/src/atdd/coach/commands/branch.py
+++ b/src/atdd/coach/commands/branch.py
@@ -1,0 +1,177 @@
+"""
+Branch (worktree) creation from ATDD issue metadata.
+
+Creates a git worktree with the correct prefix/slug naming derived from
+the issue manifest. Updates the GitHub "ATDD: Branch" field and refreshes
+the VS Code workspace file.
+
+Usage:
+    atdd branch 69                        # Create worktree from issue #69
+    atdd branch 69 --prefix fix           # Override prefix (default: from type)
+
+Convention: CLAUDE.md git.branching
+"""
+import logging
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+from atdd.coach.commands.issue import ALLOWED_BRANCH_PREFIXES, TYPE_TO_PREFIX
+from atdd.coach.github import GitHubClient, GitHubClientError, ProjectConfig
+
+logger = logging.getLogger(__name__)
+
+
+class BranchManager:
+    """Create worktree branches from ATDD issue metadata."""
+
+    def __init__(self, target_dir: Optional[Path] = None):
+        self.target_dir = target_dir or Path.cwd()
+        self.atdd_config_dir = self.target_dir / ".atdd"
+        self.manifest_file = self.atdd_config_dir / "manifest.yaml"
+        self.config_file = self.atdd_config_dir / "config.yaml"
+
+    def _load_manifest(self):
+        if not self.manifest_file.exists():
+            return {}
+        with open(self.manifest_file) as f:
+            return yaml.safe_load(f) or {}
+
+    def _find_issue(self, issue_number: int):
+        """Find an issue in the manifest by number. Returns the entry or None."""
+        manifest = self._load_manifest()
+        for entry in manifest.get("sessions", []):
+            if entry.get("issue_number") == issue_number:
+                return entry
+        return None
+
+    def branch(self, issue_number: int, prefix: Optional[str] = None) -> int:
+        """Create a worktree branch for the given issue.
+
+        Args:
+            issue_number: GitHub issue number.
+            prefix: Override branch prefix (e.g. "fix"). Derived from type if None.
+
+        Returns:
+            0 on success, 1 on error.
+        """
+        from atdd.coach.utils.repo import detect_worktree_layout
+
+        # Verify worktree-ready layout
+        layout = detect_worktree_layout(self.target_dir)
+        if layout != "worktree-ready":
+            print(
+                f"Error: Repository layout is '{layout}', expected 'worktree-ready'.\n"
+                "Run `atdd init --worktree-layout` from the repo root first."
+            )
+            return 1
+
+        # Look up issue in manifest
+        entry = self._find_issue(issue_number)
+        if entry is None:
+            print(
+                f"Error: Issue #{issue_number} not found in manifest.\n"
+                f"Create it first with: atdd new <slug>"
+            )
+            return 1
+
+        slug = entry["slug"]
+        issue_type = entry.get("type", "implementation")
+
+        # Derive prefix
+        if prefix is None:
+            prefix = TYPE_TO_PREFIX.get(issue_type, "feat")
+
+        if prefix not in ALLOWED_BRANCH_PREFIXES:
+            print(
+                f"Error: Prefix '{prefix}' is not allowed.\n"
+                f"Allowed: {', '.join(ALLOWED_BRANCH_PREFIXES)}"
+            )
+            return 1
+
+        branch_name = f"{prefix}/{slug}"
+        worktree_dir_name = f"{prefix}-{slug}"
+        worktree_path = self.target_dir.parent / worktree_dir_name
+
+        # Check if worktree directory already exists
+        if worktree_path.exists():
+            print(
+                f"Error: Directory already exists: {worktree_path}\n"
+                f"Either remove it or work in it directly:\n"
+                f"  cd {worktree_path}"
+            )
+            return 1
+
+        # Fetch remote to check for existing remote branch
+        subprocess.run(
+            ["git", "fetch", "origin"],
+            capture_output=True, text=True, timeout=30,
+            cwd=self.target_dir,
+        )
+
+        # Check if remote branch exists
+        result = subprocess.run(
+            ["git", "branch", "-r", "--list", f"origin/{branch_name}"],
+            capture_output=True, text=True, timeout=10,
+            cwd=self.target_dir,
+        )
+        remote_exists = bool(result.stdout.strip())
+
+        # Create worktree
+        if remote_exists:
+            cmd = [
+                "git", "worktree", "add",
+                str(worktree_path),
+                f"origin/{branch_name}",
+            ]
+            print(f"Attaching to existing remote branch: {branch_name}")
+        else:
+            cmd = [
+                "git", "worktree", "add",
+                str(worktree_path),
+                "-b", branch_name,
+            ]
+            print(f"Creating new branch: {branch_name}")
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True, text=True, timeout=30,
+            cwd=self.target_dir,
+        )
+        if result.returncode != 0:
+            print(f"Error: git worktree add failed:\n{result.stderr.strip()}")
+            return 1
+
+        print(f"  Worktree: {worktree_path}")
+
+        # Update GitHub "ATDD: Branch" field
+        try:
+            proj = ProjectConfig.from_config(self.config_file)
+            client = GitHubClient(
+                repo=proj.repo,
+                project_id=proj.project_id,
+            )
+            item_id = client.get_project_item_id(issue_number)
+            if item_id:
+                fields = client.get_project_fields()
+                if "ATDD: Branch" in fields:
+                    client.set_project_field_text(
+                        item_id, fields["ATDD: Branch"]["id"], branch_name,
+                    )
+                    print(f"  Updated ATDD: Branch → {branch_name}")
+            else:
+                print("  Warning: Issue not found in Project; Branch field not updated.")
+        except GitHubClientError as e:
+            print(f"  Warning: Could not update Branch field: {e}")
+
+        # Refresh VS Code workspace file
+        try:
+            from atdd.coach.commands.initializer import write_workspace
+            write_workspace(self.target_dir)
+        except Exception as e:
+            print(f"  Warning: Could not refresh workspace file: {e}")
+
+        print(f"\n  cd {worktree_path}")
+        return 0

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -32,6 +32,74 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+# Known branch prefixes for slug → branch name mapping
+_BRANCH_PREFIXES = ("feat", "fix", "refactor", "chore", "docs", "devops")
+
+
+def slug_to_branch_name(slug: str) -> str:
+    """Convert worktree directory slug to branch-style name.
+
+    Maps the first hyphen after a known prefix back to '/':
+        feat-some-feature → feat/some-feature
+        fix-typo          → fix/typo
+        main              → main  (no prefix match)
+    """
+    for prefix in _BRANCH_PREFIXES:
+        if slug.startswith(prefix + "-"):
+            return prefix + "/" + slug[len(prefix) + 1:]
+    return slug
+
+
+def write_workspace(target_dir: Path) -> None:
+    """Write a VS Code .code-workspace file in the parent directory.
+
+    Scans sibling directories for git worktrees and generates a multi-root
+    workspace so VS Code shows branch info per folder.
+
+    Args:
+        target_dir: The main checkout directory (e.g. .../project/main).
+    """
+    parent = target_dir.parent
+    workspace_name = parent.name
+    workspace_path = parent / f"{workspace_name}.code-workspace"
+
+    folders = []
+    for child in sorted(parent.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name.startswith("."):
+            continue
+        git_marker = child / ".git"
+        if not (git_marker.is_file() or git_marker.is_dir()):
+            continue
+        folders.append({
+            "path": child.name,
+            "name": slug_to_branch_name(child.name),
+        })
+
+    # Ensure main is listed first
+    main_entry = next((f for f in folders if f["path"] == "main"), None)
+    if main_entry:
+        folders.remove(main_entry)
+        folders.insert(0, main_entry)
+
+    workspace = {
+        "folders": folders,
+        "settings": {
+            "workbench.colorCustomizations": {
+                "titleBar.activeBackground": "#FFC107",
+                "titleBar.activeForeground": "#000000",
+                "statusBar.background": "#FFC107",
+                "statusBar.foreground": "#000000",
+            },
+        },
+    }
+
+    workspace_path.write_text(
+        json.dumps(workspace, indent=2) + "\n"
+    )
+    print(f"Wrote: {workspace_path}")
+
 
 class ProjectInitializer:
     """Initialize ATDD structure in consumer repo."""
@@ -76,68 +144,9 @@ class ProjectInitializer:
                     break
         return worktrees
 
-    # Known branch prefixes for slug → branch name mapping
-    _BRANCH_PREFIXES = ("feat", "fix", "refactor", "chore", "docs", "devops")
-
-    def _slug_to_branch_name(self, slug: str) -> str:
-        """Convert worktree directory slug to branch-style name.
-
-        Maps the first hyphen after a known prefix back to '/':
-            feat-some-feature → feat/some-feature
-            fix-typo          → fix/typo
-            main              → main  (no prefix match)
-        """
-        for prefix in self._BRANCH_PREFIXES:
-            if slug.startswith(prefix + "-"):
-                return prefix + "/" + slug[len(prefix) + 1:]
-        return slug
-
     def _write_workspace(self) -> None:
-        """Write a VS Code .code-workspace file in the parent directory.
-
-        Scans sibling directories for git worktrees and generates a multi-root
-        workspace so VS Code shows branch info per folder.
-        """
-        parent = self.target_dir.parent
-        workspace_name = parent.name
-        workspace_path = parent / f"{workspace_name}.code-workspace"
-
-        folders = []
-        for child in sorted(parent.iterdir()):
-            if not child.is_dir():
-                continue
-            if child.name.startswith("."):
-                continue
-            git_marker = child / ".git"
-            if not (git_marker.is_file() or git_marker.is_dir()):
-                continue
-            folders.append({
-                "path": child.name,
-                "name": self._slug_to_branch_name(child.name),
-            })
-
-        # Ensure main is listed first
-        main_entry = next((f for f in folders if f["path"] == "main"), None)
-        if main_entry:
-            folders.remove(main_entry)
-            folders.insert(0, main_entry)
-
-        workspace = {
-            "folders": folders,
-            "settings": {
-                "workbench.colorCustomizations": {
-                    "titleBar.activeBackground": "#FFC107",
-                    "titleBar.activeForeground": "#000000",
-                    "statusBar.background": "#FFC107",
-                    "statusBar.foreground": "#000000",
-                },
-            },
-        }
-
-        workspace_path.write_text(
-            json.dumps(workspace, indent=2) + "\n"
-        )
-        print(f"Wrote: {workspace_path}")
+        """Write a VS Code .code-workspace file (delegates to module-level)."""
+        write_workspace(self.target_dir)
 
     def _migrate_to_worktree_layout(self) -> Path:
         """

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -26,6 +26,21 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
+# Issue type → conventional commit / branch prefix mapping.
+# Used by `atdd new` (title prefix) and `atdd branch` (worktree prefix).
+TYPE_TO_PREFIX = {
+    "implementation": "feat",
+    "migration": "feat",
+    "refactor": "refactor",
+    "analysis": "chore",
+    "planning": "chore",
+    "cleanup": "chore",
+    "tracking": "chore",
+}
+
+# Allowed branch prefixes (derived from TYPE_TO_PREFIX values + fix, docs, devops).
+ALLOWED_BRANCH_PREFIXES = ("feat", "fix", "refactor", "chore", "docs", "devops")
+
 # Step code to step name mapping
 STEP_CODES = {
     "D": "Define",
@@ -389,7 +404,8 @@ class IssueManager:
 
         today = date.today().isoformat()
         title_text = slug.replace("-", " ").title()
-        title = f"feat(atdd): {title_text}"
+        prefix = TYPE_TO_PREFIX.get(issue_type, "feat")
+        title = f"{prefix}(atdd): {title_text}"
 
         train_display = train or "TBD"
         archetypes_display = archetypes if archetypes else "TBD"
@@ -1307,7 +1323,7 @@ class IssueManager:
 
         # Validate branch prefix (every branch = a worktree)
         if branch:
-            allowed = ("feat/", "fix/", "refactor/", "chore/", "docs/", "devops/")
+            allowed = tuple(f"{p}/" for p in ALLOWED_BRANCH_PREFIXES)
             if not any(branch.startswith(p) for p in allowed):
                 print(
                     f"Error: Branch '{branch}' must start with an allowed prefix: "


### PR DESCRIPTION
## Summary
- Add `TYPE_TO_PREFIX` mapping and `ALLOWED_BRANCH_PREFIXES` constant to `issue.py` as canonical source for type-to-prefix derivation
- Fix `atdd new` to use the correct conventional commit prefix per issue type (was hardcoded to `feat`)
- Add `atdd branch <N>` command that creates a git worktree from issue metadata, updates the GitHub "ATDD: Branch" field, and refreshes the VS Code workspace file
- Extract `write_workspace()` and `slug_to_branch_name()` from `ProjectInitializer` as reusable module-level functions

## Test plan
- [x] All imports verified (`issue.py`, `initializer.py`, `branch.py`, `cli.py`)
- [x] `atdd validate` passes (1 pre-existing failure in `test_C002_project_board` unrelated)
- [x] `atdd branch --help` renders correctly
- [ ] `atdd new <slug> --type refactor` creates issue with `refactor(atdd):` title
- [ ] `atdd branch <N>` creates worktree with correct naming
- [ ] `atdd branch <N> --prefix fix` overrides prefix

Closes #69