### PR TITLE
fix(coach): improve pre-commit hook feedback for AI agents

### DIFF
--- a/.atdd/hooks/pre-commit
+++ b/.atdd/hooks/pre-commit
@@ -21,11 +21,19 @@ case "$BRANCH" in
         fi
         cat >&2 <<EOF
 
-ATDD: All direct commits to $BRANCH are blocked.
+ATDD: Commit blocked — you are on $BRANCH.
 
-Every change must go through a worktree branch.
-Create one first:
+NEVER edit files directly on $BRANCH.
+Always create a worktree branch FIRST, before making any changes:
+
   atdd branch <issue-number>
+
+If you already have uncommitted changes, recover them:
+
+  git stash
+  atdd branch <issue-number>
+  cd ../<worktree-dir>
+  git stash pop
 
 CI bypass (requires CI=true):
   CI=true ATDD_ALLOW_MAIN_COMMIT=1 git commit ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.40.0"
+version = "1.40.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/templates/hooks/pre-commit
+++ b/src/atdd/coach/templates/hooks/pre-commit
@@ -21,11 +21,19 @@ case "$BRANCH" in
         fi
         cat >&2 <<EOF
 
-ATDD: All direct commits to $BRANCH are blocked.
+ATDD: Commit blocked — you are on $BRANCH.
 
-Every change must go through a worktree branch.
-Create one first:
+NEVER edit files directly on $BRANCH.
+Always create a worktree branch FIRST, before making any changes:
+
   atdd branch <issue-number>
+
+If you already have uncommitted changes, recover them:
+
+  git stash
+  atdd branch <issue-number>
+  cd ../<worktree-dir>
+  git stash pop
 
 CI bypass (requires CI=true):
   CI=true ATDD_ALLOW_MAIN_COMMIT=1 git commit ...


### PR DESCRIPTION
## Summary
- Rewrites the pre-commit hook's main-branch block message to explicitly state **NEVER edit files on main** and to create a worktree **FIRST**
- Adds stash-based recovery steps (`git stash` → `atdd branch` → `cd` → `git stash pop`) so uncommitted work is not lost
- CI bypass (`CI=true ATDD_ALLOW_MAIN_COMMIT=1`) remains unchanged
- PreToolUse agent-level guard is out of scope (per review comment on #224)

Closes #224

## Test plan
- [ ] Run `atdd init` in a fresh repo, verify the installed pre-commit hook contains the updated message
- [ ] Attempt a commit on main, confirm the new message appears with stash recovery steps
- [ ] Verify CI bypass still works with `CI=true ATDD_ALLOW_MAIN_COMMIT=1`