### PR TITLE
feat(cli): add atdd issue open command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.10.2"
+version = "1.11.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -473,6 +473,39 @@ Phase descriptions:
     close_wmbt_top_parser.add_argument("wmbt_id", type=str, help="WMBT ID (e.g., D001, E003)")
     close_wmbt_top_parser.add_argument("--force", "-f", action="store_true", help="Close even if ATDD cycle checkboxes are unchecked")
 
+    # ----- atdd issue {open} -----
+    issue_parser = subparsers.add_parser(
+        "issue",
+        help="GitHub issue commands",
+        description="Subcommands for GitHub issue operations"
+    )
+    issue_subparsers = issue_parser.add_subparsers(
+        dest="issue_command",
+        help="Issue commands"
+    )
+
+    # atdd issue open
+    open_parser = issue_subparsers.add_parser(
+        "open",
+        help="List open GitHub issues"
+    )
+    open_parser.add_argument(
+        "--label", "-l",
+        type=str,
+        help="Filter by label"
+    )
+    open_parser.add_argument(
+        "--limit", "-n",
+        type=int,
+        default=30,
+        help="Maximum number of issues (default: 30)"
+    )
+    open_parser.add_argument(
+        "--assignee",
+        type=str,
+        help="Filter by assignee login"
+    )
+
     # ----- atdd color [value] -----
     color_parser = subparsers.add_parser(
         "color",
@@ -909,6 +942,19 @@ Phase descriptions:
             wmbt_id=args.wmbt_id,
             force=args.force,
         )
+
+    # atdd issue {open}
+    elif args.command == "issue":
+        if getattr(args, 'issue_command', None) == "open":
+            manager = IssueManager()
+            return manager.open_issues(
+                label=getattr(args, 'label', None),
+                limit=getattr(args, 'limit', 30),
+                assignee=getattr(args, 'assignee', None),
+            )
+        else:
+            issue_parser.print_help()
+            return 0
 
     # atdd color [value]
     elif args.command == "color":

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -619,6 +619,63 @@ class IssueManager:
         return 0
 
     # -------------------------------------------------------------------------
+    # E010: open_issues (all open issues, not just ATDD-labeled)
+    # -------------------------------------------------------------------------
+
+    def open_issues(
+        self,
+        label: Optional[str] = None,
+        limit: int = 30,
+        assignee: Optional[str] = None,
+    ) -> int:
+        """List open GitHub issues (all, not just ATDD-labeled).
+
+        Args:
+            label: Optional label filter.
+            limit: Max issues to return (default 30).
+            assignee: Optional assignee login filter.
+
+        Returns:
+            0 on success, 1 on error.
+        """
+        if not self._check_initialized():
+            return 1
+
+        from atdd.coach.github import GitHubClientError
+
+        try:
+            client = self._get_github_client()
+            issues = client.list_open_issues(
+                label=label, limit=limit, assignee=assignee,
+            )
+        except (GitHubClientError, Exception) as e:
+            print(f"Error: {e}")
+            return 1
+
+        if not issues:
+            print("No open issues found.")
+            return 0
+
+        print("\n" + "=" * 80)
+        print("Open Issues")
+        print("=" * 80)
+        print(f"{'#':<7} {'Title':<42} {'Labels':<16} {'Created':<12}")
+        print("-" * 80)
+
+        for issue in sorted(issues, key=lambda x: x["number"]):
+            num = issue["number"]
+            title = issue["title"][:41]
+            label_names = [l["name"] for l in issue.get("labels", [])]
+            labels_str = ",".join(label_names)[:15] if label_names else "-"
+            created = issue.get("createdAt", "")[:10]
+
+            print(f"#{num:<6} {title:<42} {labels_str:<16} {created}")
+
+        print("-" * 80)
+        print(f"Total: {len(issues)} open issue{'s' if len(issues) != 1 else ''}")
+        return 0
+
+    # -------------------------------------------------------------------------
     # E003: archive
     # -------------------------------------------------------------------------
 

--- a/src/atdd/coach/github.py
+++ b/src/atdd/coach/github.py
@@ -511,6 +511,36 @@ class GitHubClient:
         ])
         return json.loads(output) if output else []
 
+    def list_open_issues(
+        self,
+        label: Optional[str] = None,
+        limit: int = 30,
+        assignee: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List open issues with optional filters.
+
+        Args:
+            label: Filter by label name.
+            limit: Maximum number of issues to return.
+            assignee: Filter by assignee login.
+
+        Returns:
+            List of issue dicts with number, title, labels, createdAt.
+        """
+        args = [
+            "issue", "list",
+            "--repo", self.repo,
+            "--state", "open",
+            "--json", "number,title,labels,createdAt",
+            "--limit", str(limit),
+        ]
+        if label:
+            args += ["--label", label]
+        if assignee:
+            args += ["--assignee", assignee]
+        output = self._run_gh(args)
+        return json.loads(output) if output else []
+
     def get_issue(self, issue_number: int) -> Dict[str, Any]:
         """Get issue details."""
         output = self._run_gh([


### PR DESCRIPTION
## Summary

- Adds `atdd issue open` CLI command to list all open GitHub issues (not just ATDD-labeled)
- Introduces `issue` subparser group, extensible for future subcommands
- Supports `--label`, `--limit`, `--assignee` filters

Closes #120

## Files Changed

| File | Change |
|------|--------|
| `src/atdd/coach/github.py` | `GitHubClient.list_open_issues()` method |
| `src/atdd/coach/commands/issue.py` | `IssueManager.open_issues()` method (E010) |
| `src/atdd/cli.py` | `issue` subparser group + `open` subcommand + dispatch |
| `pyproject.toml` | Version bump 1.10.2 → 1.11.0 (MINOR: new command) |

## Test plan

- [x] `atdd issue open` — lists open issues
- [x] `atdd issue open --limit 5` — limited results
- [x] `atdd issue open --label enhancement` — filtered by label
- [x] `atdd issue` — shows help for issue subgroup
- [x] `atdd --help` — shows `issue` in command list

🤖 Generated with [Claude Code](https://claude.com/claude-code)