### PR TITLE
docs: add micro-commit discipline to ATDD.md agent instructions

### DIFF
--- a/src/atdd/coach/templates/ATDD.md
+++ b/src/atdd/coach/templates/ATDD.md
@@ -216,6 +216,35 @@ git:
     format: "conventional commits (feat:, fix:, docs:, refactor:, test:)"
     atomic: "One commit per phase transition when meaningful"
 
+  # ─── MICRO-COMMIT DISCIPLINE (MANDATORY FOR ALL AGENTS) ───────────────
+  # Agents MUST commit frequently to avoid losing work.
+  # Large uncommitted deltas are the #1 cause of lost agent work
+  # (incident: 64 files edited on main, all lost when pre-commit hook blocked).
+  #
+  # Rules:
+  #   1. Commit after EVERY completed sub-task (file created, test written, bug fixed).
+  #   2. Never accumulate more than 5 modified files without committing.
+  #   3. If you realize you are on main: STOP editing immediately.
+  #      Recovery: git stash → atdd branch <N> → cd worktree → git stash pop
+  #   4. Prefer many small commits over one large commit — they are easier to
+  #      review, revert, and bisect.
+  #   5. A commit message can be short ("add CameoRepository") — frequency
+  #      matters more than message polish during active development.
+  #
+  # Anti-patterns (NEVER do these):
+  #   - Edit 10+ files then commit once at the end
+  #   - Defer commits until "everything works"
+  #   - Batch unrelated changes in one commit
+  # ───────────────────────────────────────────────────────────────────────
+  commit_discipline:
+    rule: "Commit after every completed sub-task. Never accumulate >5 modified files."
+    frequency: "After each file creation, test addition, or bug fix"
+    on_main_detection: "STOP immediately. git stash → atdd branch <N> → cd worktree → git stash pop"
+    anti_patterns:
+      - "Editing 10+ files before committing"
+      - "Deferring commits until everything works"
+      - "Batching unrelated changes in one commit"
+
   branching:
     rule: "Every new branch MUST be created as a git worktree (flat sibling of main)"
     layout: |


### PR DESCRIPTION
## Summary
- Adds mandatory micro-commit discipline section to ATDD.md template
- All agents that load ATDD.md (Claude, Gemini, Qwen, etc.) will see these rules
- Rules: commit after every sub-task, never >5 uncommitted files, stop immediately if on main

Prevents the #224 incident (64 files edited on main, all lost when hook blocked).

## Test plan
- [ ] `atdd validate coach` passes
- [ ] `atdd sync` propagates updated ATDD.md to consumer repos