### PR TITLE
fix: init --force preserves user preferences

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.10.1"
+version = "1.10.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -422,8 +422,14 @@ class ProjectInitializer:
         """
         Create or update .atdd/config.yaml.
 
+        When force=True and config already exists, deep-merges defaults into
+        the existing config — preserving user-set values (workspace.color,
+        github.*, customised release/sync settings) while filling in any
+        missing default keys and always updating toolkit.last_version.
+
         Args:
-            force: If True, overwrite existing config.
+            force: If True, merge defaults into existing config instead of
+                   skipping.
         """
         if self.config_file.exists() and not force:
             print(f"Config already exists: {self.config_file}")
@@ -436,24 +442,43 @@ class ProjectInitializer:
         except ImportError:
             toolkit_version = "0.0.0"
 
-        config = {
+        defaults = {
             "version": "1.0",
             "release": {
                 "version_file": "VERSION",
                 "tag_prefix": "v",
             },
             "sync": {
-                "agents": ["claude"],  # Default: only Claude
+                "agents": ["claude"],
             },
             "toolkit": {
-                "last_version": toolkit_version,  # Track installed version
+                "last_version": toolkit_version,
             },
         }
 
-        with open(self.config_file, "w") as f:
-            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        # Merge: preserve existing user values, fill in missing defaults
+        existing = {}
+        is_update = self.config_file.exists()
+        if is_update:
+            with open(self.config_file) as f:
+                existing = yaml.safe_load(f) or {}
 
-        print(f"Created: {self.config_file}")
+        for key, value in defaults.items():
+            if key not in existing:
+                existing[key] = value
+            elif isinstance(value, dict) and isinstance(existing[key], dict):
+                for sub_key, sub_value in value.items():
+                    if sub_key not in existing[key]:
+                        existing[key][sub_key] = sub_value
+
+        # Always update toolkit version to current
+        existing.setdefault("toolkit", {})["last_version"] = toolkit_version
+
+        with open(self.config_file, "w") as f:
+            yaml.dump(existing, f, default_flow_style=False, sort_keys=False)
+
+        action = "Updated" if is_update else "Created"
+        print(f"{action}: {self.config_file}")
 
     def _install_hooks(self, force: bool = False) -> None:
         """Install git hooks from package templates into .atdd/hooks/.


### PR DESCRIPTION
## Summary
- `atdd init --force` now deep-merges defaults into existing config instead of overwriting
- User-set values (`workspace.color`, `github.*`, customized `release`/`sync`) are preserved
- Missing default keys are filled in; `toolkit.last_version` always updated to current install

## Test plan
- [ ] `atdd init --force` on repo with existing config → user preferences preserved
- [ ] `atdd init --force` on repo with no config → fresh defaults created
- [ ] `atdd init` (no force) → skips entirely (unchanged behavior)