### PR TITLE
fix(coach): session-scope URN traceability fixtures — 20min → 2min

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.45.0"
+version = "1.45.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/validators/test_urn_traceability.py
+++ b/src/atdd/coach/validators/test_urn_traceability.py
@@ -32,21 +32,21 @@ from atdd.coach.utils.graph.edge_validator import (
 REPO_ROOT = find_repo_root()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def resolver_registry():
-    """Provide resolver registry for tests."""
+    """Provide resolver registry for tests (session-scoped — built once, reused)."""
     return ResolverRegistry(REPO_ROOT)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def graph_builder():
-    """Provide graph builder for tests."""
+    """Provide graph builder for tests (session-scoped — build() is expensive ~100s)."""
     return GraphBuilder(REPO_ROOT)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def edge_validator():
-    """Provide edge validator for tests."""
+    """Provide edge validator for tests (session-scoped — uses graph internally)."""
     return EdgeValidator(REPO_ROOT)
 
 


### PR DESCRIPTION
## Summary
- `GraphBuilder.build()` takes 104s in large consumer repos (4,017 URN nodes)
- With function-scoped fixtures, 5 tests each rebuild = 9+ minutes total
- Changed `resolver_registry`, `graph_builder`, `edge_validator` fixtures to `scope="session"` 
- Graph built once, reused across all 12 tests

Fixes #242. Unblocks `validate-coach` in consumer repos.

## Test plan
- [ ] `atdd validate coach --local` completes in <3 minutes (was 28+ min)
- [ ] All 12 URN traceability tests still pass
- [ ] No test isolation issues from session-scoped fixtures