### PR TITLE
fix: batch sub-issues query to eliminate N+1 API calls

### DIFF
--- a/src/atdd/coach/github.py
+++ b/src/atdd/coach/github.py
@@ -100,9 +100,14 @@ class GitHubClient:
             )
         return result.stdout.strip()
 
-    def _graphql(self, query: str) -> Dict[str, Any]:
+    def _graphql(
+        self, query: str, headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
         """Execute a GraphQL query via `gh api graphql`."""
-        output = self._run_gh(["api", "graphql", "-f", f"query={query}"])
+        args = ["api", "graphql", "-f", f"query={query}"]
+        for key, value in (headers or {}).items():
+            args.extend(["-H", f"{key}: {value}"])
+        output = self._run_gh(args)
         data = json.loads(output)
         if "errors" in data:
             raise GitHubClientError(
@@ -182,6 +187,70 @@ class GitHubClient:
             f'}}) {{ issue {{ id }} subIssue {{ id }} }} }}'
         )
         logger.info("Linked #%d as sub-issue of #%d", child_number, parent_number)
+
+    def get_all_sub_issues(
+        self, label: str, state: str = "OPEN",
+    ) -> Dict[int, List[Dict[str, Any]]]:
+        """Batch-fetch sub-issues for all issues matching *label* and *state*.
+
+        Single paginated GraphQL query replaces N sequential REST calls to
+        ``get_sub_issues()``.  Requires the ``sub_issues`` GraphQL preview
+        header.
+
+        Args:
+            label: Filter parent issues by this label (e.g. ``"atdd-issue"``).
+            state: GitHub issue state filter — ``"OPEN"`` or ``"CLOSED"``.
+
+        Returns:
+            Dict mapping parent issue number to its list of sub-issue dicts.
+            Sub-issue dicts contain ``number``, ``title``, ``state``, and
+            ``labels`` (normalised to lowercase state values for REST parity).
+        """
+        owner, name = self.repo.split("/")
+        state_upper = state.upper()
+        result: Dict[int, List[Dict[str, Any]]] = {}
+        cursor = None
+        headers = {"GraphQL-Features": "sub_issues"}
+
+        while True:
+            after = f', after: "{cursor}"' if cursor else ""
+            data = self._graphql(
+                f'{{ repository(owner:"{owner}", name:"{name}") {{ '
+                f'issues(first: 50, labels: ["{label}"], states: [{state_upper}]{after}) {{ '
+                f'pageInfo {{ hasNextPage endCursor }} '
+                f'nodes {{ '
+                f'number '
+                f'subIssues(first: 50) {{ nodes {{ '
+                f'number title state '
+                f'labels(first: 10) {{ nodes {{ name }} }} '
+                f'}} }} '
+                f'}} }} }} }}',
+                headers=headers,
+            )
+
+            repo_data = data["data"]["repository"]
+            for node in repo_data["issues"]["nodes"]:
+                parent_num = node["number"]
+                subs = []
+                for sub in node["subIssues"]["nodes"]:
+                    subs.append({
+                        "number": sub["number"],
+                        "title": sub["title"],
+                        "state": sub["state"].lower(),
+                        "labels": [{"name": l["name"]} for l in sub["labels"]["nodes"]],
+                    })
+                result[parent_num] = subs
+
+            page_info = repo_data["issues"]["pageInfo"]
+            if page_info["hasNextPage"]:
+                cursor = page_info["endCursor"]
+            else:
+                break
+
+        logger.debug(
+            "Fetched sub-issues for %d %s issues in batch", len(result), state_upper,
+        )
+        return result
 
     # -------------------------------------------------------------------------
     # Labels

--- a/src/atdd/coach/validators/conftest.py
+++ b/src/atdd/coach/validators/conftest.py
@@ -104,19 +104,30 @@ def github_project_items(github_client):
 
 
 @pytest.fixture(scope="session")
-def github_sub_issues(github_client, github_issues):
+def github_sub_issues(github_client):
     """Sub-issues for all open parent issues (fetched once per session).
 
     Returns dict mapping issue_number -> list[dict] of sub-issues.
-    Replaces N+1 calls to get_sub_issues() in individual tests.
+    Single batch GraphQL query replaces N sequential REST calls.
     """
     from atdd.coach.github import GitHubClientError
 
-    result = {}
-    for issue in github_issues:
-        num = issue["number"]
-        try:
-            result[num] = github_client.get_sub_issues(num)
-        except GitHubClientError:
-            result[num] = []
-    return result
+    try:
+        return github_client.get_all_sub_issues("atdd-issue", "OPEN")
+    except GitHubClientError as e:
+        pytest.skip(f"Cannot batch-query sub-issues: {e}")
+
+
+@pytest.fixture(scope="session")
+def github_closed_sub_issues(github_client):
+    """Sub-issues for all closed parent issues (fetched once per session).
+
+    Returns dict mapping issue_number -> list[dict] of sub-issues.
+    Enables test_archived_issues to use cached data instead of N+1 calls.
+    """
+    from atdd.coach.github import GitHubClientError
+
+    try:
+        return github_client.get_all_sub_issues("atdd-issue", "CLOSED")
+    except GitHubClientError as e:
+        pytest.skip(f"Cannot batch-query closed sub-issues: {e}")

--- a/src/atdd/coach/validators/test_C001_roundtrip.py
+++ b/src/atdd/coach/validators/test_C001_roundtrip.py
@@ -14,10 +14,7 @@ These tests run against the LIVE GitHub API and require:
 
 Run: atdd validate coach
 """
-import json
 import pytest
-
-from atdd.coach.github import GitHubClientError
 
 pytestmark = [pytest.mark.platform, pytest.mark.github_api]
 
@@ -61,6 +58,7 @@ def test_github_client_methods_exist():
 
     required_methods = [
         "create_issue", "close_issue", "add_sub_issue", "get_sub_issues",
+        "get_all_sub_issues",
         "list_issues_by_label", "get_project_fields", "add_issue_to_project",
         "set_project_field_text", "set_project_field_select",
         "set_project_field_number", "get_project_item_id",
@@ -121,7 +119,7 @@ def test_sub_issue_progress_is_trackable(github_sub_issues):
     pytest.skip("No issue with sub-issues found")
 
 
-def test_archived_issues_have_no_orphaned_sub_issues(github_client):
+def test_archived_issues_have_no_orphaned_sub_issues(github_closed_sub_issues):
     """
     SPEC-COACH-C001-0005: Archived (closed) issues have no open sub-issues
 
@@ -130,35 +128,17 @@ def test_archived_issues_have_no_orphaned_sub_issues(github_client):
     Then: All sub-issues of closed parent issues are also closed
           (no orphaned open sub-issues)
     """
-    try:
-        # Get closed issues (separate query, not cached — closed issues are rare)
-        output = github_client._run_gh([
-            "issue", "list",
-            "--repo", github_client.repo,
-            "--label", "atdd-issue",
-            "--state", "closed",
-            "--json", "number,title",
-            "--limit", "20",
-        ])
-        closed_issues = json.loads(output) if output else []
-    except GitHubClientError as e:
-        pytest.skip(f"Cannot query GitHub: {e}")
-
-    if not closed_issues:
+    if not github_closed_sub_issues:
         pytest.skip("No closed issues found")
 
     orphans = []
-    for issue in closed_issues:
-        try:
-            subs = github_client.get_sub_issues(issue["number"])
-            open_subs = [s for s in subs if s.get("state") == "open"]
-            if open_subs:
-                sub_nums = ", ".join(f"#{s['number']}" for s in open_subs)
-                orphans.append(
-                    f"#{issue['number']}: {len(open_subs)} open sub-issues ({sub_nums})"
-                )
-        except GitHubClientError:
-            continue
+    for num, subs in github_closed_sub_issues.items():
+        open_subs = [s for s in subs if s.get("state") == "open"]
+        if open_subs:
+            sub_nums = ", ".join(f"#{s['number']}" for s in open_subs)
+            orphans.append(
+                f"#{num}: {len(open_subs)} open sub-issues ({sub_nums})"
+            )
 
     assert not orphans, (
         f"\nClosed issues with orphaned open sub-issues:\n  "

--- a/src/atdd/coach/validators/test_issue_gate_completion.py
+++ b/src/atdd/coach/validators/test_issue_gate_completion.py
@@ -53,13 +53,22 @@ def test_complete_issues_gate_tests_pass(github_complete_issues):
             continue
 
         for gate in gates:
+            cmd = gate["command"]
+            # Skip commands that would recursively invoke this test suite.
+            # Bare `atdd validate` runs all phases; `atdd validate coach`
+            # runs coach validators (including this file) → recursion.
+            if cmd.strip().startswith("atdd validate"):
+                tail = cmd.strip()[len("atdd validate"):].lstrip()
+                if not tail or tail.startswith("--") or tail.startswith("coach"):
+                    continue
+
             result = subprocess.run(
-                gate["command"],
+                cmd,
                 shell=True,
                 capture_output=True,
                 text=True,
                 cwd=str(REPO_ROOT),
-                timeout=300,
+                timeout=120,
             )
             if result.returncode != 0:
                 stderr_tail = result.stderr.strip().splitlines()[-3:] if result.stderr else []


### PR DESCRIPTION
## Summary
- Add `get_all_sub_issues()` batch GraphQL method to `GitHubClient` — single paginated query replaces N sequential REST calls to `get_sub_issues()`
- Replace N+1 fixture loop in `conftest.py` with batch call; add `github_closed_sub_issues` session fixture
- Refactor `test_archived_issues` to use session-cached fixture instead of raw `_run_gh` + per-issue loop
- Guard gate completion test against recursive `atdd validate` invocation; reduce timeout 300s → 120s

Closes #85

## Test plan
- [x] `python3 -m pytest src/atdd/coach/validators/ -v` — 53 passed, 12 skipped, 0 failures (9.67s)
- [ ] CI pipeline confirms Stage 2 (GitHub API tests) completes in < 5 min
- [ ] `get_all_sub_issues` returns same data shape as old per-issue REST fixture