### PR TITLE
feat(coder): security pattern validator (#150)

### DIFF
--- a/plan/_trains.yaml
+++ b/plan/_trains.yaml
@@ -10,3 +10,4 @@ trains:
           - implement-code
           - govern-lifecycle
           - self-compliance-migration
+          - security-patterns

--- a/plan/_trains/0001-self-compliance-validate.yaml
+++ b/plan/_trains/0001-self-compliance-validate.yaml
@@ -10,6 +10,7 @@ participants:
   - "wagon:implement-code"
   - "wagon:govern-lifecycle"
   - "wagon:self-compliance-migration"
+  - "wagon:security-patterns"
   - "system:atdd-cli"
 sequence:
   - step: 1

--- a/plan/_wagons.yaml
+++ b/plan/_wagons.yaml
@@ -53,3 +53,14 @@ wagons:
     outcome: "GREEN tests passing with domain-application-integration-presentation layers"
     path: "plan/implement_code/"
     manifest: "plan/implement_code/_implement_code.yaml"
+
+  - wagon: security-patterns
+    description: "AST-based validator that scans consumer code for known-bad security patterns — SQL injection, missing auth, hardcoded secrets, XSS"
+    theme: commons
+    subject: "coder:security"
+    context: "in-coder-phase, code-review-rules-encodable"
+    action: "scans consumer code via AST and regex for security anti-patterns"
+    goal: "catch security violations that code review catches but are fully automatable"
+    outcome: "zero known-bad security patterns in consumer codebase"
+    path: "plan/security_patterns/"
+    manifest: "plan/security_patterns/_security_patterns.yaml"

--- a/plan/security_patterns/D001.yaml
+++ b/plan/security_patterns/D001.yaml
@@ -1,0 +1,34 @@
+urn: "wmbt:security-patterns:D001"
+step: "define"
+direction: "maximize"
+dimension: "quantity"
+object_of_control: "security-rule-coverage"
+context_clarifier: "when security convention must define all detectable anti-patterns"
+lens: "functional.effectiveness"
+statement: "maximize quantity of security-rule-coverage when security convention must define all detectable anti-patterns"
+
+acceptances:
+  - identity:
+      urn: "acc:security-patterns:D001-UNIT-001-convention-defines-rules"
+      id: "AC-UNIT-001"
+      purpose: "Security convention YAML defines all 4 rule categories with patterns and exclusions"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "security.convention.yaml exists in coder/conventions/"
+    when:
+      abstract: "Loading and parsing the convention file"
+    then:
+      abstract:
+        - "4 rules defined: sql_injection, missing_auth, hardcoded_secrets, xss_patterns"
+        - "Each rule has id, patterns/keywords, and exclusions"
+        - "Exclusions use glob patterns compatible with fnmatch"
+    signal:
+      metric: "rule_count"
+      threshold: 4
+    metadata:
+      author: "atdd:security-patterns"
+      created: "2026-03-31"

--- a/plan/security_patterns/D002.yaml
+++ b/plan/security_patterns/D002.yaml
@@ -1,0 +1,33 @@
+urn: "wmbt:security-patterns:D002"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "sql-injection-vectors"
+context_clarifier: "when Python code uses string concatenation or f-strings in SQL execute calls"
+lens: "functional.effectiveness"
+statement: "minimize quantity of sql-injection-vectors when Python code uses string concatenation or f-strings in SQL execute calls"
+
+acceptances:
+  - identity:
+      urn: "acc:security-patterns:D002-UNIT-001-detect-sql-fstring"
+      id: "AC-UNIT-001"
+      purpose: "Detect f-string SQL in .execute() calls via AST analysis"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Python file with db.execute(f\"SELECT * FROM {table} WHERE id = {user_id}\")"
+    when:
+      abstract: "Running SQL injection AST check"
+    then:
+      abstract:
+        - "Violation reported with file path, line number, and SQL keyword found"
+        - "Files matching exclusion globs are skipped"
+    signal:
+      metric: "sql_violations"
+      threshold: 0
+    metadata:
+      author: "atdd:security-patterns"
+      created: "2026-03-31"

--- a/plan/security_patterns/D003.yaml
+++ b/plan/security_patterns/D003.yaml
@@ -1,0 +1,33 @@
+urn: "wmbt:security-patterns:D003"
+step: "define"
+direction: "maximize"
+dimension: "quantity"
+object_of_control: "authenticated-route-coverage"
+context_clarifier: "when FastAPI routes must enforce auth via dependency injection"
+lens: "functional.effectiveness"
+statement: "maximize quantity of authenticated-route-coverage when FastAPI routes must enforce auth via dependency injection"
+
+acceptances:
+  - identity:
+      urn: "acc:security-patterns:D003-UNIT-001-detect-missing-auth"
+      id: "AC-UNIT-001"
+      purpose: "Detect FastAPI routes without Depends(auth_function) in parameters"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Python file with @router.get('/items') and no auth dependency in function parameters"
+    when:
+      abstract: "Running missing auth dependency AST check"
+    then:
+      abstract:
+        - "Violation reported for route missing Depends(get_current_user) or equivalent"
+        - "Health check and public endpoint files excluded via glob patterns"
+    signal:
+      metric: "unauth_routes"
+      threshold: 0
+    metadata:
+      author: "atdd:security-patterns"
+      created: "2026-03-31"

--- a/plan/security_patterns/D004.yaml
+++ b/plan/security_patterns/D004.yaml
@@ -1,0 +1,34 @@
+urn: "wmbt:security-patterns:D004"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "hardcoded-secret-occurrences"
+context_clarifier: "when source code must not contain embedded credentials or API keys"
+lens: "functional.effectiveness"
+statement: "minimize quantity of hardcoded-secret-occurrences when source code must not contain embedded credentials or API keys"
+
+acceptances:
+  - identity:
+      urn: "acc:security-patterns:D004-UNIT-001-detect-hardcoded-secrets"
+      id: "AC-UNIT-001"
+      purpose: "Detect AWS keys, private key headers, password assignments, and API key literals"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Python file with password = \"hunter2\" or AKIA followed by 16 alphanumeric characters"
+    when:
+      abstract: "Running hardcoded secret regex scan"
+    then:
+      abstract:
+        - "Violation reported with pattern name, line number, and truncated match"
+        - "Comment-only lines skipped"
+        - "Test and fixture files excluded via glob patterns"
+    signal:
+      metric: "secret_violations"
+      threshold: 0
+    metadata:
+      author: "atdd:security-patterns"
+      created: "2026-03-31"

--- a/plan/security_patterns/D005.yaml
+++ b/plan/security_patterns/D005.yaml
@@ -1,0 +1,33 @@
+urn: "wmbt:security-patterns:D005"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "xss-prone-dom-manipulation"
+context_clarifier: "when frontend code must not use raw innerHTML or dangerouslySetInnerHTML"
+lens: "functional.effectiveness"
+statement: "minimize quantity of xss-prone-dom-manipulation when frontend code must not use raw innerHTML or dangerouslySetInnerHTML"
+
+acceptances:
+  - identity:
+      urn: "acc:security-patterns:D005-UNIT-001-detect-xss-patterns"
+      id: "AC-UNIT-001"
+      purpose: "Detect innerHTML and dangerouslySetInnerHTML in TypeScript/JSX files"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "frontend"
+    given:
+      abstract:
+        - "TypeScript file with element.innerHTML = userInput or dangerouslySetInnerHTML={{__html: data}}"
+    when:
+      abstract: "Running XSS pattern regex scan on .ts/.tsx/.jsx files"
+    then:
+      abstract:
+        - "Violation reported with file path, line number, and matched pattern"
+        - "Type declaration files (.d.ts) and test files excluded"
+    signal:
+      metric: "xss_violations"
+      threshold: 0
+    metadata:
+      author: "atdd:security-patterns"
+      created: "2026-03-31"

--- a/plan/security_patterns/E001.yaml
+++ b/plan/security_patterns/E001.yaml
@@ -1,0 +1,33 @@
+urn: "wmbt:security-patterns:E001"
+step: "execute"
+direction: "maximize"
+dimension: "quantity"
+object_of_control: "validator-pass-rate"
+context_clarifier: "when all 4 security validators run against a clean codebase"
+lens: "functional.effectiveness"
+statement: "maximize quantity of validator-pass-rate when all 4 security validators run against a clean codebase"
+
+acceptances:
+  - identity:
+      urn: "acc:security-patterns:E001-UNIT-001-validators-pass-clean"
+      id: "AC-UNIT-001"
+      purpose: "All 4 security validators pass or skip on a codebase with no violations"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Consumer codebase with no security anti-patterns (or no consumer dirs)"
+    when:
+      abstract: "Running pytest on test_security_patterns.py and test_frontend_security_patterns.py"
+    then:
+      abstract:
+        - "All tests pass or skip (no failures)"
+        - "Tests skip gracefully when consumer directories do not exist"
+    signal:
+      metric: "test_pass_rate"
+      threshold: 100
+    metadata:
+      author: "atdd:security-patterns"
+      created: "2026-03-31"

--- a/plan/security_patterns/_security_patterns.yaml
+++ b/plan/security_patterns/_security_patterns.yaml
@@ -1,0 +1,31 @@
+wagon: security-patterns
+urn: "wagon:security-patterns"
+name: "Security Patterns"
+description: "AST-based validator that scans consumer code for known-bad security patterns — SQL injection, missing auth, hardcoded secrets, XSS"
+theme: commons
+
+subject: "coder:security"
+context: "in-coder-phase, code-review-rules-encodable"
+action: "scans consumer code via AST and regex for security anti-patterns"
+goal: "catch security violations that code review catches but are fully automatable"
+outcome: "zero known-bad security patterns in consumer codebase"
+
+features:
+  - urn: "feature:security-patterns:detect-security-patterns"
+
+produce:
+  - name: commons:security:violations
+    contract: null
+    telemetry: null
+    to: internal
+
+consume: []
+
+wmbt:
+  total: 6
+  D001: "Define security convention YAML with rules, patterns, and exclusion mechanisms"
+  D002: "Define SQL injection AST detection for string concatenation in execute calls"
+  D003: "Define missing auth dependency detection for FastAPI route handlers"
+  D004: "Define hardcoded secret regex patterns (AWS keys, private keys, passwords, tokens)"
+  D005: "Define XSS pattern detection for innerHTML and dangerouslySetInnerHTML in frontend code"
+  E001: "All 4 security validators pass on a clean codebase with no violations"

--- a/plan/security_patterns/features/detect_security_patterns.yaml
+++ b/plan/security_patterns/features/detect_security_patterns.yaml
@@ -1,0 +1,35 @@
+urn: "feature:security-patterns:detect-security-patterns"
+wagon: "wagon:security-patterns"
+description: "Detect known-bad security patterns in consumer codebases via AST analysis and regex scanning"
+
+sizing:
+  wmbts: 6
+  footprint_score: 8
+  footprint_size: "M"
+
+wmbts:
+  - "wmbt:security-patterns:D001"
+  - "wmbt:security-patterns:D002"
+  - "wmbt:security-patterns:D003"
+  - "wmbt:security-patterns:D004"
+  - "wmbt:security-patterns:D005"
+  - "wmbt:security-patterns:E001"
+
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 0
+        rationale: "No new CLI commands — plugs into existing atdd validate coder"
+    application:
+      - type: "use_cases"
+        count: 0
+        rationale: "No new use cases — validators are pytest-based"
+    domain:
+      - type: "entities"
+        count: 0
+        rationale: "No new domain entities — rules defined in convention YAML"
+    integration:
+      - type: "repositories"
+        count: 0
+        rationale: "No new persistence — convention YAML is static config"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.19.0"
+version = "1.20.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coder/conventions/security.convention.yaml
+++ b/src/atdd/coder/conventions/security.convention.yaml
@@ -1,0 +1,120 @@
+version: "1.0"
+convention_id: "coder.security"
+name: "Security Pattern Convention"
+description: |
+  Defines known-bad security patterns that consumer codebases must not contain.
+  Phase 1: AST-based Python analysis + regex-based frontend analysis.
+  Phase 2 (future): entropy-based secret detection.
+
+security:
+  rules:
+    # ------------------------------------------------------------------
+    # SPEC-CODER-SEC-0001: SQL Injection via string concatenation
+    # ------------------------------------------------------------------
+    sql_injection:
+      id: "SPEC-CODER-SEC-0001"
+      description: "No raw SQL string concatenation in execute calls"
+      severity: error
+      language: python
+      detection: ast
+      sql_keywords:
+        - SELECT
+        - INSERT
+        - UPDATE
+        - DELETE
+        - DROP
+        - ALTER
+        - CREATE
+      sink_methods:
+        - execute
+        - executemany
+        - raw
+        - execute_sql
+      exclusions:
+        - "**/tests/**"
+        - "**/test_*.py"
+        - "**/conftest.py"
+        - "**/migrations/**"
+
+    # ------------------------------------------------------------------
+    # SPEC-CODER-SEC-0002: Missing auth dependency on FastAPI routes
+    # ------------------------------------------------------------------
+    missing_auth:
+      id: "SPEC-CODER-SEC-0002"
+      description: "FastAPI routes must have auth dependency injection"
+      severity: error
+      language: python
+      detection: ast
+      route_decorators:
+        - get
+        - post
+        - put
+        - delete
+        - patch
+        - options
+        - head
+      router_objects:
+        - app
+        - router
+      auth_dependencies:
+        - get_current_user
+        - require_auth
+        - verify_token
+        - get_authenticated_user
+      exclusions:
+        - "**/health*.py"
+        - "**/public*.py"
+        - "**/openapi*.py"
+        - "**/docs*.py"
+
+    # ------------------------------------------------------------------
+    # SPEC-CODER-SEC-0003: Hardcoded secrets
+    # ------------------------------------------------------------------
+    hardcoded_secrets:
+      id: "SPEC-CODER-SEC-0003"
+      description: "No hardcoded secrets (AWS keys, private keys, passwords, API keys)"
+      severity: error
+      language: python
+      detection: regex
+      patterns:
+        - name: aws_access_key
+          regex: "AKIA[0-9A-Z]{16}"
+        - name: private_key_header
+          regex: "-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----"
+        - name: password_assignment
+          regex: "(password|passwd|pwd)\\s*=\\s*[\"'][^\"']{8,}[\"']"
+        - name: api_key_assignment
+          regex: "(api_key|apikey|api_secret|secret_key)\\s*=\\s*[\"'][^\"']{8,}[\"']"
+        - name: generic_token
+          regex: "(token|auth_token|access_token)\\s*=\\s*[\"'][a-zA-Z0-9_\\-]{20,}[\"']"
+      exclusions:
+        - "**/tests/**"
+        - "**/test_*.py"
+        - "**/conftest.py"
+        - "**/.env.example"
+        - "**/fixtures/**"
+
+    # ------------------------------------------------------------------
+    # SPEC-CODER-SEC-0004: XSS-prone DOM patterns
+    # ------------------------------------------------------------------
+    xss_patterns:
+      id: "SPEC-CODER-SEC-0004"
+      description: "No innerHTML or dangerouslySetInnerHTML in frontend code"
+      severity: error
+      language: typescript
+      detection: regex
+      patterns:
+        - innerHTML
+        - dangerouslySetInnerHTML
+        - "outerHTML\\s*="
+      file_extensions:
+        - ".ts"
+        - ".tsx"
+        - ".jsx"
+      exclusions:
+        - "**/node_modules/**"
+        - "**/*.d.ts"
+        - "**/*.test.ts"
+        - "**/*.test.tsx"
+        - "**/sanitize*.ts"
+        - "**/sanitize*.tsx"

--- a/src/atdd/coder/validators/test_frontend_security_patterns.py
+++ b/src/atdd/coder/validators/test_frontend_security_patterns.py
@@ -1,0 +1,180 @@
+"""
+Test frontend code for known-bad security patterns.
+
+Validates:
+- No innerHTML or dangerouslySetInnerHTML usage in TypeScript/JSX files
+
+Conventions from:
+- atdd/coder/conventions/security.convention.yaml
+
+Rationale: Direct DOM manipulation via innerHTML is the most common
+XSS vector in frontend code.  Safe alternatives exist (textContent,
+React's JSX escaping, DOMPurify).
+"""
+
+import fnmatch
+import os
+import re
+import yaml
+import pytest
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import atdd
+from atdd.coach.utils.repo import find_repo_root
+
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+REPO_ROOT = find_repo_root()
+WEB_DIR = REPO_ROOT / "web"
+FRONTEND_DIRS = [
+    REPO_ROOT / "web",
+    REPO_ROOT / "frontend",
+]
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+SECURITY_CONVENTION = ATDD_PKG_DIR / "coder" / "conventions" / "security.convention.yaml"
+
+_SKIP_DIRS = {
+    ".git", "__pycache__", "node_modules", ".dart_tool",
+    "build", ".pub-cache", "dist", ".next", ".nuxt", "coverage",
+    ".venv", "venv", "env", ".tox", ".mypy_cache", ".pytest_cache",
+}
+
+
+# ---------------------------------------------------------------------------
+# Convention loader
+# ---------------------------------------------------------------------------
+def load_security_convention() -> Dict:
+    """Load security convention YAML.  Returns empty dict when missing."""
+    if not SECURITY_CONVENTION.exists():
+        return {}
+    with open(SECURITY_CONVENTION, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+        return data.get("security", {})
+
+
+# ---------------------------------------------------------------------------
+# File helpers
+# ---------------------------------------------------------------------------
+def matches_exclusion(
+    file_path: Path,
+    exclusions: List[str],
+    base_dir: Path,
+) -> bool:
+    """Return True if *file_path* matches any exclusion glob relative to *base_dir*."""
+    try:
+        rel = str(file_path.relative_to(base_dir))
+    except ValueError:
+        rel = str(file_path)
+    return any(fnmatch.fnmatch(rel, pat) for pat in exclusions)
+
+
+def find_frontend_files(
+    dirs: List[Path],
+    extensions: List[str],
+    exclude_patterns: Optional[List[str]] = None,
+) -> List[Path]:
+    """Walk directories for files matching *extensions*, honouring exclusions."""
+    exclude_patterns = exclude_patterns or []
+    files: List[Path] = []
+    for base_dir in dirs:
+        if not base_dir.exists():
+            continue
+        for dirpath, dirnames, filenames in os.walk(base_dir):
+            dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+            for fname in filenames:
+                if not any(fname.endswith(ext) for ext in extensions):
+                    continue
+                full = Path(dirpath) / fname
+                if matches_exclusion(full, exclude_patterns, base_dir):
+                    continue
+                files.append(full)
+    return files
+
+
+# ---------------------------------------------------------------------------
+# XSS pattern detector  (regex)
+# ---------------------------------------------------------------------------
+def check_xss_patterns(
+    file_path: Path,
+    patterns: List[str],
+) -> List[Dict]:
+    """Line-by-line regex scan for XSS-prone DOM patterns."""
+    try:
+        lines = file_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+
+    compiled = [(p, re.compile(p)) for p in patterns]
+    violations: List[Dict] = []
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        # Skip comments
+        if stripped.startswith("//") or stripped.startswith("/*"):
+            continue
+        for pattern_str, regex in compiled:
+            if regex.search(line):
+                snippet = stripped[:80] + ("..." if len(stripped) > 80 else "")
+                violations.append({
+                    "file": file_path,
+                    "line": lineno,
+                    "detail": f"XSS pattern '{pattern_str}' found: {snippet}",
+                })
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Violation formatter
+# ---------------------------------------------------------------------------
+def _format_violations(violations: List[Dict], base_dir: Path) -> str:
+    """Format violations for pytest.fail() output."""
+    lines = []
+    for v in violations[:10]:
+        try:
+            rel = v["file"].relative_to(base_dir)
+        except ValueError:
+            rel = v["file"]
+        lines.append(f"{rel}:{v['line']}\n  {v['detail']}")
+    header = f"\n\nFound {len(violations)} security violation(s):\n\n"
+    body = "\n\n".join(lines)
+    tail = ""
+    if len(violations) > 10:
+        tail = f"\n\n... and {len(violations) - 10} more"
+    return header + body + tail
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+@pytest.mark.coder
+def test_no_xss_prone_patterns():
+    """
+    SPEC-CODER-SEC-0004: No innerHTML or dangerouslySetInnerHTML in frontend code.
+
+    Direct DOM manipulation via innerHTML is the most common XSS vector.
+    Use textContent, framework-safe APIs, or DOMPurify instead.
+
+    Given: TypeScript/JSX files in web/ or frontend/
+    When:  Scanning for innerHTML and dangerouslySetInnerHTML patterns
+    Then:  No XSS-prone DOM manipulation found
+    """
+    convention = load_security_convention()
+    rule = convention.get("rules", {}).get("xss_patterns", {})
+    patterns = rule.get("patterns", ["innerHTML", "dangerouslySetInnerHTML", r"outerHTML\s*="])
+    extensions = rule.get("file_extensions", [".ts", ".tsx", ".jsx"])
+    exclusions = rule.get("exclusions", [])
+
+    files = find_frontend_files(FRONTEND_DIRS, extensions, exclusions)
+    if not files:
+        pytest.skip("No frontend files found in web/ or frontend/")
+
+    violations: List[Dict] = []
+    for f in files:
+        violations.extend(check_xss_patterns(f, patterns))
+
+    if violations:
+        pytest.fail(_format_violations(violations, REPO_ROOT))

--- a/src/atdd/coder/validators/test_security_patterns.py
+++ b/src/atdd/coder/validators/test_security_patterns.py
@@ -1,0 +1,395 @@
+"""
+Test Python code for known-bad security patterns.
+
+Validates:
+- No raw SQL string concatenation in .execute() calls
+- FastAPI routes have auth dependency injection
+- No hardcoded secrets (AWS keys, private keys, passwords, API keys)
+
+Conventions from:
+- atdd/coder/conventions/security.convention.yaml
+
+Rationale: These patterns pretend to be opinions during code review
+but are fully encodable as AST/regex rules. Phase 1: AST for SQL
+and auth, regex for secrets. Entropy-based detection deferred.
+"""
+
+import ast
+import fnmatch
+import os
+import re
+import yaml
+import pytest
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import atdd
+from atdd.coach.utils.repo import find_repo_root
+
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+REPO_ROOT = find_repo_root()
+PYTHON_DIR = REPO_ROOT / "python"
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+SECURITY_CONVENTION = ATDD_PKG_DIR / "coder" / "conventions" / "security.convention.yaml"
+
+_SKIP_DIRS = {
+    ".git", "__pycache__", "node_modules", ".dart_tool",
+    "build", ".pub-cache", "dist", ".next", ".nuxt", "coverage",
+    ".venv", "venv", "env", ".tox", ".mypy_cache", ".pytest_cache",
+}
+
+
+# ---------------------------------------------------------------------------
+# Convention loader
+# ---------------------------------------------------------------------------
+def load_security_convention() -> Dict:
+    """Load security convention YAML.  Returns empty dict when missing."""
+    if not SECURITY_CONVENTION.exists():
+        return {}
+    with open(SECURITY_CONVENTION, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+        return data.get("security", {})
+
+
+# ---------------------------------------------------------------------------
+# File helpers
+# ---------------------------------------------------------------------------
+def matches_exclusion(
+    file_path: Path,
+    exclusions: List[str],
+    base_dir: Path,
+) -> bool:
+    """Return True if *file_path* matches any exclusion glob relative to *base_dir*."""
+    try:
+        rel = str(file_path.relative_to(base_dir))
+    except ValueError:
+        rel = str(file_path)
+    return any(fnmatch.fnmatch(rel, pat) for pat in exclusions)
+
+
+def find_python_files(
+    base_dir: Path,
+    exclude_patterns: Optional[List[str]] = None,
+) -> List[Path]:
+    """Walk *base_dir* for ``*.py`` files, honouring skip-dirs and exclusions."""
+    if not base_dir.exists():
+        return []
+    exclude_patterns = exclude_patterns or []
+    files: List[Path] = []
+    for dirpath, dirnames, filenames in os.walk(base_dir):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for fname in filenames:
+            if not fname.endswith(".py"):
+                continue
+            full = Path(dirpath) / fname
+            if matches_exclusion(full, exclude_patterns, base_dir):
+                continue
+            files.append(full)
+    return files
+
+
+def _parse_ast(file_path: Path) -> Optional[ast.Module]:
+    """Parse a Python file, returning None on syntax errors."""
+    try:
+        source = file_path.read_text(encoding="utf-8", errors="replace")
+        return ast.parse(source, filename=str(file_path))
+    except SyntaxError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# SQL injection detector  (AST)
+# ---------------------------------------------------------------------------
+def _contains_sql_keyword(node: ast.expr, keywords: List[str]) -> Optional[str]:
+    """Walk an AST expression for string constants containing SQL keywords."""
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            upper = child.value.upper()
+            for kw in keywords:
+                if kw in upper:
+                    return kw
+    return None
+
+
+def check_sql_concatenation(
+    file_path: Path,
+    sql_keywords: List[str],
+    sink_methods: List[str],
+) -> List[Dict]:
+    """Detect f-string or ``+`` concatenation with SQL keywords inside sink calls."""
+    tree = _parse_ast(file_path)
+    if tree is None:
+        return []
+
+    violations: List[Dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        # Match  obj.execute(...)  or  obj.executemany(...)
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr in sink_methods):
+            continue
+
+        for arg in node.args:
+            matched_kw: Optional[str] = None
+
+            # f-string:  f"SELECT ... {var}"
+            if isinstance(arg, ast.JoinedStr):
+                matched_kw = _contains_sql_keyword(arg, sql_keywords)
+
+            # concatenation:  "SELECT " + var
+            elif isinstance(arg, ast.BinOp) and isinstance(arg.op, ast.Add):
+                matched_kw = _contains_sql_keyword(arg, sql_keywords)
+
+            if matched_kw:
+                violations.append({
+                    "file": file_path,
+                    "line": arg.lineno,
+                    "detail": f"SQL keyword '{matched_kw}' in dynamic string passed to .{func.attr}()",
+                })
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Missing auth detector  (AST)
+# ---------------------------------------------------------------------------
+def _is_route_decorator(
+    decorator: ast.expr,
+    route_decorators: List[str],
+    router_objects: List[str],
+) -> bool:
+    """Return True if *decorator* looks like ``@router.get(...)``."""
+    if not isinstance(decorator, ast.Call):
+        return False
+    func = decorator.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if func.attr not in route_decorators:
+        return False
+    # router.get  or  app.post  etc.
+    if isinstance(func.value, ast.Name) and func.value.id in router_objects:
+        return True
+    return False
+
+
+def _has_auth_dependency(
+    func_def: ast.FunctionDef,
+    auth_dependencies: List[str],
+) -> bool:
+    """Return True if any parameter default is ``Depends(auth_fn)``."""
+    defaults = list(func_def.args.defaults) + list(func_def.args.kw_defaults)
+    for default in defaults:
+        if default is None:
+            continue
+        if not isinstance(default, ast.Call):
+            continue
+        callee = default.func
+        callee_name = None
+        if isinstance(callee, ast.Name):
+            callee_name = callee.id
+        elif isinstance(callee, ast.Attribute):
+            callee_name = callee.attr
+        if callee_name != "Depends":
+            continue
+        # Check first positional arg of Depends(...)
+        if default.args:
+            first = default.args[0]
+            if isinstance(first, ast.Name) and first.id in auth_dependencies:
+                return True
+    return False
+
+
+def check_missing_auth(
+    file_path: Path,
+    route_decorators: List[str],
+    router_objects: List[str],
+    auth_dependencies: List[str],
+) -> List[Dict]:
+    """Detect FastAPI route functions without auth dependency injection."""
+    tree = _parse_ast(file_path)
+    if tree is None:
+        return []
+
+    violations: List[Dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        is_route = any(
+            _is_route_decorator(d, route_decorators, router_objects)
+            for d in node.decorator_list
+        )
+        if not is_route:
+            continue
+        if not _has_auth_dependency(node, auth_dependencies):
+            violations.append({
+                "file": file_path,
+                "line": node.lineno,
+                "detail": f"Route '{node.name}' has no auth dependency (expected Depends(<auth_fn>))",
+            })
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Hardcoded secret detector  (regex)
+# ---------------------------------------------------------------------------
+def check_hardcoded_secrets(
+    file_path: Path,
+    patterns: List[Dict],
+) -> List[Dict]:
+    """Line-by-line regex scan for secret-like strings.  Skips comment lines."""
+    try:
+        lines = file_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+
+    compiled = []
+    for pat in patterns:
+        flags = 0
+        # Case-insensitive for password/token patterns, exact for AWS keys
+        if pat["name"] not in ("aws_access_key", "private_key_header"):
+            flags = re.IGNORECASE
+        compiled.append((pat["name"], re.compile(pat["regex"], flags)))
+
+    violations: List[Dict] = []
+    for lineno, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        for name, regex in compiled:
+            if regex.search(line):
+                # Truncate to avoid leaking actual secrets
+                snippet = stripped[:60] + ("..." if len(stripped) > 60 else "")
+                violations.append({
+                    "file": file_path,
+                    "line": lineno,
+                    "detail": f"Pattern '{name}' matched: {snippet}",
+                })
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Violation formatter  (shared across tests)
+# ---------------------------------------------------------------------------
+def _format_violations(violations: List[Dict], base_dir: Path) -> str:
+    """Format violations for pytest.fail() output."""
+    lines = []
+    for v in violations[:10]:
+        try:
+            rel = v["file"].relative_to(base_dir)
+        except ValueError:
+            rel = v["file"]
+        lines.append(f"{rel}:{v['line']}\n  {v['detail']}")
+    header = f"\n\nFound {len(violations)} security violation(s):\n\n"
+    body = "\n\n".join(lines)
+    tail = ""
+    if len(violations) > 10:
+        tail = f"\n\n... and {len(violations) - 10} more"
+    return header + body + tail
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+@pytest.mark.coder
+def test_no_raw_sql_concatenation():
+    """
+    SPEC-CODER-SEC-0001: No raw SQL string concatenation in execute calls.
+
+    SQL injection via f-strings or string concatenation is a critical
+    vulnerability.  Parameterized queries must be used instead.
+
+    Given: Python files in python/
+    When:  Parsing AST for SQL keywords in dynamic strings passed to sink methods
+    Then:  No violations found
+    """
+    convention = load_security_convention()
+    rule = convention.get("rules", {}).get("sql_injection", {})
+    sql_keywords = rule.get("sql_keywords", ["SELECT", "INSERT", "UPDATE", "DELETE", "DROP", "ALTER", "CREATE"])
+    sink_methods = rule.get("sink_methods", ["execute", "executemany", "raw", "execute_sql"])
+    exclusions = rule.get("exclusions", [])
+
+    files = find_python_files(PYTHON_DIR, exclusions)
+    if not files:
+        pytest.skip("No Python files found in python/")
+
+    violations: List[Dict] = []
+    for f in files:
+        violations.extend(check_sql_concatenation(f, sql_keywords, sink_methods))
+
+    if violations:
+        pytest.fail(_format_violations(violations, REPO_ROOT))
+
+
+@pytest.mark.coder
+def test_fastapi_routes_have_auth_dependency():
+    """
+    SPEC-CODER-SEC-0002: FastAPI routes must have auth dependency injection.
+
+    Every route handler decorated with @router.get/post/etc must include
+    a Depends(auth_function) parameter to enforce authentication.
+
+    Given: Python files in python/ with FastAPI route decorators
+    When:  Checking function parameters for Depends(auth_fn)
+    Then:  All route functions include auth dependency
+    """
+    convention = load_security_convention()
+    rule = convention.get("rules", {}).get("missing_auth", {})
+    route_decorators = rule.get("route_decorators", ["get", "post", "put", "delete", "patch", "options", "head"])
+    router_objects = rule.get("router_objects", ["app", "router"])
+    auth_deps = rule.get("auth_dependencies", ["get_current_user", "require_auth", "verify_token"])
+    exclusions = rule.get("exclusions", [])
+
+    files = find_python_files(PYTHON_DIR, exclusions)
+    if not files:
+        pytest.skip("No Python files found in python/")
+
+    violations: List[Dict] = []
+    for f in files:
+        violations.extend(check_missing_auth(f, route_decorators, router_objects, auth_deps))
+
+    if not violations:
+        # No route-decorated functions found counts as pass (not skip)
+        return
+
+    pytest.fail(_format_violations(violations, REPO_ROOT))
+
+
+@pytest.mark.coder
+def test_no_hardcoded_secrets():
+    """
+    SPEC-CODER-SEC-0003: No hardcoded secrets in Python source files.
+
+    AWS access keys, private key headers, password assignments, API key
+    literals, and bearer tokens must never appear in source code.
+
+    Given: Python files in python/
+    When:  Scanning with regex patterns for secret-like strings
+    Then:  No matches found
+    """
+    convention = load_security_convention()
+    rule = convention.get("rules", {}).get("hardcoded_secrets", {})
+    patterns = rule.get("patterns", [
+        {"name": "aws_access_key", "regex": r"AKIA[0-9A-Z]{16}"},
+        {"name": "private_key_header", "regex": r"-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----"},
+        {"name": "password_assignment", "regex": r'(password|passwd|pwd)\s*=\s*["\'][^"\']{8,}["\']'},
+        {"name": "api_key_assignment", "regex": r'(api_key|apikey|api_secret|secret_key)\s*=\s*["\'][^"\']{8,}["\']'},
+        {"name": "generic_token", "regex": r'(token|auth_token|access_token)\s*=\s*["\'][a-zA-Z0-9_\-]{20,}["\']'},
+    ])
+    exclusions = rule.get("exclusions", [])
+
+    files = find_python_files(PYTHON_DIR, exclusions)
+    if not files:
+        pytest.skip("No Python files found in python/")
+
+    violations: List[Dict] = []
+    for f in files:
+        violations.extend(check_hardcoded_secrets(f, patterns))
+
+    if violations:
+        pytest.fail(_format_violations(violations, REPO_ROOT))


### PR DESCRIPTION
## Summary

- New ATDD coder-phase validator scanning consumer code for 4 categories of security anti-patterns via AST and regex analysis
- **SPEC-CODER-SEC-0001**: SQL injection — detects f-string/concat SQL in `.execute()` calls (AST)
- **SPEC-CODER-SEC-0002**: Missing auth — detects FastAPI routes without `Depends(auth_fn)` (AST)
- **SPEC-CODER-SEC-0003**: Hardcoded secrets — AWS keys, private keys, passwords, API keys (regex)
- **SPEC-CODER-SEC-0004**: XSS patterns — `innerHTML`/`dangerouslySetInnerHTML` in frontend code (regex)
- New `security.convention.yaml` with configurable rules, patterns, and file-glob exclusions per rule
- Full wagon plan artifacts: manifest, feature, 6 WMBTs (D001-D005, E001)
- Version bump: 1.18.0 → 1.19.0

## Open Gap Resolutions

| Gap | Decision |
|-----|----------|
| Auth pattern | `Depends(get_current_user)` + configurable `auth_dependencies` list |
| Secret entropy | Deferred to Phase 2 — regex-only for Phase 1 |
| Allowlist | File-glob exclusions per rule in convention YAML via `fnmatch` |

## Test plan

- [x] `atdd validate planner --local` — 89 passed, 0 failed
- [x] `atdd validate tester --local` — 96 passed, 0 failed
- [x] `atdd validate coder --local` — 39 passed, 0 failed
- [x] `atdd validate --local` — 263 passed, 0 failed (full suite)
- [x] Direct pytest run: 4 tests skip cleanly (no consumer dirs in ATDD repo)

Closes #150