### PR TITLE
chore: add pre-push hook to guard main branch

### DIFF
--- a/.atdd/config.yaml
+++ b/.atdd/config.yaml
@@ -6,7 +6,7 @@ sync:
   agents:
   - claude
 toolkit:
-  last_version: 1.8.0
+  last_version: 1.10.0
 github:
   repo: afokapu/atdd
   project_number: 1

--- a/.atdd/hooks/pre-commit
+++ b/.atdd/hooks/pre-commit
@@ -1,0 +1,57 @@
+#!/bin/sh
+# ATDD pre-commit hook — blocks code commits on main/master.
+# Installed by `atdd init`. Override with ATDD_ALLOW_MAIN_COMMIT=1.
+# Standard bypass: git commit --no-verify
+
+set -e
+
+# --- Resolve current branch ---
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+# Allow: detached HEAD (CI), any non-main branch
+case "$BRANCH" in
+    main|master) ;;
+    *) exit 0 ;;
+esac
+
+# Allow: explicit env bypass (CI version bumps, emergencies)
+if [ "${ATDD_ALLOW_MAIN_COMMIT:-0}" = "1" ]; then
+    exit 0
+fi
+
+# --- Protected path prefixes (code/test directories) ---
+PROTECTED="src/ tests/ packages/ web/ supabase/ python/ e2e/"
+
+# Check staged files against protected paths
+BLOCKED_FILES=""
+for file in $(git diff --cached --name-only --diff-filter=ACMR); do
+    for prefix in $PROTECTED; do
+        case "$file" in
+            "$prefix"*)
+                BLOCKED_FILES="$BLOCKED_FILES  $file
+"
+                break
+                ;;
+        esac
+    done
+done
+
+if [ -z "$BLOCKED_FILES" ]; then
+    exit 0
+fi
+
+# --- Block with actionable error ---
+cat >&2 <<EOF
+
+ATDD: Direct code commits to $BRANCH are not allowed.
+
+Blocked files:
+$BLOCKED_FILES
+Create a worktree branch first:
+  atdd branch <issue-number>
+
+Or bypass for emergencies:
+  ATDD_ALLOW_MAIN_COMMIT=1 git commit ...
+
+EOF
+exit 1

--- a/.atdd/hooks/pre-push
+++ b/.atdd/hooks/pre-push
@@ -1,0 +1,68 @@
+#!/bin/sh
+# ATDD pre-push hook — blocks pushing code changes to main/master on remote.
+# Installed by `atdd init`. Override with ATDD_ALLOW_MAIN_PUSH=1.
+# Standard bypass: git push --no-verify
+
+set -e
+
+REMOTE="$1"
+URL="$2"
+
+# Allow: explicit env bypass (CI, emergencies)
+if [ "${ATDD_ALLOW_MAIN_PUSH:-0}" = "1" ]; then
+    exit 0
+fi
+
+# --- Protected path prefixes (code/test directories) ---
+PROTECTED="src/ tests/ packages/ web/ supabase/ python/ e2e/"
+
+# Read each ref being pushed (stdin: local_ref local_sha remote_ref remote_sha)
+while read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
+    # Only guard pushes targeting main or master
+    case "$REMOTE_REF" in
+        refs/heads/main|refs/heads/master) ;;
+        *) continue ;;
+    esac
+
+    # New branch (remote_sha is zero) — compare against remote HEAD
+    ZERO="0000000000000000000000000000000000000000"
+    if [ "$REMOTE_SHA" = "$ZERO" ]; then
+        RANGE="$LOCAL_SHA"
+    else
+        RANGE="$REMOTE_SHA..$LOCAL_SHA"
+    fi
+
+    # Check changed files in the push range against protected paths
+    BLOCKED_FILES=""
+    for file in $(git diff --name-only --diff-filter=ACMR "$RANGE" 2>/dev/null); do
+        for prefix in $PROTECTED; do
+            case "$file" in
+                "$prefix"*)
+                    BLOCKED_FILES="$BLOCKED_FILES  $file
+"
+                    break
+                    ;;
+            esac
+        done
+    done
+
+    if [ -n "$BLOCKED_FILES" ]; then
+        BRANCH=$(echo "$REMOTE_REF" | sed 's|refs/heads/||')
+        cat >&2 <<EOF
+
+ATDD: Direct push of code changes to $BRANCH is not allowed.
+
+Blocked files:
+$BLOCKED_FILES
+Use a worktree branch and open a PR instead:
+  atdd branch <issue-number>
+
+Or bypass for emergencies:
+  ATDD_ALLOW_MAIN_PUSH=1 git push ...
+
+EOF
+        exit 1
+    fi
+done
+
+exit 0


### PR DESCRIPTION
## Summary
- Add `pre-push` hook that blocks pushing code changes to `main`/`master` for protected paths
- Include existing `pre-commit` hook (was untracked) that blocks direct commits on main
- Both hooks allow config-only changes and provide env var bypass for emergencies

## Test plan
- [ ] Verify `pre-push` blocks push to main with protected-path changes
- [ ] Verify `pre-push` allows push to main with config-only changes
- [ ] Verify `ATDD_ALLOW_MAIN_PUSH=1` bypass works
- [ ] Verify pushes to non-main branches are unaffected