### PR TITLE
refactor: fix self-validate compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.4.1"
+version = "1.5.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -426,13 +426,13 @@ Phase descriptions:
         help="Update issue Project fields and labels"
     )
     update_top_parser.add_argument("session_id", type=str, help="Issue number")
-    update_top_parser.add_argument("--status", "-s", type=str, help="ATDD: Status (INIT/PLANNED/RED/GREEN/REFACTOR/COMPLETE/BLOCKED)")
-    update_top_parser.add_argument("--phase", "-p", type=str, help="ATDD: Phase (Planner/Tester/Coder)")
-    update_top_parser.add_argument("--branch", "-b", type=str, help="ATDD: Branch name")
-    update_top_parser.add_argument("--train", type=str, help="ATDD: Train URN")
-    update_top_parser.add_argument("--feature-urn", type=str, help="ATDD: Feature URN")
-    update_top_parser.add_argument("--archetypes", type=str, help="ATDD: Archetypes (comma-separated)")
-    update_top_parser.add_argument("--complexity", type=str, help="ATDD: Complexity (e.g., 4-High)")
+    update_top_parser.add_argument("--status", "-s", type=str, help="ATDD Status (INIT/PLANNED/RED/GREEN/REFACTOR/COMPLETE/BLOCKED)")
+    update_top_parser.add_argument("--phase", "-p", type=str, help="ATDD Phase (Planner/Tester/Coder)")
+    update_top_parser.add_argument("--branch", "-b", type=str, help="ATDD Branch name")
+    update_top_parser.add_argument("--train", type=str, help="ATDD Train URN")
+    update_top_parser.add_argument("--feature-urn", type=str, help="ATDD Feature URN")
+    update_top_parser.add_argument("--archetypes", type=str, help="ATDD Archetypes (comma-separated)")
+    update_top_parser.add_argument("--complexity", type=str, help="ATDD Complexity (e.g., 4-High)")
     update_top_parser.add_argument("--force", "-f", action="store_true", help="Bypass gate/body checks on COMPLETE (train still enforced)")
 
     # ----- atdd branch <issue_number> -----

--- a/src/atdd/coach/commands/branch.py
+++ b/src/atdd/coach/commands/branch.py
@@ -2,7 +2,7 @@
 Branch (worktree) creation from ATDD issue metadata.
 
 Creates a git worktree with the correct prefix/slug naming derived from
-the issue manifest. Updates the GitHub "ATDD: Branch" field and refreshes
+the issue manifest. Updates the GitHub "ATDD Branch" field and refreshes
 the VS Code workspace file.
 
 Usage:
@@ -146,7 +146,7 @@ class BranchManager:
 
         print(f"  Worktree: {worktree_path}")
 
-        # Update GitHub "ATDD: Branch" field
+        # Update GitHub "ATDD Branch" field
         try:
             proj = ProjectConfig.from_config(self.config_file)
             client = GitHubClient(
@@ -156,11 +156,11 @@ class BranchManager:
             item_id = client.get_project_item_id(issue_number)
             if item_id:
                 fields = client.get_project_fields()
-                if "ATDD: Branch" in fields:
+                if "ATDD Branch" in fields:
                     client.set_project_field_text(
-                        item_id, fields["ATDD: Branch"]["id"], branch_name,
+                        item_id, fields["ATDD Branch"]["id"], branch_name,
                     )
-                    print(f"  Updated ATDD: Branch → {branch_name}")
+                    print(f"  Updated ATDD Branch → {branch_name}")
             else:
                 print("  Warning: Issue not found in Project; Branch field not updated.")
         except GitHubClientError as e:

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -625,19 +625,18 @@ class ProjectInitializer:
         return None
 
     # v1 → v2 field migration map: old_name → new_name (None = delete)
+    # NOTE: GitHub Project v2 field names cannot contain colons.
     _FIELD_MIGRATION: Dict[str, Optional[str]] = {
         "Session Number": None,              # DELETE — redundant with GitHub issue number
-        "ATDD Status":    "ATDD: Status",
-        "ATDD Phase":     "ATDD: Phase",
-        "Session Type":   "ATDD: Issue Type",
-        "Complexity":     "ATDD: Complexity",
-        "Archetypes":     "ATDD: Archetypes",
-        "Branch":         "ATDD: Branch",
-        "Train":          "ATDD: Train",
-        "Feature URN":    "ATDD: Feature URN",
-        "WMBT ID":        "ATDD: WMBT ID",
-        "WMBT Step":      "ATDD: WMBT Step",
-        "WMBT Phase":     "ATDD: WMBT Phase",
+        "Session Type":   "ATDD Issue Type",
+        "Complexity":     "ATDD Complexity",
+        "Archetypes":     "ATDD Archetypes",
+        "Branch":         "ATDD Branch",
+        "Train":          "ATDD Train",
+        "Feature URN":    "ATDD Feature URN",
+        "WMBT ID":        "ATDD WMBT ID",
+        "WMBT Step":      "ATDD WMBT Step",
+        "WMBT Phase":     "ATDD WMBT Phase",
     }
 
     def _query_project_field_names_and_ids(self, project_id: str) -> Dict[str, str]:

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -439,40 +439,40 @@ class IssueManager:
             item_id = client.add_issue_to_project(parent_number)
             fields = client.get_project_fields()
 
-            # Set ATDD: Status = INIT
-            if "ATDD: Status" in fields:
-                options = fields["ATDD: Status"].get("options", {})
+            # Set ATDD Status = INIT
+            if "ATDD Status" in fields:
+                options = fields["ATDD Status"].get("options", {})
                 if "INIT" in options:
                     client.set_project_field_select(
-                        item_id, fields["ATDD: Status"]["id"], options["INIT"]
+                        item_id, fields["ATDD Status"]["id"], options["INIT"]
                     )
 
-            # Set issue type (Project field: "ATDD: Issue Type")
-            if "ATDD: Issue Type" in fields:
-                options = fields["ATDD: Issue Type"].get("options", {})
+            # Set issue type (Project field: "ATDD Issue Type")
+            if "ATDD Issue Type" in fields:
+                options = fields["ATDD Issue Type"].get("options", {})
                 if issue_type in options:
                     client.set_project_field_select(
-                        item_id, fields["ATDD: Issue Type"]["id"], options[issue_type]
+                        item_id, fields["ATDD Issue Type"]["id"], options[issue_type]
                     )
 
-            # Set ATDD: Phase = Planner
-            if "ATDD: Phase" in fields:
-                options = fields["ATDD: Phase"].get("options", {})
+            # Set ATDD Phase = Planner
+            if "ATDD Phase" in fields:
+                options = fields["ATDD Phase"].get("options", {})
                 if "Planner" in options:
                     client.set_project_field_select(
-                        item_id, fields["ATDD: Phase"]["id"], options["Planner"]
+                        item_id, fields["ATDD Phase"]["id"], options["Planner"]
                     )
 
             # E008: Set Train field if provided
-            if train and "ATDD: Train" in fields:
+            if train and "ATDD Train" in fields:
                 client.set_project_field_text(
-                    item_id, fields["ATDD: Train"]["id"], train
+                    item_id, fields["ATDD Train"]["id"], train
                 )
 
             # E010: Set Archetypes field if provided
-            if archetypes and "ATDD: Archetypes" in fields:
+            if archetypes and "ATDD Archetypes" in fields:
                 client.set_project_field_text(
-                    item_id, fields["ATDD: Archetypes"]["id"], archetypes
+                    item_id, fields["ATDD Archetypes"]["id"], archetypes
                 )
 
             print(f"  Added to Project with custom fields")
@@ -518,15 +518,15 @@ class IssueManager:
                 # Add to Project and set WMBT fields
                 try:
                     sub_item_id = client.add_issue_to_project(sub_number)
-                    if "ATDD: WMBT ID" in fields:
+                    if "ATDD WMBT ID" in fields:
                         client.set_project_field_text(
-                            sub_item_id, fields["ATDD: WMBT ID"]["id"], wmbt_id
+                            sub_item_id, fields["ATDD WMBT ID"]["id"], wmbt_id
                         )
-                    if "ATDD: WMBT Step" in fields:
-                        step_options = fields["ATDD: WMBT Step"].get("options", {})
+                    if "ATDD WMBT Step" in fields:
+                        step_options = fields["ATDD WMBT Step"].get("options", {})
                         if step_name in step_options:
                             client.set_project_field_select(
-                                sub_item_id, fields["ATDD: WMBT Step"]["id"],
+                                sub_item_id, fields["ATDD WMBT Step"]["id"],
                                 step_options[step_name],
                             )
                 except GitHubClientError as e:
@@ -681,11 +681,11 @@ class IssueManager:
         try:
             fields = client.get_project_fields()
             item_id = client.get_project_item_id(issue_number)
-            if item_id and "ATDD: Status" in fields:
-                options = fields["ATDD: Status"].get("options", {})
+            if item_id and "ATDD Status" in fields:
+                options = fields["ATDD Status"].get("options", {})
                 if "COMPLETE" in options:
                     client.set_project_field_select(
-                        item_id, fields["ATDD: Status"]["id"], options["COMPLETE"]
+                        item_id, fields["ATDD Status"]["id"], options["COMPLETE"]
                     )
         except GitHubClientError:
             pass
@@ -1185,7 +1185,7 @@ class IssueManager:
                 # Check if Train is already set on the project item
                 try:
                     field_values = client.get_project_item_field_values(item_id)
-                    current_train = (field_values.get("ATDD: Train") or "").strip()
+                    current_train = (field_values.get("ATDD Train") or "").strip()
                     if not current_train or current_train.upper() == "TBD":
                         print(f"Error: Train field required for {issue_type or 'unknown'} type before transitioning to {status}")
                         print(f"  Current Train: {current_train or '(empty)'}")
@@ -1300,22 +1300,22 @@ class IssueManager:
             client.add_label(issue_number, [f"atdd:{status}"])
 
             # Update Project field
-            if "ATDD: Status" in fields:
-                options = fields["ATDD: Status"].get("options", {})
+            if "ATDD Status" in fields:
+                options = fields["ATDD Status"].get("options", {})
                 if status in options:
                     client.set_project_field_select(
-                        item_id, fields["ATDD: Status"]["id"], options[status]
+                        item_id, fields["ATDD Status"]["id"], options[status]
                     )
             updated.append(f"status: {status}")
 
         # Phase (Planner/Tester/Coder)
         if phase:
             phase_cap = phase.capitalize()
-            if "ATDD: Phase" in fields:
-                options = fields["ATDD: Phase"].get("options", {})
+            if "ATDD Phase" in fields:
+                options = fields["ATDD Phase"].get("options", {})
                 if phase_cap in options:
                     client.set_project_field_select(
-                        item_id, fields["ATDD: Phase"]["id"], options[phase_cap]
+                        item_id, fields["ATDD Phase"]["id"], options[phase_cap]
                     )
                     updated.append(f"phase: {phase_cap}")
                 else:
@@ -1334,25 +1334,25 @@ class IssueManager:
 
         # Text fields
         text_updates = {
-            "ATDD: Branch": branch,
-            "ATDD: Train": train,
-            "ATDD: Feature URN": feature_urn,
-            "ATDD: Archetypes": archetypes,
+            "ATDD Branch": branch,
+            "ATDD Train": train,
+            "ATDD Feature URN": feature_urn,
+            "ATDD Archetypes": archetypes,
         }
         for field_name, value in text_updates.items():
             if value and field_name in fields:
                 client.set_project_field_text(item_id, fields[field_name]["id"], value)
-                # Display the short name (strip "ATDD: " prefix)
-                display_name = field_name.removeprefix("ATDD: ").lower()
+                # Display the short name (strip "ATDD " prefix)
+                display_name = field_name.removeprefix("ATDD ").lower()
                 updated.append(f"{display_name}: {value}")
 
         # Complexity
         if complexity:
-            if "ATDD: Complexity" in fields:
-                options = fields["ATDD: Complexity"].get("options", {})
+            if "ATDD Complexity" in fields:
+                options = fields["ATDD Complexity"].get("options", {})
                 if complexity in options:
                     client.set_project_field_select(
-                        item_id, fields["ATDD: Complexity"]["id"], options[complexity]
+                        item_id, fields["ATDD Complexity"]["id"], options[complexity]
                     )
                     updated.append(f"complexity: {complexity}")
 

--- a/src/atdd/coach/schemas/project_fields.schema.json
+++ b/src/atdd/coach/schemas/project_fields.schema.json
@@ -53,7 +53,7 @@
           "type": "object",
           "description": "Current ATDD lifecycle status",
           "properties": {
-            "name": { "const": "ATDD: Status" },
+            "name": { "const": "ATDD Status" },
             "data_type": { "const": "SINGLE_SELECT" },
             "required": { "const": true },
             "options": {
@@ -78,7 +78,7 @@
           "type": "object",
           "description": "Current agent phase (which agent owns the work)",
           "properties": {
-            "name": { "const": "ATDD: Phase" },
+            "name": { "const": "ATDD Phase" },
             "data_type": { "const": "SINGLE_SELECT" },
             "required": { "const": true },
             "options": {
@@ -99,7 +99,7 @@
           "type": "object",
           "description": "Type of issue determining required workflow phases",
           "properties": {
-            "name": { "const": "ATDD: Issue Type" },
+            "name": { "const": "ATDD Issue Type" },
             "data_type": { "const": "SINGLE_SELECT" },
             "required": { "const": true },
             "options": {
@@ -123,7 +123,7 @@
           "type": "object",
           "description": "Complexity rating for effort estimation",
           "properties": {
-            "name": { "const": "ATDD: Complexity" },
+            "name": { "const": "ATDD Complexity" },
             "data_type": { "const": "SINGLE_SELECT" },
             "required": { "const": true },
             "options": {
@@ -146,7 +146,7 @@
           "type": "object",
           "description": "Affected infrastructure archetypes (comma-separated)",
           "properties": {
-            "name": { "const": "ATDD: Archetypes" },
+            "name": { "const": "ATDD Archetypes" },
             "data_type": { "const": "TEXT" },
             "required": { "const": true },
             "validation": {
@@ -167,7 +167,7 @@
           "type": "object",
           "description": "Git branch associated with this issue",
           "properties": {
-            "name": { "const": "ATDD: Branch" },
+            "name": { "const": "ATDD Branch" },
             "data_type": { "const": "TEXT" },
             "required": { "const": false },
             "description": { "const": "Git branch name. TBD until branch is created." }
@@ -178,7 +178,7 @@
           "type": "object",
           "description": "Train URN this issue belongs to",
           "properties": {
-            "name": { "const": "ATDD: Train" },
+            "name": { "const": "ATDD Train" },
             "data_type": { "const": "TEXT" },
             "required": { "const": false },
             "validation": {
@@ -194,7 +194,7 @@
           "type": "object",
           "description": "Feature URN this issue implements",
           "properties": {
-            "name": { "const": "ATDD: Feature URN" },
+            "name": { "const": "ATDD Feature URN" },
             "data_type": { "const": "TEXT" },
             "required": { "const": false },
             "validation": {
@@ -217,7 +217,7 @@
           "type": "object",
           "description": "WMBT identifier (e.g., D001, E003, C002)",
           "properties": {
-            "name": { "const": "ATDD: WMBT ID" },
+            "name": { "const": "ATDD WMBT ID" },
             "data_type": { "const": "TEXT" },
             "required": { "const": true },
             "validation": {
@@ -233,7 +233,7 @@
           "type": "object",
           "description": "WMBT lifecycle step category",
           "properties": {
-            "name": { "const": "ATDD: WMBT Step" },
+            "name": { "const": "ATDD WMBT Step" },
             "data_type": { "const": "SINGLE_SELECT" },
             "required": { "const": true },
             "options": {
@@ -257,7 +257,7 @@
           "type": "object",
           "description": "Current ATDD phase of this WMBT",
           "properties": {
-            "name": { "const": "ATDD: WMBT Phase" },
+            "name": { "const": "ATDD WMBT Phase" },
             "data_type": { "const": "SINGLE_SELECT" },
             "required": { "const": true },
             "options": {

--- a/src/atdd/coach/utils/graph/resolver.py
+++ b/src/atdd/coach/utils/graph/resolver.py
@@ -1072,6 +1072,8 @@ class TestResolver(BaseResolver):
     """
     Resolver for test: URNs.
 
+    NOTE: __test__ = False prevents pytest from collecting this as a test class.
+
     V3 behavior:
     - Scans test files for explicit ``# URN: test:...`` headers (S8.4)
     - Parses metadata lines: Acceptance:, WMBT:, Train:, Phase:, Layer:
@@ -1079,6 +1081,8 @@ class TestResolver(BaseResolver):
 
     Resolution: test:{...} -> test file path
     """
+
+    __test__ = False  # Prevent pytest collection
 
     # Comment-style URN pattern (# URN: ... or // URN: ...)
     _URN_COMMENT_RE = re.compile(r"(?:#|//)\s*[Uu][Rr][Nn]:\s*([^\s]+)")

--- a/src/atdd/coach/validators/test_C002_project_board.py
+++ b/src/atdd/coach/validators/test_C002_project_board.py
@@ -23,14 +23,14 @@ pytestmark = [pytest.mark.platform, pytest.mark.github_api]
 # ---------------------------------------------------------------------------
 
 REQUIRED_FIELDS = [
-    "ATDD: Status",
-    "ATDD: Phase",
-    "ATDD: Issue Type",
-    "ATDD: Complexity",
-    "ATDD: Archetypes",
-    "ATDD: Branch",
-    "ATDD: Train",
-    "ATDD: Feature URN",
+    "ATDD Status",
+    "ATDD Phase",
+    "ATDD Issue Type",
+    "ATDD Complexity",
+    "ATDD Archetypes",
+    "ATDD Branch",
+    "ATDD Train",
+    "ATDD Feature URN",
 ]
 
 REQUIRED_STATUS_OPTIONS = {"INIT", "PLANNED", "RED", "GREEN", "REFACTOR", "COMPLETE", "BLOCKED"}
@@ -67,10 +67,10 @@ def test_atdd_status_field_has_required_options(github_project_fields):
     When: Checking available options
     Then: All lifecycle statuses are present (INIT through COMPLETE + BLOCKED)
     """
-    if "ATDD: Status" not in github_project_fields:
+    if "ATDD Status" not in github_project_fields:
         pytest.skip("ATDD Status field not found")
 
-    options = set(github_project_fields["ATDD: Status"].get("options", {}).keys())
+    options = set(github_project_fields["ATDD Status"].get("options", {}).keys())
     missing = REQUIRED_STATUS_OPTIONS - options
 
     assert not missing, (
@@ -88,10 +88,10 @@ def test_atdd_phase_field_has_required_options(github_project_fields):
     When: Checking available options
     Then: Planner, Tester, Coder are present
     """
-    if "ATDD: Phase" not in github_project_fields:
+    if "ATDD Phase" not in github_project_fields:
         pytest.skip("ATDD Phase field not found")
 
-    options = set(github_project_fields["ATDD: Phase"].get("options", {}).keys())
+    options = set(github_project_fields["ATDD Phase"].get("options", {}).keys())
     missing = REQUIRED_PHASE_OPTIONS - options
 
     assert not missing, (
@@ -131,11 +131,11 @@ def test_issues_have_status_field_set(github_issues, github_project_fields, gith
     Then: At least one issue has a non-empty ATDD Status
           (confirming field values are set, enabling board filtering)
     """
-    if "ATDD: Status" not in github_project_fields:
+    if "ATDD Status" not in github_project_fields:
         pytest.skip("ATDD Status field not configured")
 
     has_status = any(
-        github_project_items[num]["fields"].get("ATDD: Status")
+        github_project_items[num]["fields"].get("ATDD Status")
         for num in (i["number"] for i in github_issues)
         if num in github_project_items
     )

--- a/src/atdd/coach/validators/test_issue_validation.py
+++ b/src/atdd/coach/validators/test_issue_validation.py
@@ -80,7 +80,7 @@ def test_issues_have_train_field(github_issues, github_project_fields, github_pr
 
     E008 acceptance criteria: `atdd validate coach` fails if issue has no train assignment.
     """
-    if "ATDD: Train" not in github_project_fields:
+    if "ATDD Train" not in github_project_fields:
         pytest.skip("Train field not configured in Project")
 
     violations = []
@@ -93,8 +93,8 @@ def test_issues_have_train_field(github_issues, github_project_fields, github_pr
             continue
 
         values = item["fields"]
-        train_value = (values.get("ATDD: Train") or "").strip()
-        status_value = (values.get("ATDD: Status") or "UNKNOWN").strip().upper()
+        train_value = (values.get("ATDD Train") or "").strip()
+        status_value = (values.get("ATDD Status") or "UNKNOWN").strip().upper()
 
         is_empty = not train_value or train_value.upper() == "TBD"
 
@@ -138,7 +138,7 @@ def test_issue_train_references_valid_train_id(github_issues, github_project_fie
     if not valid_train_ids:
         pytest.skip("No trains found in plan/_trains.yaml")
 
-    if "ATDD: Train" not in github_project_fields:
+    if "ATDD Train" not in github_project_fields:
         pytest.skip("Train field not configured in Project")
 
     invalid = []
@@ -149,7 +149,7 @@ def test_issue_train_references_valid_train_id(github_issues, github_project_fie
         if not item:
             continue
 
-        train_value = (item["fields"].get("ATDD: Train") or "").strip()
+        train_value = (item["fields"].get("ATDD Train") or "").strip()
 
         # Skip empty/TBD — handled by SPEC-SESSION-VAL-0050
         if not train_value or train_value.upper() == "TBD":

--- a/src/atdd/tester/validators/test_coverage_adequacy.py
+++ b/src/atdd/tester/validators/test_coverage_adequacy.py
@@ -8,8 +8,8 @@ Validates:
 - Coverage percentage meets threshold
 
 Architecture:
-- Entities: Domain models (ACDefinition, TestCase, CoverageReport)
-- Use Cases: Business logic (ACFinder, TestFinder, CoverageAnalyzer)
+- Entities: Domain models (ACDefinition, CoverageCase, CoverageReport)
+- Use Cases: Business logic (ACFinder, CoverageFinder, CoverageAnalyzer)
 - Adapters: Infrastructure (YAMLReader, TestFileReader, ReportFormatter)
 - Tests: Orchestration layer (pytest test functions)
 
@@ -76,7 +76,7 @@ class ACDefinition:
 
 
 @dataclass
-class TestCase:
+class CoverageCase:
     """
     Test case entity.
 
@@ -169,7 +169,7 @@ class ACFinder:
         return acs
 
 
-class TestFinder:
+class CoverageFinder:
     """
     Use case: Find all test cases in the repository.
 
@@ -180,7 +180,7 @@ class TestFinder:
         self.python_dir = python_dir
         self.lib_dir = lib_dir
 
-    def find_python_tests(self) -> List[TestCase]:
+    def find_python_tests(self) -> List[CoverageCase]:
         """Find all Python test cases."""
         if not self.python_dir.exists():
             return []
@@ -203,7 +203,7 @@ class TestFinder:
                 # Extract AC reference from test name or docstring
                 ac_ref = self._extract_ac_reference(content, test_name, rel_path)
 
-                test = TestCase(
+                test = CoverageCase(
                     name=test_name,
                     file_path=rel_path,
                     ac_reference=ac_ref
@@ -212,7 +212,7 @@ class TestFinder:
 
         return tests
 
-    def find_dart_tests(self) -> List[TestCase]:
+    def find_dart_tests(self) -> List[CoverageCase]:
         """Find all Dart test cases."""
         if not TEST_DIR.exists():
             return []
@@ -235,7 +235,7 @@ class TestFinder:
 
                 rel_path = str(test_file.relative_to(REPO_ROOT))
 
-                test = TestCase(
+                test = CoverageCase(
                     name=test_name,
                     file_path=rel_path,
                     ac_reference=ac_ref
@@ -259,7 +259,7 @@ class TestFinder:
 
         return None
 
-    def find_typescript_tests(self) -> List[TestCase]:
+    def find_typescript_tests(self) -> List[CoverageCase]:
         """Find all TypeScript test cases per conventions.
 
         Scans (aligns with Python structure):
@@ -300,7 +300,7 @@ class TestFinder:
 
         return tests
 
-    def _scan_ts_directory(self, directory: Path) -> List[TestCase]:
+    def _scan_ts_directory(self, directory: Path) -> List[CoverageCase]:
         """Scan a directory for TypeScript test files."""
         tests = []
 
@@ -322,7 +322,7 @@ class TestFinder:
 
                     rel_path = str(test_file.relative_to(REPO_ROOT))
 
-                    test = TestCase(
+                    test = CoverageCase(
                         name=test_name,
                         file_path=rel_path,
                         ac_reference=ac_ref
@@ -395,13 +395,13 @@ class CoverageAnalyzer:
     Maps tests to ACs and generates coverage reports.
     """
 
-    def __init__(self, acs: List[ACDefinition], tests: List[TestCase]):
+    def __init__(self, acs: List[ACDefinition], tests: List[CoverageCase]):
         self.acs = acs
         self.tests = tests
         self._ac_map = {ac.urn: ac for ac in acs}
         self._test_map = self._build_test_map()
 
-    def _build_test_map(self) -> Dict[str, List[TestCase]]:
+    def _build_test_map(self) -> Dict[str, List[CoverageCase]]:
         """Build map of AC URN to test cases."""
         test_map = defaultdict(list)
 
@@ -475,7 +475,7 @@ class CoverageAnalyzer:
 
         return dict(category_counts)
 
-    def find_orphaned_tests(self) -> List[TestCase]:
+    def find_orphaned_tests(self) -> List[CoverageCase]:
         """Find tests that reference non-existent ACs."""
         orphaned = []
 
@@ -624,7 +624,7 @@ class ReportFormatter:
         return "\n".join(lines)
 
     @staticmethod
-    def format_orphaned_report(orphaned: List[TestCase]) -> str:
+    def format_orphaned_report(orphaned: List[CoverageCase]) -> str:
         """Format orphaned tests report."""
         lines = []
 
@@ -665,13 +665,13 @@ def test_all_acceptance_criteria_have_tests():
     Then: Every AC has at least one test
 
     Architecture: Uses clean architecture layers
-    - Entities: ACDefinition, TestCase
-    - Use Cases: ACFinder, TestFinder, CoverageAnalyzer
+    - Entities: ACDefinition, CoverageCase
+    - Use Cases: ACFinder, CoverageFinder, CoverageAnalyzer
     - Adapters: ReportFormatter
     """
     # Layer 2: Use Cases
     ac_finder = ACFinder(PLAN_DIR)
-    test_finder = TestFinder(PYTHON_DIR, LIB_DIR)
+    test_finder = CoverageFinder(PYTHON_DIR, LIB_DIR)
 
     # Find all ACs and tests (Python, Dart, and TypeScript)
     acs = ac_finder.find_all()
@@ -716,12 +716,12 @@ def test_coverage_meets_threshold():
 
     Architecture: Uses clean architecture layers
     - Entities: CoverageReport
-    - Use Cases: ACFinder, TestFinder, CoverageAnalyzer
+    - Use Cases: ACFinder, CoverageFinder, CoverageAnalyzer
     - Adapters: ReportFormatter
     """
     # Layer 2: Use Cases
     ac_finder = ACFinder(PLAN_DIR)
-    test_finder = TestFinder(PYTHON_DIR, LIB_DIR)
+    test_finder = CoverageFinder(PYTHON_DIR, LIB_DIR)
 
     # Find all ACs and tests
     acs = ac_finder.find_all()
@@ -765,13 +765,13 @@ def test_no_orphaned_tests():
     Then: All tests reference an existing AC
 
     Architecture: Uses clean architecture layers
-    - Entities: TestCase
-    - Use Cases: ACFinder, TestFinder, CoverageAnalyzer
+    - Entities: CoverageCase
+    - Use Cases: ACFinder, CoverageFinder, CoverageAnalyzer
     - Adapters: ReportFormatter
     """
     # Layer 2: Use Cases
     ac_finder = ACFinder(PLAN_DIR)
-    test_finder = TestFinder(PYTHON_DIR, LIB_DIR)
+    test_finder = CoverageFinder(PYTHON_DIR, LIB_DIR)
 
     # Find all ACs and tests
     acs = ac_finder.find_all()


### PR DESCRIPTION
## Summary
- Remove colons from GitHub Project v2 field names — GitHub's API rejects `:` in field names, causing `atdd init` field migration to silently fail and `test_project_has_required_custom_fields` to always FAIL in CI
- Rename `TestCase` → `CoverageCase`, `TestFinder` → `CoverageFinder` in `test_coverage_adequacy.py` and add `__test__ = False` to `TestResolver` — eliminates 24 PytestCollectionWarnings in `atdd validate` output
- Bump version 1.4.1 → 1.5.0 (MINOR: field naming convention change)

## Root Cause
GitHub Project v2 API returns `UNPROCESSABLE: Name cannot contain any of the following characters: :` when renaming fields. The schema, validators, and initializer all specified field names with `:` prefix (e.g., `"ATDD: Status"`) — a convention that is impossible on the platform.

## Files Changed (10)
| File | Change |
|------|--------|
| `pyproject.toml` | Version bump 1.4.1 → 1.5.0 |
| `src/atdd/cli.py` | CLI help strings: remove colon from field names |
| `src/atdd/coach/commands/branch.py` | Field references: `ATDD: Branch` → `ATDD Branch` |
| `src/atdd/coach/commands/initializer.py` | Migration map: colon-free targets + comment |
| `src/atdd/coach/commands/issue.py` | All 30+ field references updated |
| `src/atdd/coach/schemas/project_fields.schema.json` | Schema: all `const` field names updated |
| `src/atdd/coach/utils/graph/resolver.py` | `TestResolver.__test__ = False` |
| `src/atdd/coach/validators/test_C002_project_board.py` | REQUIRED_FIELDS list updated |
| `src/atdd/coach/validators/test_issue_validation.py` | Field references updated |
| `src/atdd/tester/validators/test_coverage_adequacy.py` | `TestCase` → `CoverageCase`, `TestFinder` → `CoverageFinder` |

## Test plan
- [x] `test_project_has_required_custom_fields` passes (was FAIL)
- [x] All 5 C002 project board tests pass
- [x] Zero PytestCollectionWarnings
- [x] 210 passed, 169 skipped, 0 warnings in fast validators
- [ ] CI workflow goes green after merge + tag

Closes #71, #72, #73, #74