### PR TITLE
fix(coach): resolve convention paths from installed package, not consumer repo

### DIFF
--- a/src/atdd/coach/validators/test_workflow_consistency.py
+++ b/src/atdd/coach/validators/test_workflow_consistency.py
@@ -12,11 +12,13 @@ from pathlib import Path
 
 import yaml
 
+import atdd
 from atdd.coach.utils.repo import find_repo_root
 
 REPO_ROOT = find_repo_root()
-ISSUE_CONVENTION = REPO_ROOT / "src" / "atdd" / "coach" / "conventions" / "issue.convention.yaml"
-ATDD_TEMPLATE = REPO_ROOT / "src" / "atdd" / "coach" / "templates" / "ATDD.md"
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+ISSUE_CONVENTION = ATDD_PKG_DIR / "coach" / "conventions" / "issue.convention.yaml"
+ATDD_TEMPLATE = ATDD_PKG_DIR / "coach" / "templates" / "ATDD.md"
 CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
 
 


### PR DESCRIPTION
## Summary
- `test_workflow_consistency.py` hardcoded `REPO_ROOT / "src" / "atdd"` which doesn't exist in consumer repos
- Now uses `ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent` — same pattern as `test_python_architecture.py`
- Unblocks `validate-gate` in all consumer repos (blocking jel-app#246)

Fixes #239

## Test plan
- [ ] `atdd validate coach --local` passes in atdd repo
- [ ] `atdd validate coach --local` passes in jel-app (consumer repo)