### PR TITLE
feat(cli): version-specific upgrade notes + atdd upgrade command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.16.4"
+version = "1.17.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -53,6 +53,7 @@ from atdd.coach.commands.issue import IssueManager
 from atdd.coach.commands.sync import AgentConfigSync
 from atdd.coach.commands.gate import ATDDGate
 from atdd.coach.commands.urn import URNCommand
+from atdd.coach.commands.upgrader import Upgrader
 from atdd.coach.utils.repo import find_repo_root
 from atdd.version_check import print_update_notice, print_upgrade_sync_notice
 
@@ -600,6 +601,18 @@ Phase descriptions:
         help="Output as JSON for programmatic use"
     )
 
+    # ----- atdd upgrade -----
+    upgrade_parser = subparsers.add_parser(
+        "upgrade",
+        help="Show what changed and run sync + init --force",
+        description="Upgrade ATDD infrastructure after pip install --upgrade atdd"
+    )
+    upgrade_parser.add_argument(
+        "--yes", "-y",
+        action="store_true",
+        help="Skip confirmation prompts"
+    )
+
     # ----- atdd urn {graph,orphans,broken,validate,resolve,declarations,viz} -----
     urn_parser = subparsers.add_parser(
         "urn",
@@ -1080,6 +1093,10 @@ Phase descriptions:
         gate = ATDDGate()
         return gate.verify(json=args.json)
 
+    elif args.command == "upgrade":
+        upgrader = Upgrader()
+        return upgrader.run(yes=args.yes)
+
     # atdd urn {graph,orphans,broken,validate,resolve,declarations,families,viz}
     elif args.command == "urn":
         repo_path = Path(args.repo) if hasattr(args, 'repo') and args.repo else None
@@ -1184,7 +1201,9 @@ Phase descriptions:
 def cli() -> int:
     """CLI entry point with version and upgrade checks."""
     # Check if repo needs sync after ATDD upgrade (at startup)
-    print_upgrade_sync_notice()
+    # Skip if running 'atdd upgrade' — it handles its own messaging
+    if not (len(sys.argv) > 1 and sys.argv[1] == "upgrade"):
+        print_upgrade_sync_notice()
 
     try:
         result = main()

--- a/src/atdd/coach/commands/upgrader.py
+++ b/src/atdd/coach/commands/upgrader.py
@@ -1,0 +1,103 @@
+"""
+ATDD upgrade orchestration.
+
+Shows what changed between installed and last_version,
+then runs sync + init --force with confirmation.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+from atdd import __version__
+from atdd.version_check import (
+    get_upgrade_notes,
+    _load_repo_config,
+    _get_last_toolkit_version,
+    update_toolkit_version,
+)
+
+
+class Upgrader:
+    """Orchestrates atdd upgrade in a consumer repo."""
+
+    def __init__(self, repo_root: Optional[Path] = None):
+        self.repo_root = repo_root or Path.cwd()
+
+    def run(self, yes: bool = False) -> int:
+        """Run the upgrade process.
+
+        Args:
+            yes: Skip confirmation prompts.
+
+        Returns:
+            0 on success, 1 on failure.
+        """
+        config, config_path = _load_repo_config()
+        if config is None:
+            print("Not an ATDD repo (no .atdd/config.yaml). Nothing to upgrade.")
+            return 1
+
+        last_version = _get_last_toolkit_version(config) or "unknown"
+        current = __version__
+
+        print(f"ATDD upgrade: {last_version} → {current}")
+        print()
+
+        # Show what changed
+        if last_version != "unknown":
+            notes = get_upgrade_notes(last_version, current)
+            if notes:
+                print("What changed:")
+                for version, note in notes:
+                    print(f"  {version}: {note}")
+                print()
+            else:
+                print("No notable changes between these versions.")
+                print()
+
+        if last_version == current:
+            print("Already up to date.")
+            return 0
+
+        # Confirm
+        if not yes:
+            print("This will run:")
+            print("  1. atdd sync       (update agent config files)")
+            print("  2. atdd init --force (update GitHub infrastructure)")
+            print()
+            answer = input("Proceed? [Y/n] ").strip().lower()
+            if answer and answer != "y":
+                print("Aborted.")
+                return 1
+
+        # Run sync
+        print()
+        print("Running: atdd sync")
+        rc = subprocess.run(
+            [sys.executable, "-m", "atdd", "sync"],
+            cwd=str(self.repo_root),
+        ).returncode
+        if rc != 0:
+            print(f"atdd sync failed (exit {rc})")
+            return 1
+
+        # Run init --force
+        print()
+        print("Running: atdd init --force")
+        rc = subprocess.run(
+            [sys.executable, "-m", "atdd", "init", "--force"],
+            cwd=str(self.repo_root),
+        ).returncode
+        if rc != 0:
+            print(f"atdd init --force failed (exit {rc})")
+            return 1
+
+        # Update last_version
+        if config_path:
+            update_toolkit_version(config_path)
+            print(f"\nUpdated toolkit.last_version to {current}")
+
+        print(f"\nUpgrade complete: {last_version} → {current}")
+        return 0

--- a/src/atdd/version_check.py
+++ b/src/atdd/version_check.py
@@ -22,6 +22,18 @@ import yaml
 
 from atdd import __version__
 
+# Version-specific upgrade notes shown to consumers after upgrade.
+# Key = version, value = short human-readable note.
+# Only versions with notable changes need entries.
+UPGRADE_NOTES: dict = {
+    "1.15.0": "SMOKE phase added between GREEN and REFACTOR",
+    "1.16.0": "Self-compliance: toolkit validates itself. New: find_python_dir(), substring class matching",
+    "1.16.1": "New: init.skip_workflows config flag prevents workflow overwrite",
+    "1.16.2": "Fixed: contract path-to-URN conversion, WMBT acceptances, 14 Phase 2 warnings resolved",
+    "1.16.3": "Fixed: kebab-case contract $id now normalizes correctly to PascalCase",
+    "1.16.4": "New: publish workflow auto-generates GitHub Release notes. Run atdd init --force to update consumer workflow",
+}
+
 # Check once per day (86400 seconds)
 CHECK_INTERVAL = 86400
 CACHE_DIR = Path.home() / ".atdd"
@@ -186,9 +198,29 @@ def check_upgrade_sync_needed() -> Optional[str]:
 
     # Compare versions
     if _is_newer(__version__, last_version):
-        return f"ATDD upgraded ({last_version} → {__version__}). Run: atdd sync && atdd init --force"
+        notes = get_upgrade_notes(last_version, __version__)
+        msg = f"ATDD upgraded ({last_version} → {__version__}). Run: atdd sync && atdd init --force"
+        if notes:
+            msg += "\n" + "\n".join(f"  → {v}: {note}" for v, note in notes)
+        return msg
 
     return None
+
+
+def get_upgrade_notes(from_version: str, to_version: str) -> list:
+    """Get upgrade notes for versions between from_version and to_version.
+
+    Returns:
+        List of (version, note) tuples for versions in range.
+    """
+    from_tuple = _parse_version(from_version)
+    to_tuple = _parse_version(to_version)
+    notes = []
+    for version, note in sorted(UPGRADE_NOTES.items(), key=lambda x: _parse_version(x[0])):
+        v_tuple = _parse_version(version)
+        if from_tuple < v_tuple <= to_tuple:
+            notes.append((version, note))
+    return notes
 
 
 def update_toolkit_version(config_path: Optional[Path] = None) -> bool:


### PR DESCRIPTION
## Summary

Consumers now know what changed after `pip install --upgrade atdd`:

```
⚠️  ATDD upgraded (1.15.0 → 1.17.0). Run: atdd sync && atdd init --force
  → 1.16.0: Self-compliance: toolkit validates itself
  → 1.16.1: New: init.skip_workflows config flag
  → 1.16.4: New: publish workflow auto-generates GitHub Release notes
  → 1.17.0: New: atdd upgrade command
```

New `atdd upgrade` command runs sync + init --force with changelog display:
```
atdd upgrade        # interactive
atdd upgrade --yes  # non-interactive
```

Closes #148

## Test plan

- [x] `get_upgrade_notes('1.15.0', '1.16.4')` returns 5 version notes
- [x] `atdd upgrade --yes` runs sync + init, updates last_version
- [x] Upgrade notice suppressed when running `atdd upgrade` (no double output)