### PR TITLE
fix(coder): ratchet 12 Category A validators to use baseline system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.45.4"
+version = "1.45.5"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/baseline.py
+++ b/src/atdd/coach/commands/baseline.py
@@ -150,7 +150,305 @@ def _contract_driven_http(repo_root: Path) -> Tuple[int, Sequence]:
     return analyze_contract_driven_http(repo_root)
 
 
+def _duplication_detector(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_duplication_detector import scan_python_duplications
+    return scan_python_duplications(repo_root)
+
+
+def _duplication_detector_typescript(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_duplication_detector_typescript import scan_typescript_duplications
+    return scan_typescript_duplications(repo_root)
+
+
+def _cyclomatic_complexity(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_complexity import scan_cyclomatic_complexity
+    return scan_cyclomatic_complexity(repo_root)
+
+
+def _nesting_depth(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_complexity import scan_nesting_depth
+    return scan_nesting_depth(repo_root)
+
+
+def _function_length(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_complexity import scan_function_length
+    return scan_function_length(repo_root)
+
+
+def _function_parameter_count(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_complexity import scan_function_params
+    return scan_function_params(repo_root)
+
+
+def _code_duplication(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_quality_metrics import (
+        find_python_files,
+        find_duplicate_code_blocks,
+        REPO_ROOT,
+    )
+    python_files = find_python_files()
+    if not python_files:
+        return 0, []
+    duplicates = find_duplicate_code_blocks(python_files[:50])
+    violations = [
+        f"{f1.relative_to(REPO_ROOT)} ↔ {f2.relative_to(REPO_ROOT)} ({len(b)} lines)"
+        for f1, f2, b in duplicates
+    ]
+    return len(duplicates), violations
+
+
+def _naming_conventions(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_quality_metrics import (
+        find_python_files,
+        check_naming_consistency,
+        REPO_ROOT,
+    )
+    violations = []
+    for py_file in find_python_files():
+        for v in check_naming_consistency(py_file):
+            violations.append(f"{py_file.relative_to(REPO_ROOT)}: {v}")
+    return len(violations), violations
+
+
+def _print_in_production(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_structured_logging import scan_print_in_production
+    return scan_print_in_production(repo_root)
+
+
+def _structured_logging_format(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_structured_logging import scan_structured_logging
+    return scan_structured_logging(repo_root)
+
+
+def _sql_concatenation(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_security_patterns import scan_sql_concatenation
+    return scan_sql_concatenation(repo_root)
+
+
+def _missing_auth_dependency(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_security_patterns import scan_missing_auth
+    return scan_missing_auth(repo_root)
+
+
+def _hardcoded_secrets(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_security_patterns import scan_hardcoded_secrets
+    return scan_hardcoded_secrets(repo_root)
+
+
+def _ds_presentation_primitives(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_design_system_compliance import scan_ds_presentation_primitives
+    return scan_ds_presentation_primitives(repo_root)
+
+
+def _ds_color_tokens(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_design_system_compliance import (
+        get_all_ui_files, extract_raw_color_values,
+    )
+    violations = []
+    for f in get_all_ui_files():
+        for line_num, issue in extract_raw_color_values(f)[:3]:
+            try:
+                rel = f.relative_to(repo_root)
+            except ValueError:
+                rel = f
+            violations.append(f"{rel}:{line_num} {issue}")
+    return len(violations), violations
+
+
+def _ds_orphaned_exports(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_design_system_compliance import (
+        get_design_system_exports, find_design_system_usage,
+    )
+    exports = get_design_system_exports()
+    used = find_design_system_usage()
+    all_exports = exports.get('primitives', set()) | exports.get('components', set())
+    orphaned = all_exports - used - {'type', 'h', 'Fragment'}
+    return len(orphaned), sorted(orphaned)
+
+
+def _ds_foundations_usage(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_design_system_compliance import (
+        extract_imports, PRIMITIVES_DIR, COMPONENTS_DIR,
+    )
+    import re as _re
+    violations = []
+    for category_dir in [PRIMITIVES_DIR, COMPONENTS_DIR]:
+        if not category_dir.exists():
+            continue
+        for f in category_dir.rglob("*.tsx"):
+            if f.name == "index.ts":
+                continue
+            try:
+                content = f.read_text(encoding='utf-8')
+            except Exception:
+                continue
+            imports = extract_imports(f)
+            uses_foundations = any('../foundations' in imp or './foundations' in imp for imp in imports)
+            raw_pixels = _re.findall(r":\s*['\"]?(\d{2,}px)['\"]?", content)
+            if raw_pixels and not uses_foundations:
+                try:
+                    rel = f.relative_to(repo_root)
+                except ValueError:
+                    rel = f
+                violations.append(f"{rel}: raw pixel values {', '.join(raw_pixels[:5])}")
+    return len(violations), violations
+
+
+def _ds_hierarchy_imports(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_design_system_compliance import (
+        extract_imports, MAINTAIN_UX, _get_maintain_ux_files,
+    )
+    violations = []
+    for f in _get_maintain_ux_files("primitives"):
+        for imp in extract_imports(f):
+            if "../components/" in imp or "../components" == imp or "../templates/" in imp or "../templates" == imp:
+                try:
+                    rel = f.relative_to(repo_root)
+                except ValueError:
+                    rel = f
+                violations.append(f"{rel}: forbidden import '{imp}'")
+    for f in _get_maintain_ux_files("components"):
+        for imp in extract_imports(f):
+            if "../templates/" in imp or "../templates" == imp:
+                try:
+                    rel = f.relative_to(repo_root)
+                except ValueError:
+                    rel = f
+                violations.append(f"{rel}: forbidden import '{imp}'")
+    if MAINTAIN_UX.exists():
+        for ext in ("*.ts", "*.tsx"):
+            for f in MAINTAIN_UX.rglob(ext):
+                if ".test." in f.name or "/tests/" in str(f):
+                    continue
+                for imp in extract_imports(f):
+                    if imp.startswith(".") or imp.startswith("@/maintain-ux"):
+                        continue
+                    if imp.startswith("preact") or imp.startswith("@preact"):
+                        continue
+                    if imp.startswith("@/") or imp.startswith("../"):
+                        try:
+                            rel = f.relative_to(repo_root)
+                        except ValueError:
+                            rel = f
+                        violations.append(f"{rel}: forbidden import '{imp}'")
+    return len(violations), violations
+
+
+def _ds_hardcoded_tokens(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_design_system_compliance import get_all_ui_files
+    import re as _re
+    patterns = [
+        (r'''(?:padding|margin|gap|top|bottom|left|right|width|height)\s*:\s*["'](\d+)px["']''', "Hardcoded pixel"),
+        (r"""\$\{\s*(\d+)\s*\}px""", "Hardcoded pixel template"),
+        (r'''borderRadius\s*:\s*["'](\d+)px["']''', "Hardcoded radius string"),
+        (r"""borderRadius\s*:\s*(\d+)\s*[,}\n]""", "Hardcoded radius number"),
+        (r'''(?:transition|animation(?:Duration)?)\s*:\s*["'][^"']*?(\d{2,})ms''', "Hardcoded duration"),
+        (r"""(?:padding|margin|gap)\s*:\s*(\d+)\s*[,}\n]""", "Hardcoded spacing"),
+    ]
+    violations = []
+    for f in get_all_ui_files():
+        try:
+            content = f.read_text(encoding='utf-8')
+        except Exception:
+            continue
+        for i, line in enumerate(content.split('\n'), 1):
+            stripped = line.strip()
+            if stripped.startswith('import') or stripped.startswith('//') or stripped.startswith('/*'):
+                continue
+            if 'spacing.' in line or 'radii.' in line or 'motion.' in line or 'tokens.' in line:
+                continue
+            for pattern, desc in patterns:
+                for match in _re.finditer(pattern, line):
+                    if int(match.group(1)) <= 4:
+                        continue
+                    try:
+                        rel = f.relative_to(repo_root)
+                    except ValueError:
+                        rel = f
+                    violations.append(f"{rel}:{i} {desc}")
+    return len(violations), violations
+
+
+def _ds_orphaned_ui(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_design_system_compliance import (
+        get_all_ui_files, extract_imports,
+    )
+    import re as _re
+    violations = []
+    for f in get_all_ui_files():
+        try:
+            content = f.read_text(encoding='utf-8')
+        except Exception:
+            continue
+        if not _re.search(r'return\s*\(?\s*<', content):
+            continue
+        imports = extract_imports(f)
+        if not any('maintain-ux' in imp or '@maintain-ux' in imp for imp in imports):
+            try:
+                rel = f.relative_to(repo_root)
+            except ValueError:
+                rel = f
+            violations.append(str(rel))
+    return len(violations), violations
+
+
+def _error_response_bare_string(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_error_response_compliance import scan_bare_string_errors
+    return scan_bare_string_errors(repo_root)
+
+
+def _error_code_format(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_error_response_compliance import scan_error_code_format
+    return scan_error_code_format(repo_root)
+
+
+def _query_count(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_query_count import scan_query_count
+    return scan_query_count(repo_root)
+
+
+def _gsap_layer_usage(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_gsap_layer_usage import scan_gsap_layer_usage
+    return scan_gsap_layer_usage(repo_root)
+
+
+def _gsap_commons(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_gsap_layer_usage import scan_gsap_commons
+    return scan_gsap_commons(repo_root)
+
+
+def _i18n_config_manifest(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_i18n_runtime import scan_i18n_config
+    return scan_i18n_config(repo_root)
+
+
+def _i18n_language_switcher(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_i18n_runtime import scan_language_switcher
+    return scan_language_switcher(repo_root)
+
+
+def _entity_cross_language(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_cross_language_consistency import scan_entity_cross_language
+    return scan_entity_cross_language(repo_root)
+
+
+def _enum_cross_language(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_cross_language_consistency import scan_enum_cross_language
+    return scan_enum_cross_language(repo_root)
+
+
+def _naming_cross_language(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_cross_language_consistency import scan_naming_cross_language
+    return scan_naming_cross_language(repo_root)
+
+
+def _api_contracts_cross_language(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coder.validators.test_cross_language_consistency import scan_api_contracts_cross_language
+    return scan_api_contracts_cross_language(repo_root)
+
+
 VALIDATORS: Dict[str, ValidatorFn] = {
+    # --- Existing ---
     "composition_completeness_python": _composition_python,
     "composition_completeness_typescript": _composition_typescript,
     "composition_completeness_supabase": _composition_supabase,
@@ -158,6 +456,38 @@ VALIDATORS: Dict[str, ValidatorFn] = {
     "dead_code_python": _dead_code_python,
     "maintainability_index": _maintainability_index,
     "code_comments": _code_comments,
+    # --- Category A: quality/style (ratcheted in #250) ---
+    "duplication_detector": _duplication_detector,
+    "duplication_detector_typescript": _duplication_detector_typescript,
+    "cyclomatic_complexity": _cyclomatic_complexity,
+    "nesting_depth": _nesting_depth,
+    "function_length": _function_length,
+    "function_parameter_count": _function_parameter_count,
+    "code_duplication": _code_duplication,
+    "naming_conventions": _naming_conventions,
+    "print_in_production": _print_in_production,
+    "structured_logging_format": _structured_logging_format,
+    "sql_concatenation": _sql_concatenation,
+    "missing_auth_dependency": _missing_auth_dependency,
+    "hardcoded_secrets": _hardcoded_secrets,
+    "ds_presentation_primitives": _ds_presentation_primitives,
+    "ds_color_tokens": _ds_color_tokens,
+    "ds_orphaned_exports": _ds_orphaned_exports,
+    "ds_foundations_usage": _ds_foundations_usage,
+    "ds_hierarchy_imports": _ds_hierarchy_imports,
+    "ds_hardcoded_tokens": _ds_hardcoded_tokens,
+    "ds_orphaned_ui": _ds_orphaned_ui,
+    "error_response_bare_string": _error_response_bare_string,
+    "error_code_format": _error_code_format,
+    "query_count": _query_count,
+    "gsap_layer_usage": _gsap_layer_usage,
+    "gsap_commons": _gsap_commons,
+    "i18n_config_manifest": _i18n_config_manifest,
+    "i18n_language_switcher": _i18n_language_switcher,
+    "entity_cross_language": _entity_cross_language,
+    "enum_cross_language": _enum_cross_language,
+    "naming_cross_language": _naming_cross_language,
+    "api_contracts_cross_language": _api_contracts_cross_language,
 }
 
 

--- a/src/atdd/coder/validators/test_complexity.py
+++ b/src/atdd/coder/validators/test_complexity.py
@@ -229,8 +229,98 @@ def count_function_parameters(function_body: str) -> int:
     return len(param_list)
 
 
+def scan_cyclomatic_complexity(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for cyclomatic complexity violations. Used by ratchet baseline."""
+    python_dir = repo_root / "python"
+    if not python_dir.exists():
+        return 0, []
+    files = []
+    for py_file in python_dir.rglob("*.py"):
+        if '/test/' in str(py_file) or py_file.name.startswith('test_'):
+            continue
+        if '__pycache__' in str(py_file) or py_file.name == '__init__.py':
+            continue
+        files.append(py_file)
+    violations = []
+    for py_file in files:
+        for func_name, line_num, func_body in extract_functions(py_file):
+            if count_function_lines(func_body) < 3:
+                continue
+            complexity = calculate_cyclomatic_complexity(func_body)
+            if complexity > MAX_CYCLOMATIC_COMPLEXITY:
+                rel_path = py_file.relative_to(repo_root)
+                violations.append(f"{rel_path}:{line_num} {func_name} complexity={complexity}")
+    return len(violations), violations
+
+
+def scan_nesting_depth(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for nesting depth violations. Used by ratchet baseline."""
+    python_dir = repo_root / "python"
+    if not python_dir.exists():
+        return 0, []
+    files = []
+    for py_file in python_dir.rglob("*.py"):
+        if '/test/' in str(py_file) or py_file.name.startswith('test_'):
+            continue
+        if '__pycache__' in str(py_file) or py_file.name == '__init__.py':
+            continue
+        files.append(py_file)
+    violations = []
+    for py_file in files:
+        for func_name, line_num, func_body in extract_functions(py_file):
+            depth = calculate_nesting_depth(func_body)
+            if depth > MAX_NESTING_DEPTH:
+                rel_path = py_file.relative_to(repo_root)
+                violations.append(f"{rel_path}:{line_num} {func_name} depth={depth}")
+    return len(violations), violations
+
+
+def scan_function_length(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for function length violations. Used by ratchet baseline."""
+    python_dir = repo_root / "python"
+    if not python_dir.exists():
+        return 0, []
+    files = []
+    for py_file in python_dir.rglob("*.py"):
+        if '/test/' in str(py_file) or py_file.name.startswith('test_'):
+            continue
+        if '__pycache__' in str(py_file) or py_file.name == '__init__.py':
+            continue
+        files.append(py_file)
+    violations = []
+    for py_file in files:
+        for func_name, line_num, func_body in extract_functions(py_file):
+            lines = count_function_lines(func_body)
+            if lines > MAX_FUNCTION_LINES:
+                rel_path = py_file.relative_to(repo_root)
+                violations.append(f"{rel_path}:{line_num} {func_name} lines={lines}")
+    return len(violations), violations
+
+
+def scan_function_params(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for function parameter count violations. Used by ratchet baseline."""
+    python_dir = repo_root / "python"
+    if not python_dir.exists():
+        return 0, []
+    files = []
+    for py_file in python_dir.rglob("*.py"):
+        if '/test/' in str(py_file) or py_file.name.startswith('test_'):
+            continue
+        if '__pycache__' in str(py_file) or py_file.name == '__init__.py':
+            continue
+        files.append(py_file)
+    violations = []
+    for py_file in files:
+        for func_name, line_num, func_body in extract_functions(py_file):
+            param_count = count_function_parameters(func_body)
+            if param_count > MAX_FUNCTION_PARAMS:
+                rel_path = py_file.relative_to(repo_root)
+                violations.append(f"{rel_path}:{line_num} {func_name} params={param_count}")
+    return len(violations), violations
+
+
 @pytest.mark.coder
-def test_cyclomatic_complexity_under_threshold():
+def test_cyclomatic_complexity_under_threshold(ratchet_baseline):
     """
     SPEC-CODER-COMPLEXITY-0001: Functions have acceptable cyclomatic complexity.
 
@@ -244,44 +334,22 @@ def test_cyclomatic_complexity_under_threshold():
 
     Given: All Python functions
     When: Calculating cyclomatic complexity
-    Then: Complexity < 10 for all functions
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_files = find_python_files()
-
     if not python_files:
         pytest.skip("No Python files found")
 
-    violations = []
-
-    for py_file in python_files:
-        functions = extract_functions(py_file)
-
-        for func_name, line_num, func_body in functions:
-            # Skip very small functions (< 3 lines)
-            if count_function_lines(func_body) < 3:
-                continue
-
-            complexity = calculate_cyclomatic_complexity(func_body)
-
-            if complexity > MAX_CYCLOMATIC_COMPLEXITY:
-                rel_path = py_file.relative_to(REPO_ROOT)
-                violations.append(
-                    f"{rel_path}:{line_num}\\n"
-                    f"  Function: {func_name}\\n"
-                    f"  Complexity: {complexity} (max: {MAX_CYCLOMATIC_COMPLEXITY})\\n"
-                    f"  Suggestion: Break into smaller functions"
-                )
-
-    if violations:
-        pytest.fail(
-            f"\\n\\nFound {len(violations)} complexity violations:\\n\\n" +
-            "\\n\\n".join(violations[:10]) +
-            (f"\\n\\n... and {len(violations) - 10} more" if len(violations) > 10 else "")
-        )
+    count, violations = scan_cyclomatic_complexity(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="cyclomatic_complexity",
+        current_count=count,
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_nesting_depth_under_threshold():
+def test_nesting_depth_under_threshold(ratchet_baseline):
     """
     SPEC-CODER-COMPLEXITY-0002: Functions have acceptable nesting depth.
 
@@ -294,40 +362,22 @@ def test_nesting_depth_under_threshold():
 
     Given: All Python functions
     When: Calculating nesting depth
-    Then: Depth < 4 for all functions
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_files = find_python_files()
-
     if not python_files:
         pytest.skip("No Python files found")
 
-    violations = []
-
-    for py_file in python_files:
-        functions = extract_functions(py_file)
-
-        for func_name, line_num, func_body in functions:
-            depth = calculate_nesting_depth(func_body)
-
-            if depth > MAX_NESTING_DEPTH:
-                rel_path = py_file.relative_to(REPO_ROOT)
-                violations.append(
-                    f"{rel_path}:{line_num}\\n"
-                    f"  Function: {func_name}\\n"
-                    f"  Nesting depth: {depth} (max: {MAX_NESTING_DEPTH})\\n"
-                    f"  Suggestion: Extract nested logic into separate functions"
-                )
-
-    if violations:
-        pytest.fail(
-            f"\\n\\nFound {len(violations)} nesting depth violations:\\n\\n" +
-            "\\n\\n".join(violations[:10]) +
-            (f"\\n\\n... and {len(violations) - 10} more" if len(violations) > 10 else "")
-        )
+    count, violations = scan_nesting_depth(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="nesting_depth",
+        current_count=count,
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_function_length_under_threshold():
+def test_function_length_under_threshold(ratchet_baseline):
     """
     SPEC-CODER-COMPLEXITY-0003: Functions are not too long.
 
@@ -340,40 +390,22 @@ def test_function_length_under_threshold():
 
     Given: All Python functions
     When: Counting lines of code
-    Then: Length < 50 for all functions
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_files = find_python_files()
-
     if not python_files:
         pytest.skip("No Python files found")
 
-    violations = []
-
-    for py_file in python_files:
-        functions = extract_functions(py_file)
-
-        for func_name, line_num, func_body in functions:
-            lines = count_function_lines(func_body)
-
-            if lines > MAX_FUNCTION_LINES:
-                rel_path = py_file.relative_to(REPO_ROOT)
-                violations.append(
-                    f"{rel_path}:{line_num}\\n"
-                    f"  Function: {func_name}\\n"
-                    f"  Lines: {lines} (max: {MAX_FUNCTION_LINES})\\n"
-                    f"  Suggestion: Break into smaller functions"
-                )
-
-    if violations:
-        pytest.fail(
-            f"\\n\\nFound {len(violations)} function length violations:\\n\\n" +
-            "\\n\\n".join(violations[:10]) +
-            (f"\\n\\n... and {len(violations) - 10} more" if len(violations) > 10 else "")
-        )
+    count, violations = scan_function_length(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="function_length",
+        current_count=count,
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_function_parameter_count_under_threshold():
+def test_function_parameter_count_under_threshold(ratchet_baseline):
     """
     SPEC-CODER-COMPLEXITY-0004: Functions don't have too many parameters.
 
@@ -386,33 +418,15 @@ def test_function_parameter_count_under_threshold():
 
     Given: All Python functions
     When: Counting parameters
-    Then: Parameters < 6 for all functions
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_files = find_python_files()
-
     if not python_files:
         pytest.skip("No Python files found")
 
-    violations = []
-
-    for py_file in python_files:
-        functions = extract_functions(py_file)
-
-        for func_name, line_num, func_body in functions:
-            param_count = count_function_parameters(func_body)
-
-            if param_count > MAX_FUNCTION_PARAMS:
-                rel_path = py_file.relative_to(REPO_ROOT)
-                violations.append(
-                    f"{rel_path}:{line_num}\\n"
-                    f"  Function: {func_name}\\n"
-                    f"  Parameters: {param_count} (max: {MAX_FUNCTION_PARAMS})\\n"
-                    f"  Suggestion: Use parameter objects or reduce responsibilities"
-                )
-
-    if violations:
-        pytest.fail(
-            f"\\n\\nFound {len(violations)} parameter count violations:\\n\\n" +
-            "\\n\\n".join(violations[:10]) +
-            (f"\\n\\n... and {len(violations) - 10} more" if len(violations) > 10 else "")
-        )
+    count, violations = scan_function_params(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="function_parameter_count",
+        current_count=count,
+        violations=violations,
+    )

--- a/src/atdd/coder/validators/test_cross_language_consistency.py
+++ b/src/atdd/coder/validators/test_cross_language_consistency.py
@@ -225,16 +225,98 @@ def find_contract_entities() -> Dict[str, Set[str]]:
     return entities
 
 
+def scan_entity_cross_language(repo_root: Path):
+    """Scan for missing entity implementations. Used by ratchet baseline."""
+    python_classes = extract_python_classes()
+    dart_classes = extract_dart_classes()
+    contract_entities = find_contract_entities()
+    if (not python_classes and not dart_classes) or not contract_entities:
+        return 0, []
+    violations = []
+    for entity_name, fields in contract_entities.items():
+        normalized = ''.join(word.capitalize() for word in re.split(r'[-_]', entity_name))
+        has_python = (normalized in python_classes or entity_name in python_classes or
+                      any(normalized in cls for cls in python_classes))
+        has_dart = (normalized in dart_classes or entity_name in dart_classes or
+                    any(normalized in cls for cls in dart_classes))
+        missing = []
+        if python_classes and not has_python:
+            missing.append("Python")
+        if dart_classes and not has_dart:
+            missing.append("Dart")
+        if missing:
+            violations.append(f"{entity_name} missing in {', '.join(missing)}")
+    return len(violations), violations
+
+
+def scan_enum_cross_language(repo_root: Path):
+    """Scan for enum mismatches across languages. Used by ratchet baseline."""
+    python_enums = extract_python_enums()
+    dart_enums = extract_dart_enums()
+    if not python_enums and not dart_enums:
+        return 0, []
+    violations = []
+    for enum_name in set(python_enums.keys()) & set(dart_enums.keys()):
+        py_lower = {v.lower() for v in python_enums[enum_name]}
+        dart_lower = {v.lower() for v in dart_enums[enum_name]}
+        if py_lower != dart_lower:
+            violations.append(f"{enum_name}: Python={py_lower - dart_lower} Dart={dart_lower - py_lower}")
+    return len(violations), violations
+
+
+def scan_naming_cross_language(repo_root: Path):
+    """Scan for naming inconsistencies across languages. Used by ratchet baseline."""
+    python_classes = extract_python_classes()
+    dart_classes = extract_dart_classes()
+    if not python_classes or not dart_classes:
+        return 0, []
+    python_suffixes = {}
+    dart_suffixes = {}
+    for name in python_classes:
+        for suffix in ['Entity', 'Model', 'DTO', 'Service', 'Repository']:
+            if name.endswith(suffix):
+                python_suffixes.setdefault(suffix, set()).add(name[:-len(suffix)])
+    for name in dart_classes:
+        for suffix in ['Entity', 'Model', 'DTO', 'Service', 'Repository']:
+            if name.endswith(suffix):
+                dart_suffixes.setdefault(suffix, set()).add(name[:-len(suffix)])
+    violations = []
+    for suffix in set(python_suffixes.keys()) | set(dart_suffixes.keys()):
+        python_bases = python_suffixes.get(suffix, set())
+        for base in python_bases:
+            for dart_suffix in dart_suffixes:
+                if suffix != dart_suffix and base in dart_suffixes[dart_suffix]:
+                    violations.append(f"{base}: Python={suffix} Dart={dart_suffix}")
+    return len(violations), violations
+
+
+def scan_api_contracts_cross_language(repo_root: Path):
+    """Scan for unimplemented contracts. Used by ratchet baseline."""
+    contract_entities = find_contract_entities()
+    python_classes = extract_python_classes()
+    dart_classes = extract_dart_classes()
+    if not contract_entities:
+        return 0, []
+    violations = []
+    for entity_name, fields in contract_entities.items():
+        normalized = ''.join(word.capitalize() for word in re.split(r'[-_]', entity_name))
+        has_any = (normalized in python_classes or entity_name in python_classes or
+                   normalized in dart_classes or entity_name in dart_classes or
+                   any(normalized in cls for cls in python_classes) or
+                   any(normalized in cls for cls in dart_classes))
+        if not has_any:
+            violations.append(f"{entity_name}: no implementations found")
+    return len(violations), violations
+
+
 @pytest.mark.coder
-def test_entity_classes_exist_across_languages():
+def test_entity_classes_exist_across_languages(ratchet_baseline):
     """
     SPEC-CODER-CONSISTENCY-0001: Core entities exist in all languages.
 
-    For polyglot codebases, core domain entities should exist in all languages.
-
     Given: Entity classes in Python, Dart, contracts
     When: Comparing entity names
-    Then: Core entities exist across languages
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_classes = extract_python_classes()
     dart_classes = extract_dart_classes()
@@ -242,60 +324,25 @@ def test_entity_classes_exist_across_languages():
 
     if not python_classes and not dart_classes:
         pytest.skip("No classes found")
-
     if not contract_entities:
         pytest.skip("No contract entities found")
 
-    # Check if contract entities have implementations
-    missing_implementations = []
-
-    for entity_name, fields in contract_entities.items():
-        # Normalize name (PascalCase)
-        normalized = ''.join(word.capitalize() for word in re.split(r'[-_]', entity_name))
-
-        # Check Python (exact or substring match for CLI contracts like ATDDGate)
-        has_python = (
-            normalized in python_classes or entity_name in python_classes or
-            any(normalized in cls for cls in python_classes)
-        )
-        # Check Dart
-        has_dart = (
-            normalized in dart_classes or entity_name in dart_classes or
-            any(normalized in cls for cls in dart_classes)
-        )
-
-        # Only report missing for languages that exist in the repo
-        missing_langs = []
-        if python_classes and not has_python:
-            missing_langs.append("Python")
-        if dart_classes and not has_dart:
-            missing_langs.append("Dart")
-
-        if missing_langs:
-            missing_implementations.append(
-                f"Contract entity: {entity_name}\\n"
-                f"  Fields: {', '.join(list(fields)[:5])}\\n"
-                f"  Missing in: {' AND '.join(missing_langs)}"
-            )
-
-    if missing_implementations:
-        pytest.fail(
-            f"\\n\\nFound {len(missing_implementations)} contract entities without implementations:\\n\\n" +
-            "\\n\\n".join(missing_implementations[:10]) +
-            (f"\\n\\n... and {len(missing_implementations) - 10} more" if len(missing_implementations) > 10 else "")
-        )
+    count, violations = scan_entity_cross_language(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="entity_cross_language",
+        current_count=count,
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_enums_match_across_languages():
+def test_enums_match_across_languages(ratchet_baseline):
     """
     SPEC-CODER-CONSISTENCY-0002: Enums match across languages.
 
-    Enums should have same values in all languages.
-
     Given: Enum definitions in Python and Dart
     When: Comparing enum values
-    Then: Enums with same name have same values
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_enums = extract_python_enums()
     dart_enums = extract_dart_enums()
@@ -303,44 +350,22 @@ def test_enums_match_across_languages():
     if not python_enums and not dart_enums:
         pytest.skip("No enums found")
 
-    mismatches = []
-
-    # Find enums with same name
-    for enum_name in set(python_enums.keys()) & set(dart_enums.keys()):
-        python_values = python_enums[enum_name]
-        dart_values = dart_enums[enum_name]
-
-        # Compare (case-insensitive)
-        python_lower = {v.lower() for v in python_values}
-        dart_lower = {v.lower() for v in dart_values}
-
-        if python_lower != dart_lower:
-            only_python = python_lower - dart_lower
-            only_dart = dart_lower - python_lower
-
-            mismatches.append(
-                f"Enum: {enum_name}\\n"
-                f"  Only in Python: {', '.join(only_python) if only_python else 'none'}\\n"
-                f"  Only in Dart: {', '.join(only_dart) if only_dart else 'none'}"
-            )
-
-    if mismatches:
-        pytest.fail(
-            f"\\n\\nFound {len(mismatches)} enum mismatches:\\n\\n" +
-            "\\n\\n".join(mismatches)
-        )
+    count, violations = scan_enum_cross_language(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="enum_cross_language",
+        current_count=count,
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_naming_conventions_consistent():
+def test_naming_conventions_consistent(ratchet_baseline):
     """
     SPEC-CODER-CONSISTENCY-0003: Naming conventions are consistent.
 
-    Similar concepts should use similar names across languages.
-
     Given: Class names in all languages
     When: Comparing patterns
-    Then: Consistent naming (e.g., XxxEntity vs Xxx)
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_classes = extract_python_classes()
     dart_classes = extract_dart_classes()
@@ -348,99 +373,31 @@ def test_naming_conventions_consistent():
     if not python_classes or not dart_classes:
         pytest.skip("Need classes in multiple languages")
 
-    # Check for common suffixes
-    python_suffixes = {}
-    dart_suffixes = {}
-
-    for name in python_classes.keys():
-        for suffix in ['Entity', 'Model', 'DTO', 'Service', 'Repository']:
-            if name.endswith(suffix):
-                base = name[:-len(suffix)]
-                python_suffixes.setdefault(suffix, set()).add(base)
-
-    for name in dart_classes.keys():
-        for suffix in ['Entity', 'Model', 'DTO', 'Service', 'Repository']:
-            if name.endswith(suffix):
-                base = name[:-len(suffix)]
-                dart_suffixes.setdefault(suffix, set()).add(base)
-
-    # Find inconsistencies
-    inconsistencies = []
-
-    for suffix in set(python_suffixes.keys()) | set(dart_suffixes.keys()):
-        python_bases = python_suffixes.get(suffix, set())
-        dart_bases = dart_suffixes.get(suffix, set())
-
-        # Find classes that use different suffixes
-        common_bases = python_bases & dart_bases
-
-        for base in common_bases:
-            # If same base exists with this suffix in both, good
-            pass
-
-        # Check if base exists with different suffix
-        for base in python_bases:
-            # Check if Dart has same base with different suffix
-            for dart_suffix in dart_suffixes.keys():
-                if suffix != dart_suffix and base in dart_suffixes[dart_suffix]:
-                    inconsistencies.append(
-                        f"Base class: {base}\\n"
-                        f"  Python uses: {suffix}\\n"
-                        f"  Dart uses: {dart_suffix}"
-                    )
-
-    if inconsistencies:
-        pytest.fail(
-            f"\\n\\nFound {len(inconsistencies)} naming inconsistencies:\\n\\n" +
-            "\\n\\n".join(inconsistencies[:10]) +
-            (f"\\n\\n... and {len(inconsistencies) - 10} more" if len(inconsistencies) > 10 else "")
-        )
+    count, violations = scan_naming_cross_language(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="naming_cross_language",
+        current_count=count,
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_api_contracts_honored_across_languages():
+def test_api_contracts_honored_across_languages(ratchet_baseline):
     """
     SPEC-CODER-CONSISTENCY-0004: API contracts honored in all implementations.
 
-    Contract schemas define API structure.
-    All language implementations should follow them.
-
     Given: Contract schemas
     When: Checking for matching entities
-    Then: Each language has entity matching contract
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     contract_entities = find_contract_entities()
-    python_classes = extract_python_classes()
-    dart_classes = extract_dart_classes()
 
     if not contract_entities:
         pytest.skip("No contracts found")
 
-    # For each contract, check if at least one language implements it
-    unimplemented = []
-
-    for entity_name, fields in contract_entities.items():
-        normalized = ''.join(word.capitalize() for word in re.split(r'[-_]', entity_name))
-
-        has_any_impl = (
-            normalized in python_classes or
-            entity_name in python_classes or
-            normalized in dart_classes or
-            entity_name in dart_classes or
-            any(normalized in cls for cls in python_classes) or
-            any(normalized in cls for cls in dart_classes)
-        )
-
-        if not has_any_impl:
-            unimplemented.append(
-                f"Contract: {entity_name}\\n"
-                f"  Fields: {', '.join(list(fields)[:5])}\\n"
-                f"  No implementations found"
-            )
-
-    if unimplemented:
-        pytest.fail(
-            f"\\n\\nFound {len(unimplemented)} unimplemented contracts:\\n\\n" +
-            "\\n\\n".join(unimplemented[:10]) +
-            (f"\\n\\n... and {len(unimplemented) - 10} more" if len(unimplemented) > 10 else "")
-        )
+    count, violations = scan_api_contracts_cross_language(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="api_contracts_cross_language",
+        current_count=count,
+        violations=violations,
+    )

--- a/src/atdd/coder/validators/test_design_system_compliance.py
+++ b/src/atdd/coder/validators/test_design_system_compliance.py
@@ -14,7 +14,7 @@ import pytest
 import re
 import warnings
 from pathlib import Path
-from typing import List, Set, Dict, Tuple
+from typing import Dict, List, Set, Tuple
 
 from atdd.coach.utils.repo import find_repo_root
 
@@ -234,63 +234,56 @@ def extract_raw_color_values(file_path: Path) -> List[Tuple[int, str]]:
     return violations
 
 
+def scan_ds_presentation_primitives(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for presentation files missing DS imports. Used by ratchet baseline."""
+    web_src = repo_root / "web" / "src"
+    if not web_src.exists():
+        return 0, []
+    violations = []
+    for f in get_presentation_files():
+        imports = extract_imports(f)
+        has_jsx = f.suffix == '.tsx'
+        has_design_system_import = any(
+            any(ds in imp for ds in DESIGN_SYSTEM_IMPORTS) for imp in imports
+        )
+        if has_jsx and not has_design_system_import:
+            try:
+                content = f.read_text(encoding='utf-8')
+                if re.search(r'return\s*\(?\s*<', content):
+                    rel_path = f.relative_to(repo_root)
+                    violations.append(f"{rel_path}: presentation component without DS imports")
+            except Exception:
+                pass
+    return len(violations), violations
+
+
 @pytest.mark.coder
-def test_presentation_uses_design_system_primitives():
+def test_presentation_uses_design_system_primitives(ratchet_baseline):
     """
     SPEC-CODER-DESIGN-001: Presentation layer must use design system primitives.
 
     GIVEN: TypeScript file in presentation layer
     WHEN: Analyzing imports for UI elements
-    THEN: Uses primitives from @/maintain-ux/primitives or @/maintain-ux/components
+    THEN: Violation count does not exceed baseline (ratchet pattern)
 
     Rationale: Consistent UI through reusable design system components
     """
-    violations = []
-
-    for f in get_presentation_files():
-        imports = extract_imports(f)
-
-        # Check if file uses preact/h but doesn't import from design system
-        has_jsx = f.suffix == '.tsx'
-        has_design_system_import = any(
-            any(ds in imp for ds in DESIGN_SYSTEM_IMPORTS)
-            for imp in imports
-        )
-
-        # If it's a .tsx file with no design system imports, flag it
-        # (Allow commons imports for utilities)
-        if has_jsx and not has_design_system_import:
-            # Check if it has any actual JSX
-            try:
-                content = f.read_text(encoding='utf-8')
-                # Look for JSX return statements
-                if re.search(r'return\s*\(?\s*<', content):
-                    rel_path = f.relative_to(REPO_ROOT)
-                    violations.append(
-                        f"{rel_path}\n"
-                        f"  Issue: Presentation component with JSX but no design system imports\n"
-                        f"  Fix: Import primitives from @/maintain-ux/primitives or @/maintain-ux/components"
-                    )
-            except Exception:
-                pass
-
-    if violations:
-        pytest.fail(
-            f"\n\nFound {len(violations)} presentation files without design system imports:\n\n" +
-            "\n\n".join(violations[:10]) +
-            (f"\n\n... and {len(violations) - 10} more" if len(violations) > 10 else "") +
-            "\n\nPresentation layer should use design system primitives for consistency."
-        )
+    count, violations = scan_ds_presentation_primitives(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="ds_presentation_primitives",
+        current_count=count,
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_ui_files_use_design_tokens_for_colors():
+def test_ui_files_use_design_tokens_for_colors(ratchet_baseline):
     """
     SPEC-CODER-DESIGN-002: UI files should use design tokens for colors.
 
     GIVEN: TypeScript/TSX file with styling
     WHEN: Analyzing for color values
-    THEN: Colors come from design tokens, not raw hex/rgb values
+    THEN: Violation count does not exceed baseline (ratchet pattern)
 
     Rationale: Consistent theming through centralized color definitions
     """
@@ -308,17 +301,15 @@ def test_ui_files_use_design_tokens_for_colors():
                 )
 
     # Allow some violations during migration (warning, not failure)
-    if len(all_violations) > 20:
-        pytest.fail(
-            f"\n\nFound {len(all_violations)} raw color values (>20 threshold):\n\n" +
-            "\n\n".join(all_violations[:10]) +
-            (f"\n\n... and {len(all_violations) - 10} more" if len(all_violations) > 10 else "") +
-            "\n\nUse colors from @/maintain-ux/foundations for consistency."
-        )
+    ratchet_baseline.assert_no_regression(
+        validator_id="ds_color_tokens",
+        current_count=len(all_violations),
+        violations=all_violations,
+    )
 
 
 @pytest.mark.coder
-def test_no_orphaned_design_system_exports():
+def test_no_orphaned_design_system_exports(ratchet_baseline):
     """
     SPEC-CODER-DESIGN-003: Design system exports should be used.
 
@@ -341,38 +332,22 @@ def test_no_orphaned_design_system_exports():
     false_positives = {'type', 'h', 'Fragment'}
     orphaned = orphaned - false_positives
 
-    if orphaned:
-        # Group by category
-        orphaned_primitives = orphaned & exports['primitives']
-        orphaned_components = orphaned & exports['components']
-
-        message = f"\n\nFound {len(orphaned)} orphaned design system exports:\n"
-
-        if orphaned_primitives:
-            message += f"\n  Primitives ({len(orphaned_primitives)}):\n"
-            message += "".join(f"    - {name}\n" for name in sorted(orphaned_primitives))
-
-        if orphaned_components:
-            message += f"\n  Components ({len(orphaned_components)}):\n"
-            message += "".join(f"    - {name}\n" for name in sorted(orphaned_components))
-
-        message += "\nConsider removing unused exports to keep design system lean."
-
-        # Warn but don't fail if under threshold
-        if len(orphaned) > 5:
-            pytest.fail(message)
-        else:
-            pytest.skip(f"Minor: {len(orphaned)} orphaned exports (under threshold)")
+    violations = sorted(orphaned)
+    ratchet_baseline.assert_no_regression(
+        validator_id="ds_orphaned_exports",
+        current_count=len(orphaned),
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_design_system_uses_foundations():
+def test_design_system_uses_foundations(ratchet_baseline):
     """
     SPEC-CODER-DESIGN-004: Design system primitives should use foundations.
 
     GIVEN: Primitive or component in maintain-ux
     WHEN: Checking for spacing/color values
-    THEN: Uses tokens from foundations (spacing, colors)
+    THEN: Violation count does not exceed baseline (ratchet pattern)
 
     Rationale: Design system itself must be consistent
     """
@@ -383,37 +358,24 @@ def test_design_system_uses_foundations():
             continue
 
         for f in category_dir.rglob("*.tsx"):
-            # Skip index files
             if f.name == "index.ts":
                 continue
-
             try:
                 content = f.read_text(encoding='utf-8')
             except Exception:
                 continue
-
-            # Check if it imports from foundations
             imports = extract_imports(f)
             uses_foundations = any('../foundations' in imp or './foundations' in imp for imp in imports)
-
-            # Check for raw pixel values in styles (allow small values like 2px, 3px for borders)
             raw_pixels = re.findall(r":\s*['\"]?(\d{2,}px)['\"]?", content)
-
             if raw_pixels and not uses_foundations:
                 rel_path = f.relative_to(REPO_ROOT)
-                violations.append(
-                    f"{rel_path}\n"
-                    f"  Raw pixel values: {', '.join(raw_pixels[:5])}\n"
-                    f"  Fix: Import spacing from ../foundations"
-                )
+                violations.append(f"{rel_path}: raw pixel values {', '.join(raw_pixels[:5])}")
 
-    if violations:
-        pytest.fail(
-            f"\n\nFound {len(violations)} design system files with raw values:\n\n" +
-            "\n\n".join(violations[:10]) +
-            (f"\n\n... and {len(violations) - 10} more" if len(violations) > 10 else "") +
-            "\n\nDesign system should use its own foundations for consistency."
-        )
+    ratchet_baseline.assert_no_regression(
+        validator_id="ds_foundations_usage",
+        current_count=len(violations),
+        violations=violations,
+    )
 
 
 def _get_maintain_ux_files(subdir: str) -> List[Path]:
@@ -430,7 +392,7 @@ def _get_maintain_ux_files(subdir: str) -> List[Path]:
 
 
 @pytest.mark.coder
-def test_design_system_hierarchy_imports():
+def test_design_system_hierarchy_imports(ratchet_baseline):
     """
     SPEC-CODER-DESIGN-005: Design system layers must respect hierarchy.
 
@@ -438,8 +400,7 @@ def test_design_system_hierarchy_imports():
 
     GIVEN: Files inside maintain-ux/{primitives,components,templates}
     WHEN: Analyzing their import paths
-    THEN: No layer imports from a higher layer, and no maintain-ux file imports
-          from feature wagons
+    THEN: Violation count does not exceed baseline (ratchet pattern)
 
     Hierarchy: tokens ← primitives ← components ← templates
     """
@@ -507,17 +468,15 @@ def test_design_system_hierarchy_imports():
                     f"  Fix: Design system must be wagon-agnostic"
                 )
 
-    if violations:
-        pytest.fail(
-            f"\n\nFound {len(violations)} hierarchy violations in design system:\n\n" +
-            "\n\n".join(violations[:15]) +
-            (f"\n\n... and {len(violations) - 15} more" if len(violations) > 15 else "") +
-            "\n\nDesign system layers must follow: tokens ← primitives ← components ← templates"
-        )
+    ratchet_baseline.assert_no_regression(
+        validator_id="ds_hierarchy_imports",
+        current_count=len(violations),
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_no_hardcoded_tokens_in_wagons():
+def test_no_hardcoded_tokens_in_wagons(ratchet_baseline):
     """
     SPEC-CODER-DESIGN-006: Wagon UI files must not use hardcoded spacing, radii, or durations.
 
@@ -525,7 +484,7 @@ def test_no_hardcoded_tokens_in_wagons():
 
     GIVEN: TSX files in web/src/ outside maintain-ux/
     WHEN: Scanning for inline pixel values, hardcoded radii, hardcoded durations
-    THEN: No more than 20 violations (threshold for gradual migration)
+    THEN: Violation count does not exceed baseline (ratchet pattern)
 
     Rationale: All visual tokens must come from design system foundations
     """
@@ -592,17 +551,15 @@ def test_no_hardcoded_tokens_in_wagons():
                     f"  Fix: Use tokens from @/maintain-ux/foundations"
                 )
 
-    if len(all_violations) > 20:
-        pytest.fail(
-            f"\n\nFound {len(all_violations)} hardcoded token values (>20 threshold):\n\n" +
-            "\n\n".join(all_violations[:10]) +
-            (f"\n\n... and {len(all_violations) - 10} more" if len(all_violations) > 10 else "") +
-            "\n\nUse spacing/radii/motion tokens from @/maintain-ux/foundations."
-        )
+    ratchet_baseline.assert_no_regression(
+        validator_id="ds_hardcoded_tokens",
+        current_count=len(all_violations),
+        violations=all_violations,
+    )
 
 
 @pytest.mark.coder
-def test_no_orphaned_ui_elements():
+def test_no_orphaned_ui_elements(ratchet_baseline):
     """
     SPEC-CODER-DESIGN-007: All TSX files must use at least one design system import.
 
@@ -611,7 +568,7 @@ def test_no_orphaned_ui_elements():
 
     GIVEN: Any .tsx file in web/src/ outside maintain-ux/ and test files
     WHEN: Checking its imports for any maintain-ux path
-    THEN: File has at least one import from maintain-ux
+    THEN: Violation count does not exceed baseline (ratchet pattern)
 
     Rationale: Complete DS bypass means unthemed, inconsistent UI
     """
@@ -646,13 +603,15 @@ def test_no_orphaned_ui_elements():
                 f"  Fix: Import primitives/components from @/maintain-ux/"
             )
 
-    if orphaned:
-        pytest.fail(
-            f"\n\nFound {len(orphaned)} orphaned UI elements (no design system imports):\n\n" +
-            "\n\n".join(orphaned[:15]) +
-            (f"\n\n... and {len(orphaned) - 15} more" if len(orphaned) > 15 else "") +
-            "\n\nAll TSX files should use at least one design system import for consistency."
-        )
+    violations = []
+    for f_path in orphaned:
+        violations.append(str(f_path))
+
+    ratchet_baseline.assert_no_regression(
+        validator_id="ds_orphaned_ui",
+        current_count=len(orphaned),
+        violations=violations,
+    )
 
 
 @pytest.mark.coder

--- a/src/atdd/coder/validators/test_duplication_detector.py
+++ b/src/atdd/coder/validators/test_duplication_detector.py
@@ -292,8 +292,47 @@ def test_duplication_convention_exists():
     )
 
 
+def scan_python_duplications(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for intra-layer Python duplications. Used by ratchet baseline."""
+    convention = load_duplication_convention()
+    rule = convention.get("rules", {}).get("intra_layer_duplication", {})
+    min_stmts = rule.get("min_fragment_statements", 5)
+    exclusions = rule.get("exclusions", [])
+    scan_dirs = rule.get("scan_dirs", ["python/"])
+
+    files: List[Path] = []
+    for rel_dir in scan_dirs:
+        files.extend(_collect_python_files(repo_root / rel_dir, exclusions))
+    if not files:
+        return 0, []
+
+    files_by_layer: Dict[str, List[Path]] = {}
+    for f in files:
+        layer = determine_layer_from_path(f)
+        if layer == "unknown":
+            continue
+        files_by_layer.setdefault(layer, []).append(f)
+
+    violations = find_intra_layer_duplicates(files_by_layer, min_stmts)
+    violation_strs = []
+    for v in violations:
+        try:
+            rel_a = v["file_a"].relative_to(repo_root)
+        except ValueError:
+            rel_a = v["file_a"]
+        try:
+            rel_b = v["file_b"].relative_to(repo_root)
+        except ValueError:
+            rel_b = v["file_b"]
+        violation_strs.append(
+            f"[{v['layer']}] {rel_a}:{v['line_a']} ↔ {rel_b}:{v['line_b']} "
+            f"({v['statements']} identical statements)"
+        )
+    return len(violations), violation_strs
+
+
 @pytest.mark.coder
-def test_no_intra_layer_duplication():
+def test_no_intra_layer_duplication(ratchet_baseline):
     """
     SPEC-CODER-DUP-0001: No structurally identical fragments within same layer.
 
@@ -303,50 +342,22 @@ def test_no_intra_layer_duplication():
 
     Given: Python files in configured scan_dirs grouped by architectural layer
     When: Extracting statement fragments and comparing hashes within each layer
-    Then: No duplicate fragments found across different files
+    Then: Violation count does not exceed baseline (ratchet pattern)
 
     Convention: atdd/coder/conventions/duplication.convention.yaml (DUP-0001)
     """
-    convention = load_duplication_convention()
-    rule = convention.get("rules", {}).get("intra_layer_duplication", {})
-    min_stmts = rule.get("min_fragment_statements", 5)
-    exclusions = rule.get("exclusions", [])
-    scan_dirs = rule.get("scan_dirs", ["python/"])
+    count, violations = scan_python_duplications(REPO_ROOT)
+    if count == 0 and not violations:
+        # Check if there were any files to scan
+        convention = load_duplication_convention()
+        rule = convention.get("rules", {}).get("intra_layer_duplication", {})
+        scan_dirs = rule.get("scan_dirs", ["python/"])
+        has_files = any((REPO_ROOT / d).exists() for d in scan_dirs)
+        if not has_files:
+            pytest.skip("No Python files found in scan_dirs to validate")
 
-    files: List[Path] = []
-    for rel_dir in scan_dirs:
-        files.extend(_collect_python_files(REPO_ROOT / rel_dir, exclusions))
-    if not files:
-        pytest.skip("No Python files found in scan_dirs to validate")
-
-    # Group files by layer
-    files_by_layer: Dict[str, List[Path]] = {}
-    for f in files:
-        layer = determine_layer_from_path(f)
-        if layer == "unknown":
-            continue
-        files_by_layer.setdefault(layer, []).append(f)
-
-    violations = find_intra_layer_duplicates(files_by_layer, min_stmts)
-
-    if violations:
-        lines = []
-        for v in violations[:10]:
-            rel_a = _rel_path(v["file_a"])
-            rel_b = _rel_path(v["file_b"])
-            lines.append(
-                f"[{v['layer']}] {rel_a}:{v['line_a']} ↔ {rel_b}:{v['line_b']} "
-                f"({v['statements']} identical statements)"
-            )
-
-        pytest.fail(
-            f"\n\nFound {len(violations)} intra-layer duplication(s):\n\n"
-            + "\n".join(lines)
-            + (
-                f"\n\n... and {len(violations) - 10} more"
-                if len(violations) > 10
-                else ""
-            )
-            + "\n\nExtract shared logic into a common module within the layer."
-            + "\nSee: atdd/coder/conventions/duplication.convention.yaml (DUP-0001)"
-        )
+    ratchet_baseline.assert_no_regression(
+        validator_id="duplication_detector",
+        current_count=count,
+        violations=violations,
+    )

--- a/src/atdd/coder/validators/test_duplication_detector_typescript.py
+++ b/src/atdd/coder/validators/test_duplication_detector_typescript.py
@@ -269,29 +269,17 @@ def _rel_path(file_path: Path) -> Path:
 # Tests
 # ===========================================================================
 
-@pytest.mark.coder
-def test_no_intra_layer_duplication_typescript():
-    """
-    SPEC-CODER-DUP-0002: No structurally identical TypeScript fragments within same layer.
-
-    Regex-based structural normalization detects copy-paste code across
-    different files in the same architectural layer under web/src/.
-    Identifiers and literals are normalized so renamed copies are caught.
-
-    Given: TypeScript files in web/src/ grouped by architectural layer
-    When: Extracting normalized line fragments and comparing hashes within each layer
-    Then: No duplicate fragments found across different files
-
-    Convention: atdd/coder/conventions/duplication.convention.yaml
-    """
+def scan_typescript_duplications(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for intra-layer TypeScript duplications. Used by ratchet baseline."""
     convention = load_duplication_convention()
     ts_rule = convention.get("rules", {}).get("intra_layer_duplication_typescript", {})
     min_lines = ts_rule.get("min_fragment_lines", 7)
     exclusions = ts_rule.get("exclusions", [])
 
-    ts_files = _collect_ts_files(WEB_SRC, exclusions)
+    web_src = repo_root / "web" / "src"
+    ts_files = _collect_ts_files(web_src, exclusions)
     if not ts_files:
-        pytest.skip("No TypeScript files found in web/src/ to validate")
+        return 0, []
 
     files_by_layer: Dict[str, List[Path]] = {}
     for f in ts_files:
@@ -301,25 +289,45 @@ def test_no_intra_layer_duplication_typescript():
         files_by_layer.setdefault(layer, []).append(f)
 
     violations = find_intra_layer_duplicates_ts(files_by_layer, min_lines)
-
-    if violations:
-        lines = []
-        for v in violations[:10]:
-            rel_a = _rel_path(v["file_a"])
-            rel_b = _rel_path(v["file_b"])
-            lines.append(
-                f"[{v['layer']}] {rel_a}:{v['line_a']} ↔ {rel_b}:{v['line_b']} "
-                f"({v['lines']} identical normalized lines)"
-            )
-
-        pytest.fail(
-            f"\n\nFound {len(violations)} intra-layer TypeScript duplication(s):\n\n"
-            + "\n".join(lines)
-            + (
-                f"\n\n... and {len(violations) - 10} more"
-                if len(violations) > 10
-                else ""
-            )
-            + "\n\nExtract shared logic into a common module within the layer."
-            + "\nSee: atdd/coder/conventions/duplication.convention.yaml"
+    violation_strs = []
+    for v in violations:
+        try:
+            rel_a = v["file_a"].relative_to(repo_root)
+        except ValueError:
+            rel_a = v["file_a"]
+        try:
+            rel_b = v["file_b"].relative_to(repo_root)
+        except ValueError:
+            rel_b = v["file_b"]
+        violation_strs.append(
+            f"[{v['layer']}] {rel_a}:{v['line_a']} ↔ {rel_b}:{v['line_b']} "
+            f"({v['lines']} identical normalized lines)"
         )
+    return len(violations), violation_strs
+
+
+@pytest.mark.coder
+def test_no_intra_layer_duplication_typescript(ratchet_baseline):
+    """
+    SPEC-CODER-DUP-0002: No structurally identical TypeScript fragments within same layer.
+
+    Regex-based structural normalization detects copy-paste code across
+    different files in the same architectural layer under web/src/.
+    Identifiers and literals are normalized so renamed copies are caught.
+
+    Given: TypeScript files in web/src/ grouped by architectural layer
+    When: Extracting normalized line fragments and comparing hashes within each layer
+    Then: Violation count does not exceed baseline (ratchet pattern)
+
+    Convention: atdd/coder/conventions/duplication.convention.yaml
+    """
+    ts_files = _collect_ts_files(WEB_SRC)
+    if not ts_files:
+        pytest.skip("No TypeScript files found in web/src/ to validate")
+
+    count, violations = scan_typescript_duplications(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="duplication_detector_typescript",
+        current_count=count,
+        violations=violations,
+    )

--- a/src/atdd/coder/validators/test_error_response_compliance.py
+++ b/src/atdd/coder/validators/test_error_response_compliance.py
@@ -235,14 +235,56 @@ def test_error_response_convention_exists():
 # ============================================================================
 
 
+def scan_bare_string_errors(repo_root: Path):
+    """Scan for bare string HTTPException details. Used by ratchet baseline."""
+    python_dir = repo_root / "python"
+    if not python_dir.exists():
+        return 0, []
+    py_files = list(python_dir.rglob("*.py"))
+    violations = []
+    for py_file in py_files:
+        if "__pycache__" in str(py_file):
+            continue
+        content = py_file.read_text(encoding="utf-8", errors="replace")
+        if "HTTPException" not in content:
+            continue
+        for match in BARE_STRING_DETAIL_RE.finditer(content):
+            line_num = content[: match.start()].count("\n") + 1
+            violations.append(
+                f"{py_file.relative_to(repo_root)}:{line_num}: bare string detail in HTTPException"
+            )
+    return len(violations), violations
+
+
+def scan_error_code_format(repo_root: Path):
+    """Scan for non-UPPER_SNAKE_CASE error codes. Used by ratchet baseline."""
+    python_dir = repo_root / "python"
+    if not python_dir.exists():
+        return 0, []
+    py_files = list(python_dir.rglob("*.py"))
+    violations = []
+    for py_file in py_files:
+        if "__pycache__" in str(py_file):
+            continue
+        content = py_file.read_text(encoding="utf-8", errors="replace")
+        for match in ERROR_CODE_VALUE_RE.finditer(content):
+            error_code = match.group(1)
+            if not UPPER_SNAKE_CASE_RE.match(error_code):
+                line_num = content[: match.start()].count("\n") + 1
+                violations.append(
+                    f"{py_file.relative_to(repo_root)}:{line_num}: error_code '{error_code}' not UPPER_SNAKE_CASE"
+                )
+    return len(violations), violations
+
+
 @pytest.mark.coder
-def test_python_endpoints_use_structured_error_responses():
+def test_python_endpoints_use_structured_error_responses(ratchet_baseline):
     """
     SPEC-CODER-ERRORRESPONSE-0004: Python endpoints use structured error responses.
 
     GIVEN: Python source files in the consumer repo
     WHEN: Scanning for HTTPException usage
-    THEN: No bare string detail= arguments found
+    THEN: Violation count does not exceed baseline (ratchet pattern)
 
     Validates: acc:verify-contracts:E001-UNIT-001, E001-UNIT-002
     """
@@ -253,38 +295,12 @@ def test_python_endpoints_use_structured_error_responses():
     if not py_files:
         pytest.skip("No Python files found in python/")
 
-    violations = []
-    files_with_httpexception = 0
-
-    for py_file in py_files:
-        if "__pycache__" in str(py_file):
-            continue
-
-        content = py_file.read_text(encoding="utf-8", errors="replace")
-        if "HTTPException" not in content:
-            continue
-
-        files_with_httpexception += 1
-
-        for match in BARE_STRING_DETAIL_RE.finditer(content):
-            line_num = content[: match.start()].count("\n") + 1
-            violations.append(
-                f"{py_file.relative_to(REPO_ROOT)}:{line_num}: "
-                f"bare string detail in HTTPException — use structured "
-                f"error response {{status_code, error_code, message}}"
-            )
-
-    if files_with_httpexception == 0:
-        pytest.skip("No files with HTTPException found in python/")
-
-    if violations:
-        pytest.fail(
-            f"\n\nBare string error responses detected "
-            f"(convention ERR-03):\n"
-            + "\n".join(f"  - {v}" for v in violations)
-            + f"\n\n  Contract: contracts/commons/error/response.schema.json"
-            + f"\n  Convention: error-response.convention.yaml"
-        )
+    count, violations = scan_bare_string_errors(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="error_response_bare_string",
+        current_count=count,
+        violations=violations,
+    )
 
 
 # ============================================================================
@@ -293,13 +309,13 @@ def test_python_endpoints_use_structured_error_responses():
 
 
 @pytest.mark.coder
-def test_error_codes_follow_enum_convention():
+def test_error_codes_follow_enum_convention(ratchet_baseline):
     """
     SPEC-CODER-ERRORRESPONSE-0005: Error codes follow UPPER_SNAKE_CASE convention.
 
     GIVEN: Python source files in the consumer repo
     WHEN: Scanning for error_code values
-    THEN: All error codes match ^[A-Z][A-Z0-9_]+$ pattern
+    THEN: Violation count does not exceed baseline (ratchet pattern)
 
     Validates: acc:verify-contracts:E001-UNIT-001 (error code format)
     """
@@ -310,32 +326,9 @@ def test_error_codes_follow_enum_convention():
     if not py_files:
         pytest.skip("No Python files found in python/")
 
-    violations = []
-    error_codes_found = 0
-
-    for py_file in py_files:
-        if "__pycache__" in str(py_file):
-            continue
-
-        content = py_file.read_text(encoding="utf-8", errors="replace")
-
-        for match in ERROR_CODE_VALUE_RE.finditer(content):
-            error_code = match.group(1)
-            error_codes_found += 1
-
-            if not UPPER_SNAKE_CASE_RE.match(error_code):
-                line_num = content[: match.start()].count("\n") + 1
-                violations.append(
-                    f"{py_file.relative_to(REPO_ROOT)}:{line_num}: "
-                    f"error_code '{error_code}' is not UPPER_SNAKE_CASE "
-                    f"(expected pattern: ^[A-Z][A-Z0-9_]+$)"
-                )
-
-    if error_codes_found == 0:
-        pytest.skip("No error_code values found in python/")
-
-    if violations:
-        pytest.fail(
-            f"\n\nError code format violations (convention ERR-02):\n"
-            + "\n".join(f"  - {v}" for v in violations)
-        )
+    count, violations = scan_error_code_format(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="error_code_format",
+        current_count=count,
+        violations=violations,
+    )

--- a/src/atdd/coder/validators/test_gsap_layer_usage.py
+++ b/src/atdd/coder/validators/test_gsap_layer_usage.py
@@ -129,94 +129,84 @@ def _scan_files_for_gsap(directory: Path) -> List[Tuple[Path, str]]:
     return violations
 
 
-@pytest.mark.coder
-def test_gsap_only_in_presentation_layer():
-    """
-    SPEC-CODER-GSAP-0001: GSAP imports allowed only in presentation layer.
-
-    GIVEN: All TypeScript files in web/src/
-    WHEN: Checking for GSAP imports
-    THEN: GSAP imports only appear in presentation layer paths
-
-    Detection patterns:
-      - ESM: import ... from "gsap", "gsap/*", "@gsap/*"
-      - Dynamic: import("gsap"), import("gsap/*")
-      - CJS: require("gsap"), require("gsap/*")
-      - Type-only: import type ... from "gsap"
-
-    Allowed paths:
-      - web/src/{wagon}/{feature}/presentation/**
-
-    Forbidden paths:
-      - web/src/{wagon}/{feature}/domain/**
-      - web/src/{wagon}/{feature}/application/**
-      - web/src/{wagon}/{feature}/integration/**
-      - web/src/commons/**
-
-    Validates: GSAP is UI-only and constrained to presentation code
-    """
-    if not WEB_SRC.exists():
-        pytest.skip("web/src does not exist")
-
-    violations = _scan_files_for_gsap(WEB_SRC)
-
-    if violations:
-        violation_details = []
-        for file_path, matched_import in violations:
-            rel_path = file_path.relative_to(REPO_ROOT)
-            violation_details.append(f"  - {rel_path}\n    Import: {matched_import}")
-
-        pytest.fail(
-            f"\n\nGSAP imports found outside presentation layer:\n\n"
-            + "\n\n".join(violation_details[:10])
-            + (f"\n\n... and {len(violations) - 10} more" if len(violations) > 10 else "")
-            + "\n\n"
-            + "GSAP is presentation-only. Move animation code to:\n"
-            + "  web/src/{wagon}/{feature}/presentation/\n"
-            + "\n"
-            + "See: technology.convention.yaml (frontend.presentation.libraries)"
-        )
+def scan_gsap_layer_usage(repo_root: Path):
+    """Scan for GSAP imports outside presentation layer. Used by ratchet baseline."""
+    web_src = repo_root / "web" / "src"
+    if not web_src.exists():
+        return 0, []
+    violations = _scan_files_for_gsap(web_src)
+    strs = []
+    for file_path, matched_import in violations:
+        try:
+            rel = file_path.relative_to(repo_root)
+        except ValueError:
+            rel = file_path
+        strs.append(f"{rel}: {matched_import}")
+    return len(violations), strs
 
 
-@pytest.mark.coder
-def test_gsap_not_in_commons():
-    """
-    SPEC-CODER-GSAP-0002: GSAP imports forbidden in commons.
-
-    GIVEN: All TypeScript files in web/src/commons/
-    WHEN: Checking for GSAP imports
-    THEN: No GSAP imports found (commons has no presentation layer)
-
-    Validates: Domain purity in commons module
-    """
-    commons_dir = WEB_SRC / "commons"
-
+def scan_gsap_commons(repo_root: Path):
+    """Scan for GSAP imports in commons. Used by ratchet baseline."""
+    commons_dir = repo_root / "web" / "src" / "commons"
     if not commons_dir.exists():
-        pytest.skip("web/src/commons does not exist")
-
-    violations: List[Tuple[Path, str]] = []
-
+        return 0, []
+    violations = []
     for ext in ["*.ts", "*.tsx"]:
         for ts_file in commons_dir.rglob(ext):
             try:
                 content = ts_file.read_text()
             except Exception:
                 continue
-
             gsap_import = _find_gsap_import(content)
             if gsap_import:
-                violations.append((ts_file, gsap_import))
+                try:
+                    rel = ts_file.relative_to(repo_root)
+                except ValueError:
+                    rel = ts_file
+                violations.append(f"{rel}: {gsap_import}")
+    return len(violations), violations
 
-    if violations:
-        violation_details = []
-        for file_path, matched_import in violations:
-            rel_path = file_path.relative_to(REPO_ROOT)
-            violation_details.append(f"  - {rel_path}\n    Import: {matched_import}")
 
-        pytest.fail(
-            f"\n\nGSAP imports found in commons (forbidden):\n\n"
-            + "\n".join(violation_details)
-            + "\n\n"
-            + "Commons has no presentation layer. GSAP is forbidden.\n"
-            + "Move animation code to wagon presentation layers."
-        )
+@pytest.mark.coder
+def test_gsap_only_in_presentation_layer(ratchet_baseline):
+    """
+    SPEC-CODER-GSAP-0001: GSAP imports allowed only in presentation layer.
+
+    GIVEN: All TypeScript files in web/src/
+    WHEN: Checking for GSAP imports
+    THEN: Violation count does not exceed baseline (ratchet pattern)
+
+    Validates: GSAP is UI-only and constrained to presentation code
+    """
+    if not WEB_SRC.exists():
+        pytest.skip("web/src does not exist")
+
+    count, violations = scan_gsap_layer_usage(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="gsap_layer_usage",
+        current_count=count,
+        violations=violations,
+    )
+
+
+@pytest.mark.coder
+def test_gsap_not_in_commons(ratchet_baseline):
+    """
+    SPEC-CODER-GSAP-0002: GSAP imports forbidden in commons.
+
+    GIVEN: All TypeScript files in web/src/commons/
+    WHEN: Checking for GSAP imports
+    THEN: Violation count does not exceed baseline (ratchet pattern)
+
+    Validates: Domain purity in commons module
+    """
+    commons_dir = WEB_SRC / "commons"
+    if not commons_dir.exists():
+        pytest.skip("web/src/commons does not exist")
+
+    count, violations = scan_gsap_commons(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="gsap_commons",
+        current_count=count,
+        violations=violations,
+    )

--- a/src/atdd/coder/validators/test_i18n_runtime.py
+++ b/src/atdd/coder/validators/test_i18n_runtime.py
@@ -40,132 +40,108 @@ def _read_file_content(path: Path) -> Optional[str]:
         return None
 
 
+def scan_i18n_config(repo_root: Path):
+    """Scan for hardcoded locale arrays in i18n config. Used by ratchet baseline."""
+    web_dir = repo_root / "web"
+    i18n_config = _find_file(
+        web_dir, "src/i18nConfig.ts", "src/i18n/config.ts",
+        "src/i18n.ts", "src/lib/i18n.ts", "src/config/i18n.ts",
+    )
+    if i18n_config is None:
+        return 0, []
+    content = _read_file_content(i18n_config)
+    if content is None:
+        return 0, []
+    hardcoded = re.compile(
+        r"(?:locales|supportedLocales|SUPPORTED_LOCALES|languages)\s*[=:]\s*\[\s*['\"][a-z]{2}",
+        re.IGNORECASE,
+    )
+    if not hardcoded.search(content):
+        return 0, []
+    manifest_patterns = [
+        r"from\s+['\"].*manifest", r"import.*manifest",
+        r"require\s*\(\s*['\"].*manifest", r"SUPPORTED_LOCALES", r"getSupportedLocales",
+    ]
+    if any(re.search(p, content, re.IGNORECASE) for p in manifest_patterns):
+        return 0, []
+    rel = i18n_config.relative_to(repo_root)
+    return 1, [f"{rel}: hardcoded locale array (should import from manifest)"]
+
+
+def scan_language_switcher(repo_root: Path):
+    """Scan for hardcoded locales in LanguageSwitcher. Used by ratchet baseline."""
+    web_dir = repo_root / "web"
+    if not web_dir.exists():
+        return 0, []
+    switcher_file = _find_file(
+        web_dir, "src/components/LanguageSwitcher.tsx",
+        "src/components/LocaleSwitcher.tsx", "src/components/ui/LanguageSwitcher.tsx",
+        "src/components/common/LanguageSwitcher.tsx", "src/features/i18n/LanguageSwitcher.tsx",
+    )
+    if switcher_file is None:
+        candidates = list(web_dir.rglob("*[Ll]anguage*[Ss]witcher*.tsx"))
+        if not candidates:
+            candidates = list(web_dir.rglob("*[Ll]ocale*[Ss]witcher*.tsx"))
+        if candidates:
+            switcher_file = candidates[0]
+    if switcher_file is None:
+        return 0, []
+    content = _read_file_content(switcher_file)
+    if content is None:
+        return 0, []
+    hardcoded = re.compile(
+        r"(?:locales|languages|options)\s*[=:]\s*\[\s*(?:\{[^}]*locale[^}]*['\"][a-z]{2}|['\"][a-z]{2})",
+        re.IGNORECASE,
+    )
+    if not hardcoded.search(content):
+        return 0, []
+    shared_patterns = [
+        r"SUPPORTED_LOCALES", r"getSupportedLocales", r"from\s+['\"].*manifest",
+        r"from\s+['\"].*i18n", r"from\s+['\"].*config", r"useLocales",
+    ]
+    if any(re.search(p, content, re.IGNORECASE) for p in shared_patterns):
+        return 0, []
+    rel = switcher_file.relative_to(repo_root)
+    return 1, [f"{rel}: hardcoded locale array (should use shared SUPPORTED_LOCALES)"]
+
+
 @pytest.mark.locale
 @pytest.mark.coder
-def test_i18n_config_uses_manifest(locale_manifest, locale_manifest_path):
+def test_i18n_config_uses_manifest(ratchet_baseline, locale_manifest, locale_manifest_path):
     """
     LOCALE-CODE-2.1: i18nConfig.ts imports from manifest (not hardcoded arrays)
 
     Given: Web application with i18n configuration
     When: Checking i18nConfig.ts or i18n.ts
-    Then: Configuration imports locales from manifest or shared constant
-          NOT hardcoded locale arrays like ['en', 'es', 'fr']
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     if locale_manifest is None:
         pytest.skip("Localization not configured")
 
-    i18n_config = _find_file(
-        WEB_DIR,
-        "src/i18nConfig.ts",
-        "src/i18n/config.ts",
-        "src/i18n.ts",
-        "src/lib/i18n.ts",
-        "src/config/i18n.ts",
+    count, violations = scan_i18n_config(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="i18n_config_manifest",
+        current_count=count,
+        violations=violations,
     )
-
-    if i18n_config is None:
-        pytest.skip("No i18n config file found in web/src/")
-
-    content = _read_file_content(i18n_config)
-    if content is None:
-        pytest.skip(f"Cannot read {i18n_config}")
-
-    hardcoded_array_pattern = re.compile(
-        r"(?:locales|supportedLocales|SUPPORTED_LOCALES|languages)\s*[=:]\s*\[\s*['\"][a-z]{2}",
-        re.IGNORECASE
-    )
-
-    if hardcoded_array_pattern.search(content):
-        manifest_import_patterns = [
-            r"from\s+['\"].*manifest",
-            r"import.*manifest",
-            r"require\s*\(\s*['\"].*manifest",
-            r"SUPPORTED_LOCALES",
-            r"getSupportedLocales",
-        ]
-
-        has_manifest_usage = any(
-            re.search(pattern, content, re.IGNORECASE)
-            for pattern in manifest_import_patterns
-        )
-
-        if not has_manifest_usage:
-            msg = (
-                f"i18n config has hardcoded locale array: {i18n_config.relative_to(REPO_ROOT)}\n"
-                f"  Should import from manifest.json or use shared SUPPORTED_LOCALES constant"
-            )
-            if should_enforce_locale(LocalePhase.FULL_ENFORCEMENT):
-                pytest.fail(msg)
-            else:
-                emit_locale_warning("LOCALE-CODE-2.1", msg, LocalePhase.FULL_ENFORCEMENT)
-                pytest.skip(msg)
 
 
 @pytest.mark.locale
 @pytest.mark.coder
-def test_language_switcher_uses_shared_locales(locale_manifest, locale_manifest_path):
+def test_language_switcher_uses_shared_locales(ratchet_baseline, locale_manifest, locale_manifest_path):
     """
     LOCALE-CODE-2.2: LanguageSwitcher uses shared SUPPORTED_LOCALES
 
     Given: Web application with language switcher component
     When: Checking LanguageSwitcher component
-    Then: Component imports locales from shared constant or manifest
-          NOT hardcoded locale arrays
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     if locale_manifest is None:
         pytest.skip("Localization not configured")
 
-    switcher_patterns = [
-        "src/components/LanguageSwitcher.tsx",
-        "src/components/LocaleSwitcher.tsx",
-        "src/components/ui/LanguageSwitcher.tsx",
-        "src/components/common/LanguageSwitcher.tsx",
-        "src/features/i18n/LanguageSwitcher.tsx",
-    ]
-
-    switcher_file = _find_file(WEB_DIR, *switcher_patterns)
-
-    if switcher_file is None:
-        switcher_files = list(WEB_DIR.rglob("*[Ll]anguage*[Ss]witcher*.tsx"))
-        if not switcher_files:
-            switcher_files = list(WEB_DIR.rglob("*[Ll]ocale*[Ss]witcher*.tsx"))
-        if switcher_files:
-            switcher_file = switcher_files[0]
-
-    if switcher_file is None:
-        pytest.skip("No LanguageSwitcher component found")
-
-    content = _read_file_content(switcher_file)
-    if content is None:
-        pytest.skip(f"Cannot read {switcher_file}")
-
-    hardcoded_array_pattern = re.compile(
-        r"(?:locales|languages|options)\s*[=:]\s*\[\s*(?:\{[^}]*locale[^}]*['\"][a-z]{2}|['\"][a-z]{2})",
-        re.IGNORECASE
+    count, violations = scan_language_switcher(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="i18n_language_switcher",
+        current_count=count,
+        violations=violations,
     )
-
-    if hardcoded_array_pattern.search(content):
-        shared_patterns = [
-            r"SUPPORTED_LOCALES",
-            r"getSupportedLocales",
-            r"from\s+['\"].*manifest",
-            r"from\s+['\"].*i18n",
-            r"from\s+['\"].*config",
-            r"useLocales",
-        ]
-
-        has_shared_usage = any(
-            re.search(pattern, content, re.IGNORECASE)
-            for pattern in shared_patterns
-        )
-
-        if not has_shared_usage:
-            msg = (
-                f"LanguageSwitcher has hardcoded locale array: {switcher_file.relative_to(REPO_ROOT)}\n"
-                f"  Should import from shared SUPPORTED_LOCALES or manifest"
-            )
-            if should_enforce_locale(LocalePhase.FULL_ENFORCEMENT):
-                pytest.fail(msg)
-            else:
-                emit_locale_warning("LOCALE-CODE-2.2", msg, LocalePhase.FULL_ENFORCEMENT)
-                pytest.skip(msg)

--- a/src/atdd/coder/validators/test_quality_metrics.py
+++ b/src/atdd/coder/validators/test_quality_metrics.py
@@ -320,7 +320,7 @@ def test_adequate_code_comments(ratchet_baseline):
 
 
 @pytest.mark.coder
-def test_no_significant_code_duplication():
+def test_no_significant_code_duplication(ratchet_baseline):
     """
     SPEC-CODER-QUALITY-0003: No significant code duplication.
 
@@ -330,7 +330,7 @@ def test_no_significant_code_duplication():
 
     Given: All Python files
     When: Checking for duplicate code blocks
-    Then: No significant duplication found
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_files = find_python_files()
 
@@ -341,26 +341,21 @@ def test_no_significant_code_duplication():
     sample_files = python_files[:50]
 
     duplicates = find_duplicate_code_blocks(sample_files)
-
-    if duplicates:
-        violations = []
-        for file1, file2, block in duplicates[:10]:
-            violations.append(
-                f"{file1.relative_to(REPO_ROOT)} ↔ {file2.relative_to(REPO_ROOT)}\\n"
-                f"  Duplicate block ({len(block)} lines):\\n" +
-                "\\n".join(f"    {line[:60]}" for line in block[:3])
-            )
-
-        pytest.fail(
-            f"\\n\\nFound {len(duplicates)} code duplication instances:\\n\\n" +
-            "\\n\\n".join(violations) +
-            (f"\\n\\n... and {len(duplicates) - 10} more" if len(duplicates) > 10 else "") +
-            "\\n\\nConsider extracting duplicate code into shared functions."
+    violations = []
+    for file1, file2, block in duplicates:
+        violations.append(
+            f"{file1.relative_to(REPO_ROOT)} ↔ {file2.relative_to(REPO_ROOT)} ({len(block)} lines)"
         )
+
+    ratchet_baseline.assert_no_regression(
+        validator_id="code_duplication",
+        current_count=len(duplicates),
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_consistent_naming_conventions():
+def test_consistent_naming_conventions(ratchet_baseline):
     """
     SPEC-CODER-QUALITY-0004: Code follows consistent naming conventions.
 
@@ -372,7 +367,7 @@ def test_consistent_naming_conventions():
 
     Given: All Python files
     When: Checking naming patterns
-    Then: Consistent naming conventions
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_files = find_python_files()
 
@@ -383,17 +378,13 @@ def test_consistent_naming_conventions():
 
     for py_file in python_files:
         violations = check_naming_consistency(py_file)
-
         if violations:
             rel_path = py_file.relative_to(REPO_ROOT)
-            all_violations.append(
-                f"{rel_path}\\n" +
-                "\\n".join(f"  - {v}" for v in violations[:5])
-            )
+            for v in violations:
+                all_violations.append(f"{rel_path}: {v}")
 
-    if all_violations:
-        pytest.fail(
-            f"\\n\\nFound {len(all_violations)} files with naming violations:\\n\\n" +
-            "\\n\\n".join(all_violations[:10]) +
-            (f"\\n\\n... and {len(all_violations) - 10} more" if len(all_violations) > 10 else "")
-        )
+    ratchet_baseline.assert_no_regression(
+        validator_id="naming_conventions",
+        current_count=len(all_violations),
+        violations=all_violations,
+    )

--- a/src/atdd/coder/validators/test_query_count.py
+++ b/src/atdd/coder/validators/test_query_count.py
@@ -192,8 +192,34 @@ def detect_n_plus_one(file_path: Path) -> List[Dict]:
     return violations
 
 
+def scan_query_count(repo_root: Path):
+    """Scan for N+1 query patterns. Used by ratchet baseline."""
+    python_dir = find_python_dir(repo_root)
+    if not python_dir.exists():
+        return 0, []
+    files = []
+    for py_file in python_dir.rglob("*.py"):
+        path_str = str(py_file)
+        if '/test/' in path_str or '/tests/' in path_str:
+            continue
+        if py_file.name.startswith('test_') or '__pycache__' in path_str:
+            continue
+        if py_file.name == '__init__.py' or '/migrations/' in path_str:
+            continue
+        files.append(py_file)
+    all_violations = []
+    for py_file in files:
+        violations = detect_n_plus_one(py_file)
+        for v in violations:
+            rel_path = v['file'].relative_to(repo_root)
+            all_violations.append(
+                f"{rel_path}:{v['line']} {v['function']} {v['call']} in {v['loop_type']}"
+            )
+    return len(all_violations), all_violations
+
+
 @pytest.mark.coder
-def test_no_db_calls_inside_loops():
+def test_no_db_calls_inside_loops(ratchet_baseline):
     """
     SPEC-CODER-PERF-0001: No database client calls inside loop bodies.
 
@@ -201,38 +227,17 @@ def test_no_db_calls_inside_loops():
     in a collection, instead of batching. This causes O(N) queries where
     O(1) would suffice.
 
-    Threshold: 0 (any DB call inside a loop body is flagged)
-
     Given: Python source files in python/ or src/
     When: AST analysis finds DB client calls inside for/while/async for loop bodies
-    Then: Report violations with file, line, function, and call pattern
+    Then: Violation count does not exceed baseline (ratchet pattern)
     """
     python_files = find_python_files()
-
     if not python_files:
         pytest.skip("No Python source files found")
 
-    all_violations = []
-
-    for py_file in python_files:
-        violations = detect_n_plus_one(py_file)
-        all_violations.extend(violations)
-
-    if all_violations:
-        details = []
-        for v in all_violations[:10]:
-            rel_path = v['file'].relative_to(REPO_ROOT)
-            details.append(
-                f"{rel_path}:{v['line']}\\n"
-                f"  Function: {v['function']}\\n"
-                f"  Loop: {v['loop_type']} at line {v['loop_line']}\\n"
-                f"  DB call: {v['call']}\\n"
-                f"  Fix: Batch the query outside the loop, or add '# noqa: N+1' to suppress"
-            )
-
-        pytest.fail(
-            f"\\n\\nFound {len(all_violations)} N+1 query risk(s):\\n\\n" +
-            "\\n\\n".join(details) +
-            (f"\\n\\n... and {len(all_violations) - 10} more"
-             if len(all_violations) > 10 else "")
-        )
+    count, violations = scan_query_count(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="query_count",
+        current_count=count,
+        violations=violations,
+    )

--- a/src/atdd/coder/validators/test_security_patterns.py
+++ b/src/atdd/coder/validators/test_security_patterns.py
@@ -296,82 +296,51 @@ def _format_violations(violations: List[Dict], base_dir: Path) -> str:
 # Tests
 # ===========================================================================
 
-@pytest.mark.coder
-def test_no_raw_sql_concatenation():
-    """
-    SPEC-CODER-SEC-0001: No raw SQL string concatenation in execute calls.
+def _violation_strs(violations: List[Dict], base_dir: Path) -> List[str]:
+    """Convert violation dicts to string list for ratchet baseline."""
+    result = []
+    for v in violations:
+        try:
+            rel = v["file"].relative_to(base_dir)
+        except ValueError:
+            rel = v["file"]
+        result.append(f"{rel}:{v['line']} {v['detail']}")
+    return result
 
-    SQL injection via f-strings or string concatenation is a critical
-    vulnerability.  Parameterized queries must be used instead.
 
-    Given: Python files in python/
-    When:  Parsing AST for SQL keywords in dynamic strings passed to sink methods
-    Then:  No violations found
-    """
+def scan_sql_concatenation(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for SQL concatenation violations. Used by ratchet baseline."""
     convention = load_security_convention()
     rule = convention.get("rules", {}).get("sql_injection", {})
     sql_keywords = rule.get("sql_keywords", ["SELECT", "INSERT", "UPDATE", "DELETE", "DROP", "ALTER", "CREATE"])
     sink_methods = rule.get("sink_methods", ["execute", "executemany", "raw", "execute_sql"])
     exclusions = rule.get("exclusions", [])
-
-    files = find_python_files(PYTHON_DIR, exclusions)
-    if not files:
-        pytest.skip("No Python files found in python/")
-
+    python_dir = repo_root / "python"
+    files = find_python_files(python_dir, exclusions)
     violations: List[Dict] = []
     for f in files:
         violations.extend(check_sql_concatenation(f, sql_keywords, sink_methods))
-
-    if violations:
-        pytest.fail(_format_violations(violations, REPO_ROOT))
+    return len(violations), _violation_strs(violations, repo_root)
 
 
-@pytest.mark.coder
-def test_fastapi_routes_have_auth_dependency():
-    """
-    SPEC-CODER-SEC-0002: FastAPI routes must have auth dependency injection.
-
-    Every route handler decorated with @router.get/post/etc must include
-    a Depends(auth_function) parameter to enforce authentication.
-
-    Given: Python files in python/ with FastAPI route decorators
-    When:  Checking function parameters for Depends(auth_fn)
-    Then:  All route functions include auth dependency
-    """
+def scan_missing_auth(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for missing auth dependency violations. Used by ratchet baseline."""
     convention = load_security_convention()
     rule = convention.get("rules", {}).get("missing_auth", {})
     route_decorators = rule.get("route_decorators", ["get", "post", "put", "delete", "patch", "options", "head"])
     router_objects = rule.get("router_objects", ["app", "router"])
     auth_deps = rule.get("auth_dependencies", ["get_current_user", "require_auth", "verify_token"])
     exclusions = rule.get("exclusions", [])
-
-    files = find_python_files(PYTHON_DIR, exclusions)
-    if not files:
-        pytest.skip("No Python files found in python/")
-
+    python_dir = repo_root / "python"
+    files = find_python_files(python_dir, exclusions)
     violations: List[Dict] = []
     for f in files:
         violations.extend(check_missing_auth(f, route_decorators, router_objects, auth_deps))
-
-    if not violations:
-        # No route-decorated functions found counts as pass (not skip)
-        return
-
-    pytest.fail(_format_violations(violations, REPO_ROOT))
+    return len(violations), _violation_strs(violations, repo_root)
 
 
-@pytest.mark.coder
-def test_no_hardcoded_secrets():
-    """
-    SPEC-CODER-SEC-0003: No hardcoded secrets in Python source files.
-
-    AWS access keys, private key headers, password assignments, API key
-    literals, and bearer tokens must never appear in source code.
-
-    Given: Python files in python/
-    When:  Scanning with regex patterns for secret-like strings
-    Then:  No matches found
-    """
+def scan_hardcoded_secrets(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for hardcoded secrets. Used by ratchet baseline."""
     convention = load_security_convention()
     rule = convention.get("rules", {}).get("hardcoded_secrets", {})
     patterns = rule.get("patterns", [
@@ -382,14 +351,81 @@ def test_no_hardcoded_secrets():
         {"name": "generic_token", "regex": r'(token|auth_token|access_token)\s*=\s*["\'][a-zA-Z0-9_\-]{20,}["\']'},
     ])
     exclusions = rule.get("exclusions", [])
-
-    files = find_python_files(PYTHON_DIR, exclusions)
-    if not files:
-        pytest.skip("No Python files found in python/")
-
+    python_dir = repo_root / "python"
+    files = find_python_files(python_dir, exclusions)
     violations: List[Dict] = []
     for f in files:
         violations.extend(check_hardcoded_secrets(f, patterns))
+    return len(violations), _violation_strs(violations, repo_root)
 
-    if violations:
-        pytest.fail(_format_violations(violations, REPO_ROOT))
+
+@pytest.mark.coder
+def test_no_raw_sql_concatenation(ratchet_baseline):
+    """
+    SPEC-CODER-SEC-0001: No raw SQL string concatenation in execute calls.
+
+    SQL injection via f-strings or string concatenation is a critical
+    vulnerability.  Parameterized queries must be used instead.
+
+    Given: Python files in python/
+    When:  Parsing AST for SQL keywords in dynamic strings passed to sink methods
+    Then:  Violation count does not exceed baseline (ratchet pattern)
+    """
+    files = find_python_files(PYTHON_DIR)
+    if not files:
+        pytest.skip("No Python files found in python/")
+
+    count, violations = scan_sql_concatenation(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="sql_concatenation",
+        current_count=count,
+        violations=violations,
+    )
+
+
+@pytest.mark.coder
+def test_fastapi_routes_have_auth_dependency(ratchet_baseline):
+    """
+    SPEC-CODER-SEC-0002: FastAPI routes must have auth dependency injection.
+
+    Every route handler decorated with @router.get/post/etc must include
+    a Depends(auth_function) parameter to enforce authentication.
+
+    Given: Python files in python/ with FastAPI route decorators
+    When:  Checking function parameters for Depends(auth_fn)
+    Then:  Violation count does not exceed baseline (ratchet pattern)
+    """
+    files = find_python_files(PYTHON_DIR)
+    if not files:
+        pytest.skip("No Python files found in python/")
+
+    count, violations = scan_missing_auth(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="missing_auth_dependency",
+        current_count=count,
+        violations=violations,
+    )
+
+
+@pytest.mark.coder
+def test_no_hardcoded_secrets(ratchet_baseline):
+    """
+    SPEC-CODER-SEC-0003: No hardcoded secrets in Python source files.
+
+    AWS access keys, private key headers, password assignments, API key
+    literals, and bearer tokens must never appear in source code.
+
+    Given: Python files in python/
+    When:  Scanning with regex patterns for secret-like strings
+    Then:  Violation count does not exceed baseline (ratchet pattern)
+    """
+    files = find_python_files(PYTHON_DIR)
+    if not files:
+        pytest.skip("No Python files found in python/")
+
+    count, violations = scan_hardcoded_secrets(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="hardcoded_secrets",
+        current_count=count,
+        violations=violations,
+    )

--- a/src/atdd/coder/validators/test_structured_logging.py
+++ b/src/atdd/coder/validators/test_structured_logging.py
@@ -132,8 +132,44 @@ def _rel_path(file_path: Path) -> Path:
         return file_path.relative_to(ATDD_PKG_DIR.parent)
 
 
+def scan_print_in_production(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for print() calls in production code. Used by ratchet baseline."""
+    python_dir = repo_root / "python"
+    python_files = _collect_files(python_dir)
+    violations = []
+    for py_file in python_files:
+        prints = detect_print_calls(py_file)
+        for lineno, col in prints:
+            try:
+                rel = py_file.relative_to(repo_root)
+            except ValueError:
+                rel = py_file
+            violations.append(f"{rel}:{lineno}:{col} — print() call")
+    return len(violations), violations
+
+
+def scan_structured_logging(repo_root: Path) -> Tuple[int, List[str]]:
+    """Scan for bare log calls. Used by ratchet baseline."""
+    python_dir = repo_root / "python"
+    atdd_dir = Path(atdd.__file__).resolve().parent
+    python_files = _collect_files(python_dir, atdd_dir)
+    violations = []
+    for py_file in python_files:
+        bare_logs = detect_bare_log_calls(py_file)
+        for lineno, col, method in bare_logs:
+            try:
+                rel = py_file.relative_to(repo_root)
+            except ValueError:
+                try:
+                    rel = py_file.relative_to(atdd_dir.parent)
+                except ValueError:
+                    rel = py_file
+            violations.append(f"{rel}:{lineno}:{col} — logger.{method}() without extra=")
+    return len(violations), violations
+
+
 @pytest.mark.coder
-def test_no_print_in_production_code():
+def test_no_print_in_production_code(ratchet_baseline):
     """
     SPEC-CODER-LOG-0001: No print() in non-test production Python code.
 
@@ -146,38 +182,24 @@ def test_no_print_in_production_code():
 
     Given: Python files in python/ (excluding tests)
     When: Checking for print() calls via AST analysis
-    Then: No print() calls found
+    Then: Violation count does not exceed baseline (ratchet pattern)
 
     Convention: atdd/coder/conventions/logging.convention.yaml (LOG-001)
     """
     python_files = _collect_files(PYTHON_DIR)
-
     if not python_files:
         pytest.skip("No Python files found in python/ to validate")
 
-    violations = []
-    for py_file in python_files:
-        prints = detect_print_calls(py_file)
-        for lineno, col in prints:
-            rel = _rel_path(py_file)
-            violations.append(f"{rel}:{lineno}:{col} — print() call")
-
-    if violations:
-        pytest.fail(
-            f"\n\nFound {len(violations)} print() violations in production code:\n\n"
-            + "\n".join(violations[:20])
-            + (
-                f"\n\n... and {len(violations) - 20} more"
-                if len(violations) > 20
-                else ""
-            )
-            + "\n\nUse logging module instead of print()."
-            + "\nSee: atdd/coder/conventions/logging.convention.yaml (LOG-001)"
-        )
+    count, violations = scan_print_in_production(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="print_in_production",
+        current_count=count,
+        violations=violations,
+    )
 
 
 @pytest.mark.coder
-def test_structured_logging_format():
+def test_structured_logging_format(ratchet_baseline):
     """
     SPEC-CODER-LOG-0002: Logger calls must include extra= context dict.
 
@@ -192,33 +214,17 @@ def test_structured_logging_format():
 
     Given: Python files in python/ and src/atdd/ (excluding tests)
     When: Checking logger calls via AST analysis
-    Then: All logger calls include extra= keyword argument
+    Then: Violation count does not exceed baseline (ratchet pattern)
 
     Convention: atdd/coder/conventions/logging.convention.yaml (LOG-002)
     """
     python_files = _collect_files(PYTHON_DIR, ATDD_PKG_DIR)
-
     if not python_files:
         pytest.skip("No Python files found to validate")
 
-    violations = []
-    for py_file in python_files:
-        bare_logs = detect_bare_log_calls(py_file)
-        for lineno, col, method in bare_logs:
-            rel = _rel_path(py_file)
-            violations.append(
-                f"{rel}:{lineno}:{col} — logger.{method}() without extra="
-            )
-
-    if violations:
-        pytest.fail(
-            f"\n\nFound {len(violations)} unstructured log call violations:\n\n"
-            + "\n".join(violations[:20])
-            + (
-                f"\n\n... and {len(violations) - 20} more"
-                if len(violations) > 20
-                else ""
-            )
-            + "\n\nUse: logger.info('message', extra={'key': 'value'})"
-            + "\nSee: atdd/coder/conventions/logging.convention.yaml (LOG-002)"
-        )
+    count, violations = scan_structured_logging(REPO_ROOT)
+    ratchet_baseline.assert_no_regression(
+        validator_id="structured_logging_format",
+        current_count=count,
+        violations=violations,
+    )


### PR DESCRIPTION
## Summary
- Wire 12 Category A (quality/style) validators to `ratchet_baseline.assert_no_regression()` instead of hard-failing with `pytest.fail()`
- Register 31 new `_baseline_scan` functions in `baseline.py` for `atdd baseline update`
- Leave 11 Category B (architecture) validators as hard-fail per review comment on #250
- Bump version to 1.45.5

## Category A validators ratcheted (12 files, 31 validator IDs)

| Validator | IDs |
|-----------|-----|
| `duplication_detector` | `duplication_detector` |
| `duplication_detector_typescript` | `duplication_detector_typescript` |
| `complexity` | `cyclomatic_complexity`, `nesting_depth`, `function_length`, `function_parameter_count` |
| `quality_metrics` | `code_duplication`, `naming_conventions` (2 already ratcheted) |
| `structured_logging` | `print_in_production`, `structured_logging_format` |
| `security_patterns` | `sql_concatenation`, `missing_auth_dependency`, `hardcoded_secrets` |
| `design_system_compliance` | `ds_presentation_primitives`, `ds_color_tokens`, `ds_orphaned_exports`, `ds_foundations_usage`, `ds_hierarchy_imports`, `ds_hardcoded_tokens`, `ds_orphaned_ui` |
| `error_response_compliance` | `error_response_bare_string`, `error_code_format` |
| `query_count` | `query_count` |
| `gsap_layer_usage` | `gsap_layer_usage`, `gsap_commons` |
| `i18n_runtime` | `i18n_config_manifest`, `i18n_language_switcher` |
| `cross_language_consistency` | `entity_cross_language`, `enum_cross_language`, `naming_cross_language`, `api_contracts_cross_language` |

## Category B validators left as hard-fail (unchanged)
`wagon_boundaries`, `import_boundaries`, `python_architecture`, `typescript_architecture`, `commons_structure`, `usecase_structure`, `init_file_urns`, `train_urns`, `train_infrastructure`, `dto_testing_patterns`, `frontend_security_patterns`

## Test plan
- [x] All 14 modified files parse without syntax errors
- [x] `pytest src/atdd/coder/validators/ -m coder` — 52 passed, 85 skipped
- [x] 38 validators registered in `baseline.py` (7 existing + 31 new)
- [ ] CI validates full suite

Closes #250