### PR TITLE
fix: point version_file to pyproject.toml

### DIFF
--- a/.atdd/config.yaml
+++ b/.atdd/config.yaml
@@ -1,12 +1,12 @@
 version: '1.0'
 release:
-  version_file: VERSION
+  version_file: pyproject.toml
   tag_prefix: v
 sync:
   agents:
   - claude
 toolkit:
-  last_version: 1.6.3
+  last_version: 1.8.0
 github:
   repo: afokapu/atdd
   project_number: 1


### PR DESCRIPTION
## Summary
- Config had `version_file: VERSION` but actual version lives in `pyproject.toml`
- This caused the publish workflow to fail with `FileNotFoundError: VERSION`
- Versions 1.9.0 and 1.10.0 were never published to PyPI because of this

## After merge
Re-trigger publish workflow to release 1.10.0 to PyPI.