### PR TITLE
fix(tester): enforce train E2E and smoke gates with ratchet (#220)

### DIFF
--- a/.atdd/config.yaml
+++ b/.atdd/config.yaml
@@ -12,7 +12,7 @@ coverage:
     features_without_implementation:
     - feature:self-compliance-migration:bootstrap-compliance
 toolkit:
-  last_version: 1.41.0
+  last_version: 1.43.0
 github:
   repo: afokapu/atdd
   project_number: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.43.1"
+version = "1.44.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/baseline.py
+++ b/src/atdd/coach/commands/baseline.py
@@ -2,9 +2,11 @@
 Baseline CLI Command
 ====================
 Provides ``atdd baseline update`` and ``atdd baseline show`` for managing
-ratchet baselines used by coder validators.
+ratchet baselines used by coder and tester validators.
 
-Baseline file: ``.atdd/baselines/coder.yaml`` in the TARGET repo.
+Baseline files:
+- ``.atdd/baselines/coder.yaml`` — coder validators
+- ``.atdd/baselines/tester.yaml`` — tester validators
 
 Usage::
 
@@ -22,6 +24,7 @@ from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from atdd.coach.utils.repo import find_repo_root
 from atdd.coder.baselines.ratchet import RatchetBaseline, default_baseline_path
+from atdd.tester.validators.conftest import tester_baseline_path
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +162,65 @@ VALIDATORS: Dict[str, ValidatorFn] = {
 
 
 # ---------------------------------------------------------------------------
+# Tester validator registry
+# ---------------------------------------------------------------------------
+
+
+def _smoke_coverage_gaps(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.tester.validators.test_smoke_coverage import (
+        CoverageAnalyzer,
+    )
+    e2e_dir = repo_root / "e2e"
+    analyzer = CoverageAnalyzer(e2e_dir)
+    trains, gaps, _, _ = analyzer.analyze()
+    violations = [
+        f"{g.train_id}: {len(g.contract_tests)} contract test(s), 0 smoke tests"
+        for g in gaps
+    ]
+    return len(violations), violations
+
+
+def _train_e2e_existence(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.tester.validators.test_train_e2e_existence import (
+        E2EExistenceAnalyzer,
+    )
+    e2e_dir = repo_root / "e2e"
+    trains_file = repo_root / "plan" / "_trains.yaml"
+    analyzer = E2EExistenceAnalyzer(e2e_dir, trains_file)
+    statuses = analyzer.analyze()
+    violations = [
+        f"{s.train_id}: no E2E tests in e2e/{s.train_id}/"
+        for s in statuses
+        if not s.has_tests
+    ]
+    return len(violations), violations
+
+
+def _train_completeness(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.tester.validators.test_train_completeness import (
+        CompletenessAnalyzer,
+    )
+    e2e_dir = repo_root / "e2e"
+    trains_file = repo_root / "plan" / "_trains.yaml"
+    analyzer = CompletenessAnalyzer(e2e_dir, trains_file)
+    statuses = analyzer.analyze()
+    incomplete = [s for s in statuses if not s.complete]
+    violations = [
+        f"{s.train_id}: {s.status_label} "
+        f"(e2e={s.e2e_count}, contract={s.contract_count}, smoke={s.smoke_count})"
+        for s in incomplete
+    ]
+    return len(violations), violations
+
+
+TESTER_VALIDATORS: Dict[str, ValidatorFn] = {
+    "smoke_coverage_gaps": _smoke_coverage_gaps,
+    "train_e2e_existence": _train_e2e_existence,
+    "train_completeness": _train_completeness,
+}
+
+
+# ---------------------------------------------------------------------------
 # Command
 # ---------------------------------------------------------------------------
 
@@ -170,10 +232,41 @@ class BaselineCommand:
         self.baseline = RatchetBaseline(
             default_baseline_path(self.repo_root),
         )
+        self.tester_baseline = RatchetBaseline(
+            tester_baseline_path(self.repo_root),
+        )
 
     # ---------------------------------------------------------------
     # atdd baseline update
     # ---------------------------------------------------------------
+
+    def _run_validators(
+        self,
+        validators: Dict[str, ValidatorFn],
+        label: str,
+        verbose: bool = False,
+    ) -> Tuple[Dict[str, int], List[str]]:
+        """Run a set of validators and return results + errors."""
+        results: Dict[str, int] = {}
+        errors: List[str] = []
+
+        print(f"  [{label}]")
+        for vid, fn in sorted(validators.items()):
+            try:
+                count, violations = fn(self.repo_root)
+                results[vid] = count
+                symbol = "✓" if count == 0 else f"▸ {count}"
+                print(f"    {vid}: {symbol}")
+                if verbose and violations:
+                    for v in violations[:5]:
+                        print(f"        {v}")
+                    if len(violations) > 5:
+                        print(f"        ... and {len(violations) - 5} more")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"    {vid}: ERROR — {exc}")
+                print(f"    {vid}: ERROR — {exc}")
+
+        return results, errors
 
     def update(
         self,
@@ -181,26 +274,16 @@ class BaselineCommand:
         verbose: bool = False,
     ) -> int:
         """Run all registered validators and write current counts."""
-        results: Dict[str, int] = {}
-        errors: List[str] = []
-
         print(f"Scanning {self.repo_root} ...\n")
 
-        for vid, fn in sorted(VALIDATORS.items()):
-            try:
-                count, violations = fn(self.repo_root)
-                results[vid] = count
-                symbol = "✓" if count == 0 else f"▸ {count}"
-                print(f"  {vid}: {symbol}")
-                if verbose and violations:
-                    for v in violations[:5]:
-                        print(f"      {v}")
-                    if len(violations) > 5:
-                        print(f"      ... and {len(violations) - 5} more")
-            except Exception as exc:  # noqa: BLE001
-                errors.append(f"  {vid}: ERROR — {exc}")
-                print(f"  {vid}: ERROR — {exc}")
+        coder_results, coder_errors = self._run_validators(
+            VALIDATORS, "coder", verbose,
+        )
+        tester_results, tester_errors = self._run_validators(
+            TESTER_VALIDATORS, "tester", verbose,
+        )
 
+        errors = coder_errors + tester_errors
         print()
 
         if errors:
@@ -211,44 +294,48 @@ class BaselineCommand:
 
         if dry_run:
             print("Dry-run — would write:\n")
-            for vid, count in sorted(results.items()):
+            for vid, count in sorted(coder_results.items()):
                 print(f"  {vid}: {count}")
-            print(f"\nTo: {self.baseline.path}")
+            print(f"  To: {self.baseline.path}\n")
+            for vid, count in sorted(tester_results.items()):
+                print(f"  {vid}: {count}")
+            print(f"  To: {self.tester_baseline.path}")
             return 0
 
-        self.baseline.update(results)
-        print(f"Baseline written to {self.baseline.path}")
+        self.baseline.update(coder_results)
+        print(f"Coder baseline written to {self.baseline.path}")
+        self.tester_baseline.update(tester_results)
+        print(f"Tester baseline written to {self.tester_baseline.path}")
         return 0
 
     # ---------------------------------------------------------------
     # atdd baseline show
     # ---------------------------------------------------------------
 
-    def show(self, verbose: bool = False) -> int:
-        """Display baseline vs current violation counts."""
-        if not self.baseline.exists:
-            print(
-                f"No baseline file found at {self.baseline.path}\n\n"
-                f"Run `atdd baseline update` to create one."
-            )
-            return 0
-
-        results: Dict[str, int] = {}
+    def _show_scope(
+        self,
+        baseline: RatchetBaseline,
+        validators: Dict[str, ValidatorFn],
+        label: str,
+    ) -> List[str]:
+        """Show baseline vs current for one scope. Returns errors."""
         errors: List[str] = []
+        results: Dict[str, int] = {}
 
-        print(f"Scanning {self.repo_root} ...\n")
-
-        for vid, fn in sorted(VALIDATORS.items()):
+        for vid, fn in sorted(validators.items()):
             try:
                 count, _ = fn(self.repo_root)
                 results[vid] = count
             except Exception as exc:  # noqa: BLE001
                 errors.append(f"  {vid}: ERROR — {exc}")
 
-        rows = self.baseline.show(results)
+        if not baseline.exists and not results:
+            return errors
 
-        # Header
+        rows = baseline.show(results)
+
         fmt = "{:<45} {:>10} {:>10} {:>8}  {}"
+        print(f"\n[{label}] {baseline.path}")
         print(fmt.format("Validator", "Baseline", "Current", "Delta", "Status"))
         print("-" * 90)
 
@@ -263,6 +350,24 @@ class BaselineCommand:
                     row["status"],
                 )
             )
+
+        return errors
+
+    def show(self, verbose: bool = False) -> int:
+        """Display baseline vs current violation counts."""
+        if not self.baseline.exists and not self.tester_baseline.exists:
+            print(
+                f"No baseline files found.\n\n"
+                f"Run `atdd baseline update` to create them."
+            )
+            return 0
+
+        print(f"Scanning {self.repo_root} ...")
+
+        errors = self._show_scope(self.baseline, VALIDATORS, "coder")
+        errors += self._show_scope(
+            self.tester_baseline, TESTER_VALIDATORS, "tester",
+        )
 
         if errors:
             print(f"\nErrors ({len(errors)}):")

--- a/src/atdd/coach/commands/tests/test_E001_cli_characterization.py
+++ b/src/atdd/coach/commands/tests/test_E001_cli_characterization.py
@@ -238,11 +238,11 @@ class TestStatusCommand:
 
         Given: ATDD status command
         When: Running `atdd status`
-        Then: Total line shows 85 files (current validator count)
+        Then: Total line shows 88 files (current validator count)
         """
         result = run_atdd("status")
-        assert "85 files" in result.stdout, (
-            f"status total should show '85 files', got: {result.stdout}"
+        assert "88 files" in result.stdout, (
+            f"status total should show '88 files', got: {result.stdout}"
         )
 
 

--- a/src/atdd/coach/utils/train_spec_phase.py
+++ b/src/atdd/coach/utils/train_spec_phase.py
@@ -36,7 +36,9 @@ class TrainSpecPhase(IntEnum):
 
 
 # Current rollout phase - update this to advance through phases
-CURRENT_PHASE = TrainSpecPhase.WARNINGS_ONLY
+# Graduated from WARNINGS_ONLY per issue #220: enforcement is now the default.
+# Individual validators can still opt into WARNINGS_ONLY during rollout.
+CURRENT_PHASE = TrainSpecPhase.FULL_ENFORCEMENT
 
 
 def should_enforce(validator_phase: TrainSpecPhase) -> bool:

--- a/src/atdd/tester/validators/conftest.py
+++ b/src/atdd/tester/validators/conftest.py
@@ -2,4 +2,35 @@
 Shared fixtures for tester tests.
 """
 # Import all shared fixtures from coach via absolute import
-from atdd.coach.validators.shared_fixtures import *
+from atdd.coach.validators.shared_fixtures import *  # noqa: F401,F403
+
+import pytest
+from pathlib import Path
+
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coder.baselines.ratchet import RatchetBaseline
+
+
+def tester_baseline_path(repo_root: Path) -> Path:
+    """Return the canonical baseline file path for tester validators."""
+    return repo_root / ".atdd" / "baselines" / "tester.yaml"
+
+
+@pytest.fixture(scope="module")
+def ratchet_baseline() -> RatchetBaseline:
+    """
+    Ratchet baseline fixture for tester validators.
+
+    Loads ``.atdd/baselines/tester.yaml`` from the target repo.
+    Validators use it to assert that violation counts do not regress::
+
+        def test_my_validator(ratchet_baseline):
+            violations = analyze(repo)
+            ratchet_baseline.assert_no_regression(
+                validator_id="my_validator",
+                current_count=len(violations),
+                violations=violations,
+            )
+    """
+    repo_root = find_repo_root()
+    return RatchetBaseline(tester_baseline_path(repo_root))

--- a/src/atdd/tester/validators/test_smoke_coverage.py
+++ b/src/atdd/tester/validators/test_smoke_coverage.py
@@ -323,45 +323,35 @@ def test_smoke_tests_have_correct_headers():
 
 
 @pytest.mark.tester
-def test_smoke_coverage_gaps():
-    """Trains with contract-level journey tests should have smoke tests.
-    Trains defined in plan/_trains.yaml should have e2e directories.
+def test_smoke_coverage_gaps(ratchet_baseline):
+    """Trains with contract-level journey tests must have smoke tests.
 
     Convention: smoke.convention.yaml > coverage > rule
     Rationale: Contract tests validate schema/sequencing but miss real infra bugs.
-    Severity: WARNING — not all trains need smoke tests immediately.
+    Severity: ERROR with ratchet — fails on regression, auto-seeds baseline for
+    existing gaps.
 
-    Two warning categories:
-    1. Plan trains with no e2e directory at all (no journey tests, no smoke tests)
-    2. E2e trains with contract tests but no smoke tests
+    Checks trains in e2e/ that have contract tests but no smoke tests.
+    (Plan trains with no e2e directory are checked by test_train_e2e_existence.)
     """
     analyzer = CoverageAnalyzer(E2E_DIR)
     trains, gaps, _, _ = analyzer.analyze()
-    plan_trains = PlanTrainDiscovery(TRAINS_FILE).discover()
 
-    if not trains and not plan_trains:
-        pytest.skip("No trains defined and no e2e/ directory")
+    if not trains:
+        pytest.skip("No e2e/ directory or no trains with tests")
 
-    # Category 1: Plan trains with no e2e coverage at all
-    e2e_train_ids = {t.train_id for t in trains}
-    missing_e2e = [tid for tid in plan_trains if tid not in e2e_train_ids]
+    violations = [
+        f"{g.train_id}: {len(g.contract_tests)} contract test(s), 0 smoke tests"
+        for g in gaps
+    ]
 
-    if missing_e2e:
-        print(
-            f"\n  WARNING: {len(missing_e2e)} train(s) defined in plan/_trains.yaml "
-            f"have no e2e/ directory:\n"
-            + "".join(f"    - {tid}\n" for tid in missing_e2e)
-            + "\n  Every train should have journey tests and smoke tests.\n"
-            "  See: src/atdd/tester/conventions/smoke.convention.yaml"
-        )
-
-    # Category 2: E2e trains with contract tests but no smoke tests
-    if gaps:
+    if violations:
         formatter = ReportFormatter()
         report = formatter.format_coverage(trains, gaps)
         print(report)
-        print(
-            f"\n  INFO: {len(gaps)} train(s) lack smoke tests. "
-            "This is a coverage gap, not a blocking error.\n"
-            "  See: src/atdd/tester/conventions/smoke.convention.yaml"
-        )
+
+    ratchet_baseline.assert_no_regression(
+        validator_id="smoke_coverage_gaps",
+        current_count=len(violations),
+        violations=violations,
+    )

--- a/src/atdd/tester/validators/test_train_completeness.py
+++ b/src/atdd/tester/validators/test_train_completeness.py
@@ -1,0 +1,176 @@
+"""
+Train completeness chain validator.
+
+Validates the full chain per train: train registered -> E2E exists -> smoke exists.
+This is the validator equivalent of ``atdd inventory --trace`` but focused on
+train-level completeness.
+
+Uses ratchet baseline for existing gaps.
+
+Convention: src/atdd/tester/conventions/train.convention.yaml
+Related:    src/atdd/tester/conventions/smoke.convention.yaml
+"""
+
+import pytest
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import List
+
+from atdd.coach.utils.repo import find_repo_root
+from atdd.tester.validators.test_smoke_coverage import PlanTrainDiscovery
+
+
+REPO_ROOT = find_repo_root()
+E2E_DIR = REPO_ROOT / "e2e"
+TRAINS_FILE = REPO_ROOT / "plan" / "_trains.yaml"
+
+
+# ============================================================================
+# LAYER 1: ENTITIES
+# ============================================================================
+
+
+@dataclass
+class TrainChainStatus:
+    """Completeness status for a single train across the full chain."""
+    train_id: str
+    has_e2e: bool = False
+    has_contract_tests: bool = False
+    has_smoke_tests: bool = False
+    e2e_count: int = 0
+    contract_count: int = 0
+    smoke_count: int = 0
+
+    @property
+    def complete(self) -> bool:
+        """Train is complete if it has both E2E and smoke tests."""
+        return self.has_e2e and self.has_smoke_tests
+
+    @property
+    def status_label(self) -> str:
+        if self.complete:
+            return "COMPLETE"
+        if not self.has_e2e:
+            return "NO_E2E"
+        if self.has_contract_tests and not self.has_smoke_tests:
+            return "NO_SMOKE"
+        return "PARTIAL"
+
+
+# ============================================================================
+# LAYER 2: USE CASES
+# ============================================================================
+
+
+class CompletenessAnalyzer:
+    """Analyze the full train -> E2E -> smoke chain for every registered train."""
+
+    def __init__(self, e2e_dir: Path, trains_file: Path):
+        self.e2e_dir = e2e_dir
+        self.plan_discovery = PlanTrainDiscovery(trains_file)
+
+    def analyze(self) -> List[TrainChainStatus]:
+        """Return chain status for every registered train."""
+        train_ids = self.plan_discovery.discover()
+        results = []
+
+        for tid in train_ids:
+            status = TrainChainStatus(train_id=tid)
+            train_dir = self.e2e_dir / tid
+
+            if not train_dir.is_dir():
+                results.append(status)
+                continue
+
+            status.has_e2e = True
+
+            # Classify test files
+            py_tests = list(train_dir.rglob("test_*.py"))
+            ts_tests = list(train_dir.rglob("*.test.ts")) + list(
+                train_dir.rglob("*.spec.ts")
+            )
+            all_tests = py_tests + ts_tests
+
+            for test_file in all_tests:
+                stem = test_file.stem
+                if "_smoke" in stem or "-smoke" in stem:
+                    status.smoke_count += 1
+                else:
+                    status.contract_count += 1
+
+            status.e2e_count = len(all_tests)
+            status.has_contract_tests = status.contract_count > 0
+            status.has_smoke_tests = status.smoke_count > 0
+
+            results.append(status)
+
+        return results
+
+
+# ============================================================================
+# LAYER 3: ADAPTERS
+# ============================================================================
+
+
+class ChainReportFormatter:
+    """Format completeness matrix for human consumption."""
+
+    @staticmethod
+    def format_matrix(statuses: List[TrainChainStatus]) -> str:
+        header = (
+            f"\n  {'Train':<40} {'E2E':>5} {'Contract':>10} {'Smoke':>7}  Status"
+        )
+        separator = "  " + "-" * 75
+        lines = ["\n=== Train Completeness Chain ===", header, separator]
+
+        for s in statuses:
+            e2e = str(s.e2e_count) if s.has_e2e else "-"
+            contract = str(s.contract_count) if s.has_contract_tests else "-"
+            smoke = str(s.smoke_count) if s.has_smoke_tests else "-"
+            lines.append(
+                f"  {s.train_id:<40} {e2e:>5} {contract:>10} {smoke:>7}  {s.status_label}"
+            )
+
+        return "\n".join(lines)
+
+
+# ============================================================================
+# LAYER 4: TESTS
+# ============================================================================
+
+
+@pytest.mark.tester
+def test_train_completeness(ratchet_baseline):
+    """Every registered train must have the full chain: E2E + smoke.
+
+    Convention: train.convention.yaml + smoke.convention.yaml
+    Chain: train registered in _trains.yaml -> e2e/{train_id}/ exists
+           -> smoke test (*_smoke.py) exists
+    Rationale: Gaps in the chain are invisible when cross-referencing 3
+    validator outputs manually.  This single validator surfaces them.
+    Severity: ERROR with ratchet.
+    """
+    analyzer = CompletenessAnalyzer(E2E_DIR, TRAINS_FILE)
+    statuses = analyzer.analyze()
+
+    if not statuses:
+        pytest.skip("No trains registered in plan/_trains.yaml")
+
+    # A train is incomplete if it's missing any link in the chain
+    incomplete = [s for s in statuses if not s.complete]
+
+    violations = [
+        f"{s.train_id}: {s.status_label} "
+        f"(e2e={s.e2e_count}, contract={s.contract_count}, smoke={s.smoke_count})"
+        for s in incomplete
+    ]
+
+    if violations:
+        report = ChainReportFormatter.format_matrix(statuses)
+        print(report)
+
+    ratchet_baseline.assert_no_regression(
+        validator_id="train_completeness",
+        current_count=len(violations),
+        violations=violations,
+    )

--- a/src/atdd/tester/validators/test_train_e2e_existence.py
+++ b/src/atdd/tester/validators/test_train_e2e_existence.py
@@ -1,0 +1,123 @@
+"""
+Train E2E existence validator.
+
+Validates that every train registered in plan/_trains.yaml has at least one
+E2E test file in e2e/{train_id}/.
+
+Uses ratchet baseline for existing gaps so CI pipelines are not broken by
+pre-existing missing coverage.  New trains that ship without E2E tests will
+be caught as regressions.
+
+Convention: src/atdd/tester/conventions/train.convention.yaml
+Related:    src/atdd/tester/conventions/smoke.convention.yaml
+
+Architecture:
+- Entities: TrainE2EStatus
+- Use Cases: E2EExistenceAnalyzer (reuses PlanTrainDiscovery from smoke coverage)
+- Tests: Orchestration layer (pytest test function)
+"""
+
+import pytest
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import List
+
+from atdd.coach.utils.repo import find_repo_root
+from atdd.tester.validators.test_smoke_coverage import PlanTrainDiscovery
+
+
+REPO_ROOT = find_repo_root()
+E2E_DIR = REPO_ROOT / "e2e"
+TRAINS_FILE = REPO_ROOT / "plan" / "_trains.yaml"
+
+
+# ============================================================================
+# LAYER 1: ENTITIES
+# ============================================================================
+
+
+@dataclass
+class TrainE2EStatus:
+    """E2E test existence status for a single train."""
+    train_id: str
+    e2e_dir: Path
+    test_files: List[Path] = field(default_factory=list)
+
+    @property
+    def has_tests(self) -> bool:
+        return len(self.test_files) > 0
+
+
+# ============================================================================
+# LAYER 2: USE CASES
+# ============================================================================
+
+
+class E2EExistenceAnalyzer:
+    """Check that registered trains have E2E test directories with test files."""
+
+    def __init__(self, e2e_dir: Path, trains_file: Path):
+        self.e2e_dir = e2e_dir
+        self.plan_discovery = PlanTrainDiscovery(trains_file)
+
+    def analyze(self) -> List[TrainE2EStatus]:
+        """Return status for every registered train."""
+        train_ids = self.plan_discovery.discover()
+        statuses = []
+
+        for tid in train_ids:
+            train_e2e = self.e2e_dir / tid
+            status = TrainE2EStatus(train_id=tid, e2e_dir=train_e2e)
+
+            if train_e2e.is_dir():
+                # Collect Python and TypeScript test files
+                status.test_files = sorted(
+                    list(train_e2e.rglob("test_*.py"))
+                    + list(train_e2e.rglob("*.test.ts"))
+                    + list(train_e2e.rglob("*.spec.ts"))
+                )
+
+            statuses.append(status)
+
+        return statuses
+
+
+# ============================================================================
+# LAYER 4: TESTS
+# ============================================================================
+
+
+@pytest.mark.tester
+def test_train_e2e_existence(ratchet_baseline):
+    """Every registered train must have at least one E2E test file.
+
+    Convention: train.convention.yaml > e2e > existence
+    Path convention: e2e/{train_id}/test_*.py | *.test.ts | *.spec.ts
+    Rationale: Trains without E2E tests have no journey-level verification.
+    The match state 401 bug demonstrated this failure mode.
+    Severity: ERROR with ratchet.
+    """
+    analyzer = E2EExistenceAnalyzer(E2E_DIR, TRAINS_FILE)
+    statuses = analyzer.analyze()
+
+    if not statuses:
+        pytest.skip("No trains registered in plan/_trains.yaml")
+
+    violations = [
+        f"{s.train_id}: no E2E tests in e2e/{s.train_id}/"
+        for s in statuses
+        if not s.has_tests
+    ]
+
+    if violations:
+        print(
+            f"\n  {len(violations)} train(s) have no E2E tests:\n"
+            + "".join(f"    - {v}\n" for v in violations)
+            + "  See: src/atdd/tester/conventions/train.convention.yaml"
+        )
+
+    ratchet_baseline.assert_no_regression(
+        validator_id="train_e2e_existence",
+        current_count=len(violations),
+        violations=violations,
+    )


### PR DESCRIPTION
## Summary

- **Ratchet baseline for tester**: Added `ratchet_baseline` fixture in tester `conftest.py` pointing to `.atdd/baselines/tester.yaml`, reusing `RatchetBaseline` from coder baselines
- **Smoke coverage promoted to ERROR**: Converted `test_smoke_coverage_gaps()` from print/WARNING to `ratchet_baseline.assert_no_regression()` — fails on regression, auto-seeds baseline for existing gaps
- **E2E existence validator**: New `test_train_e2e_existence` checks every registered train has at least one E2E test file in `e2e/{train_id}/`
- **Train completeness chain validator**: New `test_train_completeness` validates the full chain per train: registered → E2E exists → smoke exists
- **TESTER_VALIDATORS registry**: All 3 tester validators registered in `baseline.py` alongside existing coder validators; `atdd baseline update/show` now handles both scopes
- **TrainSpecPhase graduation**: Default changed from `WARNINGS_ONLY` to `FULL_ENFORCEMENT` — all train validators now enforce strict mode by default

## Test plan

- [x] All 406 validators pass (0 failures, 146 skipped, 13 warnings)
- [x] New validators use ratchet pattern — auto-seed on first run, fail on regression
- [x] `TrainSpecPhase.FULL_ENFORCEMENT` does not break existing validators (they already handle both paths)
- [x] CLI characterization test updated for new validator count (85 → 88)

Closes #220