### PR TITLE
feat(coach): TRAIN_STEP edges from train sequence[] handoffs (#287 PR 1)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -33,3 +33,11 @@ sessions:
   status: INIT
   created: '2026-04-15'
   archived: null
+- id: '287'
+  slug: train-step-journey-mode
+  file: null
+  issue_number: 287
+  type: implementation
+  status: INIT
+  created: '2026-04-15'
+  archived: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.55.1"
+version = "1.56.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/utils/graph/graph_builder.py
+++ b/src/atdd/coach/utils/graph/graph_builder.py
@@ -42,6 +42,7 @@ class EdgeType(Enum):
     IMPLEMENTS = "implements"  # Implementation relationship (component implements feature)
     REFERENCES = "references"  # General reference relationship
     INCLUDES = "includes"  # Train includes wagons (many-to-many)
+    TRAIN_STEP = "train_step"  # Ordered wagon→wagon handoff inside a train's sequence[] (#287)
     TESTED_BY = "tested_by"  # Verification relationship (acc/component tested by test)
 
 
@@ -230,13 +231,25 @@ class TraceabilityGraph:
             edges = [e for e in edges if e.edge_type == edge_type]
         return [self._nodes[e.source_urn] for e in edges if e.source_urn in self._nodes]
 
-    def get_subgraph(self, root_urn: str, max_depth: int = -1) -> "TraceabilityGraph":
+    def get_subgraph(
+        self,
+        root_urn: str,
+        max_depth: int = -1,
+        edge_type_exclude: Optional[Set[EdgeType]] = None,
+    ) -> "TraceabilityGraph":
         """
         Extract a subgraph starting from a root node.
 
         Args:
             root_urn: Starting node URN
             max_depth: Maximum traversal depth (-1 for unlimited)
+            edge_type_exclude: Optional set of EdgeType values to skip during
+                traversal. Edges of these types are neither copied into the
+                subgraph nor followed to their targets. Structural consumers
+                pass ``{EdgeType.TRAIN_STEP}`` to prevent wagon-rooted
+                subgraphs from leaking cross-train wagons via shared
+                handoffs (#287). Defaults to None (existing behavior:
+                traverse every edge).
 
         Returns:
             New graph containing only reachable nodes and edges
@@ -244,6 +257,7 @@ class TraceabilityGraph:
         subgraph = TraceabilityGraph()
         visited: Set[str] = set()
         queue: List[Tuple[str, int]] = [(root_urn, 0)]
+        excluded = edge_type_exclude or set()
 
         while queue:
             urn, depth = queue.pop(0)
@@ -259,6 +273,8 @@ class TraceabilityGraph:
                 subgraph.add_node(node)
 
             for edge in self.get_outgoing_edges(urn):
+                if edge.edge_type in excluded:
+                    continue
                 subgraph.add_edge(edge)
                 if edge.target_urn not in visited:
                     queue.append((edge.target_urn, depth + 1))
@@ -1057,6 +1073,57 @@ class GraphBuilder:
                             edge_type=EdgeType.INCLUDES,
                         )
                     )
+
+                # TRAIN_STEP edges (#287): one directed wagon→wagon edge per
+                # handoff in the train's sequence[]. A "handoff" is a
+                # sequence[] entry where `from != to` and both are `wagon:*`
+                # URNs. Internal-phase steps (from == to) are skipped — they
+                # don't advance the pipeline and would clutter journey mode.
+                # Non-wagon participants (user:*, system:*) on either side
+                # are ignored — TRAIN_STEP is strictly wagon-to-wagon.
+                #
+                # Category is derived from train_id[1] per the naming
+                # convention `{theme}{category}{variation}-slug`:
+                #   0 = nominal, 1 = error, 2 = alternate, 3 = exception.
+                _TRAIN_CATEGORY_BY_DIGIT = {
+                    "0": "nominal",
+                    "1": "error",
+                    "2": "alternate",
+                    "3": "exception",
+                }
+                category = "nominal"
+                if isinstance(train_id, str) and len(train_id) > 1:
+                    category = _TRAIN_CATEGORY_BY_DIGIT.get(train_id[1], "nominal")
+
+                sequence = data.get("sequence") or []
+                if isinstance(sequence, list):
+                    ordered_steps = sorted(
+                        (s for s in sequence if isinstance(s, dict)),
+                        key=lambda s: s.get("step", 0),
+                    )
+                    for item in ordered_steps:
+                        frm = item.get("from") or ""
+                        to = item.get("to") or ""
+                        if not isinstance(frm, str) or not isinstance(to, str):
+                            continue
+                        if not frm.startswith("wagon:") or not to.startswith("wagon:"):
+                            continue
+                        if frm == to:
+                            continue  # internal-phase step
+                        graph.add_edge(
+                            URNEdge(
+                                source_urn=frm,
+                                target_urn=to,
+                                edge_type=EdgeType.TRAIN_STEP,
+                                metadata={
+                                    "train": train_urn,
+                                    "step": item.get("step", 0),
+                                    "intent": item.get("intent", ""),
+                                    "category": category,
+                                    "source": "train-sequence",
+                                },
+                            )
+                        )
 
             except Exception:
                 continue

--- a/src/atdd/coach/utils/graph/tests/test_get_subgraph_edge_type_exclude.py
+++ b/src/atdd/coach/utils/graph/tests/test_get_subgraph_edge_type_exclude.py
@@ -1,0 +1,134 @@
+# URN: test:coach:traceability_graph:get_subgraph_edge_type_exclude
+"""
+Regression test for issue #287: TraceabilityGraph.get_subgraph must accept
+an `edge_type_exclude` parameter so structural consumers can hide TRAIN_STEP
+edges and wagon-rooted subgraphs do not leak cross-train wagons.
+
+Without this filter, once TRAIN_STEP edges exist, a subgraph rooted at a
+wagon would pull in every other wagon reachable via a shared handoff from
+any train, polluting the structural view. The filter keeps the graph honest
+(edges remain first-class) while giving each consumer explicit control.
+
+Rules pinned here:
+  - get_subgraph(root, edge_type_exclude={TRAIN_STEP}) does NOT traverse
+    TRAIN_STEP edges — their targets are never queued, never added.
+  - get_subgraph(root, edge_type_exclude=None) still traverses every edge
+    (the existing behavior is preserved as the default).
+  - Train-rooted subgraphs with no exclusion contain every TRAIN_STEP edge
+    whose owning train matches the root (the journey-mode query).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from atdd.coach.utils.graph.graph_builder import (
+    EdgeType,
+    TraceabilityGraph,
+    URNEdge,
+    URNNode,
+)
+
+
+def _make_graph() -> TraceabilityGraph:
+    g = TraceabilityGraph()
+    # Nodes
+    for urn, fam in [
+        ("train:0205-renewal", "train"),
+        ("train:0105-error", "train"),
+        ("wagon:stage", "wagon"),
+        ("wagon:dispatch", "wagon"),
+        ("wagon:audit", "wagon"),
+        ("feature:stage:prep", "feature"),
+    ]:
+        g.add_node(URNNode(urn=urn, family=fam))
+
+    # INCLUDES: train → wagon
+    g.add_edge(URNEdge("train:0205-renewal", "wagon:stage", EdgeType.INCLUDES))
+    g.add_edge(URNEdge("train:0205-renewal", "wagon:dispatch", EdgeType.INCLUDES))
+    g.add_edge(URNEdge("train:0105-error", "wagon:dispatch", EdgeType.INCLUDES))
+    g.add_edge(URNEdge("train:0105-error", "wagon:audit", EdgeType.INCLUDES))
+
+    # TRAIN_STEP: wagon → wagon, labeled by owning train
+    g.add_edge(
+        URNEdge(
+            "wagon:stage",
+            "wagon:dispatch",
+            EdgeType.TRAIN_STEP,
+            metadata={"train": "train:0205-renewal", "step": 2, "category": "alternate"},
+        )
+    )
+    g.add_edge(
+        URNEdge(
+            "wagon:dispatch",
+            "wagon:audit",
+            EdgeType.TRAIN_STEP,
+            metadata={"train": "train:0105-error", "step": 2, "category": "error"},
+        )
+    )
+
+    # CONTAINS: wagon → feature
+    g.add_edge(URNEdge("wagon:stage", "feature:stage:prep", EdgeType.CONTAINS))
+    return g
+
+
+def test_wagon_rooted_subgraph_excludes_train_step_does_not_leak(_monkey=None):
+    g = _make_graph()
+    sub = g.get_subgraph(
+        "wagon:stage", max_depth=-1, edge_type_exclude={EdgeType.TRAIN_STEP}
+    )
+    urns = set(sub.nodes.keys())
+    assert "wagon:dispatch" not in urns, (
+        "TRAIN_STEP edge must not pull in dispatch when excluded"
+    )
+    assert "wagon:audit" not in urns
+    assert "feature:stage:prep" in urns, (
+        "CONTAINS edges must still be traversed"
+    )
+    train_step = [e for e in sub.edges if e.edge_type == EdgeType.TRAIN_STEP]
+    assert train_step == [], "Excluded edge type must not appear in subgraph"
+
+
+def test_wagon_rooted_subgraph_default_leaks_via_train_step_to_show_why_filter_is_needed():
+    """
+    Baseline: with no exclude, a wagon-rooted subgraph DOES traverse TRAIN_STEP
+    edges and pull in cross-train wagons. This test pins the motivation for
+    the filter — it proves the default is promiscuous.
+    """
+    g = _make_graph()
+    sub = g.get_subgraph("wagon:stage", max_depth=-1)
+    urns = set(sub.nodes.keys())
+    assert "wagon:dispatch" in urns, (
+        "Without exclude, TRAIN_STEP should still be traversed"
+    )
+
+
+def test_train_rooted_subgraph_contains_its_train_step_edges():
+    """
+    A subgraph rooted at a train, with no exclusion, must contain every
+    TRAIN_STEP edge whose metadata.train matches the root. This is the
+    journey-mode query shape.
+    """
+    g = _make_graph()
+    sub = g.get_subgraph("train:0205-renewal", max_depth=-1)
+    own_steps = [
+        e
+        for e in sub.edges
+        if e.edge_type == EdgeType.TRAIN_STEP
+        and e.metadata.get("train") == "train:0205-renewal"
+    ]
+    assert len(own_steps) == 1
+    assert own_steps[0].source_urn == "wagon:stage"
+    assert own_steps[0].target_urn == "wagon:dispatch"
+
+
+def test_edge_type_exclude_default_preserves_existing_behavior():
+    """
+    Callers that do not pass edge_type_exclude must see identical behavior
+    to the pre-#287 signature — backward-compat guard on the new parameter.
+    """
+    g = _make_graph()
+    a = g.get_subgraph("train:0205-renewal", max_depth=-1)
+    b = g.get_subgraph("train:0205-renewal", max_depth=-1, edge_type_exclude=None)
+    assert len(a.edges) == len(b.edges)
+    assert set(a.nodes.keys()) == set(b.nodes.keys())

--- a/src/atdd/coach/utils/graph/tests/test_graph_builder_train_step_edges.py
+++ b/src/atdd/coach/utils/graph/tests/test_graph_builder_train_step_edges.py
@@ -1,0 +1,301 @@
+# URN: test:coach:graph_builder:train_step_edges
+"""
+Regression test for issue #287: TRAIN_STEP edges from train sequence[] handoffs.
+
+The URN graph must encode the ordered wagon-to-wagon handoffs inside each
+train's sequence[] as first-class edges, so per-train subgraph consumers
+(notably the new viz journey mode) can render pipelines linearly without
+re-parsing YAML.
+
+Rules pinned here:
+  - One TRAIN_STEP edge per sequence[] entry where
+    `from != to` and both are wagon:* URNs ("handoff").
+  - Internal-phase steps (`from == to`) are skipped — they don't advance
+    the pipeline and would clutter the journey-mode render.
+  - Non-wagon participants on from/to (user:*, system:*) are ignored.
+  - Each emitted edge carries metadata {train, step, intent, category, source}.
+  - Multiple trains traversing the same handoff each emit their own edge
+    (parallel edges, filterable by metadata.train).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.utils.graph.graph_builder import (
+    EdgeType,
+    GraphBuilder,
+    TraceabilityGraph,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_wagon(plan_dir: Path, slug: str) -> None:
+    wagon_dir = plan_dir / slug.replace("-", "_")
+    wagon_dir.mkdir(parents=True, exist_ok=True)
+    wagon_file = wagon_dir / f"_{slug.replace('-', '_')}.yaml"
+    wagon_file.write_text(
+        "\n".join(
+            [
+                f"wagon: {slug}",
+                f"urn: wagon:{slug}",
+                'description: "wagon for TRAIN_STEP regression test"',
+                "theme: commons",
+                'subject: "test:worker"',
+                'context: "test"',
+                'action: "x"',
+                'goal: "y"',
+                'outcome: "z"',
+                "produce: []",
+                "consume: []",
+                "wmbt:",
+                "  total: 0",
+                "",
+            ]
+        )
+    )
+
+
+def _write_train(plan_dir: Path, train_id: str, body: str) -> None:
+    trains_dir = plan_dir / "_trains"
+    trains_dir.mkdir(parents=True, exist_ok=True)
+    (trains_dir / f"{train_id}.yaml").write_text(body)
+
+
+def _build(repo_root: Path) -> TraceabilityGraph:
+    builder = GraphBuilder(repo_root=repo_root, use_cache=False)
+    graph = TraceabilityGraph()
+    builder._build_train_edges(graph)
+    return graph
+
+
+def _train_step_edges(graph: TraceabilityGraph, train_urn: str | None = None):
+    out = [e for e in graph.edges if e.edge_type == EdgeType.TRAIN_STEP]
+    if train_urn is not None:
+        out = [e for e in out if e.metadata.get("train") == train_urn]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_single_wagon_train_emits_no_train_step_edges(tmp_path):
+    """
+    A train whose only sequence entry is an internal-phase step (from==to)
+    must not produce any TRAIN_STEP edges. There are no handoffs.
+    """
+    plan = tmp_path / "plan"
+    plan.mkdir()
+    _write_wagon(plan, "dispatch-call")
+    _write_train(
+        plan,
+        "0001-first-run-nominal",
+        "\n".join(
+            [
+                'train_id: "0001-first-run-nominal"',
+                'title: "First run nominal"',
+                'description: "Single-wagon internal-phase only"',
+                "themes: [commons]",
+                'participants: ["wagon:dispatch-call"]',
+                "sequence:",
+                "  - step: 1",
+                '    intent: "internal prep"',
+                "    from: wagon:dispatch-call",
+                "    to:   wagon:dispatch-call",
+                '    artifact: "dispatch:scenario-step"',
+                "",
+            ]
+        ),
+    )
+    graph = _build(plan.parent)
+    assert _train_step_edges(graph) == [], (
+        "Single-wagon train (internal-phase only) must emit zero TRAIN_STEP edges"
+    )
+
+
+def test_two_wagon_handoff_emits_one_train_step_edge_with_metadata(tmp_path):
+    """
+    A two-wagon train with one handoff must produce exactly one TRAIN_STEP
+    edge whose metadata captures train/step/intent/category/source.
+    """
+    plan = tmp_path / "plan"
+    plan.mkdir()
+    _write_wagon(plan, "stage-request")
+    _write_wagon(plan, "dispatch-call")
+    _write_train(
+        plan,
+        "0205-renewal-before-deadline",
+        "\n".join(
+            [
+                'train_id: "0205-renewal-before-deadline"',
+                'title: "Renewal before deadline"',
+                'description: "Alternate scenario (category=2): stage -> dispatch handoff"',
+                "themes: [commons]",
+                "participants:",
+                "  - wagon:stage-request",
+                "  - wagon:dispatch-call",
+                "sequence:",
+                "  - step: 1",
+                '    intent: "Prepare inputs"',
+                "    from: wagon:stage-request",
+                "    to:   wagon:stage-request",
+                '    artifact: "stage:scenario-step"',
+                "  - step: 2",
+                '    intent: "Hand off to dispatch and issue request"',
+                "    from: wagon:stage-request",
+                "    to:   wagon:dispatch-call",
+                '    artifact: "dispatch:scenario-step"',
+                "",
+            ]
+        ),
+    )
+    graph = _build(plan.parent)
+    edges = _train_step_edges(graph, "train:0205-renewal-before-deadline")
+    assert len(edges) == 1, (
+        f"Expected exactly 1 TRAIN_STEP edge for the single handoff; got {len(edges)}"
+    )
+    e = edges[0]
+    assert e.source_urn == "wagon:stage-request"
+    assert e.target_urn == "wagon:dispatch-call"
+    assert e.metadata["train"] == "train:0205-renewal-before-deadline"
+    assert e.metadata["step"] == 2
+    assert "Hand off" in e.metadata["intent"]
+    assert e.metadata["category"] == "alternate", (
+        "0205 has category digit 2 → alternate; got "
+        f"{e.metadata.get('category')!r}"
+    )
+    assert e.metadata["source"] == "train-sequence"
+
+
+def test_internal_phase_steps_are_skipped(tmp_path):
+    """
+    A train with multiple internal-phase steps and one real handoff must
+    emit exactly one TRAIN_STEP edge — the handoff. Self-loops never materialize.
+    """
+    plan = tmp_path / "plan"
+    plan.mkdir()
+    _write_wagon(plan, "a")
+    _write_wagon(plan, "b")
+    _write_train(
+        plan,
+        "0102-redirect-timeout",
+        "\n".join(
+            [
+                'train_id: "0102-redirect-timeout"',
+                'title: "Error scenario"',
+                'description: "Category=1 error; two internal steps, one handoff"',
+                "themes: [commons]",
+                'participants: ["wagon:a", "wagon:b"]',
+                "sequence:",
+                "  - {step: 1, intent: internal, from: wagon:a, to: wagon:a, artifact: x}",
+                "  - {step: 2, intent: handoff, from: wagon:a, to: wagon:b, artifact: x}",
+                "  - {step: 3, intent: internal, from: wagon:b, to: wagon:b, artifact: x}",
+                "",
+            ]
+        ),
+    )
+    graph = _build(plan.parent)
+    edges = _train_step_edges(graph, "train:0102-redirect-timeout")
+    assert len(edges) == 1
+    assert edges[0].source_urn == "wagon:a"
+    assert edges[0].target_urn == "wagon:b"
+    assert edges[0].metadata["category"] == "error"
+
+
+def test_non_wagon_participants_in_sequence_are_ignored(tmp_path):
+    """
+    sequence[] entries whose from/to are user:*/system:* (not wagon:*) must
+    not produce TRAIN_STEP edges. TRAIN_STEP is strictly wagon-to-wagon.
+    """
+    plan = tmp_path / "plan"
+    plan.mkdir()
+    _write_wagon(plan, "a")
+    _write_train(
+        plan,
+        "0001-actor-edges",
+        "\n".join(
+            [
+                'train_id: "0001-actor-edges"',
+                'title: "User/system actors"',
+                'description: "Ensure non-wagon sides are ignored"',
+                "themes: [commons]",
+                'participants: ["wagon:a", "user:customer"]',
+                "sequence:",
+                "  - {step: 1, intent: x, from: user:customer, to: wagon:a, artifact: x}",
+                "  - {step: 2, intent: x, from: wagon:a, to: system:payment, artifact: x}",
+                "",
+            ]
+        ),
+    )
+    graph = _build(plan.parent)
+    edges = _train_step_edges(graph, "train:0001-actor-edges")
+    assert edges == [], (
+        f"Non-wagon sides must not produce TRAIN_STEP edges; got {edges}"
+    )
+
+
+def test_multiple_trains_overlapping_handoff_emit_parallel_edges(tmp_path):
+    """
+    Three trains traversing the same wagon→wagon handoff must each produce
+    their own TRAIN_STEP edge. The underlying graph holds three parallel
+    edges, distinguishable by metadata.train — journey mode always filters
+    to one train at render time so this is not a visual problem.
+    """
+    plan = tmp_path / "plan"
+    plan.mkdir()
+    _write_wagon(plan, "stage-request")
+    _write_wagon(plan, "dispatch-call")
+    for tid, cat in [
+        ("0205-renewal-before-deadline", "alternate"),
+        ("0105-deadline-expired-silently", "error"),
+        ("0201-first-flow-via-stage", "alternate"),
+    ]:
+        _write_train(
+            plan,
+            tid,
+            "\n".join(
+                [
+                    f'train_id: "{tid}"',
+                    f'title: "{tid}"',
+                    f'description: "Shares stage->dispatch handoff ({cat})"',
+                    "themes: [commons]",
+                    'participants: ["wagon:stage-request", "wagon:dispatch-call"]',
+                    "sequence:",
+                    "  - {step: 1, intent: handoff, from: wagon:stage-request, to: wagon:dispatch-call, artifact: x}",
+                    "",
+                ]
+            ),
+        )
+    graph = _build(plan.parent)
+    edges = [
+        e
+        for e in graph.edges
+        if e.edge_type == EdgeType.TRAIN_STEP
+        and e.source_urn == "wagon:stage-request"
+        and e.target_urn == "wagon:dispatch-call"
+    ]
+    LOG.info("parallel TRAIN_STEP edges on shared handoff: %d", len(edges))
+    assert len(edges) == 3, (
+        f"Each overlapping train must emit its own TRAIN_STEP edge; got {len(edges)}"
+    )
+    train_urns = {e.metadata["train"] for e in edges}
+    assert train_urns == {
+        "train:0205-renewal-before-deadline",
+        "train:0105-deadline-expired-silently",
+        "train:0201-first-flow-via-stage",
+    }
+    categories = {e.metadata["category"] for e in edges}
+    assert categories == {"alternate", "error"}, (
+        f"Categories must be derived from train_id[1]; got {categories}"
+    )


### PR DESCRIPTION
## Summary

PR 1 of 2 for #287. Ships the graph-data side of the journey-mode feature so JSON/DOT consumers can immediately query ordered train pipelines. The viz UX (PR 2) will land on top of this.

- New `EdgeType.TRAIN_STEP` — ordered `wagon → wagon` handoffs from each train's `sequence[]`.
- `_build_train_edges` walks every train YAML's `sequence[]` (sorted by `step`) and emits one `TRAIN_STEP` edge per **handoff** (`from != to`, both `wagon:*`). Internal-phase steps and non-wagon sides are skipped.
- Every emitted edge carries `metadata = {train, step, intent, category, source}`. Category derives from `train_id[1]` per `{theme}{category}{variation}` (`0`=nominal, `1`=error, `2`=alternate, `3`=exception).
- `TraceabilityGraph.get_subgraph()` gains an `edge_type_exclude: Optional[Set[EdgeType]]` parameter. Structural consumers pass `{TRAIN_STEP}` to prevent wagon-rooted subgraphs from leaking cross-train wagons via shared handoffs. Default is `None` — pre-#287 behavior preserved.
- Registers #287 in `.atdd/manifest.yaml`.
- MINOR bump: `1.55.1 → 1.56.0`. Cache disk key hashes `atdd.__version__`, so stale graphs invalidate automatically on upgrade.

## Decisions shipped

- Edge name → `TRAIN_STEP` (short, domain-scoped).
- Handoff-only (skip `from == to`).
- Filter responsibility lives in the graph API (`get_subgraph` param), not each consumer.
- Two PRs: this one is graph data only; viz UX ships in PR 2 when Streamlit design is finalized.

## Test plan

- [x] RED: 9/9 regression tests fail on `main` (TRAIN_STEP does not exist)
- [x] GREEN: 9/9 regression tests pass
  - [x] Single-wagon internal-phase train → zero TRAIN_STEP edges
  - [x] Two-wagon handoff → exactly one edge with full metadata
  - [x] Internal-phase steps skipped (no self-loops)
  - [x] `user:*` / `system:*` sides filtered out
  - [x] Three overlapping trains on shared handoff → three parallel edges
  - [x] `get_subgraph(edge_type_exclude={TRAIN_STEP})` does NOT leak cross-train wagons
  - [x] `get_subgraph` default preserves pre-#287 behavior
  - [x] Train-rooted subgraph contains its own TRAIN_STEP edges
- [x] `pytest src/atdd/planner/validators src/atdd/tester/validators src/atdd/coder/validators src/atdd/coach/utils/graph/tests`: **289 passed, 0 failed, 1 xfailed**

## Follow-up

- PR 2 (`feat(coach): journey mode in atdd urn viz`): Streamlit radio toggle, train dropdown, filtered subgraph render with `EDGE_STYLES_MAP[TRAIN_STEP]` Cytoscape class. Depends on this PR.
- Typed edges for `user:*` / `system:*` participants (currently filtered out) — tracked as a separate issue.