### PR TITLE
feat(ci): auto-release with version bump, tag, and publish after merge

### DIFF
--- a/.github/workflows/atdd-validate.yml
+++ b/.github/workflows/atdd-validate.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     if: >-
       github.event_name != 'issues' ||
       contains(github.event.issue.labels.*.name, 'atdd-issue') ||
@@ -49,29 +51,77 @@ jobs:
               body: `${emoji} ATDD validation: **${result}**`
             });
 
-  tag-release:
+  # ---------------------------------------------------------------------------
+  # Auto-release: bump version, tag, publish after merge to main
+  # ---------------------------------------------------------------------------
+  # Reads the conventional commit prefix from the merge commit title to
+  # determine the bump type (feat → MINOR, everything else → PATCH).
+  # Serialized via concurrency group to handle parallel PR merges safely.
+  auto-release:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: validate
+    concurrency:
+      group: auto-release
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Read version and create tag
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Pull latest main (serialization safety)
+        run: git pull origin main --rebase
+
+      - name: Determine bump type from commit title
+        run: |
+          TITLE=$(git log -1 --format='%s')
+          echo "Commit title: $TITLE"
+
+          # Extract prefix from conventional commit or PR merge title
+          # Handles: "feat: ...", "feat(scope): ...", "Merge pull request ... from user/feat/..."
+          if echo "$TITLE" | grep -qiE '^feat(\(|:)'; then
+            BUMP=minor
+          elif echo "$TITLE" | grep -qiE '^(fix|refactor|chore|docs|devops|test|ci|perf|style|build)(\(|:)'; then
+            BUMP=patch
+          elif echo "$TITLE" | grep -qiE 'from .*/feat/'; then
+            BUMP=minor
+          elif echo "$TITLE" | grep -qiE 'from .*/(fix|refactor|chore|docs|devops)/'; then
+            BUMP=patch
+          else
+            echo "No conventional commit prefix found, skipping release"
+            echo "SKIP=true" >> "$GITHUB_ENV"
+            BUMP=none
+          fi
+
+          echo "BUMP=$BUMP" >> "$GITHUB_ENV"
+          echo "Bump type: $BUMP"
+
+      - name: Bump version, tag, and push
+        if: env.SKIP != 'true'
         run: |
           pip3 install pyyaml -q
-          TAG=$(python3 - <<'PYEOF'
-          import yaml, re, json
+
+          python3 - <<'PYEOF'
+          import yaml, re, json, os, sys
+
+          bump = os.environ["BUMP"]
           cfg = yaml.safe_load(open(".atdd/config.yaml"))
           vf = cfg["release"]["version_file"]
           prefix = cfg["release"].get("tag_prefix", "v")
+
+          # Read current version
           if vf.endswith(".toml"):
               text = open(vf).read()
               m = re.search(r'^version\s*=\s*["\x27]([^"\x27]+)["\x27]', text, re.M)
@@ -80,25 +130,60 @@ jobs:
               ver = json.load(open(vf)).get("version", "")
           else:
               ver = open(vf).read().strip().split()[0]
-          print(f"{prefix}{ver}")
-          PYEOF
-          )
-          echo "TAG=$TAG" >> "$GITHUB_ENV"
 
-      - name: Create and push tag (idempotent)
+          if not ver:
+              print("ERROR: Could not read version")
+              sys.exit(1)
+
+          # Parse semver
+          parts = ver.split(".")
+          major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+
+          # Bump
+          if bump == "major":
+              major += 1; minor = 0; patch = 0
+          elif bump == "minor":
+              minor += 1; patch = 0
+          else:
+              patch += 1
+
+          new_ver = f"{major}.{minor}.{patch}"
+          tag = f"{prefix}{new_ver}"
+          print(f"Bumping {ver} → {new_ver} ({bump})")
+
+          # Write new version
+          if vf.endswith(".toml"):
+              new_text = re.sub(
+                  r'^(version\s*=\s*["\x27])[^"\x27]+(["\x27])',
+                  rf'\g<1>{new_ver}\2',
+                  text,
+                  count=1,
+                  flags=re.M,
+              )
+              open(vf, "w").write(new_text)
+          elif vf.endswith(".json"):
+              data = json.load(open(vf))
+              data["version"] = new_ver
+              json.dump(data, open(vf, "w"), indent=2)
+          else:
+              open(vf, "w").write(new_ver + "\n")
+
+          # Export for shell steps
+          with open(os.environ["GITHUB_ENV"], "a") as f:
+              f.write(f"NEW_VERSION={new_ver}\n")
+              f.write(f"TAG={tag}\n")
+          PYEOF
+
+      - name: Commit, tag, and push
+        if: env.SKIP != 'true'
         run: |
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping"
-            echo "CREATED=false" >> "$GITHUB_ENV"
-          else
-            git tag "$TAG"
-            git push origin "$TAG"
-            echo "Created and pushed tag $TAG"
-            echo "CREATED=true" >> "$GITHUB_ENV"
-          fi
+          git add -A
+          git commit -m "Bump version to $NEW_VERSION"
+          git tag "$TAG"
+          git push origin main --tags
 
       - name: Trigger publish workflow
-        if: env.CREATED == 'true'
+        if: env.SKIP != 'true'
         run: gh workflow run publish.yml --ref "$TAG"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,37 +519,39 @@ git:
       - "GREEN: commit passing implementation"
       - "REFACTOR: commit clean architecture"
 
-# Release Gate (MANDATORY - session completion)
-# Every session MUST end with version bump + tag
+# Release Gate (automated via CI)
+# CI auto-release bumps version, tags, and publishes after merge to main.
+# Bump type derived from conventional commit prefix in merge commit title.
 release:
-  mandatory: true
-
-  rules:
-    - "Version file is required (configured in .atdd/config.yaml)"
-    - "Tag must match version exactly: v{version}"
-    - "Tag must be on HEAD"
-    - "No tag without version bump"
-    - "No version bump without tag"
-    - "Every repo MUST have versioning"
+  automated: true
 
   change_class:
-    PATCH: "bug fixes, docs, refactors, internal changes"
-    MINOR: "new feature, new validator, new command, new convention (non-breaking)"
-    MAJOR: "breaking API/CLI/schema/convention change or behavior removal"
+    PATCH: "fix/, refactor/, chore/, docs/, devops/ branches"
+    MINOR: "feat/ branches"
+    MAJOR: "manual only — break glass for breaking changes"
 
-  workflow:
-    - "Determine change class"
-    - "Bump version in version file"
-    - "Commit: 'Bump version to {version}'"
-    - "Create tag: git tag v{version}"
-    - "Push with tags: git push origin {branch} --tags"
-    - "Record in Session Log: 'Released: v{version}'"
+  ci_workflow:
+    trigger: "push to main (after validate passes)"
+    steps:
+      - "Read merge commit title prefix (feat: → MINOR, fix: → PATCH, etc.)"
+      - "Pull latest main (concurrency-safe rebase)"
+      - "Bump version in version file"
+      - "Commit: 'Bump version to {version}'"
+      - "Tag: v{version}"
+      - "Push commit + tag"
+      - "Trigger publish workflow → PyPI"
+    concurrency: "serialized via concurrency group (parallel PR merges safe)"
+
+  agent_rules:
+    - "DO NOT manually bump versions in PRs"
+    - "DO NOT manually create tags"
+    - "Use correct branch prefix (feat/, fix/, etc.) — CI derives bump from it"
+    - "For MAJOR bumps: manually bump version in PR, CI will skip auto-bump if tag exists"
 
   # Config (required in .atdd/config.yaml):
   # release:
   #   version_file: "pyproject.toml"  # or package.json, VERSION, etc.
   #   tag_prefix: "v"
-  # Validator: atdd validate coach enforces version file + tag on HEAD
 
 # Agent Coordination (Detailed in action files)
 agents:

--- a/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
+++ b/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
@@ -150,12 +150,11 @@
 
 ## Release Gate
 
-- [ ] Determine change class: PATCH / MINOR / MAJOR
-- [ ] Bump version in version file
-- [ ] Commit: "Bump version to {{version}}" (last commit in PR branch)
-- [ ] Merge PR (version bump included in the PR)
-- [ ] After merge: `git tag v{{version}}` on merge commit, then `git push origin --tags`
-- [ ] Record tag in Activity Log: "Released: v{{version}}"
+CI auto-release handles version bump, tag, and publish after merge to main.
+The bump type is derived from the PR branch prefix: `feat/` → MINOR, `fix/` → PATCH.
+
+- [ ] Verify PR branch uses correct conventional prefix (`feat/`, `fix/`, `refactor/`, etc.)
+- [ ] Merge PR → CI bumps version, tags, publishes to PyPI
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace manual version bumps with CI automation
- After merge to main, `auto-release` job reads conventional commit prefix from merge commit title (`feat:` → MINOR, `fix:/refactor:/chore:` → PATCH), bumps pyproject.toml, commits, tags, and triggers publish to PyPI
- Concurrency group serializes parallel PR merges safely (rebase before bumping)
- Update CLAUDE.md release rules: agents should NOT manually bump versions
- Simplify Release Gate section in parent issue template

## Test plan
- [ ] Merge this PR → CI auto-bumps to 1.6.0 (MINOR, feat/ branch)
- [ ] Verify tag v1.6.0 created on main
- [ ] Verify publish workflow triggered and 1.6.0 appears on PyPI
- [ ] Merge a subsequent fix/ PR → verify PATCH bump to 1.6.1

Closes #90