### PR TITLE
feat(coach): micro-commit enforcement — warn on large uncommitted deltas

### DIFF
--- a/.atdd/hooks/pre-commit
+++ b/.atdd/hooks/pre-commit
@@ -78,4 +78,13 @@ EOF
     fi
 fi
 
+# --- Staged file count warning (advisory only — never blocks) ---
+STAGED=$(git diff --cached --name-only | wc -l | tr -d ' ')
+MAX_STAGED=${ATDD_MAX_STAGED:-20}
+
+if [ "$STAGED" -gt "$MAX_STAGED" ]; then
+    echo "ATDD WARNING: $STAGED files staged. Consider splitting into smaller commits." >&2
+    echo "Override: ATDD_MAX_STAGED=999 git commit" >&2
+fi
+
 exit 0

--- a/.atdd/hooks/pre-push
+++ b/.atdd/hooks/pre-push
@@ -62,4 +62,26 @@ EOF
     exit 1
 done
 
+# --- Uncommitted delta warning (advisory only — never blocks) ---
+UNCOMMITTED=$(git diff --name-only 2>/dev/null | wc -l | tr -d ' ')
+UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
+TOTAL=$((UNCOMMITTED + UNTRACKED))
+MAX_UNCOMMITTED=${ATDD_MAX_UNCOMMITTED:-10}
+
+if [ "$TOTAL" -gt "$MAX_UNCOMMITTED" ]; then
+    cat >&2 <<WARN
+
+ATDD WARNING: $TOTAL uncommitted/untracked files detected.
+
+Consider committing your work in smaller increments.
+Large uncommitted deltas risk losing work if a hook blocks.
+
+  git add -p    # Stage incrementally
+  git commit    # Commit frequently
+
+Override: ATDD_MAX_UNCOMMITTED=999 git push
+
+WARN
+fi
+
 exit 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.41.0"
+version = "1.42.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/templates/ATDD.md
+++ b/src/atdd/coach/templates/ATDD.md
@@ -241,6 +241,15 @@ git:
       - "GREEN: commit passing implementation"
       - "REFACTOR: commit clean architecture"
 
+  micro_commit_hooks:
+    purpose: "Advisory warnings to encourage smaller commits (all exit 0, never block)"
+    pre_push: "Warns when >10 uncommitted/untracked files (override: ATDD_MAX_UNCOMMITTED)"
+    pre_commit: "Warns when >20 staged files (override: ATDD_MAX_STAGED)"
+    claude_code:
+      template: "src/atdd/coach/templates/hooks/claude-pre-tool-use.sh"
+      install: "cp src/atdd/coach/templates/hooks/claude-pre-tool-use.sh .claude/hooks/pre_tool_use.sh"
+      behavior: "Reminds agent to commit when >5 files modified since last commit"
+
 # Release Gate (MANDATORY - session completion)
 # Every session MUST end with version bump + tag
 release:

--- a/src/atdd/coach/templates/hooks/claude-pre-tool-use.sh
+++ b/src/atdd/coach/templates/hooks/claude-pre-tool-use.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Periodic commit reminder for AI agent workflows.
+# Install: cp this to .claude/hooks/pre_tool_use.sh
+#
+# Claude Code runs this before each tool use. If >5 files are modified
+# since the last commit, it prints a reminder to stderr (advisory only).
+
+MODIFIED=$(git diff --name-only 2>/dev/null | wc -l | tr -d ' ')
+if [ "$MODIFIED" -gt 5 ]; then
+    echo "ATDD REMINDER: $MODIFIED files modified since last commit. Consider committing before continuing." >&2
+fi

--- a/src/atdd/coach/templates/hooks/pre-commit
+++ b/src/atdd/coach/templates/hooks/pre-commit
@@ -78,4 +78,13 @@ EOF
     fi
 fi
 
+# --- Staged file count warning (advisory only — never blocks) ---
+STAGED=$(git diff --cached --name-only | wc -l | tr -d ' ')
+MAX_STAGED=${ATDD_MAX_STAGED:-20}
+
+if [ "$STAGED" -gt "$MAX_STAGED" ]; then
+    echo "ATDD WARNING: $STAGED files staged. Consider splitting into smaller commits." >&2
+    echo "Override: ATDD_MAX_STAGED=999 git commit" >&2
+fi
+
 exit 0

--- a/src/atdd/coach/templates/hooks/pre-push
+++ b/src/atdd/coach/templates/hooks/pre-push
@@ -62,4 +62,26 @@ EOF
     exit 1
 done
 
+# --- Uncommitted delta warning (advisory only — never blocks) ---
+UNCOMMITTED=$(git diff --name-only 2>/dev/null | wc -l | tr -d ' ')
+UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')
+TOTAL=$((UNCOMMITTED + UNTRACKED))
+MAX_UNCOMMITTED=${ATDD_MAX_UNCOMMITTED:-10}
+
+if [ "$TOTAL" -gt "$MAX_UNCOMMITTED" ]; then
+    cat >&2 <<WARN
+
+ATDD WARNING: $TOTAL uncommitted/untracked files detected.
+
+Consider committing your work in smaller increments.
+Large uncommitted deltas risk losing work if a hook blocks.
+
+  git add -p    # Stage incrementally
+  git commit    # Commit frequently
+
+Override: ATDD_MAX_UNCOMMITTED=999 git push
+
+WARN
+fi
+
 exit 0


### PR DESCRIPTION
## Summary

- **Pre-push hook**: warns when >10 uncommitted/untracked files (prevents #224 scenario where 64 files were at risk)
- **Pre-commit hook**: warns when >20 staged files (encourages smaller commits)
- **Claude Code hook template**: `claude-pre-tool-use.sh` reminds agent to commit when >5 files modified
- All warnings exit 0 — advisory only, never block
- Thresholds configurable via `ATDD_MAX_UNCOMMITTED` and `ATDD_MAX_STAGED` env vars
- Version bump: 1.41.0 → 1.42.0 (MINOR — new feature)

## Files Changed

| File | Change |
|------|--------|
| `src/atdd/coach/templates/hooks/pre-push` | Uncommitted delta warning |
| `src/atdd/coach/templates/hooks/pre-commit` | Staged file count warning |
| `src/atdd/coach/templates/hooks/claude-pre-tool-use.sh` | New — Claude Code hook template |
| `src/atdd/coach/templates/ATDD.md` | Document micro-commit hooks |
| `.atdd/hooks/pre-push` | Synced with template |
| `.atdd/hooks/pre-commit` | Synced with template |
| `pyproject.toml` | Version 1.41.0 → 1.42.0 |

## Test plan

- [ ] `ATDD_MAX_UNCOMMITTED=0 git push` triggers warning on any uncommitted files
- [ ] `ATDD_MAX_STAGED=0 git commit` triggers warning on any staged files
- [ ] Both warnings exit 0 (push/commit still succeeds)
- [ ] `ATDD_MAX_UNCOMMITTED=999 git push` suppresses warning
- [ ] `claude-pre-tool-use.sh` prints reminder when >5 files modified
- [ ] Installed hooks match templates (`diff .atdd/hooks/pre-push src/atdd/coach/templates/hooks/pre-push`)

Closes #233