### PR TITLE
chore(coach): add coach as first-class archetype

### DIFF
--- a/.atdd/config.yaml
+++ b/.atdd/config.yaml
@@ -10,9 +10,9 @@ init:
 coverage:
   exceptions:
     features_without_implementation:
-      - "feature:self-compliance-migration:bootstrap-compliance"
+    - feature:self-compliance-migration:bootstrap-compliance
 toolkit:
-  last_version: 1.16.0
+  last_version: 1.25.2
 github:
   repo: afokapu/atdd
   project_number: 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -621,6 +621,7 @@ issues:
     train: "Journey orchestration (linear trains)"
     telemetry: "Observability artifacts"
     migrations: "Database schema evolution"
+    coach: "ATDD orchestration, conventions, hooks, validators, CLI"
 
   atdd_phases:
     RED: "Write failing tests from acceptances"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -611,6 +611,16 @@ issues:
     close_wmbt: "atdd issue <N> --close-wmbt <ID>  # Close a WMBT sub-issue"
     validate: "atdd validate coach                 # Validate Project fields + sub-issue state"
 
+  # MANDATORY: All issue and PR operations MUST go through the atdd CLI.
+  # NEVER use `gh issue create`, `gh pr create`, or the GitHub web UI directly.
+  # Reason: Direct creation bypasses manifest registration, WMBT sub-issue
+  # generation, Project v2 field setup, and worktree metadata.
+  # The coach validator (`atdd validate coach`) will flag issues that exist
+  # on GitHub but are missing from .atdd/manifest.yaml.
+  prohibited_commands:
+    - "gh issue create    → use: atdd issue <slug>"
+    - "gh pr create       → use: atdd branch <N> (creates worktree + PR-ready branch)"
+
   archetypes:
     db: "Supabase PostgreSQL + JSONB"
     be: "Python FastAPI 4-layer"

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -86,6 +86,10 @@ ARCHETYPE_GATES = {
     "telemetry": [
         ("GT-080", "tester", "atdd validate tester", "src/atdd/tester/validators/test_telemetry_validation.py"),
     ],
+    "coach": [
+        ("GT-090", "implementation", "atdd validate coach", "src/atdd/coach/validators/test_issue_validation.py"),
+        ("GT-091", "implementation", "atdd validate coach", "src/atdd/coach/validators/test_registry.py"),
+    ],
 }
 
 

--- a/src/atdd/coach/conventions/issue.convention.yaml
+++ b/src/atdd/coach/conventions/issue.convention.yaml
@@ -228,6 +228,7 @@ github_issue_tracking:
       - { name: "archetype:train",   color: "D4C5F9", applies_to: "parent",    description: "Journey orchestration" }
       - { name: "archetype:telemetry", color: "D4C5F9", applies_to: "parent",  description: "Observability artifacts" }
       - { name: "archetype:migrations", color: "D4C5F9", applies_to: "parent", description: "Database schema evolution" }
+      - { name: "archetype:coach", color: "D4C5F9", applies_to: "parent",      description: "ATDD orchestration and CLI" }
     dynamic_labels:
       wagon:
         pattern: "wagon:{slug}"
@@ -626,6 +627,20 @@ archetypes:
     preconditions:
       - "See rules.supabase_branching"
 
+  coach:
+    id: "coach"
+    description: "ATDD orchestration, conventions, hooks, validators, and CLI behavior"
+    artifacts:
+      - "src/atdd/**"
+      - ".atdd/**"
+      - ".github/workflows/atdd-*.yml"
+    patterns:
+      - "Issue lifecycle: commands, validators, templates"
+      - "Hooks: pre-push, pre-commit, worktree enforcement"
+      - "Conventions: YAML specs that govern agent behavior"
+      - "Schemas: JSON Schema for labels, projects, sessions"
+    validation: "atdd validate coach"
+
 # Mandatory sections - ALL sessions must have these
 sections:
   header:
@@ -891,7 +906,7 @@ gate_tests:
       description: "Which phase this gate applies to"
     archetype:
       type: "string"
-      values: ["db", "be", "fe", "contracts", "wmbt", "wagon", "train", "telemetry", "migrations", "all"]
+      values: ["db", "be", "fe", "contracts", "wmbt", "wagon", "train", "telemetry", "migrations", "coach", "all"]
       description: "Which archetype this gate validates (or 'all')"
     command:
       type: "string"
@@ -955,6 +970,12 @@ gate_tests:
         atdd_validator: "manual"
       - command: "atdd validate tester"
         atdd_validator: "atdd/tester/validators/test_migration_coverage.py"
+
+    coach:
+      - command: "atdd validate coach"
+        atdd_validator: "atdd/coach/validators/test_issue_validation.py"
+      - command: "atdd validate coach"
+        atdd_validator: "atdd/coach/validators/test_registry.py"
 
   # Universal gates (all sessions)
   universal:

--- a/src/atdd/coach/schemas/label_taxonomy.schema.json
+++ b/src/atdd/coach/schemas/label_taxonomy.schema.json
@@ -95,10 +95,11 @@
                 { "properties": { "name": { "const": "archetype:wagon" },      "color": { "const": "D4C5F9" }, "description": { "const": "Bounded context module" } } },
                 { "properties": { "name": { "const": "archetype:train" },      "color": { "const": "D4C5F9" }, "description": { "const": "Journey orchestration" } } },
                 { "properties": { "name": { "const": "archetype:telemetry" },  "color": { "const": "D4C5F9" }, "description": { "const": "Observability artifacts" } } },
-                { "properties": { "name": { "const": "archetype:migrations" }, "color": { "const": "D4C5F9" }, "description": { "const": "Database schema evolution" } } }
+                { "properties": { "name": { "const": "archetype:migrations" }, "color": { "const": "D4C5F9" }, "description": { "const": "Database schema evolution" } } },
+                { "properties": { "name": { "const": "archetype:coach" },      "color": { "const": "D4C5F9" }, "description": { "const": "ATDD orchestration and CLI" } } }
               ],
-              "minItems": 9,
-              "maxItems": 9
+              "minItems": 10,
+              "maxItems": 10
             }
           }
         },

--- a/src/atdd/coach/schemas/project_fields.schema.json
+++ b/src/atdd/coach/schemas/project_fields.schema.json
@@ -157,7 +157,7 @@
                 "allowed_values": {
                   "type": "array",
                   "items": { "type": "string" },
-                  "const": ["db", "be", "fe", "contracts", "wmbt", "wagon", "train", "telemetry", "migrations"]
+                  "const": ["db", "be", "fe", "contracts", "wmbt", "wagon", "train", "telemetry", "migrations", "coach"]
                 }
               }
             }

--- a/src/atdd/coach/schemas/session.schema.json
+++ b/src/atdd/coach/schemas/session.schema.json
@@ -64,7 +64,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "enum": ["db", "be", "fe", "contracts", "wmbt", "wagon", "train", "telemetry", "migrations"]
+        "enum": ["db", "be", "fe", "contracts", "wmbt", "wagon", "train", "telemetry", "migrations", "coach"]
       },
       "minItems": 1,
       "uniqueItems": true,

--- a/src/atdd/coach/templates/ATDD-ISSUE-TEMPLATE.md
+++ b/src/atdd/coach/templates/ATDD-ISSUE-TEMPLATE.md
@@ -20,7 +20,7 @@ branch: "{branch-name}"
 type: "{type}"  # implementation | migration | refactor | analysis | planning | cleanup | tracking
 complexity: 3  # 1=Trivial, 2=Low, 3=Medium, 4=High, 5=Very High
 archetypes:
-  - "{archetype}"  # db | be | fe | contracts | wmbt | wagon | train | telemetry | migrations
+  - "{archetype}"  # db | be | fe | contracts | wmbt | wagon | train | telemetry | migrations | coach
   # NOTE: If archetypes includes 'train', you MUST create/update BOTH:
   #   1. plan/_trains.yaml (registry entry with train_id, description, path, wagons)
   #   2. plan/_trains/{train_id}.yaml (full spec with participants, sequence, etc.)

--- a/src/atdd/coach/templates/ATDD.md
+++ b/src/atdd/coach/templates/ATDD.md
@@ -324,6 +324,7 @@ issues:
     train: "Journey orchestration (linear trains)"
     telemetry: "Observability artifacts"
     migrations: "Database schema evolution"
+    coach: "ATDD orchestration, conventions, hooks, validators, CLI"
 
   atdd_phases:
     RED: "Write failing tests from acceptances"

--- a/src/atdd/coach/templates/ATDD.md
+++ b/src/atdd/coach/templates/ATDD.md
@@ -314,6 +314,16 @@ issues:
     close_wmbt: "atdd issue <N> --close-wmbt <ID>  # Close a WMBT sub-issue"
     validate: "atdd validate coach                 # Validate Project fields + sub-issue state"
 
+  # MANDATORY: All issue and PR operations MUST go through the atdd CLI.
+  # NEVER use `gh issue create`, `gh pr create`, or the GitHub web UI directly.
+  # Reason: Direct creation bypasses manifest registration, WMBT sub-issue
+  # generation, Project v2 field setup, and worktree metadata.
+  # The coach validator (`atdd validate coach`) will flag issues that exist
+  # on GitHub but are missing from .atdd/manifest.yaml.
+  prohibited_commands:
+    - "gh issue create    → use: atdd issue <slug>"
+    - "gh pr create       → use: atdd branch <N> (creates worktree + PR-ready branch)"
+
   archetypes:
     db: "Supabase PostgreSQL + JSONB"
     be: "Python FastAPI 4-layer"

--- a/src/atdd/coach/validators/test_issue_validation.py
+++ b/src/atdd/coach/validators/test_issue_validation.py
@@ -16,6 +16,12 @@ E011: Branch naming validator (SPEC-SESSION-VAL-0070):
 - Issues past PLANNED must have a Branch field matching an allowed prefix
 - Branch = worktree (every branch is created as a git worktree)
 
+E012: Manifest consistency validator (SPEC-SESSION-VAL-0080):
+- Every open GitHub issue with atdd-issue label must have a corresponding
+  entry in .atdd/manifest.yaml
+- Detects issues created directly via `gh issue create` or the GitHub UI
+  instead of through `atdd issue <slug>`
+
 Run: atdd validate coach
 """
 import re
@@ -286,3 +292,57 @@ def test_issue_branch_follows_worktree_convention(github_issues):
         f"Example: git worktree add ../feat-my-feature -b feat/my-feature\n\n"
         f"Violations ({len(violations)}):\n  " + "\n  ".join(violations)
     )
+
+
+# ============================================================================
+# E012: Manifest Consistency Validation (GitHub Issues vs .atdd/manifest.yaml)
+# ============================================================================
+
+
+def _load_manifest_issue_numbers():
+    """Load issue numbers registered in .atdd/manifest.yaml."""
+    manifest_file = REPO_ROOT / ".atdd" / "manifest.yaml"
+    if not manifest_file.exists():
+        return set()
+    with open(manifest_file) as f:
+        data = yaml.safe_load(f) or {}
+    return {
+        entry["issue_number"]
+        for entry in data.get("sessions", [])
+        if "issue_number" in entry
+    }
+
+
+def test_github_issues_registered_in_manifest(github_issues):
+    """
+    SPEC-SESSION-VAL-0080: GitHub issues must have manifest entries
+
+    Given: Open issues on GitHub with the atdd-issue label
+    When: Cross-referencing against .atdd/manifest.yaml sessions
+    Then: Every issue number must appear in the manifest
+
+    E012 acceptance criteria: `atdd validate coach` warns when an issue
+    exists on GitHub but was not created through `atdd issue <slug>`.
+    This catches direct `gh issue create` or GitHub UI usage that bypasses
+    manifest registration, WMBT sub-issue generation, and Project v2 setup.
+    """
+    manifest_numbers = _load_manifest_issue_numbers()
+
+    unregistered = []
+    for issue in github_issues:
+        num = issue["number"]
+        if num not in manifest_numbers:
+            title = issue.get("title", "(no title)")
+            unregistered.append(f"#{num}: {title}")
+
+    if unregistered:
+        w.warn(
+            f"Issues on GitHub missing from .atdd/manifest.yaml "
+            f"({len(unregistered)}):\n  "
+            + "\n  ".join(unregistered)
+            + "\n\nThese issues were likely created outside `atdd issue <slug>`."
+            + "\nFix: Re-create via `atdd issue <slug>` or register manually"
+            + " in .atdd/manifest.yaml.",
+            category=UserWarning,
+            stacklevel=1,
+        )


### PR DESCRIPTION
## Summary

- Adds `coach` as a first-class archetype so toolkit self-work (issue lifecycle, hooks, validators, schemas, CLI) no longer borrows `archetype:be`
- Updates all 8 archetype-aware files: convention, label taxonomy, project fields schema, session schema, ARCHETYPE_GATES, templates, and CLAUDE.md (via sync)
- Defines coach-specific default gates (GT-090, GT-091) targeting `atdd validate coach` validators

Closes #176

## Merge Order

**#176** → #174 → #175 → #177 → #173

## Files Changed

| File | Change |
|------|--------|
| `issue.convention.yaml` | Coach archetype definition, static label, gate values, required_by_archetype |
| `label_taxonomy.schema.json` | `archetype:coach` label entry, min/maxItems 9 → 10 |
| `project_fields.schema.json` | `"coach"` in archetypes const array |
| `session.schema.json` | `"coach"` in archetypes enum array |
| `issue.py` | GT-090/GT-091 in `ARCHETYPE_GATES` |
| `ATDD.md` / `ATDD-ISSUE-TEMPLATE.md` | Coach in archetype docs |
| `CLAUDE.md` | Auto-synced from ATDD.md |

## Test plan

- [x] `ARCHETYPE_GATES["coach"]` returns GT-090/GT-091 entries
- [x] `label_taxonomy.schema.json` has 10 archetype labels (minItems/maxItems = 10)
- [x] `project_fields.schema.json` includes `"coach"` in const array
- [x] `session.schema.json` includes `"coach"` in enum array
- [ ] `atdd validate coach` passes after merge
- [ ] `atdd init` creates `archetype:coach` label on GitHub