### PR TITLE
fix(coder): extend duplication detector to scan src/atdd/ (#164)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.24.0"
+version = "1.24.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coder/conventions/duplication.convention.yaml
+++ b/src/atdd/coder/conventions/duplication.convention.yaml
@@ -31,9 +31,10 @@ duplication:
         - presentation
         - integration
 
-      # Directories to scan
+      # Directories to scan (relative to repo root)
       scan_dirs:
         - "python/"
+        - "src/atdd/"
 
       exclusions:
         - "**/tests/**"
@@ -42,3 +43,5 @@ duplication:
         - "**/__init__.py"
         - "**/__pycache__/**"
         - "**/migrations/**"
+        - "**/validators/**"
+        - "**/templates/**"

--- a/src/atdd/coder/validators/test_duplication_detector.py
+++ b/src/atdd/coder/validators/test_duplication_detector.py
@@ -301,7 +301,7 @@ def test_no_intra_layer_duplication():
     the same architectural layer.  Variable names and literals are normalized
     so renamed copies are still caught.
 
-    Given: Python files in python/ grouped by architectural layer
+    Given: Python files in configured scan_dirs grouped by architectural layer
     When: Extracting statement fragments and comparing hashes within each layer
     Then: No duplicate fragments found across different files
 
@@ -311,10 +311,13 @@ def test_no_intra_layer_duplication():
     rule = convention.get("rules", {}).get("intra_layer_duplication", {})
     min_stmts = rule.get("min_fragment_statements", 5)
     exclusions = rule.get("exclusions", [])
+    scan_dirs = rule.get("scan_dirs", ["python/"])
 
-    files = _collect_python_files(PYTHON_DIR, exclusions)
+    files: List[Path] = []
+    for rel_dir in scan_dirs:
+        files.extend(_collect_python_files(REPO_ROOT / rel_dir, exclusions))
     if not files:
-        pytest.skip("No Python files found in python/ to validate")
+        pytest.skip("No Python files found in scan_dirs to validate")
 
     # Group files by layer
     files_by_layer: Dict[str, List[Path]] = {}


### PR DESCRIPTION
## Summary

- Duplication detector now reads `scan_dirs` from convention YAML instead of hardcoding `python/`
- Added `src/atdd/` to scan scope (dogfooding — toolkit enforces its own rules)
- Added `validators/**` and `templates/**` to exclusions (structurally similar by design)
- Version bump: 1.24.0 → 1.24.1

## Test plan

- [x] `test_duplication_detector.py` — 2 passed (convention exists + no duplicates in src/atdd/)
- [x] `atdd validate --local` — 272 passed, 0 failures
- [x] No false positives in validator files (excluded by convention)

Closes #164