### PR TITLE
fix: add init.skip_workflows config flag

### DIFF
--- a/.atdd/config.yaml
+++ b/.atdd/config.yaml
@@ -5,8 +5,10 @@ release:
 sync:
   agents:
   - claude
+init:
+  skip_workflows: true
 toolkit:
-  last_version: 1.15.0
+  last_version: 1.16.0
 github:
   repo: afokapu/atdd
   project_number: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.16.0"
+version = "1.16.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -594,9 +594,22 @@ class ProjectInitializer:
         if project_id:
             fields_created = self._create_project_fields(project_id)
 
-        # Write workflow files
-        workflow_written = self._write_workflow(repo)
-        publish_written = self._write_publish_workflow()
+        # Write workflow files (skip if config says so)
+        skip_workflows = False
+        if self.config_file.exists():
+            try:
+                cfg = yaml.safe_load(self.config_file.read_text()) or {}
+                skip_workflows = cfg.get("init", {}).get("skip_workflows", False)
+            except (yaml.YAMLError, OSError):
+                pass
+
+        if skip_workflows:
+            print("Workflows: skipped (init.skip_workflows=true in config)")
+            workflow_written = False
+            publish_written = False
+        else:
+            workflow_written = self._write_workflow(repo)
+            publish_written = self._write_publish_workflow()
 
         # Configure branch protection on main
         protection_set = self._set_branch_protection(repo)

--- a/src/atdd/coach/schemas/config.schema.json
+++ b/src/atdd/coach/schemas/config.schema.json
@@ -47,6 +47,18 @@
       },
       "additionalProperties": false
     },
+    "init": {
+      "type": "object",
+      "description": "Settings for atdd init behavior",
+      "properties": {
+        "skip_workflows": {
+          "type": "boolean",
+          "description": "Skip generating CI workflow files during atdd init. Use for repos that maintain their own workflows (e.g., the atdd toolkit itself).",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
     "toolkit": {
       "type": "object",
       "description": "ATDD toolkit metadata",


### PR DESCRIPTION
## Summary

- Add `init.skip_workflows` flag to `.atdd/config.yaml` schema
- When `true`, `atdd init --force` skips generating CI workflow files
- Set `true` in the toolkit repo to prevent overwriting its custom workflow
- Closes #141

## Context

`atdd init --force` was overwriting the toolkit's custom CI workflow (which runs validators from `src/` via `PYTHONPATH`) with the consumer template (which installs from PyPI). This caused CI failures in #138.

## Test plan

- [x] `atdd init --force` with `skip_workflows: true` prints "Workflows: skipped" and does not touch `.github/workflows/`
- [x] Config schema updated with `init.skip_workflows` field