### PR TITLE
fix: add `atdd branch` to template and convention docs

### DIFF
--- a/src/atdd/coach/conventions/issue.convention.yaml
+++ b/src/atdd/coach/conventions/issue.convention.yaml
@@ -253,6 +253,7 @@ github_issue_tracking:
     update: "atdd update <NN> --status <S> — updates Project fields + labels"
     close_wmbt: "atdd close-wmbt <NN> <WMBT_ID> — closes WMBT sub-issue"
     archive: "atdd archive <NN> — closes parent + all sub-issues"
+    branch: "atdd branch <NN> — creates worktree branch from issue metadata"
     validate: "atdd validate coach — validates Project fields + sub-issue state"
 
   hard_dependencies:
@@ -331,7 +332,7 @@ github_issue_tracking:
   # The template produces 11 structured sections matching the `sections:` spec.
   parent_issue_template:
     file: "atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md"
-    title_format: "feat(atdd): {Title}"
+    title_format: "{prefix}(atdd): {Title}  # prefix derived from TYPE_TO_PREFIX[issue_type]"
 
     placeholders:
       today:

--- a/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
+++ b/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
@@ -126,6 +126,7 @@
 - Issue created via `atdd new {slug}`
 
 **Next:**
+- Create branch: `atdd branch <N>` (this issue's number)
 - Fill Context, Scope, and Architecture sections
 - Define phases and gate tests
 


### PR DESCRIPTION
## Summary
- Add `atdd branch <N>` as first "Next" step in parent issue Activity Log template
- Update convention `title_format` from hardcoded `feat(atdd):` to `{prefix}(atdd):`
- Add `branch` to `cli_commands` list in issue convention

## Test plan
- [ ] `atdd new` renders template with branch step in Activity Log
- [ ] Convention docs reflect the new command