### PR TITLE
fix(ci): handle pytest exit code 5 in validate split mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.25.1"
+version = "1.25.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/test_runner.py
+++ b/src/atdd/coach/commands/test_runner.py
@@ -203,6 +203,12 @@ class TestRunner:
         print("\n[2/2] GitHub API validators (live API):")
         slow_rc = self._run_pytest(slow_cmd)
 
+        # Exit code 5 = "no tests collected" — expected when a phase has no
+        # github_api-marked tests (planner, tester, coder currently have none).
+        if slow_rc == 5:
+            print("  No github_api tests collected for this phase — OK")
+            slow_rc = 0
+
         # Fail if either stage failed
         if fast_rc != 0:
             return fast_rc

--- a/src/atdd/version_check.py
+++ b/src/atdd/version_check.py
@@ -216,7 +216,7 @@ def get_upgrade_notes(from_version: str, to_version: str) -> list:
     from_tuple = _parse_version(from_version)
     to_tuple = _parse_version(to_version)
     notes = []
-    for version, note in sorted(UPGRADE_NOTES.items(), key=lambda x: _parse_version(x[0])):
+    for version, note in sorted(UPGRADE_NOTES.items(), key=lambda x: _parse_version(x[0]), reverse=True):
         v_tuple = _parse_version(version)
         if from_tuple < v_tuple <= to_tuple:
             notes.append((version, note))


### PR DESCRIPTION
## Summary

- Treat pytest exit code 5 (no tests collected) as success in stage 2 of split-mode validation — planner/tester/coder phases have no `github_api`-marked tests, so exit 5 is guaranteed and expected
- Reverse upgrade notes order in version recap to show newest changes first

Closes #171

## Test plan

- [ ] `atdd validate planner --local` exits 0 (no longer blocked by exit 5)
- [ ] `atdd validate tester --local` exits 0
- [ ] `atdd validate coder --local` exits 0
- [ ] `atdd validate coach --local` still runs github_api tests when available
- [ ] Upgrade notes display newest version first in `⚠️ ATDD upgraded` banner