### PR TITLE
feat(hooks): version gate + tag guard (#125)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.12.0"
+version = "1.13.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -483,30 +483,37 @@ class ProjectInitializer:
     def _install_hooks(self, force: bool = False) -> None:
         """Install git hooks from package templates into .atdd/hooks/.
 
-        Copies the pre-commit template, makes it executable, and sets
-        ``git config core.hooksPath`` to the absolute path so that all
-        worktrees sharing this repository inherit the hook automatically.
+        Copies all hook templates (pre-commit, pre-push, pre-merge-commit,
+        etc.), makes them executable, and sets ``git config core.hooksPath``
+        to the absolute path so that all worktrees sharing this repository
+        inherit the hooks automatically.
 
         Args:
-            force: If True, overwrite an existing hook.
+            force: If True, overwrite existing hooks.
         """
         hooks_dir = self.atdd_config_dir / "hooks"
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
         template_dir = self.package_root / "templates" / "hooks"
-        hook_src = template_dir / "pre-commit"
-        hook_dst = hooks_dir / "pre-commit"
-
-        if not hook_src.exists():
-            logger.warning("Hook template not found: %s", hook_src)
+        if not template_dir.exists():
+            logger.warning("Hook template directory not found: %s", template_dir)
             return
 
-        if hook_dst.exists() and not force:
-            print(f"Hook already exists: {hook_dst}")
-        else:
-            shutil.copy2(hook_src, hook_dst)
-            os.chmod(hook_dst, hook_dst.stat().st_mode | 0o111)
-            print(f"Installed: {hook_dst}")
+        installed = 0
+        for hook_src in sorted(template_dir.iterdir()):
+            if hook_src.name.startswith(("__", ".")) or hook_src.is_dir():
+                continue
+            hook_dst = hooks_dir / hook_src.name
+            if hook_dst.exists() and not force:
+                print(f"Hook exists (skip): {hook_dst}")
+            else:
+                shutil.copy2(hook_src, hook_dst)
+                os.chmod(hook_dst, hook_dst.stat().st_mode | 0o111)
+                print(f"Installed: {hook_dst}")
+                installed += 1
+
+        if installed == 0 and not force:
+            print("All hooks already installed.")
 
         # Point git to the hooks directory (absolute path survives worktrees)
         abs_hooks = str(hooks_dir.resolve())

--- a/src/atdd/coach/templates/hooks/pre-merge-commit
+++ b/src/atdd/coach/templates/hooks/pre-merge-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+# ATDD pre-merge-commit hook — version gate.
+# Installed by `atdd init`. Skip with ATDD_SKIP_VERSION_GATE=1.
+# Standard bypass: git merge --no-verify
+
+set -e
+
+# --- Version gate ---
+if [ "${ATDD_SKIP_VERSION_GATE:-0}" != "1" ]; then
+    python3 -c "from atdd.version_check import _gate_main; _gate_main()" 2>&1
+    if [ $? -ne 0 ]; then exit 1; fi
+fi
+
+exit 0

--- a/src/atdd/coach/templates/hooks/pre-push
+++ b/src/atdd/coach/templates/hooks/pre-push
@@ -1,0 +1,82 @@
+#!/bin/sh
+# ATDD pre-push hook — version gate + branch protection.
+# Installed by `atdd init`. Override push with ATDD_ALLOW_MAIN_PUSH=1.
+# Standard bypass: git push --no-verify
+
+set -e
+
+# --- Version gate (skip with ATDD_SKIP_VERSION_GATE=1) ---
+if [ "${ATDD_SKIP_VERSION_GATE:-0}" != "1" ]; then
+    python3 -c "from atdd.version_check import _gate_main; _gate_main()" 2>&1
+    if [ $? -ne 0 ]; then exit 1; fi
+fi
+
+REMOTE="$1"
+URL="$2"
+
+# Allow: explicit env bypass (CI, emergencies)
+if [ "${ATDD_ALLOW_MAIN_PUSH:-0}" = "1" ]; then
+    exit 0
+fi
+
+# --- Protected path prefixes (code/test directories) ---
+PROTECTED="src/ tests/ packages/ web/ supabase/ python/ e2e/"
+
+# Read each ref being pushed (stdin: local_ref local_sha remote_ref remote_sha)
+while read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
+    # Block manual tag pushes (tags should only come from CI publish workflow)
+    case "$LOCAL_REF" in
+        refs/tags/*)
+            echo "ATDD: Manual tag pushes blocked. Tags are created by the publish workflow." >&2
+            exit 1
+            ;;
+    esac
+
+    # Only guard pushes targeting main or master
+    case "$REMOTE_REF" in
+        refs/heads/main|refs/heads/master) ;;
+        *) continue ;;
+    esac
+
+    # New branch (remote_sha is zero) — compare against remote HEAD
+    ZERO="0000000000000000000000000000000000000000"
+    if [ "$REMOTE_SHA" = "$ZERO" ]; then
+        RANGE="$LOCAL_SHA"
+    else
+        RANGE="$REMOTE_SHA..$LOCAL_SHA"
+    fi
+
+    # Check changed files in the push range against protected paths
+    BLOCKED_FILES=""
+    for file in $(git diff --name-only --diff-filter=ACMR "$RANGE" 2>/dev/null); do
+        for prefix in $PROTECTED; do
+            case "$file" in
+                "$prefix"*)
+                    BLOCKED_FILES="$BLOCKED_FILES  $file
+"
+                    break
+                    ;;
+            esac
+        done
+    done
+
+    if [ -n "$BLOCKED_FILES" ]; then
+        BRANCH=$(echo "$REMOTE_REF" | sed 's|refs/heads/||')
+        cat >&2 <<EOF
+
+ATDD: Direct push of code changes to $BRANCH is not allowed.
+
+Blocked files:
+$BLOCKED_FILES
+Use a worktree branch and open a PR instead:
+  atdd branch <issue-number>
+
+Or bypass for emergencies:
+  ATDD_ALLOW_MAIN_PUSH=1 git push ...
+
+EOF
+        exit 1
+    fi
+done
+
+exit 0

--- a/src/atdd/version_check.py
+++ b/src/atdd/version_check.py
@@ -232,3 +232,73 @@ def print_upgrade_sync_notice() -> None:
             print(f"\n⚠️  {notice}\n", file=sys.stderr)
     except Exception:
         pass  # Never fail the main command
+
+
+# --- Version gate (git hook enforcement) ---
+
+def is_outdated() -> Tuple[bool, str, str]:
+    """Check if installed atdd is outdated vs PyPI (no cache).
+
+    Returns:
+        Tuple of (outdated, current_version, latest_version).
+        If PyPI is unreachable, returns (False, current, "").
+    """
+    current = __version__
+    if current == "0.0.0":
+        return False, current, ""
+
+    latest = _fetch_latest_version()
+    if latest is None:
+        return False, current, ""
+
+    return _is_newer(latest, current), current, latest
+
+
+def auto_upgrade() -> bool:
+    """Run pip install --upgrade atdd. Returns True on success."""
+    import subprocess as _sp
+
+    try:
+        result = _sp.run(
+            [sys.executable, "-m", "pip", "install", "--upgrade", "atdd"],
+            capture_output=True, text=True, timeout=120,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _gate_main() -> None:
+    """CLI entry point for version-gate hook.
+
+    Exit 0 = allow, exit 1 = block (outdated, upgraded, retry needed).
+    """
+    outdated, current, latest = is_outdated()
+
+    if not outdated:
+        if not latest:
+            print(f"WARNING: Could not reach PyPI — skipping version gate (atdd {current})",
+                  file=sys.stderr)
+        else:
+            print(f"atdd {current} is up to date")
+        return  # exit 0
+
+    print(f"atdd {current} is outdated (latest: {latest}). Upgrading...")
+    if auto_upgrade():
+        print(f"Upgraded atdd to {latest}. Please retry your git operation.")
+    else:
+        print(f"Auto-upgrade failed. Run manually: pip install --upgrade atdd")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gate", action="store_true", help="Version gate check")
+    args = parser.parse_args()
+
+    if args.gate:
+        _gate_main()
+    else:
+        print_update_notice()


### PR DESCRIPTION
## Summary
- Version gate on pre-push and pre-merge-commit hooks: blocks git operations when `atdd` is outdated, auto-upgrades, prompts retry
- Tag guard on pre-push: blocks manual tag pushes (tags only from CI publish workflow)
- `_install_hooks()` now loops all templates in `hooks/` — future hooks auto-installed
- PyPI unreachable: warns to stderr but allows (exit 0)
- Skip with `ATDD_SKIP_VERSION_GATE=1`

Closes #125

## Files changed
| File | Change |
|------|--------|
| `src/atdd/version_check.py` | `is_outdated()`, `auto_upgrade()`, `_gate_main()`, `__main__` block |
| `src/atdd/coach/templates/hooks/pre-push` | **New** — version gate + tag guard + branch protection |
| `src/atdd/coach/templates/hooks/pre-merge-commit` | **New** — version gate only |
| `src/atdd/coach/commands/initializer.py` | `_install_hooks()` loops all hook templates |

## Test plan
- [ ] `python3 -c "from atdd.version_check import _gate_main; _gate_main()"` prints up-to-date or PyPI warning
- [ ] `atdd init --force` installs 3 hooks (pre-commit, pre-push, pre-merge-commit)
- [ ] `ls -la .atdd/hooks/` confirms all 3 present and executable
- [ ] `git push` on branch passes version gate
- [ ] `git push origin v0.0.0` blocked by tag guard