### PR TITLE
refactor(coach): extract is_manifest_slug to shared util

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.45.6"
+version = "1.45.7"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/utils/manifest.py
+++ b/src/atdd/coach/utils/manifest.py
@@ -1,0 +1,42 @@
+"""
+Manifest file detection utilities.
+
+Helpers for distinguishing wagon-level manifest/aggregator files from real
+feature definitions inside ``plan/<wagon>/features/``.
+
+Background
+----------
+The ATDD convention (see ``coach/templates/ATDD.md``) declares the wagon
+feature manifest at ``plan/*/_features.yaml``. The shared ``feature_files``
+fixture (``coach/validators/shared_fixtures.py``) globs ``*.yaml`` inside
+each ``features/`` directory and yields every match — including
+``_features.yaml``. Coverage validators must skip the manifest entry,
+otherwise the underscore-to-hyphen slug normalisation produces an
+illegal slug ``-features`` that can never appear in any wagon
+manifest's ``features[]`` list (it would fail the URN regex
+``^feature:[a-z][a-z0-9-]+:[a-z][a-z0-9-]+$``).
+
+Prior to consolidation, the planner and coder validators each carried
+their own copy of this skip helper, and at least one call site (the
+planner) lacked the helper entirely — see issue #252. This module is
+the single source of truth so all sister validators stay in sync.
+"""
+
+# Slugs produced by stem extraction + underscore→hyphen normalisation when
+# the file is a manifest/aggregator rather than a real feature definition.
+# - "_features"  → raw stem of "_features.yaml"
+# - "-features"  → after replace("_", "-")
+# - ""           → defensive: stem of an empty/odd filename
+_MANIFEST_SLUGS = frozenset(("-features", "_features", ""))
+
+
+def is_manifest_slug(feature_slug: str) -> bool:
+    """
+    Return True if ``feature_slug`` refers to a manifest file, not a feature.
+
+    Manifest files like ``_features.yaml`` produce slugs such as
+    ``-features`` or ``_features`` after stem extraction and hyphen
+    normalisation. Coverage validators iterating ``feature_files`` should
+    skip these entries before applying any slug- or URN-based checks.
+    """
+    return feature_slug in _MANIFEST_SLUGS

--- a/src/atdd/coder/validators/test_hierarchy_coverage.py
+++ b/src/atdd/coder/validators/test_hierarchy_coverage.py
@@ -23,6 +23,7 @@ from atdd.coach.utils.coverage_phase import (
     should_enforce,
     emit_coverage_warning
 )
+from atdd.coach.utils.manifest import is_manifest_slug
 
 
 # Path constants
@@ -142,16 +143,6 @@ def find_web_implementations(wagon_slug: str, feature_slug: str) -> List[Path]:
     return implementations
 
 
-def _is_manifest_slug(feature_slug: str) -> bool:
-    """
-    Return True if the feature slug refers to a manifest file, not a real feature.
-
-    Manifest files like ``_features.yaml`` produce slugs such as ``-features``
-    or ``_features`` after stem extraction and hyphen normalisation.
-    """
-    return feature_slug in ("-features", "_features", "")
-
-
 def has_implementation(wagon_slug: str, feature_slug: str) -> bool:
     """
     Check if a feature has any implementation.
@@ -247,7 +238,7 @@ def test_all_features_have_implementations(feature_files, coverage_exceptions, r
         feature_slug = path.stem.replace("_", "-")
 
         # Skip manifest files (_features.yaml) that are not real features
-        if _is_manifest_slug(feature_slug):
+        if is_manifest_slug(feature_slug):
             continue
 
         feature_urn = feature_data.get("urn", f"feature:{wagon_slug}:{feature_slug}")

--- a/src/atdd/planner/validators/test_hierarchy_coverage.py
+++ b/src/atdd/planner/validators/test_hierarchy_coverage.py
@@ -26,27 +26,12 @@ from atdd.coach.utils.coverage_phase import (
     should_enforce,
     emit_coverage_warning
 )
+from atdd.coach.utils.manifest import is_manifest_slug
 
 
 # Path constants
 REPO_ROOT = find_repo_root()
 PLAN_DIR = REPO_ROOT / "plan"
-
-
-def _is_manifest_slug(feature_slug: str) -> bool:
-    """
-    Return True if the feature slug refers to a manifest file, not a real feature.
-
-    Manifest files like ``_features.yaml`` produce slugs such as ``-features``
-    or ``_features`` after stem extraction and hyphen normalisation. The
-    ``_features.yaml`` path is declared by the ATDD convention as the wagon
-    feature manifest (see ``coach/templates/ATDD.md``) and must not be treated
-    as a feature definition by coverage validators.
-
-    Mirrors ``atdd.coder.validators.test_hierarchy_coverage._is_manifest_slug``
-    so the planner and coder validators stay consistent.
-    """
-    return feature_slug in ("-features", "_features", "")
 
 
 # ============================================================================
@@ -196,9 +181,8 @@ def test_all_features_in_wagon_manifest(feature_files, wagon_manifests, coverage
         feature_slug = feature_filename.replace("_", "-")
 
         # Skip manifest files (_features.yaml) that are not real features.
-        # See atdd/coder/validators/test_hierarchy_coverage.py for the
-        # equivalent skip on the coder side. Issue #252.
-        if _is_manifest_slug(feature_slug):
+        # Issue #252.
+        if is_manifest_slug(feature_slug):
             continue
 
         # Also check for URN in feature data


### PR DESCRIPTION
## Summary

Follow-up to #254 (fix for #252). The planner and coder hierarchy validators each carried a copy of the manifest-slug skip helper. This PR extracts a single `is_manifest_slug()` into `atdd.coach.utils.manifest` so both validators import the same source.

## Why

#252 was caused by exactly this pattern: a small helper duplicated across sister validators, with one copy missing. Extracting to a shared util eliminates the entire class of skip-helper drift bugs across COVERAGE-PLAN-2.2a and COVERAGE-CODE-4.1.

The new module is documented with the full background — slug set, why each value matters, and a pointer back to the convention that produces \`_features.yaml\`.

## Changes

- **New:** \`src/atdd/coach/utils/manifest.py\` — single source of truth for the manifest slug set
- **Updated:** \`planner/validators/test_hierarchy_coverage.py\` — drops local helper, imports shared
- **Updated:** \`coder/validators/test_hierarchy_coverage.py\` — drops local helper, imports shared
- **Bump:** 1.45.6 → 1.45.7 (pure refactor, no behavior change)

## Out of scope

\`coach/commands/traceability.py:822\` has a related but structurally different inconsistency: \`rglob(\"features/*.yaml\")\` does not skip \`_features.yaml\` even though the sibling block on line 830 does. That is a filename-level bug (not slug-level) and would need a different helper. Filing separately if it bites anyone.

## Test plan

- [x] Import smoke test: \`is_manifest_slug\` is the same object when imported from \`coach.utils.manifest\`, \`planner.validators.test_hierarchy_coverage\`, and \`coder.validators.test_hierarchy_coverage\`
- [x] Helper unit-checked with \`-features\`, \`_features\`, \`''\`, real verb-object slugs
- [x] End-to-end: ran \`pytest test_all_features_in_wagon_manifest test_all_features_have_implementations\` from patched source against a jel-app worktree (13 \`_features.yaml\` files) — both pass, zero false-positive warnings, identical to 1.45.6 output
- [ ] CI green on this PR

Refs: #252, #254