### PR TITLE
fix(coder): allow domain/ports/ in conventions — align with Hexagonal Architecture

### DIFF
--- a/src/atdd/coder/conventions/backend.convention.yaml
+++ b/src/atdd/coder/conventions/backend.convention.yaml
@@ -118,6 +118,14 @@ backend:
             python: "protocols.py, *_port.py"
             typescript: "*-port.ts, *-interface.ts"
             dart: "*_port.dart"
+          allowed_layers: [domain, application]
+          forbidden_layers: [integration, presentation]
+          preferred_layer: domain
+          rationale: |
+            Hexagonal Architecture (Ports & Adapters) places ports at the domain boundary.
+            Onion Architecture historically placed them in application, but modern consensus
+            (Alistair Cockburn, Vaughn Vernon) treats ports as domain contracts that adapters
+            implement. Both domain/ports/ and application/ports/ are valid; domain/ is preferred.
           examples:
             - "Repository interfaces"
             - "External service interfaces"

--- a/src/atdd/coder/conventions/frontend.convention.yaml
+++ b/src/atdd/coder/conventions/frontend.convention.yaml
@@ -160,6 +160,9 @@ frontend:
           suffix:
             dart: "*_port.dart"
             typescript: "*-port.ts, *-interface.ts"
+          allowed_layers: [domain, application]
+          forbidden_layers: [integration, presentation]
+          preferred_layer: domain
           examples:
             - "Repository interfaces"
             - "API client interfaces"
@@ -409,7 +412,7 @@ frontend:
       layer_mapping:
         presentation: ["pages", "components", "hooks", "styles"]
         application: ["use-cases", "hooks", "ports", "context"]
-        domain: ["entities", "value-objects", "services", "types", "constants"]
+        domain: ["entities", "value-objects", "services", "types", "constants", "ports"]
         integration: ["api", "repositories", "mappers", "adapters", "stores"]
       import_restrictions:
         domain:

--- a/src/atdd/coder/validators/test_import_boundaries.py
+++ b/src/atdd/coder/validators/test_import_boundaries.py
@@ -348,13 +348,15 @@ def test_imports_follow_layer_boundaries():
         # Determine this module's layer
         if '/domain/' in module_path:
             current_layer = 'domain'
+            # Domain files can import from domain (including domain/ports/)
             allowed_layers = ['domain']
         elif '/application/' in module_path:
             current_layer = 'application'
             allowed_layers = ['domain', 'application']
         elif '/integration/' in module_path or '/infrastructure/' in module_path:
             current_layer = 'integration'
-            allowed_layers = ['domain', 'integration', 'infrastructure']
+            # Integration implements ports (from domain or application) and uses domain types
+            allowed_layers = ['domain', 'application', 'integration', 'infrastructure']
         elif '/presentation/' in module_path:
             current_layer = 'presentation'
             allowed_layers = ['domain', 'application', 'presentation']

--- a/src/atdd/coder/validators/test_python_architecture.py
+++ b/src/atdd/coder/validators/test_python_architecture.py
@@ -114,16 +114,24 @@ def infer_layer_from_import(import_path: str) -> str:
 
     # Check if it's a relative import - can't determine layer reliably
     if import_path.startswith('.'):
-        # Exception: relative imports to 'ports' are application layer
-        if 'ports' in import_lower or '_port' in import_lower:
+        # Relative imports with explicit layer path segments
+        if '.domain.' in import_lower or '/domain/' in import_lower:
+            return 'domain'
+        if '.application.' in import_lower or '/application/' in import_lower:
             return 'application'
         return 'unknown'
 
     # Check for layer indicators in import path (order matters - more specific first)
 
-    # Ports are in application layer (interfaces), not integration
+    # Ports can live in domain or application (Hexagonal Architecture)
+    # Resolve from actual path segment, not keyword alone
     if 'ports' in import_lower or '_port' in import_lower:
-        return 'application'
+        if '.domain.' in import_lower or '/domain/' in import_lower:
+            return 'domain'
+        if '.application.' in import_lower or '/application/' in import_lower:
+            return 'application'
+        # Default: treat as domain (preferred per convention)
+        return 'domain'
 
     # Domain layer
     if '.domain.' in import_lower or '/domain/' in import_lower:
@@ -502,7 +510,7 @@ def test_python_component_naming_follows_conventions():
         'monitors': ['domain', 'application', 'integration'],  # Domain: business state, Integration: infra
         'services': ['domain', 'application'],  # Domain services (logic) and Application services (orchestration)
         'handlers': ['application', 'domain'],  # Application: CQRS, Domain: domain event handlers
-        'ports': ['application', 'integration'],  # Application defines ports, Integration can have internal ports
+        'ports': ['domain', 'application'],  # Hexagonal: domain defines ports, application also valid (Onion style)
         'engines': ['integration', 'domain'],  # Integration: external, Domain: pure computation
         'formatters': ['integration', 'domain'],  # Integration: output, Domain: value formatting
     }


### PR DESCRIPTION
Closes #189

## Summary
- Update `backend.convention.yaml` and `frontend.convention.yaml` to allow `domain` as valid layer for ports (Hexagonal Architecture)
- Fix 3 hardcoded port-to-application assumptions in `test_python_architecture.py` and `test_import_boundaries.py`
- Eliminates 55+ false positives from validators on every `atdd validate coder` run

## Changes
- **Convention**: ports `allowed_layers: [domain, application]`, `preferred_layer: domain`, `forbidden_layers: [integration, presentation]`
- **`infer_layer_from_import()`**: resolves port layer from file path segments instead of keyword matching
- **`FLEXIBLE_LAYERS`**: ports now `['domain', 'application']`
- **Import boundaries**: integration layer can import from application (to reach application/ports/)

## Test plan
- [x] `test_python_architecture.py` — 4 tests pass/expected-skip
- [x] `test_import_boundaries.py` — 2 pass, 2 expected-skip
- [x] YAML syntax valid for both conventions
- [ ] Run `atdd validate coder --local` against jel-app to confirm 55+ false positives eliminated
- [ ] Verify real boundary violations still caught (domain importing application use cases)