### PR TITLE
feat(coach): journey mode in atdd urn viz (#287 PR 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.56.0"
+version = "1.57.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/viz_app.py
+++ b/src/atdd/coach/commands/viz_app.py
@@ -25,7 +25,7 @@ _src_root = str(Path(__file__).resolve().parents[3])
 if _src_root not in sys.path:
     sys.path.insert(0, _src_root)
 
-from atdd.coach.utils.graph.graph_builder import GraphBuilder
+from atdd.coach.utils.graph.graph_builder import EdgeType, GraphBuilder
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -66,6 +66,31 @@ EDGE_STYLES_MAP = {
     "implements": "dotted",
     "references": "dotted",
     "tested_by": "dashed",
+    # #287: ordered wagon→wagon handoff inside a train's sequence[].
+    # Rendered as a solid directed arrow in Journey mode; suppressed
+    # from Structural mode via edge_type_exclude.
+    "train_step": "solid",
+}
+
+# #287: edge types that Structural mode hides by default. Journey mode
+# clears this filter so TRAIN_STEP handoffs are visible.
+STRUCTURAL_MODE_EDGE_EXCLUDE: frozenset[EdgeType] = frozenset({EdgeType.TRAIN_STEP})
+
+# Category → color for TRAIN_STEP edge labels in Journey mode.
+# Matches the train_id naming convention {theme}{category}{variation}:
+# 0=nominal, 1=error, 2=alternate, 3=exception.
+TRAIN_CATEGORY_COLORS = {
+    "nominal":   "#27AE60",
+    "error":     "#E74C3C",
+    "alternate": "#E67E22",
+    "exception": "#8E44AD",
+}
+
+TRAIN_CATEGORY_BADGES = {
+    "nominal":   "🟢",
+    "error":     "🔴",
+    "alternate": "🟡",
+    "exception": "🟣",
 }
 
 FALLBACK_COLOR = "#95A5A6"
@@ -87,12 +112,33 @@ def load_graph(
     root_urn: str | None,
     max_depth: int,
     families: tuple[str, ...] | None,
+    exclude_edge_types: tuple[str, ...] = (),
 ) -> dict:
+    """
+    Build and serialize the URN traceability graph.
+
+    Args:
+        repo_root: Absolute path to the repo root.
+        root_urn: Optional URN to root a subgraph at.
+        max_depth: Traversal depth (-1 = unlimited).
+        families: Optional tuple of families to include.
+        exclude_edge_types: Tuple of edge-type string values to drop from
+            the subgraph (e.g. ``("train_step",)`` for Structural mode).
+            Applied only when ``root_urn`` is set — a full-graph build
+            always returns every edge. The argument is a tuple of strings
+            (not a set of EdgeType) so Streamlit's cache can hash it.
+    """
     builder = GraphBuilder(Path(repo_root))
     family_list = list(families) if families else None
 
+    exclude: set[EdgeType] | None = None
+    if exclude_edge_types:
+        exclude = {EdgeType(v) for v in exclude_edge_types}
+
     if root_urn:
-        graph = builder.build_from_root(root_urn, max_depth, family_list)
+        graph = builder.build_from_root(
+            root_urn, max_depth, family_list, edge_type_exclude=exclude
+        )
     else:
         graph = builder.build(family_list)
 
@@ -201,26 +247,106 @@ def main():
     with st.sidebar:
         st.header("Controls")
 
-        root_urn = st.text_input(
-            "Root URN (subgraph)",
-            value=env_root_urn or "",
-            placeholder="e.g. wagon:my-wagon",
+        # #287: view mode toggle. Structural is today's behavior and stays
+        # the default — journey mode is opt-in.
+        mode = st.radio(
+            "View mode",
+            options=["Structural", "Journey"],
+            index=0,
+            horizontal=True,
+            help=(
+                "Structural: full URN graph minus per-train handoffs. "
+                "Journey: one chosen train rendered as an ordered pipeline."
+            ),
         )
-        root_urn = root_urn.strip() or None
 
-        depth = st.number_input(
-            "Depth (-1 = unlimited)",
-            min_value=-1,
-            value=env_depth,
-            step=1,
-        )
+        if mode == "Journey":
+            # Discover trains from the full graph (no root, no exclude) so
+            # the dropdown is populated even before a selection is made.
+            _journey_discovery = load_graph(
+                repo_root,
+                None,
+                env_depth,
+                tuple(env_families) if env_families else None,
+                (),
+            )
+            train_nodes = [
+                n for n in _journey_discovery.get("nodes", [])
+                if n.get("family") == "train"
+            ]
 
-        # Load graph to discover available families
+            if not train_nodes:
+                st.warning(
+                    "Journey mode needs at least one `train:*` node in the graph. "
+                    "No trains were discovered — falling back to Structural."
+                )
+                mode = "Structural"
+                selected_train_urn = None
+            else:
+                # Build dropdown entries as "{badge} {train_id} — {title}"
+                # so the user can scan by scenario category (🟢 🔴 🟡 🟣).
+                def _train_entry_label(node: dict) -> str:
+                    urn = node["urn"]
+                    train_id = urn.split(":", 1)[1] if ":" in urn else urn
+                    category_digit = train_id[1] if len(train_id) > 1 else "0"
+                    category = {
+                        "0": "nominal",
+                        "1": "error",
+                        "2": "alternate",
+                        "3": "exception",
+                    }.get(category_digit, "nominal")
+                    badge = TRAIN_CATEGORY_BADGES.get(category, "⚪")
+                    title = (node.get("label") or "").strip() or train_id
+                    return f"{badge} {train_id} — {title}"
+
+                train_options = sorted(train_nodes, key=lambda n: n["urn"])
+                labels = [_train_entry_label(n) for n in train_options]
+                urn_by_label = {lbl: tn["urn"] for lbl, tn in zip(labels, train_options)}
+
+                selected_label = st.selectbox(
+                    "Train",
+                    options=labels,
+                    index=0,
+                    help="Choose a train to render its wagon pipeline.",
+                )
+                selected_train_urn = urn_by_label[selected_label]
+
+            root_urn = selected_train_urn
+            depth = -1
+            st.caption(
+                f"Journey mode — rooted at `{selected_train_urn}` (depth = unlimited)."
+                if selected_train_urn
+                else "Journey mode — waiting for a train selection."
+            )
+        else:
+            selected_train_urn = None
+            root_urn = st.text_input(
+                "Root URN (subgraph)",
+                value=env_root_urn or "",
+                placeholder="e.g. wagon:my-wagon",
+            )
+            root_urn = root_urn.strip() or None
+
+            depth = st.number_input(
+                "Depth (-1 = unlimited)",
+                min_value=-1,
+                value=env_depth,
+                step=1,
+            )
+
+        # Load the graph. Structural mode hides TRAIN_STEP via the exclude
+        # tuple; Journey mode passes no exclude so handoffs are rendered.
+        if mode == "Structural":
+            exclude_edges = tuple(et.value for et in STRUCTURAL_MODE_EDGE_EXCLUDE)
+        else:
+            exclude_edges = ()
+
         graph_data = load_graph(
             repo_root,
             root_urn,
             depth,
             tuple(env_families) if env_families else None,
+            exclude_edges,
         )
 
         available_families = sorted(

--- a/src/atdd/coach/utils/graph/graph_builder.py
+++ b/src/atdd/coach/utils/graph/graph_builder.py
@@ -1403,7 +1403,11 @@ class GraphBuilder:
                 continue
 
     def build_from_root(
-        self, root_urn: str, max_depth: int = -1, families: Optional[List[str]] = None
+        self,
+        root_urn: str,
+        max_depth: int = -1,
+        families: Optional[List[str]] = None,
+        edge_type_exclude: Optional[Set[EdgeType]] = None,
     ) -> TraceabilityGraph:
         """
         Build a subgraph starting from a specific URN.
@@ -1412,9 +1416,16 @@ class GraphBuilder:
             root_urn: Starting URN for the subgraph
             max_depth: Maximum traversal depth (-1 for unlimited)
             families: Optional list of families to include
+            edge_type_exclude: Optional set of edge types to skip during
+                traversal. Pipes through to ``TraceabilityGraph.get_subgraph``.
+                Structural viz consumers pass ``{EdgeType.TRAIN_STEP}`` to
+                hide journey handoffs from the default wagon/feature view
+                (#287).
 
         Returns:
             Subgraph rooted at the specified URN
         """
         full_graph = self.build(families)
-        return full_graph.get_subgraph(root_urn, max_depth)
+        return full_graph.get_subgraph(
+            root_urn, max_depth, edge_type_exclude=edge_type_exclude
+        )

--- a/src/atdd/coach/utils/graph/tests/test_build_from_root_edge_type_exclude.py
+++ b/src/atdd/coach/utils/graph/tests/test_build_from_root_edge_type_exclude.py
@@ -1,0 +1,123 @@
+# URN: test:coach:graph_builder:build_from_root_edge_type_exclude
+"""
+Regression test for issue #287 PR 2: GraphBuilder.build_from_root must
+pipe the `edge_type_exclude` parameter through to TraceabilityGraph
+.get_subgraph, so the viz `Structural` mode can hide TRAIN_STEP edges
+via the same filter contract that PR 1 added to get_subgraph.
+
+This is a thin plumbing test — the underlying exclusion logic is already
+pinned by test_get_subgraph_edge_type_exclude.py. What we check here is
+that the builder-level entry point doesn't silently drop the parameter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from atdd.coach.utils.graph.graph_builder import (
+    EdgeType,
+    GraphBuilder,
+)
+
+
+def _write_wagon(plan: Path, slug: str) -> None:
+    d = plan / slug.replace("-", "_")
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"_{slug.replace('-', '_')}.yaml").write_text(
+        "\n".join(
+            [
+                f"wagon: {slug}",
+                f"urn: wagon:{slug}",
+                'description: "x"',
+                "theme: commons",
+                'subject: "s"',
+                'context: "c"',
+                'action: "a"',
+                'goal: "g"',
+                'outcome: "o"',
+                "produce: []",
+                "consume: []",
+                "wmbt: {total: 0}",
+                "",
+            ]
+        )
+    )
+
+
+def _write_train(plan: Path, train_id: str, body: str) -> None:
+    trains = plan / "_trains"
+    trains.mkdir(parents=True, exist_ok=True)
+    (trains / f"{train_id}.yaml").write_text(body)
+
+
+def test_build_from_root_pipes_edge_type_exclude_through(tmp_path):
+    """
+    Given a repo with one two-wagon train that would normally emit a
+    TRAIN_STEP edge between its wagons, building a subgraph rooted at the
+    upstream wagon with `edge_type_exclude={TRAIN_STEP}` must NOT pull in
+    the downstream wagon (no leak via the handoff).
+    """
+    plan = tmp_path / "plan"
+    plan.mkdir()
+    _write_wagon(plan, "stage")
+    _write_wagon(plan, "dispatch")
+    _write_train(
+        plan,
+        "0205-alt",
+        "\n".join(
+            [
+                'train_id: "0205-alt"',
+                'title: "alt"',
+                'description: "two-wagon handoff"',
+                "themes: [commons]",
+                'participants: ["wagon:stage", "wagon:dispatch"]',
+                "sequence:",
+                "  - {step: 1, intent: x, from: wagon:stage, to: wagon:dispatch, artifact: x}",
+                "",
+            ]
+        ),
+    )
+
+    builder = GraphBuilder(repo_root=tmp_path, use_cache=False)
+    sub = builder.build_from_root(
+        "wagon:stage",
+        max_depth=-1,
+        edge_type_exclude={EdgeType.TRAIN_STEP},
+    )
+    assert "wagon:dispatch" not in sub.nodes, (
+        "edge_type_exclude must prevent the wagon-rooted subgraph from "
+        "leaking into the handoff target"
+    )
+
+
+def test_build_from_root_default_leaves_exclude_none(tmp_path):
+    """
+    Backward-compat guard: callers passing no exclude must see pre-PR-2
+    behavior (TRAIN_STEP edges traversed normally).
+    """
+    plan = tmp_path / "plan"
+    plan.mkdir()
+    _write_wagon(plan, "stage")
+    _write_wagon(plan, "dispatch")
+    _write_train(
+        plan,
+        "0205-alt",
+        "\n".join(
+            [
+                'train_id: "0205-alt"',
+                'title: "alt"',
+                'description: "two-wagon handoff"',
+                "themes: [commons]",
+                'participants: ["wagon:stage", "wagon:dispatch"]',
+                "sequence:",
+                "  - {step: 1, intent: x, from: wagon:stage, to: wagon:dispatch, artifact: x}",
+                "",
+            ]
+        ),
+    )
+
+    builder = GraphBuilder(repo_root=tmp_path, use_cache=False)
+    sub = builder.build_from_root("wagon:stage", max_depth=-1)
+    assert "wagon:dispatch" in sub.nodes, (
+        "Without exclude, TRAIN_STEP should be traversed as before"
+    )


### PR DESCRIPTION
## Summary

PR 2 of 2 for #287. Builds on PR #288 (TRAIN_STEP edges shipped in 1.56.0).

- Extends \`GraphBuilder.build_from_root\` with an \`edge_type_exclude\` parameter that forwards to \`TraceabilityGraph.get_subgraph\` — the plumbing the viz needs to hide TRAIN_STEP edges in Structural mode.
- Adds a **Structural | Journey** view toggle to the URN visualizer.
- **Structural mode (default)**: identical to pre-PR-2 behavior, except TRAIN_STEP edges are now hidden via \`edge_type_exclude={TRAIN_STEP}\` so wagon-rooted subgraphs don't leak cross-train wagons via shared handoffs.
- **Journey mode**: discovers all \`train:*\` nodes from the full graph, presents a dropdown with category-badged entries (🟢 nominal / 🔴 error / 🟡 alternate / 🟣 exception), and renders the subgraph rooted at the selected train with INCLUDES + TRAIN_STEP both visible. Falls back to Structural with a warning if no trains exist.
- Adds \`train_step\` entry to \`EDGE_STYLES_MAP\` and introduces explicit \`STRUCTURAL_MODE_EDGE_EXCLUDE\` / \`TRAIN_CATEGORY_BADGES\` constants for auditability.
- MINOR bump: \`1.56.0 → 1.57.0\`.

## Decisions shipped

- **Filter responsibility lives in the graph API** (not each consumer) — Structural mode passes \`STRUCTURAL_MODE_EDGE_EXCLUDE = {TRAIN_STEP}\` once at the sidebar and \`load_graph\` translates it into the proper \`EdgeType\` set.
- **Journey mode is opt-in** via an explicit radio toggle. Default view is unchanged for existing users.
- **Category badges over color-only** in the dropdown — emoji badges work in Streamlit's selectbox without extra theming.

## Test plan

- [x] \`pytest src/atdd/coach/utils/graph/tests\`: **15 passed**
  - [x] 2 new: \`build_from_root\` pipes \`edge_type_exclude\` through; default preserves pre-PR-2 behavior
  - [x] 13 existing from #285 / #287 PR 1 still pass
- [x] \`pytest planner/tester/coder/graph\`: **291 passed, 0 failed, 1 xfailed**
- [x] \`ast.parse(viz_app.py)\`: syntax OK
- [ ] **UI smoke test (Streamlit):** \`streamlit run src/atdd/coach/commands/viz_app.py\` — I could not drive a browser session in this environment. Needs a human smoke test: toggle to Journey, pick a two-wagon train, confirm the subgraph renders the ordered handoff; toggle back to Structural, confirm no TRAIN_STEP arrows bleed into the wagon-rooted view.

## Notes

- Cache invalidation: \`_compute_cache_key\` hashes \`atdd.__version__\`, so the 1.57.0 bump invalidates stale disk graphs automatically.
- \`st_link_analysis\` is already an import-time dependency in \`viz_app.py\`; no \`pyproject.toml\` dependency change required.
- Follow-up (tracked elsewhere): typed edges for \`user:*\` / \`system:*\` participants; shareable journey URLs via \`st.query_params\`; step-by-step tooltips on TRAIN_STEP arrows.