### PR TITLE
feat: minimal default workspace layout

### DIFF
--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -134,6 +134,14 @@ def write_workspace(target_dir: Path) -> None:
                 "statusBar.background": bg,
                 "statusBar.foreground": fg,
             },
+            # Minimal default layout: Explorer + Terminal only
+            "workbench.panel.defaultLocation": "bottom",
+            "panel.defaultVisibility": "hidden",
+            "workbench.sideBar.location": "left",
+            "workbench.activityBar.location": "top",
+            "editor.minimap.enabled": False,
+            "breadcrumbs.enabled": False,
+            "workbench.secondarySideBar.visible": False,
         },
     }
 


### PR DESCRIPTION
## Summary
- Hide bottom panel, right sidebar, minimap, breadcrumbs by default in generated `.code-workspace`
- Only Explorer (left) visible on open; Terminal via Ctrl+`
- Applied to all consumer repos via `write_workspace()`