### PR TITLE
chore: add project URLs to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,12 @@ readme = "README.md"
 license = {text = "MIT"}
 dependencies = ["pyyaml", "pytest>=7.0", "pytest-xdist", "jsonschema", "pytest-html", "radon>=5.0"]
 
+[project.urls]
+Homepage = "https://github.com/afokapu/atdd"
+Repository = "https://github.com/afokapu/atdd"
+Issues = "https://github.com/afokapu/atdd/issues"
+Changelog = "https://github.com/afokapu/atdd/releases"
+
 [project.optional-dependencies]
 dev = []
 viz = ["streamlit", "st-link-analysis"]


### PR DESCRIPTION
## Summary
- Adds `[project.urls]` section with Homepage, Repository, Issues, and Changelog links
- PyPI will display these as clickable links on the package page
- Consumer repos can find the issue tracker at `https://github.com/afokapu/atdd/issues`

## Test plan
- [ ] `pip install atdd` shows URLs on PyPI page
- [ ] `pip show atdd` includes project URLs