### PR TITLE
chore(coach): align after_coder guidance to SMOKE transition (#174)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -400,7 +400,7 @@ audits:
   workflow:
     after_planner: "atdd validate planner   # Before transitioning to RED"
     after_tester: "atdd validate tester     # Before transitioning to GREEN"
-    after_coder: "atdd validate coder       # Before transitioning to REFACTOR"
+    after_coder: "atdd validate coder       # Before transitioning to SMOKE"
     after_coach: "atdd validate coach       # Train + body section enforcement"
     full_suite: "atdd validate              # All phases (CI runs this)"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.25.2"
+version = "1.25.3"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/issue_lifecycle.py
+++ b/src/atdd/coach/commands/issue_lifecycle.py
@@ -286,6 +286,9 @@ class IssueLifecycle:
             print("  Next: Implement to make tests pass (GREEN), then transition:")
             print(f"         atdd issue {number} --status GREEN")
         elif status == "GREEN":
+            print("  Next: Run tester SMOKE verification, then transition:")
+            print(f"         atdd issue {number} --status SMOKE")
+        elif status == "SMOKE":
             print("  Next: Refactor to clean architecture, then transition:")
             print(f"         atdd issue {number} --status REFACTOR")
         elif status == "REFACTOR":

--- a/src/atdd/coach/commands/tests/test_issue_lifecycle.py
+++ b/src/atdd/coach/commands/tests/test_issue_lifecycle.py
@@ -1,0 +1,47 @@
+"""
+Regression tests for issue lifecycle next-step guidance.
+
+Purpose:
+  Ensure the lifecycle helper keeps the canonical ATDD transition
+  sequence GREEN -> SMOKE -> REFACTOR.
+"""
+
+from pathlib import Path
+
+from atdd.coach.commands.issue_lifecycle import IssueLifecycle
+
+
+def _print_context_for_status(status: str, capsys) -> str:
+    lifecycle = IssueLifecycle(target_dir=Path.cwd())
+    issue = {"number": 174, "title": "Workflow consistency", "state": "OPEN"}
+
+    lifecycle._print_context(
+        issue=issue,
+        status=status,
+        sub_issues=[],
+        slug="smoke-workflow-consistency",
+        prefix="chore",
+        worktree_path=None,
+    )
+
+    return capsys.readouterr().out
+
+
+def test_green_status_points_to_smoke(capsys):
+    """
+    SPEC-COACH-WORKFLOW-0001: GREEN helper output points to SMOKE.
+    """
+    output = _print_context_for_status("GREEN", capsys)
+
+    assert "Run tester SMOKE verification" in output
+    assert "atdd issue 174 --status SMOKE" in output
+
+
+def test_smoke_status_points_to_refactor(capsys):
+    """
+    SPEC-COACH-WORKFLOW-0002: SMOKE helper output points to REFACTOR.
+    """
+    output = _print_context_for_status("SMOKE", capsys)
+
+    assert "Refactor to clean architecture" in output
+    assert "atdd issue 174 --status REFACTOR" in output

--- a/src/atdd/coach/conventions/issue.convention.yaml
+++ b/src/atdd/coach/conventions/issue.convention.yaml
@@ -158,7 +158,7 @@ workflow:
   session_type_workflows:
     implementation:
       required_phases: ["planner", "tester", "coder"]
-      workflow: "Full ATDD cycle: Plan → Test (RED) → Code (GREEN) → Refactor"
+      workflow: "Full ATDD cycle: Plan → Test (RED) → Code (GREEN) → Test (SMOKE) → Refactor"
 
     migration:
       required_phases: ["planner", "tester", "coder"]

--- a/src/atdd/coach/templates/ATDD.md
+++ b/src/atdd/coach/templates/ATDD.md
@@ -103,7 +103,7 @@ audits:
   workflow:
     after_planner: "atdd validate planner   # Before transitioning to RED"
     after_tester: "atdd validate tester     # Before transitioning to GREEN"
-    after_coder: "atdd validate coder       # Before transitioning to REFACTOR"
+    after_coder: "atdd validate coder       # Before transitioning to SMOKE"
     after_coach: "atdd validate coach       # Train + body section enforcement"
     full_suite: "atdd validate              # All phases (CI runs this)"
 

--- a/src/atdd/coach/validators/test_workflow_consistency.py
+++ b/src/atdd/coach/validators/test_workflow_consistency.py
@@ -1,0 +1,47 @@
+"""
+Workflow consistency checks for ATDD guidance documents.
+
+Purpose:
+  Keep the authoritative workflow docs aligned with the enforced
+  state machine: GREEN -> SMOKE -> REFACTOR.
+
+Run: atdd validate coach --local
+"""
+
+from pathlib import Path
+
+import yaml
+
+from atdd.coach.utils.repo import find_repo_root
+
+REPO_ROOT = find_repo_root()
+ISSUE_CONVENTION = REPO_ROOT / "src" / "atdd" / "coach" / "conventions" / "issue.convention.yaml"
+ATDD_TEMPLATE = REPO_ROOT / "src" / "atdd" / "coach" / "templates" / "ATDD.md"
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+
+
+def test_issue_convention_workflow_includes_smoke():
+    """
+    SPEC-COACH-WORKFLOW-0003: implementation workflow summary includes SMOKE.
+    """
+    with ISSUE_CONVENTION.open() as f:
+        convention = yaml.safe_load(f) or {}
+
+    workflow = convention["workflow"]["session_type_workflows"]["implementation"]["workflow"]
+    assert workflow == "Full ATDD cycle: Plan \u2192 Test (RED) \u2192 Code (GREEN) \u2192 Test (SMOKE) \u2192 Refactor"
+
+
+def test_atdd_template_after_coder_points_to_smoke():
+    """
+    SPEC-COACH-WORKFLOW-0004: ATDD template guidance points coder validation to SMOKE.
+    """
+    content = ATDD_TEMPLATE.read_text()
+    assert 'after_coder: "atdd validate coder       # Before transitioning to SMOKE"' in content
+
+
+def test_claude_after_coder_points_to_smoke():
+    """
+    SPEC-COACH-WORKFLOW-0005: CLAUDE guidance mirrors the SMOKE transition.
+    """
+    content = CLAUDE_MD.read_text()
+    assert 'after_coder: "atdd validate coder       # Before transitioning to SMOKE"' in content


### PR DESCRIPTION
## Summary
- Update `after_coder` workflow comment in CLAUDE.md and ATDD.md template from REFACTOR → SMOKE
- Update implementation workflow description in `issue.convention.yaml` to include SMOKE step
- Add SMOKE transition step in `issue_lifecycle.py` CLI guidance (GREEN → SMOKE → REFACTOR)
- Add 5 regression tests (SPEC-COACH-WORKFLOW-0001–0005) locking the workflow sequence

## Test plan
- [x] `pytest src/atdd/coach/commands/tests/test_issue_lifecycle.py` — 2 passed
- [x] `pytest src/atdd/coach/validators/test_workflow_consistency.py` — 3 passed

Closes #174