### PR TITLE
fix(ci): add write permission for tag-release

### DIFF
--- a/.github/workflows/atdd-validate.yml
+++ b/.github/workflows/atdd-validate.yml
@@ -53,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: validate
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to `tag-release` job
- Fixes `Permission to afokapu/atdd.git denied to github-actions[bot]` on tag push

## Test plan
- [ ] CI passes
- [ ] After merge, `tag-release` creates and pushes `v1.5.1`