### PR TITLE
chore(atdd): manifest sync for #287 + gitignore agent-local state

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -38,6 +38,22 @@ sessions:
   file: null
   issue_number: 287
   type: implementation
-  status: INIT
+  status: GREEN
   created: '2026-04-15'
+  archived: null
+- id: '296'
+  slug: enforce-issue-label-compliance
+  file: null
+  issue_number: 296
+  type: implementation
+  status: INIT
+  created: '2026-04-17'
+  archived: null
+- id: '304'
+  slug: fix-github-client-mock-drift
+  file: null
+  issue_number: 304
+  type: implementation
+  status: INIT
+  created: '2026-04-17'
   archived: null

--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,10 @@ coverage.xml
 *.swp
 *.swo
 
-# ATDD cache
+# ATDD cache + agent-local state
 .atdd/cache/
+.atdd/orchestration-log.jsonl
+.scratch/
 
 # OS
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.56.1"
+version = "1.56.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- `5da2538` — manifest sync recording #287 transition to GREEN (originally committed on main during workspace:14 apply; moved here to restore branch discipline per CLAUDE.md).
- `6665c5e` — gitignore `.atdd/orchestration-log.jsonl` and `.scratch/` so future agent-local state doesn't pollute worktrees.

## Why not a tracked atdd issue?
Pure housekeeping recovery from a policy violation — no new feature, test, or behavior. Opening this as a standalone PR to keep main clean without the overhead of creating an ATDD parent issue for a 2-commit chore. If the team prefers a tracked issue retroactively, happy to file one.

## Test plan
- [ ] `git log --oneline origin/main..HEAD` shows only the two intended commits
- [ ] `git status` on main post-merge shows the previously-untracked files now ignored
- [ ] `atdd validate coach` still passes (manifest sync is already reflected on GitHub via #287 labels/transitions)