### PR TITLE
fix(coder): gate composition_completeness fixture tests to atdd source repo (#276)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.53.1"
+version = "1.53.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/tests/test_is_atdd_source_repo.py
+++ b/src/atdd/coach/commands/tests/test_is_atdd_source_repo.py
@@ -1,0 +1,61 @@
+"""
+Unit tests for `is_atdd_source_repo()` — the dogfood-scope guard.
+
+Regression for #276: fixture-based dogfood tests must be gated by this helper
+so they don't leak into consumer `atdd validate coder` runs. The helper must
+return True only in the atdd source checkout and False in any pip-installed
+/ vendored / consumer-repo layout.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from atdd.coach.utils.repo import is_atdd_source_repo, find_repo_root
+
+pytestmark = [pytest.mark.platform]
+
+
+def _make_fake_consumer_repo(root: Path) -> None:
+    (root / ".git").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "consumer-app"\nversion = "0.1.0"\n'
+    )
+
+
+def test_returns_false_when_pkg_in_site_packages(tmp_path, monkeypatch):
+    """pip-installed atdd lives under .../site-packages/atdd — never source."""
+    _make_fake_consumer_repo(tmp_path)
+    fake_pkg = tmp_path / ".venv" / "lib" / "python3.14" / "site-packages" / "atdd"
+    (fake_pkg).mkdir(parents=True)
+    (fake_pkg / "__init__.py").write_text("")
+
+    fake_atdd = type("FakeAtdd", (), {"__file__": str(fake_pkg / "__init__.py")})
+
+    monkeypatch.chdir(tmp_path)
+    find_repo_root.cache_clear()
+    with patch.dict("sys.modules", {"atdd": fake_atdd}):
+        assert is_atdd_source_repo() is False
+
+
+def test_returns_false_when_pyproject_name_is_not_atdd(tmp_path, monkeypatch):
+    """Consumer repo whose pyproject.toml has a different name — not source."""
+    _make_fake_consumer_repo(tmp_path)
+    consumer_pkg = tmp_path / "src" / "atdd"
+    consumer_pkg.mkdir(parents=True)
+    (consumer_pkg / "__init__.py").write_text("")
+
+    fake_atdd = type("FakeAtdd", (), {"__file__": str(consumer_pkg / "__init__.py")})
+
+    monkeypatch.chdir(tmp_path)
+    find_repo_root.cache_clear()
+    with patch.dict("sys.modules", {"atdd": fake_atdd}):
+        assert is_atdd_source_repo() is False
+
+
+def test_returns_true_inside_actual_source_repo():
+    """When the real test is collected from the atdd source repo, True."""
+    find_repo_root.cache_clear()
+    assert is_atdd_source_repo() is True

--- a/src/atdd/coach/utils/repo.py
+++ b/src/atdd/coach/utils/repo.py
@@ -154,3 +154,62 @@ def require_repo_root(start: Optional[Path] = None) -> Path:
         f"No ATDD project markers found searching from {start_path}. "
         "Expected one of: .atdd/manifest.yaml, plan/ + contracts/, or .git/"
     )
+
+
+# Path parts that indicate a pip-installed / vendored location. Even if the
+# consumer's `.venv` sits inside their repo root, `atdd.__file__` under any of
+# these is a consumer install, NOT the atdd source repo.
+_VENDORED_PATH_MARKERS = frozenset(
+    {
+        "site-packages",
+        ".venv",
+        "venv",
+        ".tox",
+        "__pypackages__",
+        "node_modules",
+    }
+)
+
+
+def is_atdd_source_repo() -> bool:
+    """
+    Return True only when running inside the atdd source repo
+    (editable / source checkout), False in any consumer install.
+
+    Dogfood tests — tests that assert behavior against fixtures shipped
+    inside `src/atdd/**/validators/fixtures/` — must call this and
+    `pytest.skip(...)` when it returns False. Otherwise those tests leak
+    into consumer `atdd validate coder` runs and fail with assertion
+    errors against toolkit fixture data (see #272, #276).
+    """
+    try:
+        import atdd  # local import to avoid cycles at module import time
+
+        pkg_dir = Path(atdd.__file__).resolve().parent
+    except (ImportError, AttributeError, TypeError):
+        return False
+
+    if any(part in _VENDORED_PATH_MARKERS for part in pkg_dir.parts):
+        return False
+
+    try:
+        repo_root = find_repo_root().resolve()
+    except RuntimeError:
+        return False
+
+    try:
+        pkg_dir.relative_to(repo_root)
+    except ValueError:
+        return False
+
+    # Source repo always has a top-level pyproject.toml whose [project].name
+    # is "atdd" — the strongest signal that we are actually in the toolkit
+    # checkout and not in a consumer repo that happens to vendor atdd.
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.is_file():
+        return False
+    try:
+        text = pyproject.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return 'name = "atdd"' in text

--- a/src/atdd/coder/validators/test_composition_completeness.py
+++ b/src/atdd/coder/validators/test_composition_completeness.py
@@ -24,7 +24,7 @@ import atdd
 import pytest
 import yaml
 
-from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.utils.repo import find_repo_root, is_atdd_source_repo
 from atdd.coder.utils.python_file_walker import walk_consumer_python_files
 
 
@@ -698,6 +698,8 @@ def test_composition_completeness_python_fixture_passes_for_complete_and_partial
     When: Analyzing composition completeness
     Then: No violations are reported
     """
+    if not is_atdd_source_repo():
+        pytest.skip("fixture-based dogfood test — runs only inside the atdd source repo (#276)")
     violations = analyze_python_repo(FIXTURE_ROOT / "python_pass")
     assert_no_violations(violations)
 
@@ -711,6 +713,8 @@ def test_composition_completeness_python_fixture_detects_missing_setter_call():
     When: Analyzing composition completeness
     Then: The composition root is reported as missing presentation reachability
     """
+    if not is_atdd_source_repo():
+        pytest.skip("fixture-based dogfood test — runs only inside the atdd source repo (#276)")
     violations = analyze_python_repo(FIXTURE_ROOT / "python_fail_setter")
     assert len(violations) == 1, "expected one composition root violation"
     violation = violations[0]
@@ -728,6 +732,8 @@ def test_composition_completeness_typescript_fixture_detects_cameo_and_import_ty
     When: Analyzing composition completeness
     Then: Application layer violations are reported for both unwired hooks
     """
+    if not is_atdd_source_repo():
+        pytest.skip("fixture-based dogfood test — runs only inside the atdd source repo (#276)")
     violations = analyze_typescript_repo(FIXTURE_ROOT / "typescript_repo")
     violation_map = {(item.feature, item.file): item for item in violations}
 
@@ -750,6 +756,8 @@ def test_composition_completeness_typescript_fixture_accepts_barrels_and_partial
     When: Analyzing composition completeness
     Then: Barrel-consumed hooks pass and partial-feature integration is skipped
     """
+    if not is_atdd_source_repo():
+        pytest.skip("fixture-based dogfood test — runs only inside the atdd source repo (#276)")
     violations = analyze_typescript_repo(FIXTURE_ROOT / "typescript_repo")
     violated_files = {item.file for item in violations}
 


### PR DESCRIPTION
## Summary

Fixes #276. Four `test_composition_completeness_*_fixture_*` tests made assertions against toolkit fixtures shipped in `src/atdd/coder/validators/fixtures/`. When a consumer runs `atdd validate coder`, pytest discovers and runs these tests from site-packages, producing assertion failures against toolkit fixture data (the `bad_match/orchestrate_bad` feature leak reported in the issue).

This is the same failure class as #272 (fixed in 1.51.1 for `test_structured_logging`).

## Changes

- **New shared helper** `atdd.coach.utils.repo.is_atdd_source_repo()`: returns True only when the atdd package lives inside a checkout whose `pyproject.toml[project].name` is `"atdd"` and whose package directory is not under any vendored marker (`site-packages`, `.venv`, `venv`, `.tox`, `__pypackages__`, `node_modules`).
- **Gate the 4 fixture tests** in `test_composition_completeness.py` with `pytest.skip(...)` when `is_atdd_source_repo()` is False.
- **Unit tests** in `test_is_atdd_source_repo.py` covering:
  - fake consumer repo with pip-installed atdd under `.venv/lib/.../site-packages/atdd` → False
  - fake consumer repo with its own `src/atdd/` and non-"atdd" pyproject name → False
  - real atdd source checkout → True

## Design notes

The helper is public and deliberately reusable. Future dogfood fixture tests in other validator modules should import it and apply the same skip pattern. Long-term, a coach validator could flag `*_fixture_*` tests that ship from `src/atdd/**/validators/` without calling this helper — left as follow-up.

## Test plan

- [x] `pytest src/atdd/coach/commands/tests/test_is_atdd_source_repo.py` — 3 passed
- [x] `pytest src/atdd/coder/validators/test_composition_completeness.py -k fixture` — 4 passed (still run in source repo)
- [ ] Manual: install the resulting wheel in a consumer repo and run `atdd validate coder`; verify the 4 fixture tests are skipped, not failed

Closes #276