### PR TITLE
fix(ci): filter publish to push-triggered validates only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     permissions:
       contents: write
       id-token: write           # required for PyPI Trusted Publishing
@@ -72,3 +73,5 @@ jobs:
       - name: Publish to PyPI
         if: env.CREATED == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.6.1"
+version = "1.6.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -874,7 +874,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary
- Filter `workflow_run` trigger to only `push`-event validates (prevents duplicate runs from issues/PR events)
- Add `skip-existing: true` to PyPI publish as safety net
- Update consumer template in `atdd init` with same fix

Follow-up to #96

## Test plan
- [ ] Merge → verify only one Publish run triggers (not two)
- [ ] Verify v1.6.2 tagged and published