### PR TITLE
fix(coder): scope structured_logging dogfooding to atdd source repo (#272)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.51.0"
+version = "1.51.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coder/utils/__init__.py
+++ b/src/atdd/coder/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Coder utilities shared across validators."""

--- a/src/atdd/coder/utils/python_file_walker.py
+++ b/src/atdd/coder/utils/python_file_walker.py
@@ -1,0 +1,160 @@
+"""
+Shared walker that yields Python source files belonging to the *consumer*
+repository under scan, excluding vendored/virtualenv/build artifacts.
+
+Why this exists
+---------------
+Historically, individual coder validators reimplemented their own
+``rglob("*.py")`` walk plus an ad-hoc skip list. When ``atdd`` is
+pip-installed into a consumer repo and the validators receive a path that
+incidentally contains ``site-packages`` or ``.venv``, those ad-hoc walks
+leaked into vendored code and produced spurious violations against third
+party libraries (issue #272).
+
+This module centralises a single walker with a canonical exclude list so
+every validator sees the same "what counts as consumer code" universe.
+
+Strategy
+--------
+1. Try ``git ls-files -- "*.py"`` with ``cwd=root``. If ``root`` is inside a
+   git working tree, this returns only tracked files — vendored code in
+   ``.venv`` / ``site-packages`` is typically untracked and therefore
+   naturally excluded.
+2. Fallback to ``Path.rglob("*.py")`` with :data:`DEFAULT_EXCLUDE_PATTERNS`
+   applied to path parts (for non-git directories, fresh clones before
+   ``git add``, or git checkouts where .venv is tracked by mistake).
+
+The exclude filter is applied in **both** strategies as a belt-and-braces
+guard, so a stray tracked ``.venv`` cannot reintroduce the site-packages
+leak.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import FrozenSet, Iterator, List, Optional, Tuple
+
+
+# Directory-name components that indicate a vendored / virtualenv / build
+# artifact location. Any path whose relative parts (relative to the walker
+# root) include one of these is skipped unconditionally.
+#
+# Kept deliberately minimal and conservative: this list covers the common
+# offenders across Python ecosystems. It is NOT intended as a replacement
+# for project-specific excludes — validators that need finer control should
+# filter the walker's output.
+DEFAULT_EXCLUDE_PATTERNS: FrozenSet[str] = frozenset(
+    {
+        # Python virtualenvs / package managers
+        "site-packages",
+        ".venv",
+        "venv",
+        "env",
+        "envs",
+        ".tox",
+        "__pypackages__",
+        ".eggs",
+        # JS (in case a python walker is pointed at a polyglot tree)
+        "node_modules",
+        # Build/dist output
+        "build",
+        "dist",
+        # Python caches
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        # Version control
+        ".git",
+        ".hg",
+        ".svn",
+    }
+)
+
+
+def _is_excluded_relative(rel_parts: Tuple[str, ...]) -> bool:
+    """Return True if any component of the relative path is vendored."""
+    for part in rel_parts:
+        if part in DEFAULT_EXCLUDE_PATTERNS:
+            return True
+        # *.dist-info / *.egg-info directories (pip metadata)
+        if part.endswith(".dist-info") or part.endswith(".egg-info"):
+            return True
+        # conda env roots (best-effort)
+        if part in {"miniconda3", "anaconda3", "miniforge3"}:
+            return True
+    return False
+
+
+def _git_ls_files(root: Path) -> Optional[List[Path]]:
+    """
+    Try ``git ls-files -- '*.py'`` with cwd=root. Returns a list of absolute
+    Paths, or None if the call failed (root not in a git tree, git missing,
+    non-zero exit).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--", "*.py"],
+            cwd=str(root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    paths: List[Path] = []
+    for line in result.stdout.splitlines():
+        if not line:
+            continue
+        candidate = (root / line).resolve()
+        if candidate.is_file():
+            paths.append(candidate)
+    return paths
+
+
+def _rglob_files(root: Path) -> List[Path]:
+    """Fallback walker — plain Path.rglob, caller filters excludes."""
+    return [p for p in root.rglob("*.py") if p.is_file()]
+
+
+def walk_consumer_python_files(repo_root: Path) -> Iterator[Path]:
+    """
+    Yield absolute :class:`pathlib.Path` objects for every Python source
+    file under ``repo_root`` that belongs to the consumer project (not
+    vendored/virtualenv/build output).
+
+    Parameters
+    ----------
+    repo_root:
+        Directory to walk. May be the repository root itself or any
+        subdirectory (e.g. ``repo_root / "python"``). A non-existent
+        directory yields nothing.
+
+    Yields
+    ------
+    Path
+        Absolute path to a ``.py`` file whose relative location under
+        ``repo_root`` does not contain any :data:`DEFAULT_EXCLUDE_PATTERNS`
+        component.
+    """
+    if not repo_root.exists():
+        return
+    resolved_root = repo_root.resolve()
+
+    files = _git_ls_files(resolved_root)
+    if files is None:
+        files = _rglob_files(resolved_root)
+
+    for path in files:
+        try:
+            rel_parts = path.resolve().relative_to(resolved_root).parts
+        except ValueError:
+            # git ls-files can surface paths outside root via symlinks;
+            # skip anything we cannot express relative to the walk root.
+            continue
+        if _is_excluded_relative(rel_parts):
+            continue
+        yield path

--- a/src/atdd/coder/utils/tests/test_python_file_walker.py
+++ b/src/atdd/coder/utils/tests/test_python_file_walker.py
@@ -1,0 +1,180 @@
+"""
+Unit tests for :mod:`atdd.coder.utils.python_file_walker`.
+
+URN: urn:atdd:test:coder:utils:python_file_walker
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from atdd.coder.utils.python_file_walker import (
+    DEFAULT_EXCLUDE_PATTERNS,
+    walk_consumer_python_files,
+)
+
+
+def _write(path: Path, content: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _rels(root: Path, paths) -> set[str]:
+    return {str(p.resolve().relative_to(root.resolve())) for p in paths}
+
+
+def test_default_exclude_patterns_cover_vendored_dirs():
+    """Regression guard for the canonical exclude list."""
+    required = {
+        "site-packages",
+        ".venv",
+        "venv",
+        ".tox",
+        "__pypackages__",
+        "node_modules",
+        "build",
+        "dist",
+        "__pycache__",
+    }
+    missing = required - DEFAULT_EXCLUDE_PATTERNS
+    assert not missing, f"DEFAULT_EXCLUDE_PATTERNS missing: {missing}"
+
+
+def test_skips_all_vendored_directories_non_git(tmp_path: Path):
+    """
+    With no .git present, the walker falls back to rglob + exclude list.
+    Files inside any vendored directory MUST NOT be yielded.
+    """
+    for rel in [
+        ".venv/lib/python3.11/site-packages/atdd/module.py",
+        "venv/lib/python3.11/site-packages/pkg/x.py",
+        ".tox/py311/lib/pkg/y.py",
+        "__pypackages__/3.11/lib/pkg/z.py",
+        "node_modules/pkg/a.py",
+        "build/lib/pkg/b.py",
+        "dist/pkg/c.py",
+        "some_pkg.dist-info/METADATA.py",
+        "some_pkg.egg-info/PKG-INFO.py",
+    ]:
+        _write(tmp_path / rel, "x = 1\n")
+
+    result = list(walk_consumer_python_files(tmp_path))
+    assert result == [], f"Expected no files, got {[str(p) for p in result]}"
+
+
+def test_non_git_fallback_yields_unexcluded_files(tmp_path: Path):
+    """Fallback walker returns .py files that lie outside excluded dirs."""
+    _write(tmp_path / "python" / "app.py", "x = 1\n")
+    _write(tmp_path / "python" / "lib" / "helper.py", "y = 2\n")
+    _write(tmp_path / ".venv" / "lib" / "vendored.py", "z = 3\n")  # excluded
+    _write(tmp_path / "web" / "src" / "index.ts", "// not python\n")
+
+    rels = _rels(tmp_path, walk_consumer_python_files(tmp_path))
+    assert rels == {"python/app.py", "python/lib/helper.py"}
+
+
+def test_nonexistent_root_yields_nothing(tmp_path: Path):
+    ghost = tmp_path / "does-not-exist"
+    assert list(walk_consumer_python_files(ghost)) == []
+
+
+def test_git_ls_files_strategy_used_when_repo_initialised(tmp_path: Path):
+    """
+    With an initialised git repo tracking only consumer files, ``git
+    ls-files`` MUST yield tracked files. Untracked vendored files (inside
+    .venv) must NOT appear even if they live on disk.
+    """
+    if not _git_available():
+        pytest.skip("git not available on PATH")
+
+    subprocess.run(
+        ["git", "init", "-q", "-b", "main"],
+        cwd=str(tmp_path),
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "config", "commit.gpgsign", "false"],
+        cwd=str(tmp_path),
+        check=True,
+    )
+
+    _write(tmp_path / "python" / "app.py", "x = 1\n")
+    _write(tmp_path / "python" / "sub" / "mod.py", "y = 2\n")
+    _write(tmp_path / ".venv" / "lib" / "vendored.py", "z = 3\n")  # untracked
+
+    subprocess.run(
+        ["git", "add", "python/app.py", "python/sub/mod.py"],
+        cwd=str(tmp_path),
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", "init"],
+        cwd=str(tmp_path),
+        check=True,
+    )
+
+    rels = _rels(tmp_path, walk_consumer_python_files(tmp_path))
+    assert rels == {"python/app.py", "python/sub/mod.py"}, rels
+
+
+def test_git_strategy_excludes_tracked_vendored_files(tmp_path: Path):
+    """
+    Belt-and-braces: even if a consumer accidentally tracks a .venv file,
+    the exclude filter catches it.
+    """
+    if not _git_available():
+        pytest.skip("git not available on PATH")
+
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=str(tmp_path), check=True)
+
+    _write(tmp_path / "python" / "app.py", "x = 1\n")
+    _write(tmp_path / ".venv" / "lib" / "oops.py", "z = 3\n")  # accidentally tracked
+
+    subprocess.run(
+        ["git", "add", "python/app.py", ".venv/lib/oops.py"],
+        cwd=str(tmp_path),
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "commit", "-q", "-m", "init"],
+        cwd=str(tmp_path),
+        check=True,
+    )
+
+    rels = _rels(tmp_path, walk_consumer_python_files(tmp_path))
+    assert rels == {"python/app.py"}, (
+        f"Tracked .venv file leaked past exclude filter: {rels}"
+    )
+
+
+def test_walking_a_subdir_works(tmp_path: Path):
+    """
+    Validators often pass ``repo_root / 'python'`` rather than the repo
+    root itself. The walker must handle subdir roots correctly.
+    """
+    _write(tmp_path / "python" / "a.py", "x = 1\n")
+    _write(tmp_path / "python" / "b.py", "y = 2\n")
+    _write(tmp_path / ".venv" / "lib" / "c.py", "z = 3\n")  # outside subdir
+
+    python_dir = tmp_path / "python"
+    rels = {str(p.resolve().relative_to(python_dir.resolve()))
+            for p in walk_consumer_python_files(python_dir)}
+    assert rels == {"a.py", "b.py"}
+
+
+def _git_available() -> bool:
+    try:
+        subprocess.run(
+            ["git", "--version"],
+            capture_output=True,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+        return False
+    return True

--- a/src/atdd/coder/validators/test_composition_completeness.py
+++ b/src/atdd/coder/validators/test_composition_completeness.py
@@ -25,6 +25,7 @@ import pytest
 import yaml
 
 from atdd.coach.utils.repo import find_repo_root
+from atdd.coder.utils.python_file_walker import walk_consumer_python_files
 
 
 REPO_ROOT = find_repo_root()
@@ -237,8 +238,9 @@ def collect_python_files(repo_root: Path) -> List[Path]:
     if not python_root.exists():
         return []
     return sorted(
-        path for path in python_root.rglob("*.py")
-        if path.is_file() and not graph_file_excluded(path)
+        path
+        for path in walk_consumer_python_files(python_root)
+        if not graph_file_excluded(path)
     )
 
 

--- a/src/atdd/coder/validators/test_duplication_detector.py
+++ b/src/atdd/coder/validators/test_duplication_detector.py
@@ -14,7 +14,6 @@ statement blocks, group by layer, report collisions across different files.
 
 import ast
 import hashlib
-import os
 import fnmatch
 import yaml
 import pytest
@@ -23,6 +22,7 @@ from typing import Dict, List, Optional, Tuple
 
 import atdd
 from atdd.coach.utils.repo import find_repo_root
+from atdd.coder.utils.python_file_walker import walk_consumer_python_files
 
 
 # ---------------------------------------------------------------------------
@@ -33,13 +33,6 @@ PYTHON_DIR = REPO_ROOT / "python"
 
 ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
 DUPLICATION_CONVENTION = ATDD_PKG_DIR / "coder" / "conventions" / "duplication.convention.yaml"
-
-_SKIP_DIRS = {
-    ".git", "__pycache__", "node_modules", ".dart_tool",
-    "build", ".pub-cache", "dist", ".next", ".nuxt", "coverage",
-    ".venv", "venv", "env", ".tox", ".mypy_cache", ".pytest_cache",
-}
-
 
 # ---------------------------------------------------------------------------
 # Convention loader
@@ -103,20 +96,20 @@ def _collect_python_files(
     base_dir: Path,
     exclusions: Optional[List[str]] = None,
 ) -> List[Path]:
-    """Walk base_dir for *.py files, honouring skip-dirs and exclusions."""
+    """Walk base_dir for *.py files, honouring project exclusions.
+
+    Vendored/virtualenv/build directory skipping is handled by the shared
+    :func:`walk_consumer_python_files` walker; the per-file exclusion globs
+    from the duplication convention are applied on top.
+    """
     if not base_dir.exists():
         return []
     exclusions = exclusions or []
     files: List[Path] = []
-    for dirpath, dirnames, filenames in os.walk(base_dir):
-        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
-        for fname in filenames:
-            if not fname.endswith(".py"):
-                continue
-            full = Path(dirpath) / fname
-            if _matches_exclusion(full, exclusions, base_dir):
-                continue
-            files.append(full)
+    for full in walk_consumer_python_files(base_dir):
+        if _matches_exclusion(full, exclusions, base_dir):
+            continue
+        files.append(full)
     return files
 
 

--- a/src/atdd/coder/validators/test_structured_logging.py
+++ b/src/atdd/coder/validators/test_structured_logging.py
@@ -32,8 +32,56 @@ REPO_ROOT = find_repo_root()
 PYTHON_DIR = REPO_ROOT / "python"
 
 # Package resources (conventions, schemas)
-ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
-LOGGING_CONVENTION = ATDD_PKG_DIR / "coder" / "conventions" / "logging.convention.yaml"
+# PKG_DIR always resolves to the installed atdd package (used for loading
+# bundled resources like conventions/schemas, regardless of install mode).
+PKG_DIR = Path(atdd.__file__).resolve().parent
+LOGGING_CONVENTION = PKG_DIR / "coder" / "conventions" / "logging.convention.yaml"
+
+
+# Path components that indicate a pip-installed/vendored location rather
+# than the atdd source tree. Even when a consumer repo has its .venv inside
+# the repo root, atdd.__file__ under any of these must not be dogfood-scanned.
+_VENDORED_PATH_MARKERS = frozenset(
+    {
+        "site-packages",
+        ".venv",
+        "venv",
+        ".tox",
+        "__pypackages__",
+        "node_modules",
+    }
+)
+
+
+def _atdd_source_dir_or_none() -> Path | None:
+    """
+    Return the atdd package directory only when running inside the atdd
+    source repo (editable/source install: ``atdd.__file__`` lives under
+    ``REPO_ROOT`` and NOT inside a vendored/virtualenv directory).
+
+    When atdd is pip-installed into a consumer repo — even into a ``.venv``
+    that happens to sit inside the consumer's repo root — ``atdd.__file__``
+    points inside site-packages and MUST NOT be scanned as "toolkit
+    dogfooding", or it would raise spurious LOG violations against vendored
+    code.
+    """
+    try:
+        pkg_dir = Path(atdd.__file__).resolve().parent
+    except (AttributeError, TypeError):
+        return None
+    try:
+        pkg_dir.relative_to(REPO_ROOT.resolve())
+    except ValueError:
+        return None
+    if any(part in _VENDORED_PATH_MARKERS for part in pkg_dir.parts):
+        return None
+    return pkg_dir
+
+
+# ATDD_PKG_DIR is ONLY set when running inside the atdd source repo.
+# In consumer repos with pip-installed atdd it is None, and dogfooding scans
+# are skipped.
+ATDD_PKG_DIR = _atdd_source_dir_or_none()
 
 # Logger method names that require extra= for structured context
 LOG_METHODS = {"debug", "info", "warning", "error", "critical", "exception", "log"}
@@ -129,7 +177,9 @@ def _rel_path(file_path: Path) -> Path:
     try:
         return file_path.relative_to(REPO_ROOT)
     except ValueError:
-        return file_path.relative_to(ATDD_PKG_DIR.parent)
+        if ATDD_PKG_DIR is not None:
+            return file_path.relative_to(ATDD_PKG_DIR.parent)
+        return file_path
 
 
 def scan_print_in_production(repo_root: Path) -> Tuple[int, List[str]]:
@@ -149,10 +199,19 @@ def scan_print_in_production(repo_root: Path) -> Tuple[int, List[str]]:
 
 
 def scan_structured_logging(repo_root: Path) -> Tuple[int, List[str]]:
-    """Scan for bare log calls. Used by ratchet baseline."""
+    """Scan for bare log calls. Used by ratchet baseline.
+
+    Scans consumer product code in ``repo_root/python/``. When running inside
+    the atdd source repo, also scans ``src/atdd/`` as toolkit dogfooding;
+    when atdd is pip-installed in a consumer repo this dogfooding scan is
+    skipped (ATDD_PKG_DIR is None) so vendored site-packages code is not
+    flagged.
+    """
     python_dir = repo_root / "python"
-    atdd_dir = Path(atdd.__file__).resolve().parent
-    python_files = _collect_files(python_dir, atdd_dir)
+    scan_dirs = [python_dir]
+    if ATDD_PKG_DIR is not None:
+        scan_dirs.append(ATDD_PKG_DIR)
+    python_files = _collect_files(*scan_dirs)
     violations = []
     for py_file in python_files:
         bare_logs = detect_bare_log_calls(py_file)
@@ -160,9 +219,12 @@ def scan_structured_logging(repo_root: Path) -> Tuple[int, List[str]]:
             try:
                 rel = py_file.relative_to(repo_root)
             except ValueError:
-                try:
-                    rel = py_file.relative_to(atdd_dir.parent)
-                except ValueError:
+                if ATDD_PKG_DIR is not None:
+                    try:
+                        rel = py_file.relative_to(ATDD_PKG_DIR.parent)
+                    except ValueError:
+                        rel = py_file
+                else:
                     rel = py_file
             violations.append(f"{rel}:{lineno}:{col} — logger.{method}() without extra=")
     return len(violations), violations
@@ -218,7 +280,10 @@ def test_structured_logging_format(ratchet_baseline):
 
     Convention: atdd/coder/conventions/logging.convention.yaml (LOG-002)
     """
-    python_files = _collect_files(PYTHON_DIR, ATDD_PKG_DIR)
+    scan_dirs = [PYTHON_DIR]
+    if ATDD_PKG_DIR is not None:
+        scan_dirs.append(ATDD_PKG_DIR)
+    python_files = _collect_files(*scan_dirs)
     if not python_files:
         pytest.skip("No Python files found to validate")
 

--- a/src/atdd/coder/validators/tests/test_structured_logging_unit.py
+++ b/src/atdd/coder/validators/tests/test_structured_logging_unit.py
@@ -1,0 +1,155 @@
+"""
+Unit tests for test_structured_logging module.
+
+Covers the source-mode detection helper that distinguishes running inside the
+atdd source repo (keep dogfooding scan of src/atdd/) from running in a
+consumer repo with pip-installed atdd (skip dogfooding — atdd.__file__ lives
+in site-packages and must not be scanned).
+
+URN: urn:atdd:test:coder:structured_logging_unit
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.fixture
+def fake_consumer_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """
+    Simulate a consumer repo layout with pip-installed atdd:
+
+        tmp_path/
+          python/app.py                              (1 bare logger call)
+          .venv/lib/python3.X/site-packages/atdd/
+             __init__.py                             (1 bare logger call — vendored)
+    """
+    consumer_python = tmp_path / "python" / "app.py"
+    _write(
+        consumer_python,
+        "import logging\nlogger = logging.getLogger(__name__)\n"
+        "def f():\n    logger.debug('consumer bare call')\n",
+    )
+
+    vendored_atdd_pkg = (
+        tmp_path
+        / ".venv"
+        / "lib"
+        / "python3.11"
+        / "site-packages"
+        / "atdd"
+    )
+    _write(vendored_atdd_pkg / "__init__.py", "")
+    _write(
+        vendored_atdd_pkg / "module.py",
+        "import logging\nlogger = logging.getLogger(__name__)\n"
+        "def g():\n    logger.debug('vendored bare call')\n",
+    )
+
+    # Marker so find_repo_root() returns tmp_path
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+def _reload_validator_with(
+    monkeypatch: pytest.MonkeyPatch,
+    repo_root: Path,
+    atdd_file: Path,
+):
+    """
+    Reload test_structured_logging with atdd.__file__ and find_repo_root()
+    monkeypatched so module-level path constants pick up the fake layout.
+    """
+    import atdd
+    from atdd.coach.utils import repo as repo_util
+
+    monkeypatch.setattr(atdd, "__file__", str(atdd_file), raising=False)
+    monkeypatch.setattr(repo_util, "find_repo_root", lambda *a, **k: repo_root)
+
+    mod_name = "atdd.coder.validators.test_structured_logging"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+    return importlib.import_module(mod_name)
+
+
+def test_consumer_mode_skips_vendored_site_packages(
+    fake_consumer_repo: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """
+    SPEC-CODER-LOG-0002-UNIT-01:
+    When atdd is pip-installed (atdd.__file__ inside site-packages under
+    .venv/), the dogfooding scan MUST be skipped. Only the consumer's
+    python/ tree is scanned — yielding exactly 1 violation, not 2.
+    """
+    vendored_init = (
+        fake_consumer_repo
+        / ".venv"
+        / "lib"
+        / "python3.11"
+        / "site-packages"
+        / "atdd"
+        / "__init__.py"
+    )
+    assert vendored_init.exists(), "fixture precondition"
+    mod = _reload_validator_with(monkeypatch, fake_consumer_repo, vendored_init)
+
+    assert mod.ATDD_PKG_DIR is None, (
+        "ATDD_PKG_DIR must be None when atdd package lives outside REPO_ROOT "
+        "(pip-installed in consumer repo)"
+    )
+
+    count, violations = mod.scan_structured_logging(fake_consumer_repo)
+    assert count == 1, (
+        f"Expected exactly 1 violation (consumer python/ only); "
+        f"got {count}: {violations}"
+    )
+    assert any("python/app.py" in v for v in violations), violations
+    assert not any("site-packages" in v for v in violations), (
+        f"Vendored site-packages must not be scanned: {violations}"
+    )
+
+
+def test_source_mode_keeps_dogfooding_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """
+    SPEC-CODER-LOG-0002-UNIT-02:
+    When running inside the atdd source repo (atdd package dir is under
+    REPO_ROOT, e.g. src/atdd/), the dogfooding scan MUST remain active so
+    toolkit regressions in src/atdd/ are caught.
+    """
+    src_atdd_dir = tmp_path / "src" / "atdd"
+    src_atdd_init = src_atdd_dir / "__init__.py"
+    _write(src_atdd_init, "")
+    _write(
+        src_atdd_dir / "toolkit.py",
+        "import logging\nlogger = logging.getLogger(__name__)\n"
+        "def g():\n    logger.debug('toolkit bare call')\n",
+    )
+    consumer_python = tmp_path / "python" / "app.py"
+    _write(
+        consumer_python,
+        "import logging\nlogger = logging.getLogger(__name__)\n"
+        "def f():\n    logger.debug('consumer bare call')\n",
+    )
+    (tmp_path / ".git").mkdir()
+
+    mod = _reload_validator_with(monkeypatch, tmp_path, src_atdd_init)
+
+    assert mod.ATDD_PKG_DIR is not None, (
+        "ATDD_PKG_DIR must be set when atdd package dir is under REPO_ROOT "
+        "(source-mode dogfooding)"
+    )
+
+    count, violations = mod.scan_structured_logging(tmp_path)
+    assert count == 2, f"Expected 2 violations (consumer + toolkit); got {count}: {violations}"


### PR DESCRIPTION
Closes #272

## Root cause

`test_structured_logging.ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent` resolved to `/.../site-packages/atdd/` when `atdd` was pip-installed in a consumer repo, and the validator intentionally scans that directory as "toolkit dogfooding". Result: spurious LOG-002 violations against vendored code.

## Phase 1 — Source-mode detection (`1691fe1`)

`fix(coder): scope structured_logging dogfooding to atdd source repo`

- New helper `_atdd_source_dir_or_none()` returns the atdd package dir only when it lives under `REPO_ROOT` **and** no path component is in `{site-packages, .venv, venv, .tox, __pypackages__, node_modules}`. Even a consumer repo whose `.venv` sits inside its own repo root is correctly classified as pip-install mode.
- `ATDD_PKG_DIR` is `None` in consumer mode; `scan_structured_logging` / `test_structured_logging_format` skip the dogfooding scan when it is `None`.
- `PKG_DIR` retained for loading bundled resources (conventions/schemas) regardless of install mode.
- Unit tests in `src/atdd/coder/validators/tests/test_structured_logging_unit.py`:
  - `test_consumer_mode_skips_vendored_site_packages` — fake `tmp_path/.venv/.../site-packages/atdd/` with monkeypatched `atdd.__file__`; expect exactly 1 violation (consumer `python/app.py`), not 2.
  - `test_source_mode_keeps_dogfooding_scan` — fake `tmp_path/src/atdd/toolkit.py` under REPO_ROOT; expect 2 violations (consumer + toolkit).

## Phase 2 — Shared walker utility (`cf1a88b`)

`feat(coder): shared walk_consumer_python_files walker`

- New `src/atdd/coder/utils/python_file_walker.py`:
  - `walk_consumer_python_files(repo_root: Path) -> Iterator[Path]`
  - `DEFAULT_EXCLUDE_PATTERNS` (canonical vendored markers)
  - Strategy: `git ls-files -- "*.py"` primary, `Path.rglob` fallback; exclude filter applied in **both** paths (belt-and-braces against accidentally-tracked `.venv` files).
- 7 unit tests in `src/atdd/coder/utils/tests/test_python_file_walker.py` cover: exclude-list coverage, non-git fallback, vendored-skip, nonexistent root, git-tracked strategy, accidentally-tracked `.venv` caught by post-filter, subdir root.

## Phase 3 — Consolidate existing walkers (`3f98733`)

`refactor(coder): route composition + duplication walks through shared walker`

- `test_composition_completeness.collect_python_files` → delegates to `walk_consumer_python_files(python_root)`, still layered with `graph_file_excluded`.
- `test_duplication_detector._collect_python_files` → delegates to the walker; convention-level exclusion globs applied on top.
- Removed dead `_SKIP_DIRS` constant and unused `os` import from duplication detector.
- Regression: composition + duplication validators still pass (8 passed, 3 skipped).

## Phase 4 — Caller audit (no code changes)

Inspected every `rglob("*.py")` caller on the audit list to confirm no sibling leaks into `REPO_ROOT` or `ATDD_PKG_DIR`:

| File | Lines | Walks from | Verdict |
|---|---|---|---|
| `test_quality_metrics.py` | 39, 242 | `PYTHON_DIR` / `repo_root/python` | ✅ bounded |
| `test_complexity.py` | 42, 379, 404, 428, 450, 472 | `python_dir` / `PYTHON_DIR` | ✅ bounded |
| `test_error_response_compliance.py` | 243, 264, 294, 325 | `python_dir` / `PYTHON_DIR` | ✅ bounded |
| `test_train_infrastructure.py` | 714 | `REPO_ROOT/python` | ✅ bounded |

**No sibling leaks found.** None of these call `rglob` on `REPO_ROOT` or `ATDD_PKG_DIR`, so none can reach vendored site-packages via the root-leak pathway that affected `test_structured_logging`.

Caveat recorded for follow-up: if a consumer puts `.venv` *inside* `python/`, these bounded walks would still leak. Migrating them onto `walk_consumer_python_files` would close that (narrow) gap.

## Deferred to follow-up issue (intentionally out of scope)

- Broader walker consolidation: **8 duplicated `_SKIP_DIRS` lists** across `test_frontend_security_patterns`, `test_page_elimination`, `test_duplication_detector_typescript`, `test_contract_driven_http`, `test_dead_code_typescript`, etc.
- Migration of the remaining `_collect_files` / ad-hoc `os.walk` helpers onto the shared walker.
- Optional: trimming polyglot noise from `DEFAULT_EXCLUDE_PATTERNS` once TS walkers share the same utility.

These are cleanups, not bug fixes — keeping this PR focused on #272.

## Phase 5 — SMOKE verification **PENDING**

⚠️ **Not run autonomously.** Requires manual run against `janetbusiness/jel-app@80d16fa6` to confirm `atdd validate coder --local` no longer flags LOG-002 violations in vendored site-packages. Will be recorded in the Activity Log post-verification.

## Local regression

- `PYTHONPATH=src python3 -m pytest src/atdd/coder/validators/tests/ src/atdd/coder/utils/tests/ -q` → **18 passed**
- `PYTHONPATH=src atdd validate coder --local` → **64 passed, 97 skipped** (unchanged)

## Version

PATCH: 1.51.0 → 1.51.1 (bug fix, no new feature/convention/schema).

## Test plan

- [ ] Reviewer pulls `fix/walker-consumer-scope`, runs unit tests
- [ ] Reviewer runs `atdd validate coder --local` on the atdd source repo (dogfooding must still flag toolkit regressions)
- [ ] SMOKE: run `atdd validate coder --local` against `janetbusiness/jel-app@80d16fa6` — expect **zero** vendored-site-packages LOG-002 hits
- [ ] After merge: tag `v1.51.1` on the merge commit