### PR TITLE
chore: add version bump PR gate

### DIFF
--- a/.github/workflows/atdd-validate.yml
+++ b/.github/workflows/atdd-validate.yml
@@ -37,6 +37,54 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  version-bump:
+    name: Version bump check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check version was bumped
+        run: |
+          pip3 install pyyaml -q
+          python3 - <<'PYEOF'
+          import yaml, re, json, subprocess, sys
+
+          cfg = yaml.safe_load(open(".atdd/config.yaml"))
+          vf = cfg["release"]["version_file"]
+
+          def read_version(content, filename):
+              if filename.endswith(".toml"):
+                  m = re.search(r'^version\s*=\s*["\x27]([^"\x27]+)["\x27]', content, re.M)
+                  return m.group(1) if m else ""
+              elif filename.endswith(".json"):
+                  return json.loads(content).get("version", "")
+              else:
+                  return content.strip().split()[0]
+
+          # PR branch version (current checkout)
+          pr_version = read_version(open(vf).read(), vf)
+
+          # Main branch version
+          main_content = subprocess.check_output(
+              ["git", "show", f"origin/main:{vf}"], text=True
+          )
+          main_version = read_version(main_content, vf)
+
+          if pr_version == main_version:
+              print(f"::error::Version not bumped. PR: {pr_version}, main: {main_version}")
+              print(f"Bump the version in {vf} before merging.")
+              sys.exit(1)
+          else:
+              print(f"Version bumped: {main_version} → {pr_version}")
+          PYEOF
+
   post-comment:
     runs-on: ubuntu-latest
     needs: validate

--- a/README.md
+++ b/README.md
@@ -135,7 +135,21 @@ After adding or removing worktrees, run `atdd sync` to refresh the workspace fil
 atdd sync   # Regenerates .code-workspace with current worktrees
 ```
 
-Open the `.code-workspace` file in VS Code ("Open Workspace from File") for multi-root, branch-aware editing — each folder shows its active branch in the status bar.
+#### Opening the Workspace
+
+After migrating to worktree layout, **always open the `.code-workspace` file** instead of individual folders:
+
+```bash
+code your-project.code-workspace   # or: File → Open Workspace from File…
+```
+
+This gives you:
+- **Branch-aware sidebar** — each worktree folder shows its active branch in the Explorer
+- **Git tracking per worktree** — Source Control panel tracks changes independently per branch
+- **Shared settings** — editor config, extensions, and tasks apply across all worktrees
+- **Auto-updated** — `atdd sync` regenerates the workspace file when worktrees are added or removed
+
+> **Do not open `main/` directly.** Without the workspace file, VS Code won't track sibling worktrees and you lose multi-branch visibility.
 
 ### Issue Management
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.10.0"
+version = "1.10.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Add `version-bump` job to `atdd-validate.yml` that fails PRs if version wasn't bumped vs main
- Add `Version bump check` as required status check in branch protection
- Update README worktree section with clearer workspace file instructions
- Bump version to 1.10.1

## Test plan
- [ ] PR should pass the new `Version bump check` (self-validating)
- [ ] Verify a PR without version bump would be blocked from merging