### PR TITLE
fix(planner): skip _features.yaml manifest in COVERAGE-PLAN-2.2a (#252)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.45.5"
+version = "1.45.6"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/planner/validators/test_hierarchy_coverage.py
+++ b/src/atdd/planner/validators/test_hierarchy_coverage.py
@@ -33,6 +33,22 @@ REPO_ROOT = find_repo_root()
 PLAN_DIR = REPO_ROOT / "plan"
 
 
+def _is_manifest_slug(feature_slug: str) -> bool:
+    """
+    Return True if the feature slug refers to a manifest file, not a real feature.
+
+    Manifest files like ``_features.yaml`` produce slugs such as ``-features``
+    or ``_features`` after stem extraction and hyphen normalisation. The
+    ``_features.yaml`` path is declared by the ATDD convention as the wagon
+    feature manifest (see ``coach/templates/ATDD.md``) and must not be treated
+    as a feature definition by coverage validators.
+
+    Mirrors ``atdd.coder.validators.test_hierarchy_coverage._is_manifest_slug``
+    so the planner and coder validators stay consistent.
+    """
+    return feature_slug in ("-features", "_features", "")
+
+
 # ============================================================================
 # COVERAGE-PLAN-2.1: Train <-> Wagon Coverage
 # ============================================================================
@@ -178,6 +194,12 @@ def test_all_features_in_wagon_manifest(feature_files, wagon_manifests, coverage
         # Feature filename (snake_case) -> slug (kebab-case)
         feature_filename = path.stem
         feature_slug = feature_filename.replace("_", "-")
+
+        # Skip manifest files (_features.yaml) that are not real features.
+        # See atdd/coder/validators/test_hierarchy_coverage.py for the
+        # equivalent skip on the coder side. Issue #252.
+        if _is_manifest_slug(feature_slug):
+            continue
 
         # Also check for URN in feature data
         feature_urn = feature_data.get("urn", "")


### PR DESCRIPTION
## Summary

Fixes #252.

The planner validator `test_all_features_in_wagon_manifest` (COVERAGE-PLAN-2.2a) derived a slug from every `*.yaml` in `plan/<wagon>/features/`, including the documented `_features.yaml` manifest file. Stem extraction + underscore-to-hyphen normalisation produced the illegal slug `-features`, which can never appear in the wagon manifest `features[]` (it would fail the URN regex `^feature:[a-z][a-z0-9-]+:[a-z][a-z0-9-]+$`).

The toolkit already recognised manifest files in two of three call sites:

| Call site | Skip logic | Status |
|---|---|---|
| `coder/validators/test_hierarchy_coverage.py` | `_is_manifest_slug()` at line 145 | already correct |
| `coach/commands/traceability.py:830` | `if feature_file.name != '_features.yaml':` | already correct |
| `planner/validators/test_hierarchy_coverage.py` | (none) | **fixed here** |

This PR adds a `_is_manifest_slug()` helper to the planner validator that mirrors the coder helper exactly and uses it to skip manifest files inside `test_all_features_in_wagon_manifest`. Keeping the helper local (rather than introducing a shared util) keeps the diff minimal; a follow-up can DRY both copies into `atdd.coach.utils` if desired.

## Why it matters

`_features.yaml` is a documented ATDD convention — declared in `coach/templates/ATDD.md:51` and shipped to every consumer on `atdd init`:

```yaml
features: "plan/*/_features.yaml"
```

Without this fix, every wagon that ships an aggregator manifest emits a `[COVERAGE-PLAN-2.2a]` warning. In the jel-app consumer repo this affects ~13 wagons. Per the validator's own message, this warning becomes a hard failure in `Phase 2: Planner+Tester Enforcement`, so the bug is on a fuse.

## Test plan

- [x] `_is_manifest_slug()` unit-checked with `-features`, `_features`, `''`, and real verb-object slugs
- [x] End-to-end: ran `pytest test_all_features_in_wagon_manifest` from the patched source against a jel-app worktree containing 13 `_features.yaml` files
- [x] Before: would emit 13 `_features.yaml` warnings
- [x] After: emits zero `_features.yaml` warnings; only one unrelated legitimate orphan warning surfaces
- [ ] CI green on this PR

Refs: #252