### PR TITLE
fix(coder): normalize kebab-case contract $id to PascalCase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.16.2"
+version = "1.16.3"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coder/validators/test_cross_language_consistency.py
+++ b/src/atdd/coder/validators/test_cross_language_consistency.py
@@ -243,7 +243,7 @@ def test_entity_classes_exist_across_languages():
 
     for entity_name, fields in contract_entities.items():
         # Normalize name (PascalCase)
-        normalized = ''.join(word.capitalize() for word in entity_name.split('_'))
+        normalized = ''.join(word.capitalize() for word in re.split(r'[-_]', entity_name))
 
         # Check Python (exact or substring match for CLI contracts like ATDDGate)
         has_python = (
@@ -412,7 +412,7 @@ def test_api_contracts_honored_across_languages():
     unimplemented = []
 
     for entity_name, fields in contract_entities.items():
-        normalized = ''.join(word.capitalize() for word in entity_name.split('_'))
+        normalized = ''.join(word.capitalize() for word in re.split(r'[-_]', entity_name))
 
         has_any_impl = (
             normalized in python_classes or


### PR DESCRIPTION
## Summary

Contract `$id` uses kebab-case per planner convention (`goal-progress`), but the coder validator only split on underscores when normalizing to PascalCase — producing `Goal-progress` instead of `GoalProgress`.

Fix: `re.split(r'[-_]', entity_name)` handles both conventions.

## Test plan

- [x] `goal-progress` → `GoalProgress` (was `Goal-progress`)
- [x] `goal_progress` → `GoalProgress` (unchanged)
- [x] All 3 cross-language consistency tests pass