### PR TITLE
feat(coder): ratchet pattern for coder validators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.28.0"
+version = "1.29.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -643,6 +643,45 @@ Phase descriptions:
         help="Skip confirmation prompts"
     )
 
+    # ----- atdd baseline {update,show} -----
+    baseline_parser = subparsers.add_parser(
+        "baseline",
+        help="Manage ratchet baselines for coder validators",
+        description="View and update violation count baselines (.atdd/baselines/coder.yaml)"
+    )
+    baseline_subparsers = baseline_parser.add_subparsers(
+        dest="baseline_command",
+        help="Baseline commands"
+    )
+
+    # atdd baseline update
+    baseline_update_parser = baseline_subparsers.add_parser(
+        "update",
+        help="Run validators and write current violation counts to baseline file"
+    )
+    baseline_update_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Show what would be written without modifying the baseline file"
+    )
+    baseline_update_parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Show per-validator violation details"
+    )
+
+    # atdd baseline show
+    baseline_show_parser = baseline_subparsers.add_parser(
+        "show",
+        help="Display baseline vs current violation counts"
+    )
+    baseline_show_parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Include per-validator detail"
+    )
+
     # ----- atdd urn {graph,orphans,broken,validate,resolve,declarations,viz} -----
     urn_parser = subparsers.add_parser(
         "urn",
@@ -1136,6 +1175,23 @@ Phase descriptions:
     elif args.command == "upgrade":
         upgrader = Upgrader()
         return upgrader.run(yes=args.yes)
+
+    # atdd baseline {update,show}
+    elif args.command == "baseline":
+        from atdd.coach.commands.baseline import BaselineCommand
+        repo_path = Path(args.repo) if hasattr(args, 'repo') and args.repo else None
+        cmd = BaselineCommand(repo_root=repo_path)
+
+        if args.baseline_command == "update":
+            return cmd.update(
+                dry_run=args.dry_run,
+                verbose=args.verbose,
+            )
+        elif args.baseline_command == "show":
+            return cmd.show(verbose=args.verbose)
+        else:
+            baseline_parser.print_help()
+            return 0
 
     # atdd urn {graph,orphans,broken,validate,resolve,declarations,families,viz}
     elif args.command == "urn":

--- a/src/atdd/coach/commands/baseline.py
+++ b/src/atdd/coach/commands/baseline.py
@@ -1,0 +1,174 @@
+"""
+Baseline CLI Command
+====================
+Provides ``atdd baseline update`` and ``atdd baseline show`` for managing
+ratchet baselines used by coder validators.
+
+Baseline file: ``.atdd/baselines/coder.yaml`` in the TARGET repo.
+
+Usage::
+
+    atdd baseline update              # Record current violation counts
+    atdd baseline update --dry-run    # Show what would be written
+    atdd baseline show                # Compare baseline vs current
+    atdd baseline show --verbose      # Include per-validator detail
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coder.baselines.ratchet import RatchetBaseline, default_baseline_path
+
+
+# ---------------------------------------------------------------------------
+# Validator registry
+# ---------------------------------------------------------------------------
+# Each entry maps a validator_id to a callable that accepts (repo_root) and
+# returns (violation_count, violations_list).  Validators register here when
+# they are retrofitted to the ratchet pattern (Phase 3).
+#
+# Import paths are deferred (inside the callable) to avoid import-time
+# failures when the target repo has no Python/TS tree to scan.
+# ---------------------------------------------------------------------------
+
+ValidatorFn = Callable[[Path], Tuple[int, Sequence]]
+
+
+def _composition_python(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_composition_completeness import (
+        analyze_python_repo,
+    )
+    violations = analyze_python_repo(repo_root)
+    return len(violations), violations
+
+
+def _composition_typescript(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_composition_completeness import (
+        analyze_typescript_repo,
+    )
+    violations = analyze_typescript_repo(repo_root)
+    return len(violations), violations
+
+
+VALIDATORS: Dict[str, ValidatorFn] = {
+    "composition_completeness_python": _composition_python,
+    "composition_completeness_typescript": _composition_typescript,
+}
+
+
+# ---------------------------------------------------------------------------
+# Command
+# ---------------------------------------------------------------------------
+
+class BaselineCommand:
+    """CLI command handler for ``atdd baseline {update,show}``."""
+
+    def __init__(self, repo_root: Optional[Path] = None) -> None:
+        self.repo_root = repo_root or find_repo_root()
+        self.baseline = RatchetBaseline(
+            default_baseline_path(self.repo_root),
+        )
+
+    # ---------------------------------------------------------------
+    # atdd baseline update
+    # ---------------------------------------------------------------
+
+    def update(
+        self,
+        dry_run: bool = False,
+        verbose: bool = False,
+    ) -> int:
+        """Run all registered validators and write current counts."""
+        results: Dict[str, int] = {}
+        errors: List[str] = []
+
+        print(f"Scanning {self.repo_root} ...\n")
+
+        for vid, fn in sorted(VALIDATORS.items()):
+            try:
+                count, violations = fn(self.repo_root)
+                results[vid] = count
+                symbol = "✓" if count == 0 else f"▸ {count}"
+                print(f"  {vid}: {symbol}")
+                if verbose and violations:
+                    for v in violations[:5]:
+                        print(f"      {v}")
+                    if len(violations) > 5:
+                        print(f"      ... and {len(violations) - 5} more")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"  {vid}: ERROR — {exc}")
+                print(f"  {vid}: ERROR — {exc}")
+
+        print()
+
+        if errors:
+            print("Errors encountered (baselines NOT updated):")
+            for e in errors:
+                print(e)
+            return 1
+
+        if dry_run:
+            print("Dry-run — would write:\n")
+            for vid, count in sorted(results.items()):
+                print(f"  {vid}: {count}")
+            print(f"\nTo: {self.baseline.path}")
+            return 0
+
+        self.baseline.update(results)
+        print(f"Baseline written to {self.baseline.path}")
+        return 0
+
+    # ---------------------------------------------------------------
+    # atdd baseline show
+    # ---------------------------------------------------------------
+
+    def show(self, verbose: bool = False) -> int:
+        """Display baseline vs current violation counts."""
+        if not self.baseline.exists:
+            print(
+                f"No baseline file found at {self.baseline.path}\n\n"
+                f"Run `atdd baseline update` to create one."
+            )
+            return 0
+
+        results: Dict[str, int] = {}
+        errors: List[str] = []
+
+        print(f"Scanning {self.repo_root} ...\n")
+
+        for vid, fn in sorted(VALIDATORS.items()):
+            try:
+                count, _ = fn(self.repo_root)
+                results[vid] = count
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"  {vid}: ERROR — {exc}")
+
+        rows = self.baseline.show(results)
+
+        # Header
+        fmt = "{:<45} {:>10} {:>10} {:>8}  {}"
+        print(fmt.format("Validator", "Baseline", "Current", "Delta", "Status"))
+        print("-" * 90)
+
+        for row in rows:
+            delta_str = f"{row['delta']:+d}" if row["delta"] != 0 else "0"
+            print(
+                fmt.format(
+                    row["validator"],
+                    row["baseline"],
+                    row["current"],
+                    delta_str,
+                    row["status"],
+                )
+            )
+
+        if errors:
+            print(f"\nErrors ({len(errors)}):")
+            for e in errors:
+                print(e)
+
+        return 0

--- a/src/atdd/coder/baselines/__init__.py
+++ b/src/atdd/coder/baselines/__init__.py
@@ -1,0 +1,7 @@
+"""
+Ratchet baseline infrastructure for coder validators.
+
+Allows validators to ship with a baseline violation count so that
+pre-existing debt does not block adoption.  The ratchet ensures
+violation counts can only decrease, never increase.
+"""

--- a/src/atdd/coder/baselines/ratchet.py
+++ b/src/atdd/coder/baselines/ratchet.py
@@ -1,0 +1,235 @@
+"""
+Ratchet baseline — load, compare, and assert violation counts.
+
+Baseline file format (.atdd/baselines/coder.yaml in the TARGET repo):
+
+    composition_completeness_python: 198
+    composition_completeness_typescript: 47
+    domain_layer_purity: 1
+
+Each key is a validator_id.  The value is the maximum allowed violation
+count.  Validators at 0 need no entry.
+
+SPEC-CODER-RATCHET-0001: Violation count must not exceed baseline.
+SPEC-CODER-RATCHET-0002: Baseline file must exist for ratcheted validators.
+SPEC-CODER-RATCHET-0003: `atdd baseline update` writes current counts atomically.
+SPEC-CODER-RATCHET-0004: Improvement below baseline produces PASS with advisory.
+SPEC-CODER-RATCHET-0005: Validator at 0 violations needs no baseline entry.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import pytest
+import yaml
+
+
+def default_baseline_path(repo_root: Path) -> Path:
+    """Return the canonical baseline file path for a repo."""
+    return repo_root / ".atdd" / "baselines" / "coder.yaml"
+
+
+class RatchetBaseline:
+    """
+    Load, compare, and enforce ratchet baselines for coder validators.
+
+    Usage in a test::
+
+        def test_my_validator(ratchet_baseline):
+            violations = analyze(repo)
+            ratchet_baseline.assert_no_regression(
+                validator_id="my_validator",
+                current_count=len(violations),
+                violations=violations,
+            )
+    """
+
+    def __init__(self, baseline_path: Path) -> None:
+        self._path = baseline_path
+        self._data: Optional[Dict[str, int]] = None
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    @property
+    def exists(self) -> bool:
+        return self._path.is_file()
+
+    # ------------------------------------------------------------------
+    # Load / save
+    # ------------------------------------------------------------------
+
+    def load(self) -> Dict[str, int]:
+        """Read the baseline file.  Returns empty dict if missing."""
+        if self._data is not None:
+            return self._data
+        if not self._path.is_file():
+            self._data = {}
+            return self._data
+        with open(self._path) as fh:
+            raw = yaml.safe_load(fh) or {}
+        self._data = {str(k): int(v) for k, v in raw.items()}
+        return self._data
+
+    def save(self, baselines: Dict[str, int]) -> None:
+        """Atomic write of *baselines* to the YAML file."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        # Write to temp file first, then rename for atomicity.
+        fd, tmp = tempfile.mkstemp(
+            dir=self._path.parent,
+            suffix=".yaml.tmp",
+        )
+        try:
+            with os.fdopen(fd, "w") as fh:
+                yaml.safe_dump(
+                    {k: v for k, v in sorted(baselines.items())},
+                    fh,
+                    default_flow_style=False,
+                    sort_keys=True,
+                )
+            os.replace(tmp, self._path)
+        except BaseException:
+            os.unlink(tmp)
+            raise
+        self._data = dict(baselines)
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def get(self, validator_id: str) -> Optional[int]:
+        """Return the baseline count for *validator_id*, or None."""
+        return self.load().get(validator_id)
+
+    # ------------------------------------------------------------------
+    # Assert
+    # ------------------------------------------------------------------
+
+    def assert_no_regression(
+        self,
+        validator_id: str,
+        current_count: int,
+        violations: Sequence[Any] = (),
+    ) -> None:
+        """
+        Assert that *current_count* does not exceed the baseline.
+
+        Behavior:
+        - No baseline entry → unconditional mode (assert 0 violations).
+        - current > baseline → ``pytest.fail()`` with regression detail.
+        - current < baseline → pass + ``warnings.warn()`` advisory.
+        - current == baseline → pass silently.
+        - current == 0 → pass (clean).
+
+        SPEC-CODER-RATCHET-0001, SPEC-CODER-RATCHET-0004, SPEC-CODER-RATCHET-0005.
+        """
+        baseline = self.get(validator_id)
+
+        # -- No baseline entry: unconditional mode --
+        if baseline is None:
+            if current_count == 0:
+                return
+            msg = (
+                f"\n\nSPEC-CODER-RATCHET-0001 FAIL: {validator_id}\n\n"
+                f"  No baseline entry — unconditional mode.\n"
+                f"  Current: {current_count} violations (expected 0)\n\n"
+                f"  Either fix all violations or add an initial baseline:\n"
+                f"    atdd baseline update\n"
+            )
+            if violations:
+                msg += _format_violations(violations)
+            pytest.fail(msg)
+
+        # -- Clean --
+        if current_count == 0:
+            return
+
+        # -- Regression --
+        if current_count > baseline:
+            delta = current_count - baseline
+            msg = (
+                f"\n\nSPEC-CODER-RATCHET-0001 FAIL: Regression in {validator_id}\n\n"
+                f"  Baseline: {baseline} violations\n"
+                f"  Current:  {current_count} violations\n"
+                f"  Delta:    +{delta} (regression)\n\n"
+                f"  Fix the {delta} new violation(s) before merging.\n"
+            )
+            if violations:
+                msg += _format_violations(violations)
+            pytest.fail(msg)
+
+        # -- Improvement --
+        if current_count < baseline:
+            delta = baseline - current_count
+            warnings.warn(
+                f"\nPASS: {validator_id} improved\n\n"
+                f"  Baseline: {baseline} violations\n"
+                f"  Current:  {current_count} violations\n"
+                f"  Delta:    -{delta} (improvement)\n\n"
+                f"  Run `atdd baseline update` to lock in the improvement.\n",
+                stacklevel=2,
+            )
+            return
+
+        # -- Holding steady --
+        return
+
+    # ------------------------------------------------------------------
+    # Bulk operations (used by CLI)
+    # ------------------------------------------------------------------
+
+    def update(self, results: Dict[str, int]) -> None:
+        """Merge *results* into the baseline and save."""
+        merged = self.load()
+        for vid, count in results.items():
+            if count == 0:
+                merged.pop(vid, None)
+            else:
+                merged[vid] = count
+        self.save(merged)
+
+    def show(self, results: Dict[str, int]) -> List[Dict[str, Any]]:
+        """Return comparison rows: validator, baseline, current, delta, status."""
+        baselines = self.load()
+        all_ids = sorted(set(baselines) | set(results))
+        rows: List[Dict[str, Any]] = []
+        for vid in all_ids:
+            bl = baselines.get(vid, 0)
+            cur = results.get(vid, 0)
+            delta = cur - bl
+            if delta > 0:
+                status = "REGRESSION"
+            elif delta < 0:
+                status = "IMPROVED"
+            elif cur == 0:
+                status = "CLEAN"
+            else:
+                status = "HOLDING"
+            rows.append({
+                "validator": vid,
+                "baseline": bl,
+                "current": cur,
+                "delta": delta,
+                "status": status,
+            })
+        return rows
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+def _format_violations(violations: Sequence[Any], limit: int = 10) -> str:
+    """Format a sample of violations for the failure message."""
+    lines = []
+    for v in violations[:limit]:
+        lines.append(f"    {v}")
+    if len(violations) > limit:
+        lines.append(f"    ... and {len(violations) - limit} more")
+    return "\n  Violations:\n" + "\n".join(lines) + "\n"

--- a/src/atdd/coder/validators/conftest.py
+++ b/src/atdd/coder/validators/conftest.py
@@ -2,4 +2,30 @@
 Shared fixtures for coder tests.
 """
 # Import all shared fixtures from coach via absolute import
-from atdd.coach.validators.shared_fixtures import *
+from atdd.coach.validators.shared_fixtures import *  # noqa: F401,F403
+
+import pytest
+from pathlib import Path
+
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coder.baselines.ratchet import RatchetBaseline, default_baseline_path
+
+
+@pytest.fixture(scope="module")
+def ratchet_baseline() -> RatchetBaseline:
+    """
+    Ratchet baseline fixture for coder validators.
+
+    Loads ``.atdd/baselines/coder.yaml`` from the target repo.
+    Validators use it to assert that violation counts do not regress::
+
+        def test_my_validator(ratchet_baseline):
+            violations = analyze(repo)
+            ratchet_baseline.assert_no_regression(
+                validator_id="my_validator",
+                current_count=len(violations),
+                violations=violations,
+            )
+    """
+    repo_root = find_repo_root()
+    return RatchetBaseline(default_baseline_path(repo_root))


### PR DESCRIPTION
Closes #190

## Summary
- Add `RatchetBaseline` class for incremental validator adoption against repos with pre-existing debt
- Validators pass if violations ≤ baseline, fail on regression, advise on improvement
- Add `atdd baseline update` and `atdd baseline show` CLI commands
- Add `ratchet_baseline` pytest fixture for validator tests

## Changes
- `src/atdd/coder/baselines/ratchet.py` — load/save/compare logic for `.atdd/baselines/coder.yaml`
- `src/atdd/coder/baselines/__init__.py` — module exports
- `src/atdd/coach/commands/baseline.py` — CLI handler for update and show subcommands
- `src/atdd/cli.py` — register baseline command (+56 lines)
- `src/atdd/coder/validators/conftest.py` — `ratchet_baseline` pytest fixture (+28 lines)

## Test plan
- [x] `atdd baseline --help` renders correctly
- [x] `atdd baseline update --dry-run` runs validators and shows output
- [x] `atdd baseline show` handles missing baseline gracefully
- [x] 136 coder validators: 52 pass / 84 skip / 0 fail — no regressions
- [ ] End-to-end: run `atdd baseline update` against jel-app, commit baseline, verify `atdd validate coder` passes
- [ ] Phase 3: retrofit existing validators to use ratchet (follow-up)