### PR TITLE
chore: sync toolkit version in config

### DIFF
--- a/.atdd/config.yaml
+++ b/.atdd/config.yaml
@@ -6,7 +6,7 @@ sync:
   agents:
   - claude
 toolkit:
-  last_version: 1.3.5
+  last_version: 1.5.0
 github:
   repo: afokapu/atdd
   project_number: 1


### PR DESCRIPTION
## Summary
- Update `toolkit.last_version` from 1.3.5 to 1.5.0 in `.atdd/config.yaml`

## Test plan
- [x] `atdd validate` passes (217 passed, 0 failed)