### PR TITLE
fix(ci): trigger publish workflow after tag creation

### DIFF
--- a/.github/workflows/atdd-validate.yml
+++ b/.github/workflows/atdd-validate.yml
@@ -89,8 +89,16 @@ jobs:
         run: |
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists, skipping"
+            echo "CREATED=false" >> "$GITHUB_ENV"
           else
             git tag "$TAG"
             git push origin "$TAG"
             echo "Created and pushed tag $TAG"
+            echo "CREATED=true" >> "$GITHUB_ENV"
           fi
+
+      - name: Trigger publish workflow
+        if: env.CREATED == 'true'
+        run: gh workflow run publish.yml --ref "$TAG"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Tags created by `GITHUB_TOKEN` in CI don't trigger other workflows (GitHub limitation)
- Add `workflow_dispatch` call to explicitly trigger publish workflow after tag-release creates a new tag
- This is why v1.5.1 and v1.5.2 were never published to PyPI

## Test plan
- [ ] Next version bump triggers tag-release → publish workflow
- [ ] Manually trigger publish for v1.5.2 after merge