### PR TITLE
chore(ci): auto-generate GitHub Release notes on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,3 +75,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
+
+      - name: Create GitHub Release
+        if: env.CREATED == 'true'
+        run: gh release create "$TAG" --generate-notes --title "$TAG"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.16.3"
+version = "1.16.4"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -1183,11 +1183,19 @@ jobs:
         run: |
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists, skipping"
+            echo "CREATED=false" >> "$GITHUB_ENV"
           else
             git tag "$TAG"
             git push origin "$TAG"
             echo "Created and pushed tag $TAG"
+            echo "CREATED=true" >> "$GITHUB_ENV"
           fi
+
+      - name: Create GitHub Release
+        if: env.CREATED == 'true'
+        run: gh release create "$TAG" --generate-notes --title "$TAG"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # -------------------------------------------------------------------------
   # TODO: Add platform-specific publish steps below.


### PR DESCRIPTION
## Summary

Every version now gets GitHub Release notes automatically — both for the toolkit and consumer repos.

- Toolkit `publish.yml`: add release creation step after PyPI publish
- Consumer template in `initializer.py`: add release step + `CREATED` tracking to generated `publish.yml`

Uses `gh release create --generate-notes` which builds changelog from PR titles.

Closes #146

## Test plan

- [x] Toolkit workflow has release step gated on `CREATED == 'true'`
- [x] Consumer template generates matching workflow with release step
- [x] Next merge to main will be the first auto-generated release (v1.16.4)