### PR TITLE
Bump version to 1.5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.5.0"
+version = "1.5.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- PATCH bump: 1.5.0 → 1.5.1
- Includes auto-tag CI feature (#78) and quote escaping fix (#79)
- First PR where `tag-release` job will auto-create the `v1.5.1` tag after merge

## Test plan
- [ ] CI validate passes (tag check skipped on PR branches)
- [ ] After merge, `tag-release` auto-creates `v1.5.1` tag
- [ ] `publish.yml` triggers on the new tag