### PR TITLE
feat(coach): auto-sync agent configs on toolkit upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.44.0"
+version = "1.45.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/version_check.py
+++ b/src/atdd/version_check.py
@@ -257,14 +257,24 @@ def update_toolkit_version(config_path: Optional[Path] = None) -> bool:
 
 
 def print_upgrade_sync_notice() -> None:
-    """Print upgrade sync notice to stderr if needed, then auto-update last_version."""
+    """Auto-sync agent configs on toolkit upgrade, then update last_version."""
     try:
         notice = check_upgrade_sync_needed()
         if notice:
-            print(f"\n⚠️  {notice}\n", file=sys.stderr)
-            # Auto-update toolkit.last_version so the warning only shows once.
-            # The user still needs to run `atdd sync` for full config migration,
-            # but the nag stops repeating on every command.
+            print(f"\n⚠️  {notice}", file=sys.stderr)
+            # Auto-sync agent configs (CLAUDE.md, GEMINI.md, etc.)
+            try:
+                from atdd.coach.commands.sync import AgentConfigSync
+                syncer = AgentConfigSync()
+                result = syncer.sync()
+                if result == 0:
+                    print("  ✓ Agent configs synced automatically.", file=sys.stderr)
+                else:
+                    print("  ⚠ Auto-sync had issues. Run `atdd sync` manually.", file=sys.stderr)
+            except Exception:
+                print("  Run `atdd sync` to update agent configs.", file=sys.stderr)
+            print(file=sys.stderr)
+            # Update toolkit.last_version so sync only runs once per upgrade.
             update_toolkit_version()
     except Exception:
         pass  # Never fail the main command


### PR DESCRIPTION
## Summary
- When the toolkit detects a version upgrade (installed > last_version), it now auto-runs `atdd sync` instead of just printing "Run: atdd sync"
- Agent config files (CLAUDE.md, GEMINI.md, etc.) are updated automatically on the first `atdd` command after `pip install --upgrade atdd`
- Falls back to manual "Run atdd sync" message if auto-sync fails

This ensures micro-commit discipline rules and other ATDD.md updates propagate to all agents immediately after toolkit upgrade — no manual step required.

## Test plan
- [ ] Upgrade atdd, run any command → agent configs auto-synced
- [ ] If sync fails (no repo), graceful fallback to manual message
- [ ] `toolkit.last_version` updated after sync — won't re-sync on next command