### PR TITLE
feat(coder): enforce train-driven frontend composition (Phases 1-3) (#261)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.47.0"
+version = "1.48.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coder/conventions/frontend.convention.yaml
+++ b/src/atdd/coder/conventions/frontend.convention.yaml
@@ -564,6 +564,32 @@ frontend:
       authentication, request/response logging, retry logic, and
       contract validation across the entire frontend codebase.
 
+  train_composition:
+    description: "Frontend routes map to trains. Trains compose wagon presentations."
+    composition_root: "FrontendTrainRunner"
+    route_pattern: "<TrainView trainId={id} /> — not direct page components"
+    wagon_registration: "Each wagon's trains.ts exports presentation components per train"
+    template_resolution: "Train YAML declares template; runner resolves from the project's design system"
+    auth_gating: "Train YAML declares auth_required; runner checks before composing"
+    permanent_exceptions:
+      criteria: "Auto-detected — pages with zero wagon imports and zero application hooks"
+      detection: >
+        Validator scans file imports. Zero wagon dependencies = no train possible
+        = permanent exception. No manual allowlist entry needed.
+    enforcement:
+      page_elimination:
+        spec_id: "SPEC-CODER-PAGE-0001"
+        rule: "Any file in scan_dirs not in allowlist and not a permanent exception is a hard failure"
+        config: ".atdd/config.yaml → page_elimination"
+      god_hook_elimination:
+        spec_id: "SPEC-CODER-PAGE-0003"
+        rule: "Hook files exceeding max_lines (default 200) not in allowlist are a hard failure"
+        config: ".atdd/config.yaml → god_hook_elimination"
+      route_train_compliance:
+        spec_id: "SPEC-CODER-PAGE-0004"
+        rule: "New routes must use TrainView, not direct page component imports"
+        config: ".atdd/config.yaml → route_train_compliance"
+
   ci_enforcement:
     checks:
       - name: "arch_import_rules"

--- a/src/atdd/coder/validators/test_god_hook_elimination.py
+++ b/src/atdd/coder/validators/test_god_hook_elimination.py
@@ -1,0 +1,218 @@
+"""
+Test that hook files exceeding a size threshold are allowlisted.
+
+Validates:
+- SPEC-CODER-PAGE-0003: Hooks exceeding max_lines not in allowlist are a hard failure
+
+God hooks (200+ lines) doing cross-wagon state coordination should be
+decomposed into smaller single-concern hooks or promoted to train-level
+artifacts.
+
+Convention: src/atdd/coder/conventions/frontend.convention.yaml → train_composition
+Config: .atdd/config.yaml → god_hook_elimination
+"""
+
+import fnmatch
+import os
+import yaml
+import pytest
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.utils.config import load_atdd_config
+
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+REPO_ROOT = find_repo_root()
+
+_SKIP_DIRS = {
+    ".git", "__pycache__", "node_modules", ".dart_tool",
+    "build", ".pub-cache", "dist", ".next", ".nuxt", "coverage",
+    ".venv", "venv", "env", ".tox", ".mypy_cache", ".pytest_cache",
+}
+
+_TS_EXTENSIONS = (".ts", ".tsx")
+
+_DEFAULT_MAX_LINES = 200
+_DEFAULT_HOOK_PATTERNS = ["use*.ts", "use*.tsx"]
+_DEFAULT_SCAN_DIR = "web/src"
+
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+def _load_god_hook_config() -> Dict:
+    """Load god_hook_elimination config from .atdd/config.yaml."""
+    config = load_atdd_config(REPO_ROOT)
+    return config.get("god_hook_elimination", {})
+
+
+def _load_allowlist(gh_config: Dict) -> Dict[str, Dict]:
+    """
+    Build path→entry map from allowlist.
+
+    Returns:
+        Dict mapping relative file paths to their full allowlist entry
+        (includes lines, migration fields).
+    """
+    allowlist = {}
+    for entry in gh_config.get("allowlist", []):
+        path = entry.get("path", "")
+        if path:
+            allowlist[path] = entry
+    return allowlist
+
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+def _find_hook_files(
+    scan_dir: str,
+    hook_patterns: List[str],
+) -> List[Path]:
+    """Find all files matching hook_patterns under scan_dir."""
+    base = REPO_ROOT / scan_dir
+    if not base.exists():
+        return []
+
+    files: List[Path] = []
+    for dirpath, dirnames, filenames in os.walk(base):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for fname in filenames:
+            if not fname.endswith(tuple(_TS_EXTENSIONS)):
+                continue
+            # Check against hook patterns
+            for pattern in hook_patterns:
+                if fnmatch.fnmatch(fname, pattern):
+                    files.append(Path(dirpath) / fname)
+                    break
+    return sorted(files)
+
+
+def _count_lines(file_path: Path) -> int:
+    """Count non-empty lines in a file."""
+    try:
+        with open(file_path, "r", encoding="utf-8") as fh:
+            return sum(1 for line in fh if line.strip())
+    except (OSError, UnicodeDecodeError):
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Test functions
+# ---------------------------------------------------------------------------
+@pytest.mark.coder
+def test_god_hooks_must_be_allowlisted():
+    """
+    SPEC-CODER-PAGE-0003: Hook files exceeding max_lines not in allowlist fail.
+
+    Large hooks (200+ lines) doing cross-wagon state coordination should be
+    decomposed or promoted to train-level artifacts. Each allowlisted hook
+    must reference a migration issue.
+
+    Given: Hook files matching hook_patterns in scan directory
+    When: Checking line count against max_lines threshold
+    Then: Hooks exceeding threshold without allowlist entry are hard failures
+    """
+    gh_config = _load_god_hook_config()
+
+    if not gh_config:
+        pytest.skip(
+            "No god_hook_elimination configured in .atdd/config.yaml — "
+            "consumer repo must define hook elimination rules"
+        )
+
+    max_lines = gh_config.get("max_lines", _DEFAULT_MAX_LINES)
+    hook_patterns = gh_config.get("hook_patterns", _DEFAULT_HOOK_PATTERNS)
+    scan_dir = gh_config.get("scan_dir", _DEFAULT_SCAN_DIR)
+    allowlist = _load_allowlist(gh_config)
+
+    hook_files = _find_hook_files(scan_dir, hook_patterns)
+
+    if not hook_files:
+        pytest.skip("No hook files found matching hook_patterns")
+
+    violations: List[str] = []
+
+    for file_path in hook_files:
+        line_count = _count_lines(file_path)
+
+        if line_count <= max_lines:
+            continue
+
+        rel_path = str(file_path.relative_to(REPO_ROOT))
+
+        if rel_path in allowlist:
+            entry = allowlist[rel_path]
+            migration = entry.get("migration", "")
+            if not migration or not migration.strip():
+                violations.append(
+                    f"  SPEC-CODER-PAGE-0003 FAIL: Allowlisted god hook missing migration reference\n"
+                    f"    File:   {rel_path}\n"
+                    f"    Lines:  {line_count} (threshold: {max_lines})\n"
+                    f"    Fix:    Add migration: \"owner/repo#NNN\" to the allowlist entry."
+                )
+            continue
+
+        violations.append(
+            f"  SPEC-CODER-PAGE-0003 FAIL: God hook exceeds {max_lines}-line threshold\n"
+            f"    File:   {rel_path}\n"
+            f"    Lines:  {line_count} (threshold: {max_lines})\n"
+            f"    Fix:    Decompose into smaller single-concern hooks,\n"
+            f"            or add to god_hook_elimination.allowlist in .atdd/config.yaml\n"
+            f"            with a migration issue reference.\n"
+            f"            See: frontend.convention.yaml → train_composition"
+        )
+
+    if violations:
+        pytest.fail(
+            f"\n\n{len(violations)} god hook violation(s):\n\n"
+            + "\n\n".join(violations)
+        )
+
+
+@pytest.mark.coder
+def test_god_hook_allowlist_entries_have_migration():
+    """
+    SPEC-CODER-PAGE-0003 (allowlist hygiene): Every god hook allowlist entry
+    must reference a migration issue and declare its current line count.
+
+    Given: god_hook_elimination.allowlist in .atdd/config.yaml
+    When: Checking each entry for required fields
+    Then: Entries missing migration or lines field fail
+    """
+    gh_config = _load_god_hook_config()
+    allowlist_entries = gh_config.get("allowlist", [])
+
+    if not allowlist_entries:
+        pytest.skip("No god_hook_elimination.allowlist entries in .atdd/config.yaml")
+
+    violations: List[str] = []
+
+    for entry in allowlist_entries:
+        path = entry.get("path", "<missing path>")
+        migration = entry.get("migration", "")
+        lines = entry.get("lines")
+
+        missing_fields = []
+        if not migration or not migration.strip():
+            missing_fields.append("migration")
+        if lines is None:
+            missing_fields.append("lines")
+
+        if missing_fields:
+            violations.append(
+                f"  SPEC-CODER-PAGE-0003 FAIL: Allowlist entry missing required field(s)\n"
+                f"    Path:    {path}\n"
+                f"    Missing: {', '.join(missing_fields)}\n"
+                f"    Fix:     Add {' and '.join(missing_fields)} to the allowlist entry."
+            )
+
+    if violations:
+        pytest.fail(
+            f"\n\n{len(violations)} god hook allowlist entry/entries with missing fields:\n\n"
+            + "\n\n".join(violations)
+        )

--- a/src/atdd/coder/validators/test_page_elimination.py
+++ b/src/atdd/coder/validators/test_page_elimination.py
@@ -1,0 +1,330 @@
+"""
+Test that all files in page directories are either allowlisted or permanent exceptions.
+
+Validates:
+- SPEC-CODER-PAGE-0001: Files in scan_dirs not in allowlist and not permanent exceptions fail
+- SPEC-CODER-PAGE-0002: Allowlist entries must reference a migration issue
+- SPEC-CODER-PAGE-0005: Pages with zero wagon imports are auto-detected permanent exceptions
+- SPEC-CODER-PAGE-0010: Subdirectories under pages/ are a hard failure
+- SPEC-CODER-PAGE-0011: Full pages/ tree scan — any file in pages/ not in allowlist fails
+
+Convention: src/atdd/coder/conventions/frontend.convention.yaml → train_composition
+Config: .atdd/config.yaml → page_elimination
+"""
+
+import os
+import re
+import yaml
+import pytest
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.utils.config import load_atdd_config
+
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+REPO_ROOT = find_repo_root()
+CONFIG_PATH = REPO_ROOT / ".atdd" / "config.yaml"
+
+_SKIP_DIRS = {
+    ".git", "__pycache__", "node_modules", ".dart_tool",
+    "build", ".pub-cache", "dist", ".next", ".nuxt", "coverage",
+    ".venv", "venv", "env", ".tox", ".mypy_cache", ".pytest_cache",
+}
+
+_TS_EXTENSIONS = (".ts", ".tsx")
+
+# Regex to detect wagon-level imports.
+# Matches: import ... from '../../<wagon>/' or '../<wagon>/' or '@<wagon>/'
+# Also matches: from '<wagon>/' style imports that reference known wagon paths.
+_IMPORT_RE = re.compile(
+    r"""(?:import\s+.*?\s+from\s+|import\s*\()\s*['"]([^'"]+)['"]"""
+)
+
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+def _load_page_elimination_config() -> Dict:
+    """Load page_elimination config from .atdd/config.yaml."""
+    config = load_atdd_config(REPO_ROOT)
+    return config.get("page_elimination", {})
+
+
+def _load_allowlist(pe_config: Dict) -> Dict[str, str]:
+    """
+    Build path→migration map from allowlist entries.
+
+    Returns:
+        Dict mapping relative file paths to migration issue references.
+    """
+    allowlist = {}
+    for entry in pe_config.get("allowlist", []):
+        path = entry.get("path", "")
+        migration = entry.get("migration", "")
+        if path:
+            allowlist[path] = migration
+    return allowlist
+
+
+# ---------------------------------------------------------------------------
+# File discovery
+# ---------------------------------------------------------------------------
+def _find_all_files_in_scan_dirs(scan_dirs: List[str]) -> List[Path]:
+    """Walk scan_dirs and collect all files (not just *Page.tsx)."""
+    files: List[Path] = []
+    for scan_dir in scan_dirs:
+        base = REPO_ROOT / scan_dir
+        if not base.exists():
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+            for fname in filenames:
+                if fname.endswith(tuple(_TS_EXTENSIONS)):
+                    files.append(Path(dirpath) / fname)
+    return sorted(files)
+
+
+def _find_subdirectories_in_scan_dirs(scan_dirs: List[str]) -> List[Path]:
+    """Find subdirectories directly under scan_dirs (pages/ should be flat)."""
+    subdirs: List[Path] = []
+    for scan_dir in scan_dirs:
+        base = REPO_ROOT / scan_dir
+        if not base.exists():
+            continue
+        for entry in sorted(base.iterdir()):
+            if entry.is_dir() and entry.name not in _SKIP_DIRS:
+                subdirs.append(entry)
+    return subdirs
+
+
+# ---------------------------------------------------------------------------
+# Import analysis for permanent exception detection
+# ---------------------------------------------------------------------------
+def _extract_imports(file_path: Path) -> List[str]:
+    """Extract import paths from a TypeScript file."""
+    try:
+        with open(file_path, "r", encoding="utf-8") as fh:
+            content = fh.read()
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    return _IMPORT_RE.findall(content)
+
+
+def _detect_wagon_dirs(scan_dirs: List[str]) -> Set[str]:
+    """
+    Detect wagon directory names by looking at the src path pattern.
+
+    Wagons are top-level directories under web/src/ that contain
+    domain/application/integration/presentation sub-layers.
+    """
+    web_src = REPO_ROOT / "web" / "src"
+    if not web_src.exists():
+        return set()
+
+    wagon_dirs: Set[str] = set()
+    layer_names = {"domain", "application", "integration", "presentation"}
+
+    for entry in web_src.iterdir():
+        if not entry.is_dir() or entry.name.startswith(".") or entry.name in _SKIP_DIRS:
+            continue
+        # A directory is a wagon if it contains at least one layer subdirectory
+        child_names = {c.name for c in entry.iterdir() if c.is_dir()}
+        if child_names & layer_names:
+            wagon_dirs.add(entry.name)
+
+    return wagon_dirs
+
+
+def _has_wagon_imports(file_path: Path, wagon_dirs: Set[str]) -> bool:
+    """
+    Check if a file imports from any wagon directory.
+
+    A file with zero wagon imports is a permanent exception — it has nothing
+    to compose into a train.
+    """
+    imports = _extract_imports(file_path)
+    for imp in imports:
+        # Check for relative imports that traverse into wagon directories
+        segments = imp.replace("\\", "/").split("/")
+        for seg in segments:
+            if seg in wagon_dirs:
+                return True
+        # Check for alias imports like @wagon-name/
+        for wagon in wagon_dirs:
+            if imp.startswith(f"@{wagon}/") or imp.startswith(f"{wagon}/"):
+                return True
+    return False
+
+
+def _has_application_hooks(file_path: Path) -> bool:
+    """
+    Check if a file imports application-layer hooks (use* from application/).
+
+    Files using application hooks are not permanent exceptions — they
+    orchestrate wagon logic and should be train compositions.
+    """
+    imports = _extract_imports(file_path)
+    for imp in imports:
+        if "/application/" in imp and "/hook" in imp.lower():
+            return True
+        if "/application/" in imp and "use" in imp.lower():
+            return True
+    return False
+
+
+def _is_permanent_exception(file_path: Path, wagon_dirs: Set[str]) -> bool:
+    """
+    Auto-detect permanent exceptions: pages with zero wagon imports
+    and zero application hooks.
+
+    These pages have nothing to compose into a train.
+    """
+    return not _has_wagon_imports(file_path, wagon_dirs) and not _has_application_hooks(file_path)
+
+
+# ---------------------------------------------------------------------------
+# Test functions
+# ---------------------------------------------------------------------------
+@pytest.mark.coder
+def test_page_files_must_be_allowlisted_or_permanent_exceptions():
+    """
+    SPEC-CODER-PAGE-0001 + SPEC-CODER-PAGE-0005 + SPEC-CODER-PAGE-0011:
+    Every file in scan_dirs must be in the allowlist or be an auto-detected
+    permanent exception (zero wagon imports and zero application hooks).
+
+    Given: All TS/TSX files in configured scan_dirs
+    When: Checking each file against allowlist and import graph
+    Then: Unlisted files with wagon dependencies are hard failures
+    """
+    pe_config = _load_page_elimination_config()
+    scan_dirs = pe_config.get("scan_dirs", [])
+
+    if not scan_dirs:
+        pytest.skip(
+            "No page_elimination.scan_dirs configured in .atdd/config.yaml — "
+            "consumer repo must define scan directories"
+        )
+
+    files = _find_all_files_in_scan_dirs(scan_dirs)
+    if not files:
+        pytest.skip("No TypeScript files found in scan_dirs")
+
+    allowlist = _load_allowlist(pe_config)
+    wagon_dirs = _detect_wagon_dirs(scan_dirs)
+
+    violations: List[str] = []
+    permanent_exceptions: List[str] = []
+
+    for file_path in files:
+        rel_path = str(file_path.relative_to(REPO_ROOT))
+
+        # Check allowlist
+        if rel_path in allowlist:
+            continue
+
+        # Check permanent exception (auto-detected)
+        if _is_permanent_exception(file_path, wagon_dirs):
+            permanent_exceptions.append(rel_path)
+            continue
+
+        violations.append(
+            f"  SPEC-CODER-PAGE-0001 FAIL: Unlisted page file\n"
+            f"    File: {rel_path}\n"
+            f"    Fix:  Route to a train instead. "
+            f"See: frontend.convention.yaml → train_composition\n"
+            f"          Create a TrainView component, not a Page component.\n"
+            f"          Or add to page_elimination.allowlist in .atdd/config.yaml "
+            f"with a migration issue."
+        )
+
+    if violations:
+        header = (
+            f"\n\n{len(violations)} unlisted page file(s) found.\n"
+            f"{len(permanent_exceptions)} auto-detected permanent exception(s) (zero wagon imports).\n\n"
+        )
+        pytest.fail(header + "\n\n".join(violations))
+
+
+@pytest.mark.coder
+def test_allowlist_entries_have_migration_references():
+    """
+    SPEC-CODER-PAGE-0002: Every allowlist entry must reference a migration issue.
+
+    The migration field creates accountability — each page has a named exit path.
+
+    Given: page_elimination.allowlist in .atdd/config.yaml
+    When: Checking each entry for migration field
+    Then: Entries without migration references fail
+    """
+    pe_config = _load_page_elimination_config()
+    allowlist_entries = pe_config.get("allowlist", [])
+
+    if not allowlist_entries:
+        pytest.skip("No page_elimination.allowlist entries in .atdd/config.yaml")
+
+    violations: List[str] = []
+
+    for entry in allowlist_entries:
+        path = entry.get("path", "<missing path>")
+        migration = entry.get("migration", "")
+
+        if not migration or not migration.strip():
+            violations.append(
+                f"  SPEC-CODER-PAGE-0002 FAIL: Allowlist entry missing migration reference\n"
+                f"    Path: {path}\n"
+                f"    Fix:  Add migration: \"owner/repo#NNN\" referencing the issue "
+                f"that will eliminate this page."
+            )
+
+    if violations:
+        pytest.fail(
+            f"\n\n{len(violations)} allowlist entry/entries missing migration reference:\n\n"
+            + "\n\n".join(violations)
+        )
+
+
+@pytest.mark.coder
+def test_no_subdirectories_in_page_dirs():
+    """
+    SPEC-CODER-PAGE-0010: Subdirectories under pages/ are a hard failure.
+
+    A page needing a subdirectory is a wagon in disguise. It should be
+    extracted into a proper wagon with its own layer structure.
+
+    Given: scan_dirs with no_subdirectories: true
+    When: Scanning for subdirectories
+    Then: Any subdirectory is a hard failure
+    """
+    pe_config = _load_page_elimination_config()
+    scan_dirs = pe_config.get("scan_dirs", [])
+    no_subdirectories = pe_config.get("no_subdirectories", True)
+
+    if not scan_dirs:
+        pytest.skip("No page_elimination.scan_dirs configured in .atdd/config.yaml")
+
+    if not no_subdirectories:
+        pytest.skip("no_subdirectories is disabled in page_elimination config")
+
+    subdirs = _find_subdirectories_in_scan_dirs(scan_dirs)
+
+    if subdirs:
+        violations = []
+        for subdir in subdirs:
+            rel = subdir.relative_to(REPO_ROOT)
+            violations.append(
+                f"  SPEC-CODER-PAGE-0010 FAIL: Subdirectory in pages/\n"
+                f"    Dir:  {rel}\n"
+                f"    Fix:  Extract into a wagon. A page needing a subdirectory "
+                f"is a wagon in disguise.\n"
+                f"          See: frontend.convention.yaml → train_composition"
+            )
+
+        pytest.fail(
+            f"\n\n{len(violations)} subdirectory/subdirectories found in page scan_dirs:\n\n"
+            + "\n\n".join(violations)
+        )

--- a/src/atdd/coder/validators/test_route_train_compliance.py
+++ b/src/atdd/coder/validators/test_route_train_compliance.py
@@ -1,0 +1,282 @@
+"""
+Test that routes use train components instead of direct page imports.
+
+Validates:
+- SPEC-CODER-PAGE-0004: New routes must use TrainView, not direct page component imports
+
+Routes should map to trains via <TrainView trainId={...} />, not directly
+import *Page.tsx components. This enforces the train-driven composition
+architecture where the FrontendTrainRunner is the composition root.
+
+Convention: src/atdd/coder/conventions/frontend.convention.yaml → train_composition
+Config: .atdd/config.yaml → route_train_compliance
+"""
+
+import re
+import yaml
+import pytest
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.utils.config import load_atdd_config
+
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+REPO_ROOT = find_repo_root()
+
+# Regex to detect page component imports in router files
+# Matches: import FooPage from './pages/FooPage'
+#          import { FooPage } from '../pages/FooPage'
+#          import FooPage from '../../pages/foo/FooPage'
+_PAGE_IMPORT_RE = re.compile(
+    r"""import\s+(?:\{[^}]*\}|[\w]+)\s+from\s+['"]([^'"]*[Pp]age[^'"]*?)['"]"""
+)
+
+# Regex to detect direct page component usage in JSX route elements
+# Matches: element={<FooPage />}   component={FooPage}   element: <FooPage>
+_PAGE_JSX_RE = re.compile(
+    r"""(?:element|component)\s*[:={]\s*<?(\w*Page)\b"""
+)
+
+# Regex to detect TrainView usage (the correct pattern)
+_TRAIN_VIEW_RE = re.compile(
+    r"""<TrainView\b"""
+)
+
+_DEFAULT_ROUTER_PATTERNS = [
+    "web/src/**/router.ts",
+    "web/src/**/router.tsx",
+    "web/src/**/routes.ts",
+    "web/src/**/routes.tsx",
+    "web/src/**/*-routes.ts",
+    "web/src/**/*-routes.tsx",
+    "web/src/**/App.tsx",
+]
+
+
+# ---------------------------------------------------------------------------
+# Config loader
+# ---------------------------------------------------------------------------
+def _load_route_config() -> Dict:
+    """Load route_train_compliance config from .atdd/config.yaml."""
+    config = load_atdd_config(REPO_ROOT)
+    return config.get("route_train_compliance", {})
+
+
+def _load_allowlist(rt_config: Dict) -> Dict[str, str]:
+    """
+    Build path→migration map from allowlist.
+
+    Existing routes using pages get allowlist treatment (warning).
+    New routes using pages are hard failures.
+    """
+    allowlist = {}
+    for entry in rt_config.get("allowlist", []):
+        path = entry.get("path", "")
+        migration = entry.get("migration", "")
+        if path:
+            allowlist[path] = migration
+    return allowlist
+
+
+# ---------------------------------------------------------------------------
+# Router file discovery
+# ---------------------------------------------------------------------------
+def _find_router_files(router_patterns: List[str]) -> List[Path]:
+    """
+    Find router configuration files matching configured glob patterns.
+
+    Falls back to default patterns if none configured.
+    """
+    files: List[Path] = []
+    seen: set = set()
+
+    for pattern in router_patterns:
+        for match in REPO_ROOT.glob(pattern):
+            if match.is_file() and match not in seen:
+                seen.add(match)
+                files.append(match)
+
+    return sorted(files)
+
+
+# ---------------------------------------------------------------------------
+# Route analysis
+# ---------------------------------------------------------------------------
+def _analyze_router_file(
+    file_path: Path,
+) -> Tuple[List[Dict], List[Dict]]:
+    """
+    Analyze a router file for page imports and TrainView usage.
+
+    Returns:
+        (page_violations, train_usages)
+        page_violations: list of dicts with line, import_path, component info
+        train_usages: list of dicts with line info
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8") as fh:
+            content = fh.read()
+            lines = content.splitlines()
+    except (OSError, UnicodeDecodeError):
+        return [], []
+
+    page_violations: List[Dict] = []
+    train_usages: List[Dict] = []
+
+    for line_num, line in enumerate(lines, start=1):
+        # Check for page imports
+        import_match = _PAGE_IMPORT_RE.search(line)
+        if import_match:
+            import_path = import_match.group(1)
+            page_violations.append({
+                "line": line_num,
+                "import_path": import_path,
+                "text": line.strip(),
+            })
+
+        # Check for direct page component usage in JSX
+        jsx_match = _PAGE_JSX_RE.search(line)
+        if jsx_match:
+            component = jsx_match.group(1)
+            page_violations.append({
+                "line": line_num,
+                "component": component,
+                "text": line.strip(),
+            })
+
+        # Track TrainView usage
+        if _TRAIN_VIEW_RE.search(line):
+            train_usages.append({
+                "line": line_num,
+                "text": line.strip(),
+            })
+
+    return page_violations, train_usages
+
+
+# ---------------------------------------------------------------------------
+# Test functions
+# ---------------------------------------------------------------------------
+@pytest.mark.coder
+def test_routes_use_train_components():
+    """
+    SPEC-CODER-PAGE-0004: Routes must use TrainView, not direct page imports.
+
+    Router files should use <TrainView trainId={...} /> to compose wagon
+    presentations via the FrontendTrainRunner. Direct imports of *Page.tsx
+    components bypass train composition.
+
+    Existing routes in the allowlist produce warnings. New routes using
+    pages are hard failures.
+
+    Given: Router configuration files
+    When: Scanning for page component imports and JSX usage
+    Then: Direct page imports not in allowlist are hard failures
+    """
+    rt_config = _load_route_config()
+    router_patterns = rt_config.get("router_patterns", _DEFAULT_ROUTER_PATTERNS)
+    allowlist = _load_allowlist(rt_config)
+
+    router_files = _find_router_files(router_patterns)
+
+    if not router_files:
+        pytest.skip(
+            "No router files found matching configured patterns. "
+            "Configure route_train_compliance.router_patterns in .atdd/config.yaml"
+        )
+
+    hard_failures: List[str] = []
+    warnings: List[str] = []
+
+    for router_file in router_files:
+        rel_path = str(router_file.relative_to(REPO_ROOT))
+        page_violations, train_usages = _analyze_router_file(router_file)
+
+        if not page_violations:
+            continue
+
+        # Deduplicate by line number
+        seen_lines: set = set()
+
+        for violation in page_violations:
+            line = violation["line"]
+            if line in seen_lines:
+                continue
+            seen_lines.add(line)
+
+            import_path = violation.get("import_path", "")
+            component = violation.get("component", "")
+            identifier = import_path or component
+            text = violation["text"]
+
+            if rel_path in allowlist:
+                warnings.append(
+                    f"  SPEC-CODER-PAGE-0004 WARN: Allowlisted route uses page component\n"
+                    f"    File:      {rel_path}:{line}\n"
+                    f"    Component: {identifier}\n"
+                    f"    Code:      {text}\n"
+                    f"    Migration: {allowlist[rel_path] or '<missing>'}"
+                )
+            else:
+                hard_failures.append(
+                    f"  SPEC-CODER-PAGE-0004 FAIL: Route uses page component instead of train\n"
+                    f"    File:      {rel_path}:{line}\n"
+                    f"    Component: {identifier}\n"
+                    f"    Code:      {text}\n"
+                    f"    Fix:       Use <TrainView trainId={{...}} /> instead.\n"
+                    f"               See: frontend.convention.yaml → train_composition"
+                )
+
+    # Log warnings but don't fail for allowlisted routes
+    if warnings:
+        for w in warnings:
+            print(f"\n{w}")
+
+    if hard_failures:
+        pytest.fail(
+            f"\n\n{len(hard_failures)} route(s) using direct page components "
+            f"(not TrainView):\n\n"
+            + "\n\n".join(hard_failures)
+            + (f"\n\n({len(warnings)} allowlisted route warning(s) also logged)"
+               if warnings else "")
+        )
+
+
+@pytest.mark.coder
+def test_route_allowlist_entries_have_migration():
+    """
+    SPEC-CODER-PAGE-0004 (allowlist hygiene): Every route allowlist entry
+    must reference a migration issue.
+
+    Given: route_train_compliance.allowlist in .atdd/config.yaml
+    When: Checking each entry for migration field
+    Then: Entries missing migration references fail
+    """
+    rt_config = _load_route_config()
+    allowlist_entries = rt_config.get("allowlist", [])
+
+    if not allowlist_entries:
+        pytest.skip("No route_train_compliance.allowlist entries in .atdd/config.yaml")
+
+    violations: List[str] = []
+
+    for entry in allowlist_entries:
+        path = entry.get("path", "<missing path>")
+        migration = entry.get("migration", "")
+
+        if not migration or not migration.strip():
+            violations.append(
+                f"  SPEC-CODER-PAGE-0004 FAIL: Route allowlist entry missing migration reference\n"
+                f"    Path: {path}\n"
+                f"    Fix:  Add migration: \"owner/repo#NNN\" to the allowlist entry."
+            )
+
+    if violations:
+        pytest.fail(
+            f"\n\n{len(violations)} route allowlist entry/entries missing migration reference:\n\n"
+            + "\n\n".join(violations)
+        )


### PR DESCRIPTION
## Summary

- Add `train_composition` section to `frontend.convention.yaml` documenting the positive architecture target (FrontendTrainRunner, TrainView, wagon registration, auth gating, permanent exceptions)
- Add `test_page_elimination.py` — scans all files in `page_elimination.scan_dirs`, hard-fails on unlisted files with wagon imports, auto-detects permanent exceptions (zero wagon imports) via import graph, enforces no subdirectories in pages/
- Add `test_god_hook_elimination.py` — scans hook files matching `hook_patterns`, hard-fails if exceeding `max_lines` (default 200) without allowlist entry
- Add `test_route_train_compliance.py` — parses router config files, flags direct page component imports, new routes must use `<TrainView>` instead

All validators read config from `.atdd/config.yaml`. Consumer repos populate allowlists with their own paths and migration issues.

Closes #261 Phases 1-3.

## SPEC IDs

| SPEC ID | Validator |
|---------|-----------|
| `SPEC-CODER-PAGE-0001` | `test_page_elimination.py` — unlisted page file |
| `SPEC-CODER-PAGE-0002` | `test_page_elimination.py` — allowlist missing migration |
| `SPEC-CODER-PAGE-0003` | `test_god_hook_elimination.py` — god hook exceeds threshold |
| `SPEC-CODER-PAGE-0004` | `test_route_train_compliance.py` — route uses page not train |
| `SPEC-CODER-PAGE-0005` | `test_page_elimination.py` — permanent exception auto-detect |
| `SPEC-CODER-PAGE-0010` | `test_page_elimination.py` — subdirectory in pages/ |
| `SPEC-CODER-PAGE-0011` | `test_page_elimination.py` — full tree scan |

## Test plan

- [ ] `atdd validate coder` passes (validators skip when no consumer config present)
- [ ] Consumer repo with `page_elimination` config: unlisted page files fail
- [ ] Consumer repo: page with zero wagon imports auto-detected as permanent exception
- [ ] Consumer repo with `god_hook_elimination` config: 250-line hook without allowlist fails
- [ ] Consumer repo with `route_train_compliance` config: route importing *Page fails
- [ ] Allowlist entries without `migration:` field fail hygiene checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)