### PR TITLE
feat(coach): add PR-merge WMBT gate validators (#256)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.46.0"
+version = "1.47.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/baseline.py
+++ b/src/atdd/coach/commands/baseline.py
@@ -27,6 +27,11 @@ from atdd.coder.baselines.ratchet import RatchetBaseline, default_baseline_path
 from atdd.tester.validators.conftest import tester_baseline_path
 
 
+def coach_baseline_path(repo_root: Path) -> Path:
+    """Return the canonical coach baseline file path."""
+    return repo_root / ".atdd" / "baselines" / "coach.yaml"
+
+
 # ---------------------------------------------------------------------------
 # Validator registry
 # ---------------------------------------------------------------------------
@@ -563,6 +568,27 @@ TESTER_VALIDATORS: Dict[str, ValidatorFn] = {
 
 
 # ---------------------------------------------------------------------------
+# Coach validator registry (github_api — requires live API access)
+# ---------------------------------------------------------------------------
+
+
+def _pr_phase_alignment(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coach.validators.test_pr_phase_alignment import scan_pr_phase_alignment
+    return scan_pr_phase_alignment(repo_root)
+
+
+def _issue_advancement(repo_root: Path) -> Tuple[int, Sequence]:
+    from atdd.coach.validators.test_issue_advancement import scan_issue_advancement
+    return scan_issue_advancement(repo_root)
+
+
+COACH_VALIDATORS: Dict[str, ValidatorFn] = {
+    "pr_phase_alignment": _pr_phase_alignment,
+    "issue_advancement": _issue_advancement,
+}
+
+
+# ---------------------------------------------------------------------------
 # Command
 # ---------------------------------------------------------------------------
 
@@ -576,6 +602,9 @@ class BaselineCommand:
         )
         self.tester_baseline = RatchetBaseline(
             tester_baseline_path(self.repo_root),
+        )
+        self.coach_baseline = RatchetBaseline(
+            coach_baseline_path(self.repo_root),
         )
 
     # ---------------------------------------------------------------
@@ -624,8 +653,11 @@ class BaselineCommand:
         tester_results, tester_errors = self._run_validators(
             TESTER_VALIDATORS, "tester", verbose,
         )
+        coach_results, coach_errors = self._run_validators(
+            COACH_VALIDATORS, "coach", verbose,
+        )
 
-        errors = coder_errors + tester_errors
+        errors = coder_errors + tester_errors + coach_errors
         print()
 
         if errors:
@@ -641,13 +673,18 @@ class BaselineCommand:
             print(f"  To: {self.baseline.path}\n")
             for vid, count in sorted(tester_results.items()):
                 print(f"  {vid}: {count}")
-            print(f"  To: {self.tester_baseline.path}")
+            print(f"  To: {self.tester_baseline.path}\n")
+            for vid, count in sorted(coach_results.items()):
+                print(f"  {vid}: {count}")
+            print(f"  To: {self.coach_baseline.path}")
             return 0
 
         self.baseline.update(coder_results)
         print(f"Coder baseline written to {self.baseline.path}")
         self.tester_baseline.update(tester_results)
         print(f"Tester baseline written to {self.tester_baseline.path}")
+        self.coach_baseline.update(coach_results)
+        print(f"Coach baseline written to {self.coach_baseline.path}")
         return 0
 
     # ---------------------------------------------------------------
@@ -697,7 +734,7 @@ class BaselineCommand:
 
     def show(self, verbose: bool = False) -> int:
         """Display baseline vs current violation counts."""
-        if not self.baseline.exists and not self.tester_baseline.exists:
+        if not self.baseline.exists and not self.tester_baseline.exists and not self.coach_baseline.exists:
             print(
                 f"No baseline files found.\n\n"
                 f"Run `atdd baseline update` to create them."
@@ -709,6 +746,9 @@ class BaselineCommand:
         errors = self._show_scope(self.baseline, VALIDATORS, "coder")
         errors += self._show_scope(
             self.tester_baseline, TESTER_VALIDATORS, "tester",
+        )
+        errors += self._show_scope(
+            self.coach_baseline, COACH_VALIDATORS, "coach",
         )
 
         if errors:

--- a/src/atdd/coach/commands/pr.py
+++ b/src/atdd/coach/commands/pr.py
@@ -21,7 +21,7 @@ import logging
 import re
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 import yaml
 
@@ -129,6 +129,196 @@ class PRManager:
         except (subprocess.TimeoutExpired, FileNotFoundError):
             pass
         return None
+
+    # ------------------------------------------------------------------
+    # PR → Issue resolution (4-strategy cascade)
+    # ------------------------------------------------------------------
+
+    # Regex for closing keywords in PR body
+    _CLOSING_RE = re.compile(
+        r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)",
+        re.IGNORECASE,
+    )
+    # Regex for issue ref in PR title, e.g. "(#123)" or "#123"
+    _TITLE_ISSUE_RE = re.compile(r"#(\d+)")
+
+    # ATDD phase labels on issues
+    _PHASE_LABELS = frozenset({
+        "atdd:INIT", "atdd:PLANNED", "atdd:RED", "atdd:GREEN",
+        "atdd:SMOKE", "atdd:REFACTOR", "atdd:COMPLETE", "atdd:OBSOLETE",
+        "atdd:BLOCKED",
+    })
+
+    def _extract_phase_label(self, issue_data: dict) -> Optional[str]:
+        """Extract the ATDD phase from issue labels (e.g. 'RED' from 'atdd:RED')."""
+        for lbl in issue_data.get("labels", []):
+            name = lbl.get("name", lbl) if isinstance(lbl, dict) else str(lbl)
+            if name in self._PHASE_LABELS:
+                return name.split(":")[1]
+        return None
+
+    def _fetch_pr(self, pr_number: int) -> Optional[dict]:
+        """Fetch PR details from GitHub via gh CLI."""
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "view", str(pr_number),
+                 "--json", "number,title,body,headRefName,state,"
+                           "closingIssuesReferences,mergedAt"],
+                capture_output=True, text=True, timeout=15,
+                cwd=self.target_dir,
+            )
+            if result.returncode != 0:
+                logger.debug("gh pr view %d failed: %s", pr_number, result.stderr.strip())
+                return None
+            return json.loads(result.stdout)
+        except (subprocess.TimeoutExpired, FileNotFoundError, ValueError) as exc:
+            logger.debug("Failed to fetch PR #%d: %s", pr_number, exc)
+            return None
+
+    def _resolve_via_api(self, pr_data: dict) -> Optional[int]:
+        """Strategy 1: GitHub closingIssuesReferences (most authoritative)."""
+        refs = pr_data.get("closingIssuesReferences", [])
+        if refs:
+            return refs[0].get("number")
+        return None
+
+    def _resolve_via_body(self, pr_data: dict) -> Optional[int]:
+        """Strategy 2: PR body regex (Closes/Fixes/Resolves #N)."""
+        body = pr_data.get("body") or ""
+        match = self._CLOSING_RE.search(body)
+        if match:
+            return int(match.group(1))
+        return None
+
+    def _resolve_via_manifest(self, pr_data: dict) -> Optional[int]:
+        """Strategy 3: Branch name → manifest slug → issue_number."""
+        branch = pr_data.get("headRefName") or ""
+        if not branch:
+            return None
+        # Branch format: prefix/slug → extract slug part
+        slug = branch.split("/", 1)[-1] if "/" in branch else branch
+        manifest = self._load_manifest()
+        for entry in manifest.get("sessions", []):
+            if entry.get("slug") == slug:
+                return entry.get("issue_number")
+        return None
+
+    def _resolve_via_title(self, pr_data: dict) -> Optional[int]:
+        """Strategy 4: PR title regex #N (weakest signal, fallback only)."""
+        title = pr_data.get("title") or ""
+        match = self._TITLE_ISSUE_RE.search(title)
+        if match:
+            return int(match.group(1))
+        return None
+
+    def resolve_linked_issue(self, pr_number: int) -> Optional[dict]:
+        """Resolve a PR to its linked ATDD issue via 4-strategy cascade.
+
+        Strategies (in priority order):
+            1. GitHub API ``closingIssuesReferences`` — most authoritative
+            2. PR body regex (``Closes #N``, ``Fixes #N``, ``Resolves #N``)
+            3. Branch name → manifest slug → ``issue_number``
+            4. PR title regex ``#N`` — weakest signal
+
+        Returns:
+            dict with ``issue_number``, ``phase_label``, ``strategy``,
+            ``pr_data``, ``issue_data``; or None if no linkage found.
+        """
+        pr_data = self._fetch_pr(pr_number)
+        if not pr_data:
+            logger.warning("Could not fetch PR #%d", pr_number, extra={"pr": pr_number})
+            return None
+
+        strategies = [
+            ("api", self._resolve_via_api),
+            ("body", self._resolve_via_body),
+            ("manifest", self._resolve_via_manifest),
+            ("title", self._resolve_via_title),
+        ]
+
+        for strategy_name, strategy_fn in strategies:
+            issue_number = strategy_fn(pr_data)
+            if issue_number is not None:
+                issue_data = self._fetch_issue(issue_number)
+                if issue_data is None:
+                    logger.debug(
+                        "Strategy '%s' resolved PR #%d → issue #%d but issue fetch failed",
+                        strategy_name, pr_number, issue_number,
+                    )
+                    continue
+                phase_label = self._extract_phase_label(issue_data)
+                logger.info(
+                    "PR #%d → issue #%d (strategy=%s, phase=%s)",
+                    pr_number, issue_number, strategy_name, phase_label,
+                    extra={
+                        "pr": pr_number,
+                        "issue": issue_number,
+                        "strategy": strategy_name,
+                        "phase": phase_label,
+                    },
+                )
+                return {
+                    "issue_number": issue_number,
+                    "phase_label": phase_label,
+                    "strategy": strategy_name,
+                    "pr_data": pr_data,
+                    "issue_data": issue_data,
+                }
+
+        logger.info("PR #%d: no linked issue found", pr_number, extra={"pr": pr_number})
+        return None
+
+    def fetch_open_prs(self) -> List[dict]:
+        """Fetch all open PRs for the repo."""
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "list", "--state", "open",
+                 "--json", "number,title,body,headRefName,state,"
+                           "closingIssuesReferences"],
+                capture_output=True, text=True, timeout=30,
+                cwd=self.target_dir,
+            )
+            if result.returncode != 0:
+                logger.debug("gh pr list failed: %s", result.stderr.strip())
+                return []
+            return json.loads(result.stdout) or []
+        except (subprocess.TimeoutExpired, FileNotFoundError, ValueError) as exc:
+            logger.debug("Failed to list open PRs: %s", exc)
+            return []
+
+    def fetch_recently_merged_prs(self, limit: int = 20) -> List[dict]:
+        """Fetch recently merged PRs for the repo."""
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "list", "--state", "merged", "--limit", str(limit),
+                 "--json", "number,title,body,headRefName,state,"
+                           "closingIssuesReferences,mergedAt"],
+                capture_output=True, text=True, timeout=30,
+                cwd=self.target_dir,
+            )
+            if result.returncode != 0:
+                logger.debug("gh pr list --merged failed: %s", result.stderr.strip())
+                return []
+            return json.loads(result.stdout) or []
+        except (subprocess.TimeoutExpired, FileNotFoundError, ValueError) as exc:
+            logger.debug("Failed to list merged PRs: %s", exc)
+            return []
+
+    def fetch_pr_changed_files(self, pr_number: int) -> List[str]:
+        """Fetch the list of files changed in a PR."""
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "view", str(pr_number),
+                 "--json", "files", "--jq", ".files[].path"],
+                capture_output=True, text=True, timeout=15,
+                cwd=self.target_dir,
+            )
+            if result.returncode != 0:
+                return []
+            return [f for f in result.stdout.strip().splitlines() if f]
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            logger.debug("Failed to fetch PR #%d files: %s", pr_number, exc)
+            return []
 
     def _build_pr_title(
         self,

--- a/src/atdd/coach/validators/test_issue_advancement.py
+++ b/src/atdd/coach/validators/test_issue_advancement.py
@@ -23,8 +23,6 @@ from atdd.coder.baselines.ratchet import RatchetBaseline
 
 pytestmark = [pytest.mark.platform, pytest.mark.github_api]
 
-logger = logging.getLogger(__name__)
-
 REPO_ROOT = find_repo_root()
 
 # Baseline path for coach validators
@@ -79,7 +77,7 @@ def scan_issue_advancement(repo_root: Path) -> Tuple[int, Sequence]:
                 f"advancement after merge. "
                 f"Fix: atdd issue {issue_number} --status <next-phase>"
             )
-            logger.warning(
+            logging.getLogger(__name__).warning(
                 "SPEC-COACH-PRGATE-0003: PR #%d merged but issue #%d "
                 "still at %s",
                 pr_number, issue_number, phase,

--- a/src/atdd/coach/validators/test_issue_advancement.py
+++ b/src/atdd/coach/validators/test_issue_advancement.py
@@ -1,0 +1,119 @@
+"""
+Post-merge issue advancement validation.
+
+Purpose: Flag merged PRs where the linked issue did not advance its ATDD
+phase label.  This catches the incident pattern from #256: PRs merge but
+issue stays at INIT, so skipped lifecycle phases go undetected.
+
+SPEC-COACH-PRGATE-0003: Merged PR with linked issue that hasn't advanced
+phase is flagged as stale.
+
+Run: atdd validate coach
+"""
+
+import logging
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+import pytest
+
+from atdd.coach.commands.pr import PRManager
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coder.baselines.ratchet import RatchetBaseline
+
+pytestmark = [pytest.mark.platform, pytest.mark.github_api]
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = find_repo_root()
+
+# Baseline path for coach validators
+COACH_BASELINE_PATH = REPO_ROOT / ".atdd" / "baselines" / "coach.yaml"
+
+# Phases that should have advanced after a PR merges.
+# If a PR merged and the issue is still at one of these, something was missed.
+_STALE_PHASES = frozenset({"INIT", "PLANNED"})
+
+# Terminal or expected post-merge phases — no advancement expected
+_TERMINAL_PHASES = frozenset({"COMPLETE", "OBSOLETE"})
+
+
+def scan_issue_advancement(repo_root: Path) -> Tuple[int, Sequence]:
+    """Scan recently merged PRs for stale linked issues.
+
+    A merged PR whose linked issue is still at INIT or PLANNED indicates
+    the issue phase was not advanced after the PR merged.
+
+    Returns (violation_count, violation_messages) for ratchet baseline.
+    """
+    mgr = PRManager(target_dir=repo_root)
+    merged_prs = mgr.fetch_recently_merged_prs(limit=20)
+    violations: List[str] = []
+
+    for pr in merged_prs:
+        pr_number = pr["number"]
+        resolution = mgr.resolve_linked_issue(pr_number)
+        if resolution is None:
+            continue
+
+        phase = resolution["phase_label"]
+        if phase is None:
+            continue
+
+        issue_number = resolution["issue_number"]
+        issue_state = resolution["issue_data"].get("state", "").upper()
+
+        # Skip closed issues — GitHub auto-close may have handled it
+        if issue_state == "CLOSED":
+            continue
+
+        # Skip terminal phases
+        if phase in _TERMINAL_PHASES:
+            continue
+
+        if phase in _STALE_PHASES:
+            merged_at = pr.get("mergedAt", "unknown")
+            violations.append(
+                f"PR #{pr_number} merged ({merged_at}) but linked issue "
+                f"#{issue_number} is still at {phase} — expected phase "
+                f"advancement after merge. "
+                f"Fix: atdd issue {issue_number} --status <next-phase>"
+            )
+            logger.warning(
+                "SPEC-COACH-PRGATE-0003: PR #%d merged but issue #%d "
+                "still at %s",
+                pr_number, issue_number, phase,
+                extra={
+                    "pr": pr_number,
+                    "issue": issue_number,
+                    "phase": phase,
+                    "merged_at": merged_at,
+                },
+            )
+
+    return len(violations), violations
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_issue_advancement():
+    """
+    SPEC-COACH-PRGATE-0003: Linked issue must advance after PR merge.
+
+    Given: Recently merged PRs with linked ATDD issues
+    When: Checking the linked issue's current phase label
+    Then: Issues still at INIT/PLANNED after PR merge are flagged
+
+    Ratchet baseline: violations must not exceed recorded baseline (Category A).
+    """
+    baseline = RatchetBaseline(COACH_BASELINE_PATH)
+    count, violations = scan_issue_advancement(REPO_ROOT)
+
+    baseline.assert_no_regression(
+        validator_id="issue_advancement",
+        current_count=count,
+        violations=violations,
+    )

--- a/src/atdd/coach/validators/test_pr_phase_alignment.py
+++ b/src/atdd/coach/validators/test_pr_phase_alignment.py
@@ -28,8 +28,6 @@ from atdd.coder.baselines.ratchet import RatchetBaseline
 
 pytestmark = [pytest.mark.platform, pytest.mark.github_api]
 
-logger = logging.getLogger(__name__)
-
 REPO_ROOT = find_repo_root()
 
 # Baseline path for coach validators
@@ -114,7 +112,7 @@ def scan_pr_phase_alignment(repo_root: Path) -> Tuple[int, Sequence]:
                 + (f" ... +{len(classified['code']) - 3} more"
                    if len(classified["code"]) > 3 else "")
             )
-            logger.warning(
+            logging.getLogger(__name__).warning(
                 "SPEC-COACH-PRGATE-0002: PR #%d has code changes but "
                 "issue #%d is at %s",
                 pr_number, resolution["issue_number"], phase,

--- a/src/atdd/coach/validators/test_pr_phase_alignment.py
+++ b/src/atdd/coach/validators/test_pr_phase_alignment.py
@@ -1,0 +1,154 @@
+"""
+PR phase alignment validation.
+
+Purpose: Verify that PR content matches the linked issue's ATDD phase label.
+A PR that merges code changes while the linked issue is still at INIT or
+PLANNED indicates skipped lifecycle phases (the incident pattern from #256).
+
+Phase mapping:
+    INIT / PLANNED  → expect plan files, contracts, WMBT definitions only
+    RED             → expect test files only
+    GREEN+          → expect code changes
+
+SPEC-COACH-PRGATE-0002: PR merging code changes warns if linked issue is
+at INIT or PLANNED.
+
+Run: atdd validate coach
+"""
+
+import logging
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+import pytest
+
+from atdd.coach.commands.pr import PRManager
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coder.baselines.ratchet import RatchetBaseline
+
+pytestmark = [pytest.mark.platform, pytest.mark.github_api]
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = find_repo_root()
+
+# Baseline path for coach validators
+COACH_BASELINE_PATH = REPO_ROOT / ".atdd" / "baselines" / "coach.yaml"
+
+# File path patterns that indicate code changes (not just planner artifacts)
+_CODE_PATH_PREFIXES = (
+    "python/",
+    "web/src/",
+    "supabase/functions/",
+    "packages/",
+    "supabase/migrations/",
+)
+
+# File path patterns that indicate test files
+_TEST_PATH_PATTERNS = (
+    "/tests/",
+    "/test_",
+    ".test.",
+    ".spec.",
+)
+
+# File path patterns that indicate planner-only artifacts
+_PLAN_PATH_PREFIXES = (
+    "plan/",
+    "contracts/",
+    "telemetry/",
+    ".atdd/",
+)
+
+# Phases where code changes in a PR are unexpected
+_EARLY_PHASES = frozenset({"INIT", "PLANNED"})
+
+
+def _classify_changed_files(files: List[str]) -> dict:
+    """Classify PR changed files into code, test, and plan categories."""
+    result = {"code": [], "test": [], "plan": [], "other": []}
+    for f in files:
+        if any(pat in f for pat in _TEST_PATH_PATTERNS):
+            result["test"].append(f)
+        elif any(f.startswith(pfx) for pfx in _CODE_PATH_PREFIXES):
+            result["code"].append(f)
+        elif any(f.startswith(pfx) for pfx in _PLAN_PATH_PREFIXES):
+            result["plan"].append(f)
+        else:
+            result["other"].append(f)
+    return result
+
+
+def scan_pr_phase_alignment(repo_root: Path) -> Tuple[int, Sequence]:
+    """Scan open PRs for phase alignment violations.
+
+    Returns (violation_count, violation_messages) for ratchet baseline.
+    """
+    mgr = PRManager(target_dir=repo_root)
+    open_prs = mgr.fetch_open_prs()
+    violations: List[str] = []
+
+    for pr in open_prs:
+        pr_number = pr["number"]
+        resolution = mgr.resolve_linked_issue(pr_number)
+        if resolution is None:
+            continue
+
+        phase = resolution["phase_label"]
+        if phase is None or phase not in _EARLY_PHASES:
+            continue
+
+        changed_files = mgr.fetch_pr_changed_files(pr_number)
+        if not changed_files:
+            continue
+
+        classified = _classify_changed_files(changed_files)
+
+        if classified["code"]:
+            code_sample = classified["code"][:3]
+            violations.append(
+                f"PR #{pr_number} → issue #{resolution['issue_number']} "
+                f"(phase={phase}): {len(classified['code'])} code file(s) "
+                f"changed — expected plan/contract artifacts only at {phase}. "
+                f"Files: {', '.join(code_sample)}"
+                + (f" ... +{len(classified['code']) - 3} more"
+                   if len(classified["code"]) > 3 else "")
+            )
+            logger.warning(
+                "SPEC-COACH-PRGATE-0002: PR #%d has code changes but "
+                "issue #%d is at %s",
+                pr_number, resolution["issue_number"], phase,
+                extra={
+                    "pr": pr_number,
+                    "issue": resolution["issue_number"],
+                    "phase": phase,
+                    "code_files": len(classified["code"]),
+                },
+            )
+
+    return len(violations), violations
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_pr_phase_alignment():
+    """
+    SPEC-COACH-PRGATE-0002: PR content must align with linked issue phase.
+
+    Given: Open PRs with linked ATDD issues
+    When: Checking PR changed files vs issue phase label
+    Then: PRs with code changes for INIT/PLANNED issues are flagged
+
+    Ratchet baseline: violations must not exceed recorded baseline (Category A).
+    """
+    baseline = RatchetBaseline(COACH_BASELINE_PATH)
+    count, violations = scan_pr_phase_alignment(REPO_ROOT)
+
+    baseline.assert_no_regression(
+        validator_id="pr_phase_alignment",
+        current_count=count,
+        violations=violations,
+    )


### PR DESCRIPTION
Closes #256

## Summary

- **Phase 0**: Add `resolve_linked_issue(pr_number)` to `PRManager` — 4-strategy cascade: GitHub API `closingIssuesReferences`, PR body regex (`Closes/Fixes/Resolves #N`), branch→manifest lookup, PR title regex `#N`
- **Phase 1**: New `test_pr_phase_alignment.py` (SPEC-COACH-PRGATE-0002) — checks issue phase label vs PR diff content; PRs with code changes for INIT/PLANNED issues are flagged
- **Phase 2**: New `test_issue_advancement.py` (SPEC-COACH-PRGATE-0003) — flags merged PRs where linked issue did not advance phase

Both validators use `resolve_linked_issue()`, ratchet baseline (Category A), `github_api` markers, and a new coach baseline registry in `baseline.py`.

## Files Changed

| File | Change |
|------|--------|
| `src/atdd/coach/commands/pr.py` | `resolve_linked_issue()`, `fetch_open_prs()`, `fetch_recently_merged_prs()`, `fetch_pr_changed_files()` |
| `src/atdd/coach/validators/test_pr_phase_alignment.py` | New — SPEC-COACH-PRGATE-0002 |
| `src/atdd/coach/validators/test_issue_advancement.py` | New — SPEC-COACH-PRGATE-0003 |
| `src/atdd/coach/commands/baseline.py` | `COACH_VALIDATORS` registry, `coach_baseline_path()`, `BaselineCommand` coach support |

## Test Plan

- [x] `python3 -m pytest src/atdd/coach/validators/test_pr_phase_alignment.py -v` — PASSED
- [x] `python3 -m pytest src/atdd/coach/validators/test_issue_advancement.py -v` — PASSED
- [x] Full coach validator suite passes (46 passed, 2 pre-existing failures in test_C002_project_board.py)
- [x] All imports verified (`PRManager`, scanner functions, `COACH_VALIDATORS`)
- [x] Version bumped to 1.46.0