### PR TITLE
fix(cli): atdd upgrade now queries PyPI before reporting up-to-date (#277)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.53.0"
+version = "1.53.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -862,13 +862,22 @@ Phase descriptions:
     # ----- atdd upgrade -----
     upgrade_parser = subparsers.add_parser(
         "upgrade",
-        help="Show what changed and run sync + init --force",
-        description="Upgrade ATDD infrastructure after pip install --upgrade atdd"
+        help="Check PyPI, pip-upgrade if needed, then sync + init --force",
+        description=(
+            "Query PyPI for a newer atdd release and run "
+            "pip install --upgrade if available; otherwise sync the consumer repo "
+            "with the installed version."
+        ),
     )
     upgrade_parser.add_argument(
         "--yes", "-y",
         action="store_true",
         help="Skip confirmation prompts"
+    )
+    upgrade_parser.add_argument(
+        "--no-pypi",
+        action="store_true",
+        help="Skip the live PyPI check (use local stamp only)",
     )
 
     # ----- atdd baseline {update,show} -----
@@ -1502,7 +1511,10 @@ Phase descriptions:
 
     elif args.command == "upgrade":
         upgrader = Upgrader()
-        return upgrader.run(yes=args.yes)
+        return upgrader.run(
+            yes=args.yes,
+            no_pypi=getattr(args, "no_pypi", False),
+        )
 
     # atdd baseline {update,show}
     elif args.command == "baseline":

--- a/src/atdd/coach/commands/tests/test_upgrader.py
+++ b/src/atdd/coach/commands/tests/test_upgrader.py
@@ -1,0 +1,119 @@
+"""
+Unit tests for `atdd upgrade` (Upgrader).
+
+Regression for #277: `atdd upgrade` reported "Already up to date" when a newer
+atdd release was available on PyPI because Upgrader only compared the installed
+version against the local `toolkit.last_version` stamp and never queried PyPI.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from atdd.coach.commands.upgrader import Upgrader
+
+pytestmark = [pytest.mark.platform]
+
+
+def _write_config(repo: Path, last_version: str) -> Path:
+    (repo / ".atdd").mkdir(parents=True, exist_ok=True)
+    cfg = repo / ".atdd" / "config.yaml"
+    cfg.write_text(f"toolkit:\n  last_version: {last_version}\n")
+    return cfg
+
+
+def test_upgrade_detects_newer_pypi_release(tmp_path, monkeypatch, capsys):
+    """When PyPI reports a newer version, upgrade should offer pip install."""
+    _write_config(tmp_path, last_version="1.49.0")
+    monkeypatch.chdir(tmp_path)
+
+    with patch("atdd.coach.commands.upgrader.__version__", "1.49.0"), \
+         patch(
+             "atdd.coach.commands.upgrader.is_outdated",
+             return_value=(True, "1.49.0", "1.53.0"),
+         ), \
+         patch(
+             "atdd.coach.commands.upgrader.auto_upgrade",
+             return_value=True,
+         ) as mock_upgrade:
+        rc = Upgrader(repo_root=tmp_path).run(yes=True)
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "1.49.0 → 1.53.0" in out
+    mock_upgrade.assert_called_once()
+    assert "Re-run `atdd upgrade`" in out
+
+
+def test_upgrade_no_pypi_flag_skips_live_check(tmp_path, monkeypatch, capsys):
+    """--no-pypi must bypass is_outdated() entirely."""
+    _write_config(tmp_path, last_version="1.49.0")
+    monkeypatch.chdir(tmp_path)
+
+    with patch("atdd.coach.commands.upgrader.__version__", "1.49.0"), \
+         patch(
+             "atdd.coach.commands.upgrader.is_outdated",
+             side_effect=AssertionError("must not be called when no_pypi=True"),
+         ), \
+         patch(
+             "atdd.coach.commands.upgrader.auto_upgrade",
+             side_effect=AssertionError("must not pip-upgrade under --no-pypi"),
+         ):
+        rc = Upgrader(repo_root=tmp_path).run(yes=True, no_pypi=True)
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Already in sync with installed version." in out
+
+
+def test_upgrade_pypi_unreachable_falls_back_to_sync(tmp_path, monkeypatch, capsys):
+    """If is_outdated() returns latest=None, skip PyPI step and continue sync."""
+    _write_config(tmp_path, last_version="1.49.0")
+    monkeypatch.chdir(tmp_path)
+
+    with patch("atdd.coach.commands.upgrader.__version__", "1.49.0"), \
+         patch(
+             "atdd.coach.commands.upgrader.is_outdated",
+             return_value=(False, "1.49.0", ""),
+         ):
+        rc = Upgrader(repo_root=tmp_path).run(yes=True)
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Could not reach PyPI" in out
+    assert "Already in sync with installed version." in out
+
+
+def test_upgrade_already_latest_runs_sync_only(tmp_path, monkeypatch, capsys):
+    """When installed == PyPI latest but stamp is stale, run sync without pip upgrade."""
+    _write_config(tmp_path, last_version="1.50.0")
+    monkeypatch.chdir(tmp_path)
+
+    ran_subprocess: list = []
+
+    def fake_run(cmd, cwd=None):
+        ran_subprocess.append(cmd)
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    with patch("atdd.coach.commands.upgrader.__version__", "1.53.0"), \
+         patch(
+             "atdd.coach.commands.upgrader.is_outdated",
+             return_value=(False, "1.53.0", "1.53.0"),
+         ), \
+         patch(
+             "atdd.coach.commands.upgrader.auto_upgrade",
+             side_effect=AssertionError("must not pip-upgrade when already latest"),
+         ), \
+         patch("atdd.coach.commands.upgrader.subprocess.run", side_effect=fake_run):
+        rc = Upgrader(repo_root=tmp_path).run(yes=True)
+
+    assert rc == 0
+    # Should have invoked sync and init --force.
+    assert any("sync" in c for c in ran_subprocess)
+    assert any("init" in c for c in ran_subprocess)

--- a/src/atdd/coach/commands/upgrader.py
+++ b/src/atdd/coach/commands/upgrader.py
@@ -16,6 +16,8 @@ from atdd.version_check import (
     _load_repo_config,
     _get_last_toolkit_version,
     update_toolkit_version,
+    is_outdated,
+    auto_upgrade,
 )
 
 
@@ -25,11 +27,12 @@ class Upgrader:
     def __init__(self, repo_root: Optional[Path] = None):
         self.repo_root = repo_root or Path.cwd()
 
-    def run(self, yes: bool = False) -> int:
+    def run(self, yes: bool = False, no_pypi: bool = False) -> int:
         """Run the upgrade process.
 
         Args:
             yes: Skip confirmation prompts.
+            no_pypi: Skip the live PyPI check (use local state only).
 
         Returns:
             0 on success, 1 on failure.
@@ -39,15 +42,58 @@ class Upgrader:
             print("Not an ATDD repo (no .atdd/config.yaml). Nothing to upgrade.")
             return 1
 
-        last_version = _get_last_toolkit_version(config) or "unknown"
-        current = __version__
+        installed = __version__
+        latest: Optional[str] = None
 
-        print(f"ATDD upgrade: {last_version} → {current}")
+        # 1. Query PyPI for the real latest version (unless --no-pypi).
+        if not no_pypi:
+            outdated, _, latest = is_outdated()
+            if latest and outdated:
+                print(f"New version on PyPI: {installed} → {latest}")
+                if not yes:
+                    answer = input(
+                        f"Run `pip install --upgrade atdd` now? [Y/n] "
+                    ).strip().lower()
+                    if answer and answer != "y":
+                        print("Skipping pip upgrade. Continuing with sync step only.")
+                    else:
+                        print("Running: pip install --upgrade atdd")
+                        if not auto_upgrade():
+                            print(
+                                "pip upgrade failed. Run manually: "
+                                "pip install --upgrade atdd"
+                            )
+                            return 1
+                        print(
+                            f"pip upgraded atdd to {latest}. "
+                            "Re-run `atdd upgrade` to finish sync with the new version."
+                        )
+                        return 0
+                else:
+                    print("Running: pip install --upgrade atdd")
+                    if not auto_upgrade():
+                        print(
+                            "pip upgrade failed. Run manually: "
+                            "pip install --upgrade atdd"
+                        )
+                        return 1
+                    print(
+                        f"pip upgraded atdd to {latest}. "
+                        "Re-run `atdd upgrade` to finish sync with the new version."
+                    )
+                    return 0
+            elif not latest:
+                print("(Could not reach PyPI — skipping live version check.)")
+
+        # 2. Local sync path: compare stamped last_version against installed.
+        last_version = _get_last_toolkit_version(config) or "unknown"
+
+        print(f"ATDD sync: {last_version} → {installed}")
         print()
 
         # Show what changed
         if last_version != "unknown":
-            notes = get_upgrade_notes(last_version, current)
+            notes = get_upgrade_notes(last_version, installed)
             if notes:
                 print("What changed:")
                 for version, note in notes:
@@ -57,8 +103,8 @@ class Upgrader:
                 print("No notable changes between these versions.")
                 print()
 
-        if last_version == current:
-            print("Already up to date.")
+        if last_version == installed:
+            print("Already in sync with installed version.")
             return 0
 
         # Confirm
@@ -97,7 +143,7 @@ class Upgrader:
         # Update last_version
         if config_path:
             update_toolkit_version(config_path)
-            print(f"\nUpdated toolkit.last_version to {current}")
+            print(f"\nUpdated toolkit.last_version to {installed}")
 
-        print(f"\nUpgrade complete: {last_version} → {current}")
+        print(f"\nSync complete: {last_version} → {installed}")
         return 0


### PR DESCRIPTION
## Summary

Fixes #277. `atdd upgrade` previously never queried PyPI — it only compared the installed `__version__` against the local `toolkit.last_version` stamp in `.atdd/config.yaml`. Consumers missed intermediate releases (e.g. 1.49.0 → 1.53.0 with 1.49.1/1.50.0/1.51.x/1.52.0 in between).

## Changes

- `Upgrader.run()` now calls `version_check.is_outdated()` first to fetch the real PyPI latest.
- If a newer release is available, offers to run `auto_upgrade()` (`pip install --upgrade atdd`) and exits so the user can re-run with the new version.
- New `--no-pypi` flag bypasses the live PyPI check for offline use or when the local stamp is all that matters.
- Renames the local-stamp code path output from "upgrade" to "sync" so the two operations are no longer conflated in user-facing text.
- New regression tests in `test_upgrader.py`:
  - `test_upgrade_detects_newer_pypi_release` — direct regression for #277
  - `test_upgrade_no_pypi_flag_skips_live_check`
  - `test_upgrade_pypi_unreachable_falls_back_to_sync`
  - `test_upgrade_already_latest_runs_sync_only`

## Test plan

- [x] `pytest src/atdd/coach/commands/tests/test_upgrader.py` — 4 passed
- [ ] Manual: `atdd upgrade` in a consumer pinned to an older atdd — should detect PyPI newer and offer pip install
- [ ] Manual: `atdd upgrade --no-pypi` — should skip PyPI and only sync

Closes #277