### PR TITLE
fix(ci): always publish to PyPI regardless of tag origin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,13 +65,11 @@ jobs:
           fi
 
       - name: Build package
-        if: env.CREATED == 'true'
         run: |
           python -m pip install -U build
           python -m build
 
       - name: Publish to PyPI
-        if: env.CREATED == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.26.0"
+version = "1.26.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Remove `CREATED == 'true'` guard from Build and Publish to PyPI steps
- `skip-existing: true` already handles idempotency on PyPI side
- GitHub Release creation remains gated (would fail on duplicates)
- Fixes: manual tag push before workflow run caused PyPI upload to be skipped entirely

## Test plan
- [x] Verify `skip-existing: true` is set on pypa/gh-action-pypi-publish
- [x] GitHub Release step still gated on `CREATED == 'true'`
- [ ] After merge: trigger `workflow_dispatch` to publish v1.26.0 to PyPI