### PR TITLE
feat(planner): support custom themes via .atdd/config.yaml (#291)

### DIFF
--- a/.atdd/baselines/coder.yaml
+++ b/.atdd/baselines/coder.yaml
@@ -1,1 +1,1 @@
-hierarchy_coverage_features: 11
+hierarchy_coverage_features: 12

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -49,7 +49,7 @@ sessions:
   file: null
   issue_number: 291
   type: implementation
-  status: INIT
+  status: PLANNED
   created: '2026-04-17'
   archived: null
   wagon: govern-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -44,6 +44,16 @@ sessions:
   status: REFACTOR
   created: '2026-04-15'
   archived: null
+- id: '291'
+  slug: custom-themes
+  file: null
+  issue_number: 291
+  type: implementation
+  status: INIT
+  created: '2026-04-17'
+  archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:custom-themes
 - id: '296'
   slug: enforce-issue-label-compliance
   file: null

--- a/plan/govern_lifecycle/C001.yaml
+++ b/plan/govern_lifecycle/C001.yaml
@@ -1,0 +1,36 @@
+urn: "wmbt:govern-lifecycle:C001"
+step: "confirm"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "invalid-custom-theme-names-accepted-into-config"
+context_clarifier: "when a consumer declares themes in .atdd/config.yaml and the validator must confirm kebab-case shape, single digit keys in range 0-9, non-empty names, and no disallowed characters before the config is loaded"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of invalid-custom-theme-names-accepted-into-config when a consumer declares themes in .atdd/config.yaml and the validator must confirm kebab-case shape, single digit keys, and non-empty names"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:C001-UNIT-001-custom-theme-validator"
+      id: "AC-UNIT-001"
+      purpose: "A dedicated validator enforces kebab-case pattern, digit-key range, and name constraints on the themes block"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "coach/validators/test_custom_theme_validation.py exists and runs as part of atdd validate coach"
+        - "Fixtures cover valid overrides, non-kebab-case names, multi-digit keys, empty names, and collision cases"
+    when:
+      abstract: "atdd validate coach runs against each fixture"
+    then:
+      abstract:
+        - "Valid themes pass with no errors"
+        - "Names violating ^[a-z][a-z0-9-]*$ are rejected with a pinpointed message"
+        - "Non-digit or multi-digit keys are rejected with a pinpointed message"
+        - "Empty name strings are rejected"
+        - "The validator exit code is non-zero on any violation"
+    signal:
+      metric: "invalid_theme_names_accepted_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/D009.yaml
+++ b/plan/govern_lifecycle/D009.yaml
@@ -1,0 +1,34 @@
+urn: "wmbt:govern-lifecycle:D009"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "config-files-unable-to-declare-domain-specific-theme-mappings"
+context_clarifier: "when a consumer repo in a non-game domain (fintech, SaaS, internal tooling) needs to declare themes that match its bounded contexts but .atdd/config.yaml has no schema slot for theme overrides"
+lens: "functional.adaptability"
+statement: "minimize quantity of config-files-unable-to-declare-domain-specific-theme-mappings when a consumer repo in a non-game domain needs to declare themes that match its bounded contexts but .atdd/config.yaml has no schema slot for theme overrides"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D009-UNIT-001-config-themes-block-accepted"
+      id: "AC-UNIT-001"
+      purpose: "config.schema.json accepts an optional themes block mapping digits 0-9 to kebab-case theme names"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - ".atdd/config.yaml declares themes: {\"1\": \"qualification\", \"2\": \"security\", \"3\": \"operations\"}"
+        - "config.schema.json exposes an optional themes property keyed by digit strings 0-9"
+    when:
+      abstract: "The config file is validated against config.schema.json"
+    then:
+      abstract:
+        - "Validation passes with no errors"
+        - "Consumers without a themes block continue to validate (backward compatible)"
+        - "Non-digit keys or non-kebab-case names fail validation with a pinpointed error"
+    signal:
+      metric: "config_themes_schema_rejection_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/D010.yaml
+++ b/plan/govern_lifecycle/D010.yaml
@@ -1,0 +1,34 @@
+urn: "wmbt:govern-lifecycle:D010"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "duplicated-hardcoded-theme-map-dicts-across-modules"
+context_clarifier: "when theme_map dicts are hardcoded in inventory.py, registry.py (2 locations), and test_train_validation.py (2 locations: theme_map at L75 and valid_themes set at L734-737) creating drift risk and blocking any config-driven override"
+lens: "functional.sustainability"
+statement: "minimize quantity of duplicated-hardcoded-theme-map-dicts-across-modules when theme_map dicts are hardcoded in inventory.py, registry.py, and test_train_validation.py blocking any config-driven override"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D010-UNIT-001-single-source-theme-map-helper"
+      id: "AC-UNIT-001"
+      purpose: "A single get_theme_map(config) helper replaces every hardcoded theme_map dict in the codebase"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "coach/utils/theme_map.py exposes get_theme_map(config) returning merged defaults + overrides"
+        - "All prior hardcoded theme_map dicts have been replaced with calls to the helper"
+    when:
+      abstract: "A grep for hardcoded theme_map dict literals runs across src/atdd"
+    then:
+      abstract:
+        - "No theme_map dict literal appears outside coach/utils/theme_map.py"
+        - "inventory.py, registry.py, and test_train_validation.py import and call get_theme_map"
+        - "The helper is the single source of truth for the digit-to-theme mapping"
+    signal:
+      metric: "hardcoded_theme_map_literal_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/E001.yaml
+++ b/plan/govern_lifecycle/E001.yaml
@@ -1,0 +1,36 @@
+urn: "wmbt:govern-lifecycle:E001"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "schema-validation-failures-on-valid-custom-theme-names"
+context_clarifier: "when a wagon or train declares theme: qualification or any other custom value from .atdd/config.yaml and static JSON Schema enums in wagon.schema.json and train.schema.json reject it despite being declared in the merged theme_map"
+lens: "functional.adaptability"
+statement: "minimize likelihood of schema-validation-failures-on-valid-custom-theme-names when a wagon or train declares a custom theme value from .atdd/config.yaml and static JSON Schema enums reject it"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:E001-UNIT-001-schema-pattern-accepts-custom-themes"
+      id: "AC-UNIT-001"
+      purpose: "wagon.schema.json and train.schema.json accept any kebab-case theme string; runtime validator checks against merged theme_map"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "wagon.schema.json and train.schema.json define theme as pattern ^[a-z][a-z0-9-]*$ instead of a static enum"
+        - ".atdd/config.yaml declares themes: {\"1\": \"qualification\"}"
+        - "A wagon YAML declares theme: qualification"
+    when:
+      abstract: "atdd validate planner runs with the merged theme_map active"
+    then:
+      abstract:
+        - "JSON Schema validation passes on the wagon"
+        - "Runtime validation confirms qualification is present in get_theme_map(config)"
+        - "A wagon with theme: not-declared-anywhere fails runtime validation with a clear error"
+        - "Existing repos without a themes block continue validating against the 10 built-in names"
+    signal:
+      metric: "valid_custom_theme_rejections_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/L001.yaml
+++ b/plan/govern_lifecycle/L001.yaml
@@ -1,0 +1,35 @@
+urn: "wmbt:govern-lifecycle:L001"
+step: "locate"
+direction: "minimize"
+dimension: "effort"
+object_of_control: "manual-theme-discovery-during-atdd-init"
+context_clarifier: "when atdd init runs in a consumer repo that already contains plan/**/*.yaml files with theme: entries and the operator would otherwise have to inspect those files by hand to decide how to populate .atdd/config.yaml themes block"
+lens: "functional.efficiency"
+statement: "minimize effort of manual-theme-discovery-during-atdd-init when atdd init runs in a consumer repo that already contains plan/**/*.yaml files with theme: entries"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:L001-UNIT-001-scanner-surfaces-existing-themes"
+      id: "AC-UNIT-001"
+      purpose: "theme_scanner walks the plan tree and repo metadata to surface existing and candidate themes before any prompt runs"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A consumer repo with plan/**/*.yaml files declaring theme: qualification, theme: security, theme: operations"
+        - "Top-level directories and pyproject.toml / package.json keywords that hint at domain tokens"
+    when:
+      abstract: "scan_existing_themes(repo_root) is invoked"
+    then:
+      abstract:
+        - "The scanner returns distinct theme values found under plan/ as the primary detected list"
+        - "Low-confidence candidate tokens from repo metadata are reported separately and never escape into the primary list"
+        - "The force-fit heuristic flags at least one wagon whose slug tokens do not overlap with its assigned theme's synonym set (e.g. authenticate-users tagged commons)"
+        - "Output is consumable by both the interactive prompt and the --themes custom non-interactive flow"
+    signal:
+      metric: "blind_prompt_count_when_plan_has_themes"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/M001.yaml
+++ b/plan/govern_lifecycle/M001.yaml
@@ -1,0 +1,34 @@
+urn: "wmbt:govern-lifecycle:M001"
+step: "monitor"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "silent-commons-digit-overrides-that-break-cross-repo-tooling"
+context_clarifier: "when a consumer overrides digit 0 in .atdd/config.yaml themes block replacing commons with a domain-specific name and cross-repo tooling that assumes commons at digit 0 would silently diverge"
+lens: "functional.sustainability"
+statement: "minimize likelihood of silent-commons-digit-overrides-that-break-cross-repo-tooling when a consumer overrides digit 0 in .atdd/config.yaml themes block replacing commons with a domain-specific name"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:M001-UNIT-001-w-theme-001-warning-emitted"
+      id: "AC-UNIT-001"
+      purpose: "Warning W-THEME-001 is emitted (not a failure) when the consumer overrides digit 0"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - ".atdd/config.yaml declares themes: {\"0\": \"foundation\"} overriding the default commons mapping"
+    when:
+      abstract: "The theme validator runs during atdd validate coach"
+    then:
+      abstract:
+        - "Warning W-THEME-001 is emitted with text that references commons and cross-repo tooling"
+        - "The override is accepted (no hard failure)"
+        - "The warning is visible in stdout and captured by --html reports"
+        - "Repos that keep digit 0 as commons emit no warning"
+    signal:
+      metric: "silent_commons_overrides_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/P001.yaml
+++ b/plan/govern_lifecycle/P001.yaml
@@ -1,0 +1,35 @@
+urn: "wmbt:govern-lifecycle:P001"
+step: "prepare"
+direction: "minimize"
+dimension: "frequency"
+object_of_control: "blind-theme-prompts-that-force-game-domain-defaults-on-non-game-repos"
+context_clarifier: "when atdd init runs interactively and currently seeds 10 game-domain theme names without asking, or worse prompts the operator cold with no reference to their existing codebase"
+lens: "functional.adaptability"
+statement: "minimize frequency of blind-theme-prompts-that-force-game-domain-defaults-on-non-game-repos when atdd init runs interactively without a scan-first flow"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:P001-UNIT-001-scan-first-init-prompt"
+      id: "AC-UNIT-001"
+      purpose: "atdd init runs the scanner first, pre-populates detections, and prompts only when the scan is empty"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd init is invoked with or without --themes {defaults|custom|skip}"
+        - "The theme scanner has run and returned either detections or an empty result"
+    when:
+      abstract: "The init flow decides whether to prompt, pre-populate, or write defaults"
+    then:
+      abstract:
+        - "When detections exist, the custom branch pre-populates with the detected themes and offers accept/edit/discard"
+        - "When detections are empty and interactive, the blind prompt offers defaults/custom/skip without naming any product category"
+        - "When --themes {defaults|custom|skip} is given, the non-interactive path writes the correct .atdd/config.yaml shape without prompting"
+        - "Prompt copy contains no forbidden tokens (game, gaming, app, saas, fintech, product category)"
+    signal:
+      metric: "blind_prompts_when_scan_has_results_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/_govern_lifecycle.yaml
+++ b/plan/govern_lifecycle/_govern_lifecycle.yaml
@@ -32,9 +32,10 @@ features:
   - urn: "feature:govern-lifecycle:fix-issue-transition-side-effects"
   - urn: "feature:govern-lifecycle:enforce-orchestrate-ready-lifecycle"
   - urn: "feature:govern-lifecycle:enforce-issue-label-compliance"
+  - urn: "feature:govern-lifecycle:custom-themes"
 
 wmbt:
-  total: 10
+  total: 17
   R001: "minimize stale local manifest status after a successful GitHub transition"
   R002: "minimize misleading layout errors during post-transition re-enter"
   D001: "minimize issues created without orchestrate-ready template body"
@@ -45,3 +46,10 @@ wmbt:
   D006: "minimize atdd-issues missing required label set (phase/archetype/wagon)"
   D007: "minimize label drift between issue body metadata and GitHub labels"
   D008: "minimize pushed commits referencing unlabeled issues"
+  D009: "minimize config files unable to declare domain-specific theme mappings"
+  D010: "minimize duplicated hardcoded theme_map dicts across modules"
+  L001: "minimize manual theme discovery during atdd init"
+  P001: "minimize blind theme prompts that force game-domain defaults on non-game repos"
+  C001: "minimize invalid custom theme names accepted into config"
+  E001: "minimize schema validation failures on valid custom theme names"
+  M001: "minimize silent commons digit overrides that break cross-repo tooling"

--- a/plan/govern_lifecycle/features/custom_themes.yaml
+++ b/plan/govern_lifecycle/features/custom_themes.yaml
@@ -1,0 +1,33 @@
+urn: "feature:govern-lifecycle:custom-themes"
+wagon: "wagon:govern-lifecycle"
+description: "Support custom themes via .atdd/config.yaml: merge defaults with overrides, relax schemas, scan existing themes, and validate custom names"
+sizing:
+  wmbts: 7
+  footprint_score: 9
+  footprint_size: "S"
+wmbts:
+  - "wmbt:govern-lifecycle:D009"
+  - "wmbt:govern-lifecycle:D010"
+  - "wmbt:govern-lifecycle:L001"
+  - "wmbt:govern-lifecycle:P001"
+  - "wmbt:govern-lifecycle:C001"
+  - "wmbt:govern-lifecycle:E001"
+  - "wmbt:govern-lifecycle:M001"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 2
+        rationale: "atdd init theme prompt extension and atdd sync ATDD-block theme renderer"
+    application:
+      - type: "use_cases"
+        count: 3
+        rationale: "merge default theme_map with overrides (get_theme_map); scan plan tree and repo metadata for existing themes; validate custom theme name shape and digit collisions"
+    domain:
+      - type: "value_objects"
+        count: 1
+        rationale: "theme_map as a first-class value object wrapping digit→name mapping with default merging semantics"
+    integration:
+      - type: "mappers"
+        count: 1
+        rationale: "config-to-theme-map mapper reading .atdd/config.yaml themes block"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.58.0"
+version = "1.59.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -37,6 +37,38 @@ logger = logging.getLogger(__name__)
 _BRANCH_PREFIXES = ("feat", "fix", "refactor", "chore", "docs", "devops")
 
 
+# Domain-agnostic prompt copy for `atdd init` theme declaration (#291,
+# Decision #7). Lists the 10 built-in names and the three mode choices
+# without referencing any product category.
+THEMES_PROMPT_COPY = """\
+ATDD ships with 10 built-in theme names mapped to digits 0-9:
+
+  0: commons        5: player
+  1: mechanic       6: league
+  2: scenario       7: audience
+  3: match          8: monetization
+  4: sensory        9: partnership
+
+These defaults may not match your domain. You can declare custom theme
+names in `.atdd/config.yaml` under the `themes:` key.
+
+Choose one:
+  - defaults  Keep the 10 built-in names. No `themes:` block is written.
+  - custom    Declare your own digit-to-name mapping now. Existing
+              `plan/**/*.yaml` is scanned first so detected themes are
+              pre-populated; low-confidence candidates from top-level
+              directories and package keywords are shown as suggestions.
+  - skip      Same as defaults, plus a reminder of where to configure
+              themes later (`.atdd/config.yaml` → `themes:`).
+
+Define themes now? [defaults / custom / skip]
+"""
+
+
+# Modes accepted by the non-interactive `--themes` flag.
+_THEME_MODES = frozenset({"defaults", "custom", "skip"})
+
+
 def slug_to_branch_name(slug: str) -> str:
     """Convert worktree directory slug to branch-style name.
 
@@ -193,6 +225,64 @@ class ProjectInitializer:
                     worktrees.append(line[len("worktree "):])
                     break
         return worktrees
+
+    def _prompt_themes(
+        self,
+        mode: str,
+        *,
+        repo_root: Optional[Path] = None,
+    ) -> Optional[Dict[str, str]]:
+        """
+        Resolve the themes block to write under `.atdd/config.yaml → themes:`.
+
+        Implements Decision #7 of #291 non-interactively. Interactive
+        prompting can be layered on top of this method by the CLI
+        wrapper; unit tests drive the non-interactive path directly.
+
+        Args:
+            mode: One of "defaults", "custom", or "skip".
+            repo_root: Repo root to scan for pre-existing themes.
+                Defaults to ``self.target_dir``.
+
+        Returns:
+            None  — caller writes no `themes:` block
+                    (`defaults` / `skip` / empty `custom` scan).
+            dict  — caller writes `themes: <dict>`.
+
+        Raises:
+            ValueError: If ``mode`` is not one of the accepted values.
+        """
+        if mode not in _THEME_MODES:
+            raise ValueError(
+                f"Unknown themes mode {mode!r}. "
+                f"Expected one of: {sorted(_THEME_MODES)}."
+            )
+
+        if mode in ("defaults", "skip"):
+            return None
+
+        # mode == "custom"
+        from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+        scan_root = Path(repo_root) if repo_root is not None else self.target_dir
+        result = scan_existing_themes(scan_root)
+
+        if not result.detected:
+            # Blind-prompt path: no detections to seed. Non-interactive
+            # callers receive None (caller may fall back to defaults
+            # behavior or write an empty `themes: {}` block).
+            return None
+
+        # Assign detected themes to digits starting at 1 so digit 0
+        # (commons) is never overridden implicitly — W-THEME-001.
+        mapping: Dict[str, str] = {}
+        digit = 1
+        for theme in result.detected:
+            if digit > 9:
+                break
+            mapping[str(digit)] = theme
+            digit += 1
+        return mapping
 
     def _prompt_workspace_color(self) -> None:
         """Prompt user to pick a workspace color if unset or default yellow."""
@@ -1484,3 +1574,9 @@ jobs:
             yaml.dump(config, f, default_flow_style=False, sort_keys=False)
 
         print(f"  Updated: {self.config_file} (github section)")
+
+
+# Public alias: the class is named ProjectInitializer internally, but
+# external callers (tests, `atdd init` CLI) import it as `Initializer`
+# so the type name matches the command surface.
+Initializer = ProjectInitializer

--- a/src/atdd/coach/commands/inventory.py
+++ b/src/atdd/coach/commands/inventory.py
@@ -21,6 +21,9 @@ from datetime import datetime
 from collections import defaultdict
 from typing import Dict, List, Any
 
+from atdd.coach.utils.config import load_atdd_config
+from atdd.coach.utils.theme_map import get_theme_map
+
 
 class RepositoryInventory:
     """Generate comprehensive repository inventory."""
@@ -132,6 +135,10 @@ class RepositoryInventory:
         missing_code_frontend = []
         missing_code_frontend_python = []
 
+        # Single source of truth for theme mapping (#291): merge
+        # built-in defaults with overrides from .atdd/config.yaml.
+        theme_map = get_theme_map(load_atdd_config(self.repo_root))
+
         for train in all_trains:
             train_id = train.get("train_id", "unknown")
             train_ids.append(train_id)
@@ -139,11 +146,6 @@ class RepositoryInventory:
             # Extract theme from train_id (first digit maps to theme)
             if train_id and len(train_id) > 0 and train_id[0].isdigit():
                 theme_digit = train_id[0]
-                theme_map = {
-                    "0": "commons", "1": "mechanic", "2": "scenario", "3": "match",
-                    "4": "sensory", "5": "player", "6": "league", "7": "audience",
-                    "8": "monetization", "9": "partnership"
-                }
                 theme = theme_map.get(theme_digit, "unknown")
                 by_theme[theme] += 1
 

--- a/src/atdd/coach/commands/registry.py
+++ b/src/atdd/coach/commands/registry.py
@@ -25,6 +25,9 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Any, Optional
 
+from atdd.coach.utils.config import load_atdd_config
+from atdd.coach.utils.theme_map import get_theme_map
+
 # Import URNBuilder for URN generation (following conventions)
 try:
     from atdd.coach.utils.graph.urn import URNBuilder
@@ -1012,12 +1015,9 @@ class RegistryBuilder:
         trains_dir = self.plan_dir / "_trains"
         registry_path = self.plan_dir / "_trains.yaml"
 
-        # Theme and category mappings
-        theme_map = {
-            "0": "commons", "1": "mechanic", "2": "scenario", "3": "match",
-            "4": "sensory", "5": "player", "6": "league", "7": "audience",
-            "8": "monetization", "9": "partnership"
-        }
+        # Theme and category mappings — merge built-in defaults with
+        # consumer overrides from .atdd/config.yaml (#291).
+        theme_map = get_theme_map(load_atdd_config(self.repo_root))
         category_map = {
             "0": "nominal", "1": "error", "2": "alternate", "3": "exception"
         }

--- a/src/atdd/coach/commands/sync.py
+++ b/src/atdd/coach/commands/sync.py
@@ -23,6 +23,8 @@ from typing import Dict, List, Optional, Tuple
 
 import yaml
 
+from atdd.coach.utils.theme_map import DEFAULT_THEME_MAP, get_theme_map
+
 
 class AgentConfigSync:
     """Sync managed ATDD blocks to agent config files."""
@@ -394,10 +396,45 @@ class AgentConfigSync:
             parts.append(f"# Agent-specific: {agent}")
             parts.append(overlay.strip())
 
+        theme_section = self._render_theme_map_section()
+        if theme_section:
+            parts.append("")
+            parts.append(theme_section)
+
         parts.append("")
         parts.append(self.BLOCK_END)
 
         return "\n".join(parts)
+
+    def _render_theme_map_section(self) -> str:
+        """
+        Render the `# Theme map` section when consumers override defaults.
+
+        Empty string when the repo uses only the built-in 10 themes —
+        this keeps CLAUDE.md from churning on repos that have not opted
+        in to custom themes. When overrides are present, the section
+        lists the effective merged digit→name mapping so agents reading
+        the rendered ATDD block see the real theme taxonomy for the
+        repo they are working in.
+
+        Reference: issue #291 Phase 4 deliverable.
+        """
+        config = self._load_config()
+        merged = get_theme_map(config)
+
+        # Nothing to render if no overrides exist.
+        if merged == DEFAULT_THEME_MAP:
+            return ""
+
+        lines: List[str] = ["# Theme map (merged from .atdd/config.yaml)"]
+        for digit in sorted(merged.keys()):
+            name = merged[digit]
+            default = DEFAULT_THEME_MAP.get(digit)
+            if default is not None and name != default:
+                lines.append(f"#   {digit}: {name}  (override; default was {default})")
+            else:
+                lines.append(f"#   {digit}: {name}")
+        return "\n".join(lines)
 
     def _read_target(self, agent: str) -> str:
         """

--- a/src/atdd/coach/conventions/naming.convention.yaml
+++ b/src/atdd/coach/conventions/naming.convention.yaml
@@ -134,7 +134,7 @@ patterns:
     regex: "^\\d{4}-[a-z][a-z0-9-]+$"
     numbering:
       pattern: "[Theme][Category][Variation]-{slug}"
-      theme_digit: "0-9 (commons=0, mechanic=1, scenario=2, match=3, etc.)"
+      theme_digit: "0-9 — resolved via `get_theme_map(config)` (atdd.coach.utils.theme_map). Built-in defaults: commons=0, mechanic=1, scenario=2, match=3, sensory=4, player=5, league=6, audience=7, monetization=8, partnership=9. Consumer repos may override via `themes:` in `.atdd/config.yaml`. Overriding digit 0 emits warning W-THEME-001 (non-blocking)."
       category_digit: "0=nominal, 1=error, 2=alternate, 3=exception"
       variation_digits: "01-99"
     examples:

--- a/src/atdd/coach/schemas/config.schema.json
+++ b/src/atdd/coach/schemas/config.schema.json
@@ -175,6 +175,20 @@
       "required": ["repo", "project_number", "project_id"],
       "additionalProperties": false
     },
+    "themes": {
+      "type": "object",
+      "description": "Optional digit (0-9) → custom theme-name mapping merged with the 10 built-in defaults. Values are resolved at runtime via `get_theme_map(config)` (atdd.coach.utils.theme_map). Overriding digit 0 emits warning W-THEME-001 (non-blocking).",
+      "propertyNames": {
+        "pattern": "^[0-9]$"
+      },
+      "additionalProperties": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]*$"
+      },
+      "examples": [
+        {"1": "qualification", "2": "security", "3": "operations"}
+      ]
+    },
     "workspace": {
       "type": "object",
       "description": "Workspace appearance settings",

--- a/src/atdd/coach/utils/theme_map.py
+++ b/src/atdd/coach/utils/theme_map.py
@@ -1,0 +1,175 @@
+"""
+Custom theme map helper (issue #291).
+
+Single source of truth for the digit → theme-name mapping used by
+planner validators, coach commands (inventory, registry, sync), and
+the init flow. Merges the 10 built-in defaults with the optional
+`themes` block in `.atdd/config.yaml` so consumer repos can override
+game-domain defaults with names that reflect their own domain.
+
+URN: coach:utils:theme_map
+
+Public surface:
+    DEFAULT_THEME_MAP         Dict[str, str]
+    get_theme_map(config)     Dict[str, str]
+    validate_theme_config     (themes) -> ValidationResult
+    Warning                   dataclass: .code, .message
+    ValidationResult          dataclass: .errors, .warnings
+
+Conventions: src/atdd/coach/conventions/naming.convention.yaml
+             src/atdd/planner/conventions/artifact-naming.convention.yaml
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional
+
+
+DEFAULT_THEME_MAP: Dict[str, str] = {
+    "0": "commons",
+    "1": "mechanic",
+    "2": "scenario",
+    "3": "match",
+    "4": "sensory",
+    "5": "player",
+    "6": "league",
+    "7": "audience",
+    "8": "monetization",
+    "9": "partnership",
+}
+
+THEME_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9-]*$")
+DIGIT_KEY_PATTERN = re.compile(r"^[0-9]$")
+
+
+@dataclass(frozen=True)
+class Warning:
+    """Non-blocking warning emitted by theme config validation."""
+
+    code: str
+    message: str
+
+
+@dataclass
+class ValidationResult:
+    errors: List[str] = field(default_factory=list)
+    warnings: List[Warning] = field(default_factory=list)
+
+
+def get_theme_map(config: Optional[Mapping[str, Any]]) -> Dict[str, str]:
+    """
+    Merge built-in defaults with optional `themes` overrides from config.
+
+    Args:
+        config: Parsed `.atdd/config.yaml` mapping. May be None or lack
+            a `themes` key entirely; both cases yield the defaults.
+
+    Returns:
+        Dict of digit(str) → theme-name(str). Overrides win; unmapped
+        digits retain their built-in value. Integer keys in the config
+        are normalized to strings.
+
+    Notes:
+        - Pure: does not mutate the input mapping.
+        - Invalid override shapes are ignored silently here; call
+          `validate_theme_config()` separately to surface errors.
+    """
+    merged = dict(DEFAULT_THEME_MAP)
+
+    if not config:
+        return merged
+
+    overrides = config.get("themes") if isinstance(config, Mapping) else None
+    if not overrides:
+        return merged
+
+    if not isinstance(overrides, Mapping):
+        return merged
+
+    for raw_key, raw_value in overrides.items():
+        key = str(raw_key)
+        if not DIGIT_KEY_PATTERN.match(key):
+            continue
+        if not isinstance(raw_value, str) or not THEME_NAME_PATTERN.match(raw_value):
+            continue
+        merged[key] = raw_value
+
+    return merged
+
+
+def validate_theme_config(themes: Optional[Mapping[Any, Any]]) -> ValidationResult:
+    """
+    Validate a raw `themes:` block from `.atdd/config.yaml`.
+
+    Rules:
+        - keys must be single digits 0-9
+        - values must match ^[a-z][a-z0-9-]*$ and be non-empty strings
+        - overriding digit 0 emits non-blocking `W-THEME-001`
+
+    Args:
+        themes: The raw mapping under the `themes:` YAML key. May be
+            None (treated as empty).
+
+    Returns:
+        `ValidationResult` with `.errors` (blocking) and `.warnings`
+        (advisory). Callers decide how to surface each.
+    """
+    result = ValidationResult()
+
+    if themes is None:
+        return result
+
+    if not isinstance(themes, Mapping):
+        result.errors.append(
+            f"themes block must be a mapping, got {type(themes).__name__}"
+        )
+        return result
+
+    for raw_key, raw_value in themes.items():
+        key = str(raw_key) if not isinstance(raw_key, str) else raw_key
+
+        if not DIGIT_KEY_PATTERN.match(key):
+            result.errors.append(
+                f"themes key must be a single digit 0-9, got {raw_key!r}"
+            )
+            continue
+
+        if raw_value is None:
+            result.errors.append(
+                f"themes[{key!r}] is null — theme name is required"
+            )
+            continue
+
+        if not isinstance(raw_value, str):
+            result.errors.append(
+                f"themes[{key!r}] must be a string, got "
+                f"{type(raw_value).__name__}"
+            )
+            continue
+
+        if not raw_value:
+            result.errors.append(
+                f"themes[{key!r}] is empty — theme name is required"
+            )
+            continue
+
+        if not THEME_NAME_PATTERN.match(raw_value):
+            result.errors.append(
+                f"themes[{key!r}] = {raw_value!r} does not match kebab-case "
+                f"pattern ^[a-z][a-z0-9-]*$"
+            )
+            continue
+
+        if key == "0":
+            result.warnings.append(
+                Warning(
+                    code="W-THEME-001",
+                    message=(
+                        "Overriding digit 0 (commons) is not recommended — "
+                        "cross-repo tooling assumes `commons` at digit 0."
+                    ),
+                )
+            )
+
+    return result

--- a/src/atdd/coach/utils/theme_scanner.py
+++ b/src/atdd/coach/utils/theme_scanner.py
@@ -1,0 +1,283 @@
+"""
+Pre-init theme scanner (issue #291, Decision #7).
+
+Walks a consumer repo BEFORE `atdd init --themes custom` prompts, and
+returns three buckets:
+
+- detected       : distinct `theme:` values seen in `plan/**/*.yaml`
+                   (primary, high-confidence — prompt pre-selects).
+- low_confidence : candidate domain tokens from top-level directories
+                   and package-manifest keywords (secondary — prompt
+                   shows as suggestions, never auto-selects).
+- force_fits     : wagons whose slug tokens do not overlap with their
+                   assigned theme's synonym set (e.g. `authenticate-
+                   users` tagged `theme: commons` — natural fit would
+                   be `security`, which does not exist in built-ins).
+
+URN: coach:utils:theme_scanner
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+import yaml
+
+
+# Theme → synonym set for the force-fit heuristic.
+# A wagon whose slug has no token overlap with its assigned theme's
+# synonyms is considered force-fit. Custom themes not in this dict are
+# skipped (no ground truth to reason about).
+_THEME_SYNONYMS: Dict[str, Set[str]] = {
+    "commons": {
+        "commons", "common", "shared", "base", "core",
+        "util", "utility", "general",
+    },
+    "mechanic": {
+        "mechanic", "mechanics", "rule", "rules", "engine",
+        "action", "compute",
+    },
+    "scenario": {
+        "scenario", "scenarios", "story", "storyline", "flow",
+        "journey",
+    },
+    "match": {
+        "match", "matches", "game", "session", "round", "turn",
+    },
+    "sensory": {
+        "sensory", "sense", "audio", "sound", "haptic", "visual",
+        "vfx", "sfx", "render",
+    },
+    "player": {
+        "player", "players", "user", "users", "avatar", "account",
+        "profile",
+    },
+    "league": {
+        "league", "leagues", "tournament", "season", "ranking",
+        "standings",
+    },
+    "audience": {
+        "audience", "spectator", "viewer", "broadcast", "stream",
+        "chat",
+    },
+    "monetization": {
+        "monetization", "monetize", "pay", "payment", "billing",
+        "subscription", "checkout", "invoice",
+    },
+    "partnership": {
+        "partnership", "partner", "partners", "affiliate", "sponsor",
+        "integration",
+    },
+}
+
+
+_KEBAB_TOKEN_SPLIT = re.compile(r"-+")
+
+
+@dataclass(frozen=True)
+class ForceFit:
+    """A wagon whose slug tokens do not overlap with its theme's synonym set."""
+
+    wagon: str
+    theme: str
+    reason: str = ""
+
+
+@dataclass
+class ScanResult:
+    detected: List[str] = field(default_factory=list)
+    low_confidence: List[str] = field(default_factory=list)
+    force_fits: List[ForceFit] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Primary source — plan/**/*.yaml
+# ---------------------------------------------------------------------------
+
+
+def _walk_plan_yaml(plan_dir: Path) -> Iterable[Path]:
+    if not plan_dir.is_dir():
+        return []
+    return sorted(plan_dir.rglob("*.yaml"))
+
+
+def _load_yaml_safely(path: Path) -> Optional[dict]:
+    try:
+        with open(path) as f:
+            doc = yaml.safe_load(f)
+    except Exception:
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def _collect_plan_themes(
+    plan_dir: Path,
+) -> tuple[List[str], List[ForceFit]]:
+    """Return (detected_themes_in_order, force_fits) from plan/ tree."""
+    detected_order: List[str] = []
+    seen: Set[str] = set()
+    force_fits: List[ForceFit] = []
+
+    for path in _walk_plan_yaml(plan_dir):
+        doc = _load_yaml_safely(path)
+        if doc is None:
+            continue
+
+        theme = doc.get("theme")
+        if not isinstance(theme, str) or not theme:
+            continue
+
+        if theme not in seen:
+            seen.add(theme)
+            detected_order.append(theme)
+
+        wagon_slug = doc.get("wagon")
+        if isinstance(wagon_slug, str) and wagon_slug:
+            if _is_force_fit(wagon_slug, theme):
+                force_fits.append(
+                    ForceFit(
+                        wagon=wagon_slug,
+                        theme=theme,
+                        reason=(
+                            f"wagon slug tokens do not overlap with "
+                            f"`{theme}` synonyms"
+                        ),
+                    )
+                )
+
+    return detected_order, force_fits
+
+
+def _is_force_fit(wagon_slug: str, theme: str) -> bool:
+    """True when wagon slug tokens do not overlap with theme synonyms."""
+    synonyms = _THEME_SYNONYMS.get(theme)
+    if synonyms is None:
+        # Custom theme — no ground truth for overlap check.
+        return False
+    tokens = set(_KEBAB_TOKEN_SPLIT.split(wagon_slug))
+    return not tokens.intersection(synonyms)
+
+
+# ---------------------------------------------------------------------------
+# Secondary source — low-confidence candidates from repo metadata
+# ---------------------------------------------------------------------------
+
+
+_IGNORED_TOP_LEVEL_DIRS: Set[str] = {
+    ".git", ".github", ".atdd", ".venv", ".idea", ".vscode",
+    "node_modules", "__pycache__", "dist", "build", "target",
+    "venv", "env", "tests", "test", "docs", "src", "web",
+    "plan",  # plan is the primary source, not a candidate
+}
+
+
+def _collect_top_level_dir_candidates(repo_root: Path) -> List[str]:
+    out: List[str] = []
+    if not repo_root.is_dir():
+        return out
+    for child in sorted(repo_root.iterdir()):
+        if not child.is_dir():
+            continue
+        name = child.name
+        if name.startswith(".") or name in _IGNORED_TOP_LEVEL_DIRS:
+            continue
+        if re.match(r"^[a-z][a-z0-9-]*$", name):
+            out.append(name)
+        elif re.match(r"^[a-z][a-z0-9_]*$", name):
+            out.append(name.replace("_", "-"))
+    return out
+
+
+def _collect_pyproject_keywords(repo_root: Path) -> List[str]:
+    path = repo_root / "pyproject.toml"
+    if not path.exists():
+        return []
+    try:
+        text = path.read_text()
+    except OSError:
+        return []
+
+    # Minimal keyword extraction: parse the `keywords = [...]` array.
+    # Avoids hard-depending on tomllib / tomli to keep this helper
+    # dependency-free.
+    match = re.search(
+        r"^\s*keywords\s*=\s*\[(?P<body>[^\]]*)\]",
+        text,
+        re.MULTILINE,
+    )
+    if not match:
+        return []
+    tokens = re.findall(r'"([^"]+)"|\'([^\']+)\'', match.group("body"))
+    return [a or b for a, b in tokens if (a or b)]
+
+
+def _collect_package_json_keywords(repo_root: Path) -> List[str]:
+    path = repo_root / "package.json"
+    if not path.exists():
+        return []
+    try:
+        import json
+
+        data = json.loads(path.read_text())
+    except Exception:
+        return []
+    keywords = data.get("keywords") if isinstance(data, dict) else None
+    if not isinstance(keywords, list):
+        return []
+    return [str(k) for k in keywords if isinstance(k, str) and k]
+
+
+def _collect_low_confidence(repo_root: Path) -> List[str]:
+    candidates: List[str] = []
+    candidates.extend(_collect_top_level_dir_candidates(repo_root))
+    candidates.extend(_collect_pyproject_keywords(repo_root))
+    candidates.extend(_collect_package_json_keywords(repo_root))
+
+    # Dedupe while preserving order and kebab-case shape.
+    seen: Set[str] = set()
+    out: List[str] = []
+    for c in candidates:
+        norm = str(c).strip().lower()
+        if not norm or not re.match(r"^[a-z][a-z0-9-]*$", norm):
+            continue
+        if norm in seen:
+            continue
+        seen.add(norm)
+        out.append(norm)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def scan_existing_themes(repo_root: Path) -> ScanResult:
+    """
+    Scan `repo_root` for theme signals.
+
+    Primary source  : `plan/**/*.yaml` → detected + force_fits
+    Secondary source: top-level dir names + pyproject/package manifests
+                      → low_confidence (only when primary is empty or
+                      as supplementary suggestions).
+
+    Tolerates missing directories, malformed YAML, and repos with no
+    package manifest — always returns a well-formed ScanResult.
+    """
+    repo_root = Path(repo_root)
+
+    detected, force_fits = _collect_plan_themes(repo_root / "plan")
+    low_confidence = _collect_low_confidence(repo_root)
+
+    # Exclude low-confidence tokens that duplicate detected entries so
+    # the prompt does not show the same token twice.
+    detected_set = set(detected)
+    low_confidence = [lc for lc in low_confidence if lc not in detected_set]
+
+    return ScanResult(
+        detected=detected,
+        low_confidence=low_confidence,
+        force_fits=force_fits,
+    )

--- a/src/atdd/coach/validators/test_config_themes.py
+++ b/src/atdd/coach/validators/test_config_themes.py
@@ -1,0 +1,271 @@
+"""
+Platform tests: `themes` section in `.atdd/config.yaml` schema.
+
+Issue: #291 (feat(planner): support custom themes via .atdd/config.yaml)
+Phase: RED — these tests FAIL on current main.
+Gate: GT-010b
+
+Validates that `src/atdd/coach/schemas/config.schema.json` declares an
+optional `themes` property accepting `{digit(0-9): kebab-case-name}`
+mappings, and rejects malformed entries.
+
+URN: test:coach:custom-themes:config-schema
+
+Acceptance:
+- Schema has a `themes` property (object, optional).
+- Empty `themes: {}` is accepted.
+- `themes: {"1": "qualification"}` validates.
+- `themes: {"1": "qualification", "2": "security"}` validates.
+- Invalid keys (non-digit, multi-char, out of 0-9) are rejected.
+- Invalid names (UPPER, spaces, digit-start, empty) are rejected.
+- The existing config (no `themes` block) still validates (backward
+  compatible).
+
+Target change (Phase 2 / GREEN): add a `themes` property to
+`src/atdd/coach/schemas/config.schema.json` with
+`propertyNames: {pattern: "^[0-9]$"}` and
+`additionalProperties: {type: string, pattern: "^[a-z][a-z0-9-]*$"}`.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.utils.repo import find_repo_root
+
+
+REPO_ROOT = find_repo_root()
+CONFIG_SCHEMA_PATH = (
+    REPO_ROOT / "src" / "atdd" / "coach" / "schemas" / "config.schema.json"
+)
+
+
+@pytest.fixture(scope="module")
+def config_schema() -> dict:
+    """Parsed config.schema.json — fails loudly if missing."""
+    assert CONFIG_SCHEMA_PATH.exists(), (
+        f"config.schema.json not found at {CONFIG_SCHEMA_PATH}"
+    )
+    with open(CONFIG_SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def _validator(config_schema):
+    """jsonschema Draft7Validator — skip if jsonschema not installed."""
+    jsonschema = pytest.importorskip("jsonschema")
+    return jsonschema.Draft7Validator(config_schema)
+
+
+@pytest.fixture
+def minimal_valid_config() -> dict:
+    """Minimum required config shape (version + release)."""
+    return {
+        "version": "1.0",
+        "release": {"version_file": "pyproject.toml", "tag_prefix": "v"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema presence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_config_schema_declares_themes_property(config_schema):
+    """
+    SPEC-COACH-CONFIG-THEMES-0001: `themes` is a declared property.
+
+    The schema must enumerate `themes` under its `properties` block so
+    that `additionalProperties: false` at the root does not reject
+    consumer configs that set it.
+    """
+    properties = config_schema.get("properties", {})
+    assert "themes" in properties, (
+        "config.schema.json is missing the `themes` property. "
+        "Add it under .properties so consumer repos can declare "
+        "custom theme mappings without tripping additionalProperties."
+    )
+
+
+@pytest.mark.platform
+def test_themes_property_is_object_type(config_schema):
+    """
+    SPEC-COACH-CONFIG-THEMES-0002: `themes` must be typed as object.
+
+    Themes are a dict of digit→name. The JSON Schema type must be
+    `object` (not array, string, or open).
+    """
+    themes = config_schema["properties"]["themes"]
+    assert themes.get("type") == "object", (
+        f"`themes` property must be type=object, got {themes.get('type')}"
+    )
+
+
+@pytest.mark.platform
+def test_themes_is_optional(config_schema):
+    """
+    SPEC-COACH-CONFIG-THEMES-0003: `themes` is NOT in required[].
+
+    Backward compatibility: existing consumer repos without a `themes`
+    block must continue to validate.
+    """
+    required = config_schema.get("required", [])
+    assert "themes" not in required, (
+        "`themes` must remain optional so existing repos validate "
+        "without change."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Valid theme configurations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_config_without_themes_still_validates(_validator, minimal_valid_config):
+    """
+    SPEC-COACH-CONFIG-THEMES-0004: No `themes` block = valid.
+
+    The current ATDD repo's own `.atdd/config.yaml` has no `themes`
+    block. It must continue to validate after schema extension.
+    """
+    errors = list(_validator.iter_errors(minimal_valid_config))
+    assert errors == [], (
+        f"Minimal config should validate, got errors: "
+        f"{[e.message for e in errors]}"
+    )
+
+
+@pytest.mark.platform
+def test_empty_themes_block_validates(_validator, minimal_valid_config):
+    """
+    SPEC-COACH-CONFIG-THEMES-0005: `themes: {}` is accepted.
+
+    An empty themes block should validate. It is semantically identical
+    to no block at all and is a natural intermediate state during
+    `atdd init --themes custom`.
+    """
+    config = {**minimal_valid_config, "themes": {}}
+    errors = list(_validator.iter_errors(config))
+    assert errors == [], (
+        f"Empty themes block should validate, got: "
+        f"{[e.message for e in errors]}"
+    )
+
+
+@pytest.mark.platform
+def test_single_theme_override_validates(_validator, minimal_valid_config):
+    """
+    SPEC-COACH-CONFIG-THEMES-0006: One digit→name mapping validates.
+    """
+    config = {**minimal_valid_config, "themes": {"1": "qualification"}}
+    errors = list(_validator.iter_errors(config))
+    assert errors == [], (
+        f"`themes: {{\"1\": \"qualification\"}}` should validate, got: "
+        f"{[e.message for e in errors]}"
+    )
+
+
+@pytest.mark.platform
+def test_pluggy_three_theme_overrides_validates(_validator, minimal_valid_config):
+    """
+    SPEC-COACH-CONFIG-THEMES-0007: The pluggy fixture config validates.
+
+    The fixture from issue #291 declares exactly three overrides.
+    This is the canonical "golden" theme config for SMOKE.
+    """
+    config = {
+        **minimal_valid_config,
+        "themes": {
+            "1": "qualification",
+            "2": "security",
+            "3": "operations",
+        },
+    }
+    errors = list(_validator.iter_errors(config))
+    assert errors == [], (
+        f"pluggy 3-override config should validate, got: "
+        f"{[e.message for e in errors]}"
+    )
+
+
+@pytest.mark.platform
+def test_all_ten_digits_can_be_overridden(_validator, minimal_valid_config):
+    """
+    SPEC-COACH-CONFIG-THEMES-0008: Keys 0-9 all accepted.
+    """
+    config = {
+        **minimal_valid_config,
+        "themes": {str(d): f"theme-{d}" for d in range(10)},
+    }
+    errors = list(_validator.iter_errors(config))
+    assert errors == [], (
+        f"All 10 digits should be valid keys, got: "
+        f"{[e.message for e in errors]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invalid theme keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize(
+    "bad_key,reason",
+    [
+        ("10", "two-digit key exceeds 0-9 range"),
+        ("a", "letters disallowed"),
+        ("", "empty key disallowed"),
+        ("01", "leading-zero multi-char key disallowed"),
+        ("1a", "mixed alphanumeric disallowed"),
+    ],
+)
+def test_invalid_theme_key_is_rejected(
+    _validator, minimal_valid_config, bad_key, reason
+):
+    """
+    SPEC-COACH-CONFIG-THEMES-0009: Non-single-digit keys rejected.
+
+    Only single digits 0-9 are valid theme-map positions. Multi-char or
+    non-digit keys must fail schema validation (prevents silent
+    acceptance of malformed themes blocks).
+    """
+    config = {**minimal_valid_config, "themes": {bad_key: "qualification"}}
+    errors = list(_validator.iter_errors(config))
+    assert errors, f"Expected rejection for bad key '{bad_key}' ({reason})"
+
+
+# ---------------------------------------------------------------------------
+# Invalid theme names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize(
+    "bad_name,reason",
+    [
+        ("Qualification", "UPPER-case letters disallowed"),
+        ("QUALIFICATION", "ALL-CAPS disallowed"),
+        ("lead qualification", "spaces disallowed"),
+        ("lead_qualification", "underscores disallowed"),
+        ("1qualification", "digit-start disallowed"),
+        ("-qualification", "hyphen-start disallowed"),
+        ("", "empty value disallowed"),
+    ],
+)
+def test_invalid_theme_name_is_rejected(
+    _validator, minimal_valid_config, bad_name, reason
+):
+    """
+    SPEC-COACH-CONFIG-THEMES-0010: Non-kebab-case names rejected.
+
+    Pattern: `^[a-z][a-z0-9-]*$`. Matches the URN slug convention used
+    everywhere else in ATDD (wagon slugs, wmbt slugs, train slugs).
+    """
+    config = {**minimal_valid_config, "themes": {"1": bad_name}}
+    errors = list(_validator.iter_errors(config))
+    assert errors, (
+        f"Expected rejection for bad name '{bad_name}' ({reason})"
+    )

--- a/src/atdd/coach/validators/test_custom_theme_validation.py
+++ b/src/atdd/coach/validators/test_custom_theme_validation.py
@@ -1,0 +1,230 @@
+"""
+Platform tests: Custom theme runtime validator.
+
+Issue: #291 (feat(planner): support custom themes via .atdd/config.yaml)
+Phase: RED — these tests FAIL on current main.
+Gates: GT-010d, GT-025
+
+Validates the runtime theme-config validator that enforces the rules
+declared in the Scope section of #291:
+- digit keys 0-9 only
+- kebab-case names (`^[a-z][a-z0-9-]*$`)
+- non-empty names
+- emits warning `W-THEME-001` when digit 0 is overridden (Decision #4:
+  non-blocking — consumers *may* override `commons` but shouldn't;
+  cross-repo tooling assumes commons at digit 0).
+
+URN: test:coach:custom-themes:runtime-validator
+
+Target module (Phase 2 / GREEN): `atdd.coach.utils.theme_map`
+- `validate_theme_config(themes: dict) -> ValidationResult`
+- ValidationResult has `.errors: list[str]` and `.warnings: list[Warning]`
+- Warning is a dataclass/namedtuple with `.code` and `.message`
+  fields; `.code == "W-THEME-001"` for the digit-0 override case.
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module import guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_validate_theme_config_is_importable():
+    """
+    SPEC-COACH-THEMES-VAL-0001: `validate_theme_config` exists and is callable.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    assert callable(validate_theme_config)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_empty_themes_is_valid():
+    """
+    SPEC-COACH-THEMES-VAL-0002: Empty dict produces no errors/warnings.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({})
+    assert list(result.errors) == []
+    assert list(result.warnings) == []
+
+
+@pytest.mark.platform
+def test_single_valid_override_produces_no_errors():
+    """
+    SPEC-COACH-THEMES-VAL-0003: Valid single override passes cleanly.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({"1": "qualification"})
+    assert list(result.errors) == []
+    assert list(result.warnings) == []
+
+
+@pytest.mark.platform
+def test_pluggy_three_overrides_pass_cleanly():
+    """
+    SPEC-COACH-THEMES-VAL-0004: Canonical pluggy fixture passes cleanly.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({
+        "1": "qualification",
+        "2": "security",
+        "3": "operations",
+    })
+    assert list(result.errors) == []
+    assert list(result.warnings) == []
+
+
+# ---------------------------------------------------------------------------
+# Error cases — invalid digit keys
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize(
+    "bad_key",
+    ["10", "a", "", "01", "1a", "-1", " 1"],
+)
+def test_non_digit_key_produces_error(bad_key):
+    """
+    SPEC-COACH-THEMES-VAL-0005: Non-single-digit keys are errors.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({bad_key: "qualification"})
+    assert result.errors, (
+        f"Expected an error for non-digit key {bad_key!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error cases — invalid theme names
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "UPPER",
+        "Qualification",
+        "QUALIFICATION",
+        "with space",
+        "with_under",
+        "1starts-digit",
+        "-leading-hyphen",
+        "",
+    ],
+)
+def test_non_kebab_case_name_produces_error(bad_name):
+    """
+    SPEC-COACH-THEMES-VAL-0006: Non-kebab-case names are errors.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({"1": bad_name})
+    assert result.errors, (
+        f"Expected an error for non-kebab-case name {bad_name!r}"
+    )
+
+
+@pytest.mark.platform
+def test_null_value_produces_error():
+    """
+    SPEC-COACH-THEMES-VAL-0007: `themes: {"1": null}` is an error.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({"1": None})
+    assert result.errors, "Null theme name must be an error"
+
+
+# ---------------------------------------------------------------------------
+# W-THEME-001 warning (Decision #4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_warning_on_commons_override():
+    """
+    SPEC-COACH-THEMES-VAL-0008: Overriding digit 0 emits W-THEME-001.
+
+    Decision #4 / Gate GT-025. The warning is NON-BLOCKING (result.errors
+    remains empty); cross-repo tooling assumes commons at digit 0 so the
+    system flags the override without forbidding it.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({"0": "baseline"})
+
+    assert not result.errors, (
+        "Overriding digit 0 must NOT be an error (only a warning)"
+    )
+    codes = [w.code for w in result.warnings]
+    assert "W-THEME-001" in codes, (
+        f"Expected warning code W-THEME-001 in warnings, got: {codes}"
+    )
+
+
+@pytest.mark.platform
+def test_no_warning_on_non_zero_override():
+    """
+    SPEC-COACH-THEMES-VAL-0009: Overriding digit 1 does NOT emit W-THEME-001.
+
+    The W-THEME-001 code is digit-0-specific. Overriding any other
+    digit (the common case) must not produce this warning.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({"1": "qualification"})
+    codes = [w.code for w in result.warnings]
+    assert "W-THEME-001" not in codes, (
+        f"W-THEME-001 is digit-0-specific; should not fire for digit 1. "
+        f"Got warnings: {codes}"
+    )
+
+
+@pytest.mark.platform
+def test_warning_message_mentions_commons():
+    """
+    SPEC-COACH-THEMES-VAL-0010: W-THEME-001 message references `commons`.
+
+    The warning copy must help the operator understand the concern
+    (cross-repo tooling assumes `commons` at digit 0).
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({"0": "baseline"})
+    msg = next(
+        (w.message for w in result.warnings if w.code == "W-THEME-001"),
+        "",
+    )
+    assert "commons" in msg.lower(), (
+        f"W-THEME-001 message should mention `commons`, got: {msg!r}"
+    )
+
+
+@pytest.mark.platform
+def test_warning_does_not_fire_when_digit_0_absent():
+    """
+    SPEC-COACH-THEMES-VAL-0011: No digit-0 key = no W-THEME-001.
+    """
+    from atdd.coach.utils.theme_map import validate_theme_config
+
+    result = validate_theme_config({
+        "1": "qualification",
+        "2": "security",
+        "3": "operations",
+    })
+    codes = [w.code for w in result.warnings]
+    assert "W-THEME-001" not in codes

--- a/src/atdd/coach/validators/test_init_themes_prompt.py
+++ b/src/atdd/coach/validators/test_init_themes_prompt.py
@@ -1,0 +1,304 @@
+"""
+Platform tests: `atdd init` theme declaration prompt.
+
+Issue: #291 (feat(planner): support custom themes via .atdd/config.yaml)
+Phase: RED — these tests FAIL on current main.
+Gates: GT-055, GT-070
+
+Validates Decision #7 from the issue: `atdd init` prompts the operator
+to declare themes, with copy that is domain-agnostic (never names a
+product category such as `game`, `saas`, `fintech`). Non-interactive
+flag `--themes {defaults|custom|skip}` routes the same flow for CI.
+
+URN: test:coach:custom-themes:init-prompt
+
+Acceptance:
+- Prompt copy contains zero forbidden product-category tokens.
+- `--themes defaults` writes no `themes:` block (built-in 10 stay
+  active by default).
+- `--themes skip` is identical to `defaults` (no `themes:` block
+  written) but echoes a reminder on where to configure later.
+- `--themes custom` writes a `themes:` block that validates against
+  `config.schema.json`.
+- Custom flow is seeded by the theme scanner (when detections exist)
+  and falls back to a blind prompt otherwise.
+
+Target changes (Phase 2 / GREEN):
+- `src/atdd/coach/commands/initializer.py`:
+    - module-level constant `THEMES_PROMPT_COPY` (the prompt text).
+    - `Initializer._prompt_themes(mode: str, *, repo_root: Path | None = None)
+       -> Optional[Dict[str, str]]`.
+    - `--themes` CLI flag on `atdd init`.
+"""
+import inspect
+from pathlib import Path
+
+import pytest
+
+
+FORBIDDEN_PROMPT_TOKENS = [
+    "game",
+    "gaming",
+    "saas",
+    "fintech",
+    "product category",
+]
+
+
+# ---------------------------------------------------------------------------
+# Module surface (Decision #7: symbols the initializer must expose)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_initializer_exposes_themes_prompt_copy():
+    """
+    SPEC-COACH-INIT-THEMES-0001: `THEMES_PROMPT_COPY` constant exists.
+
+    The prompt text is extracted as a module-level constant so tests
+    can inspect it (GT-070) without invoking I/O.
+    """
+    from atdd.coach.commands import initializer
+
+    assert hasattr(initializer, "THEMES_PROMPT_COPY"), (
+        "Initializer must expose THEMES_PROMPT_COPY for test inspection"
+    )
+    assert isinstance(initializer.THEMES_PROMPT_COPY, str)
+    assert initializer.THEMES_PROMPT_COPY.strip(), (
+        "THEMES_PROMPT_COPY must be non-empty"
+    )
+
+
+@pytest.mark.platform
+def test_initializer_has_prompt_themes_method():
+    """
+    SPEC-COACH-INIT-THEMES-0002: `Initializer._prompt_themes` is defined.
+    """
+    from atdd.coach.commands.initializer import Initializer
+
+    assert hasattr(Initializer, "_prompt_themes"), (
+        "Initializer must define `_prompt_themes(mode, *, repo_root=None)`"
+    )
+    sig = inspect.signature(Initializer._prompt_themes)
+    params = set(sig.parameters)
+    assert "mode" in params, (
+        f"_prompt_themes must accept `mode` parameter, got {params}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Domain-agnostic prompt copy (GT-070)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_prompt_copy_is_domain_agnostic():
+    """
+    SPEC-COACH-INIT-THEMES-0003 / GT-070: No forbidden product-category tokens.
+
+    The prompt must not bake in assumptions about who adopts ATDD.
+    Forbidden tokens: game, gaming, saas, fintech, product category.
+    """
+    from atdd.coach.commands.initializer import THEMES_PROMPT_COPY
+
+    lower = THEMES_PROMPT_COPY.lower()
+    hits = [t for t in FORBIDDEN_PROMPT_TOKENS if t in lower]
+    assert not hits, (
+        f"Prompt copy must be domain-agnostic — found forbidden tokens "
+        f"{hits} in THEMES_PROMPT_COPY. Decision #7 mandates no product-"
+        f"category words."
+    )
+
+
+@pytest.mark.platform
+def test_prompt_copy_mentions_three_mode_choices():
+    """
+    SPEC-COACH-INIT-THEMES-0004: Prompt copy references defaults/custom/skip.
+
+    Operator must be able to read the prompt and understand the three
+    flow options (Decision #7).
+    """
+    from atdd.coach.commands.initializer import THEMES_PROMPT_COPY
+
+    lower = THEMES_PROMPT_COPY.lower()
+    for choice in ("defaults", "custom", "skip"):
+        assert choice in lower, (
+            f"Prompt copy should mention the `{choice}` mode, got: "
+            f"{THEMES_PROMPT_COPY!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Flag routing (defaults / skip / custom)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_defaults_mode_returns_none(tmp_path):
+    """
+    SPEC-COACH-INIT-THEMES-0005: `--themes defaults` yields no block.
+
+    `defaults` means "use built-in 10; write no `themes:` block".
+    `_prompt_themes("defaults", ...)` must return None to signal that
+    the caller should skip writing the block.
+    """
+    from atdd.coach.commands.initializer import Initializer
+
+    initializer = Initializer(target_dir=tmp_path)
+    result = initializer._prompt_themes("defaults", repo_root=tmp_path)
+
+    assert result is None, (
+        f"defaults mode must yield None (no themes block), got {result!r}"
+    )
+
+
+@pytest.mark.platform
+def test_skip_mode_returns_none(tmp_path):
+    """
+    SPEC-COACH-INIT-THEMES-0006: `--themes skip` yields no block.
+    """
+    from atdd.coach.commands.initializer import Initializer
+
+    initializer = Initializer(target_dir=tmp_path)
+    result = initializer._prompt_themes("skip", repo_root=tmp_path)
+
+    assert result is None, (
+        f"skip mode must yield None (no themes block), got {result!r}"
+    )
+
+
+@pytest.mark.platform
+def test_invalid_mode_raises(tmp_path):
+    """
+    SPEC-COACH-INIT-THEMES-0007: Unknown mode raises ValueError.
+
+    CI callers supplying `--themes wizard` (typo) must get a clear
+    failure, not silent fallback.
+    """
+    from atdd.coach.commands.initializer import Initializer
+
+    initializer = Initializer(target_dir=tmp_path)
+    with pytest.raises(ValueError):
+        initializer._prompt_themes("wizard", repo_root=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Custom mode: scanner-seeded, writes valid YAML
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_custom_mode_with_scanner_detections_seeds_mapping(tmp_path):
+    """
+    SPEC-COACH-INIT-THEMES-0008 / GT-060: Scanner seeds the custom flow.
+
+    When `plan/**/*.yaml` contains `theme: qualification`, invoking
+    `--themes custom` (non-interactive) must pre-populate the mapping
+    with `qualification` on some digit. This is the primary integration
+    point between the scanner and the prompt.
+    """
+    from atdd.coach.commands.initializer import Initializer
+
+    # Seed a plan/ tree with an existing custom theme value.
+    plan_dir = tmp_path / "plan" / "qualify_leads"
+    plan_dir.mkdir(parents=True)
+    (plan_dir / "_qualify_leads.yaml").write_text(
+        "wagon: qualify-leads\n"
+        "description: Qualify inbound leads\n"
+        "theme: qualification\n"
+        "subject: agent:qualifier\n"
+        "context: inbound chat\n"
+        "action: scores lead\n"
+        "goal: qualify lead\n"
+        "outcome: lead qualified\n"
+        "produce: []\n"
+        "consume: []\n"
+        "wmbt: []\n"
+    )
+
+    initializer = Initializer(target_dir=tmp_path)
+    result = initializer._prompt_themes("custom", repo_root=tmp_path)
+
+    assert isinstance(result, dict), (
+        f"custom mode must return a dict of digit→name, got {type(result).__name__}"
+    )
+    assert "qualification" in result.values(), (
+        f"Scanner should have seeded 'qualification' into mapping, "
+        f"got: {result}"
+    )
+
+
+@pytest.mark.platform
+def test_custom_mode_output_validates_against_config_schema(tmp_path):
+    """
+    SPEC-COACH-INIT-THEMES-0009 / GT-060: Custom output validates.
+
+    The dict returned by `_prompt_themes("custom", ...)` must, when
+    written under the `themes:` key of `.atdd/config.yaml`, validate
+    against `coach/schemas/config.schema.json`.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    import json
+
+    from atdd.coach.commands.initializer import Initializer
+    from atdd.coach.utils.repo import find_repo_root
+
+    # Seed scanner input so custom mode has something to return.
+    plan_dir = tmp_path / "plan" / "secure_ops"
+    plan_dir.mkdir(parents=True)
+    (plan_dir / "_secure_ops.yaml").write_text(
+        "wagon: secure-ops\n"
+        "description: Secure operational access\n"
+        "theme: security\n"
+        "subject: agent:guard\n"
+        "context: runtime\n"
+        "action: guards access\n"
+        "goal: keep access safe\n"
+        "outcome: access is safe\n"
+        "produce: []\n"
+        "consume: []\n"
+        "wmbt: []\n"
+    )
+
+    initializer = Initializer(target_dir=tmp_path)
+    themes = initializer._prompt_themes("custom", repo_root=tmp_path)
+    assert isinstance(themes, dict) and themes, "custom mode yielded no mapping"
+
+    schema_path = (
+        find_repo_root() / "src" / "atdd" / "coach" / "schemas" / "config.schema.json"
+    )
+    with open(schema_path) as f:
+        schema = json.load(f)
+    validator = jsonschema.Draft7Validator(schema)
+
+    config_doc = {
+        "version": "1.0",
+        "release": {"version_file": "pyproject.toml", "tag_prefix": "v"},
+        "themes": themes,
+    }
+    errors = list(validator.iter_errors(config_doc))
+    assert not errors, (
+        f"Custom-mode themes block must validate against config.schema.json, "
+        f"got: {[e.message for e in errors]}"
+    )
+
+
+@pytest.mark.platform
+def test_custom_mode_on_empty_repo_does_not_crash(tmp_path):
+    """
+    SPEC-COACH-INIT-THEMES-0010: Blind prompt path — empty repo is OK.
+
+    When the scanner returns nothing (greenfield repo), the non-
+    interactive custom flow must still complete without raising. It is
+    allowed to return an empty dict (caller writes `themes: {}` — valid
+    per config.schema.json).
+    """
+    from atdd.coach.commands.initializer import Initializer
+
+    initializer = Initializer(target_dir=tmp_path)
+    result = initializer._prompt_themes("custom", repo_root=tmp_path)
+
+    assert result is None or isinstance(result, dict), (
+        f"custom mode on empty repo must return None or dict, got "
+        f"{type(result).__name__}"
+    )

--- a/src/atdd/coach/validators/test_sync_theme_block.py
+++ b/src/atdd/coach/validators/test_sync_theme_block.py
@@ -1,0 +1,117 @@
+"""
+Platform tests: `atdd sync` renders custom themes in the CLAUDE.md block.
+
+Issue: #291 Phase 4 (REFACTOR) deliverable.
+
+When `.atdd/config.yaml` declares a `themes:` block, the managed ATDD
+section written by `atdd sync` must include a `# Theme map` comment
+listing the merged digit→name mapping. When no overrides exist, the
+section is omitted (keeps CLAUDE.md deterministic for repos that
+opted out).
+
+URN: test:coach:custom-themes:sync-block
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_config(repo: Path, themes: dict | None) -> None:
+    repo.joinpath(".atdd").mkdir(parents=True, exist_ok=True)
+    cfg = {
+        "version": "1.0",
+        "release": {"version_file": "pyproject.toml", "tag_prefix": "v"},
+        "sync": {"agents": ["claude"]},
+    }
+    if themes is not None:
+        cfg["themes"] = themes
+    (repo / ".atdd" / "config.yaml").write_text(yaml.safe_dump(cfg))
+
+
+# ---------------------------------------------------------------------------
+# Rendering behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_theme_section_is_empty_without_overrides(tmp_path):
+    """
+    SPEC-COACH-SYNC-THEMES-0001: No overrides → no theme section.
+
+    Backward compatibility: the ATDD block written by `atdd sync` into
+    CLAUDE.md must not drift for repos that have not opted in to
+    custom themes.
+    """
+    from atdd.coach.commands.sync import AgentConfigSync
+
+    _write_config(tmp_path, themes=None)
+    sync = AgentConfigSync(target_dir=tmp_path)
+
+    section = sync._render_theme_map_section()
+
+    assert section == "", (
+        f"Expected empty theme section when no overrides configured, "
+        f"got: {section!r}"
+    )
+
+
+@pytest.mark.platform
+def test_theme_section_renders_merged_mapping_when_overrides_present(tmp_path):
+    """
+    SPEC-COACH-SYNC-THEMES-0002: Overrides → rendered block lists the merge.
+
+    The pluggy fixture (from issue body) declares 3 overrides. The
+    rendered section must include each override's digit → custom name
+    alongside the original default for operator cross-reference.
+    """
+    from atdd.coach.commands.sync import AgentConfigSync
+
+    _write_config(
+        tmp_path,
+        themes={"1": "qualification", "2": "security", "3": "operations"},
+    )
+    sync = AgentConfigSync(target_dir=tmp_path)
+
+    section = sync._render_theme_map_section()
+
+    assert section.startswith("# Theme map"), (
+        f"Section must start with `# Theme map` header, got: {section!r}"
+    )
+    assert "1: qualification" in section
+    assert "2: security" in section
+    assert "3: operations" in section
+    assert "default was mechanic" in section
+    assert "default was scenario" in section
+    assert "default was match" in section
+    assert "0: commons" in section, "Unoverridden digits still listed"
+
+
+@pytest.mark.platform
+def test_theme_section_is_included_inside_managed_block(tmp_path):
+    """
+    SPEC-COACH-SYNC-THEMES-0003: Section appears inside BEGIN/END markers.
+
+    The renderer must place the theme block between the ATDD BEGIN and
+    END markers so consumers reading CLAUDE.md see it as part of the
+    managed block, not free-form content.
+    """
+    from atdd.coach.commands.sync import AgentConfigSync
+
+    _write_config(tmp_path, themes={"1": "qualification"})
+    sync = AgentConfigSync(target_dir=tmp_path)
+
+    rendered = sync._generate_block("claude", "base atdd content placeholder")
+
+    begin_idx = rendered.index(sync.BLOCK_BEGIN)
+    end_idx = rendered.index(sync.BLOCK_END)
+    theme_idx = rendered.index("# Theme map")
+
+    assert begin_idx < theme_idx < end_idx, (
+        "Theme map section must appear between BLOCK_BEGIN and BLOCK_END"
+    )

--- a/src/atdd/coach/validators/test_theme_scanner.py
+++ b/src/atdd/coach/validators/test_theme_scanner.py
@@ -1,0 +1,305 @@
+"""
+Platform tests: Theme scanner (plan/ tree + repo-metadata discovery).
+
+Issue: #291 (feat(planner): support custom themes via .atdd/config.yaml)
+Phase: RED — these tests FAIL on current main.
+Gate: GT-050
+
+Validates the pre-init scanner defined in Decision #7 of the issue.
+The scanner walks a consumer repo BEFORE `atdd init --themes custom`
+prompts and returns:
+- `detected`     : distinct `theme:` values found in `plan/**/*.yaml`
+                   (primary, high-confidence).
+- `low_confidence`: candidate domain tokens from top-level dir names +
+                    `pyproject.toml` / `package.json` keywords
+                    (secondary, advisory only — must never silently
+                    land in the primary list).
+- `force_fits`   : wagons whose slug does not overlap with their
+                   assigned theme's synonym set
+                   (e.g. wagon `authenticate-users` tagged
+                   `theme: commons` → flagged for operator review).
+
+URN: test:coach:custom-themes:theme-scanner
+
+Target module (Phase 2 / GREEN): `atdd.coach.utils.theme_scanner`
+- `scan_existing_themes(repo_root: Path) -> ScanResult`
+- `ScanResult` exposes `.detected`, `.low_confidence`, `.force_fits`.
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module import guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_theme_scanner_module_is_importable():
+    """
+    SPEC-COACH-SCANNER-0001: `atdd.coach.utils.theme_scanner` exists.
+    """
+    from atdd.coach.utils import theme_scanner  # noqa: F401
+
+
+@pytest.mark.platform
+def test_scan_existing_themes_is_callable():
+    """
+    SPEC-COACH-SCANNER-0002: `scan_existing_themes(repo_root)` exists.
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    assert callable(scan_existing_themes)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for fixture construction
+# ---------------------------------------------------------------------------
+
+
+def _write_wagon(dir_path, slug: str, theme: str) -> None:
+    """Write a minimal valid wagon yaml under `dir_path`."""
+    dir_path.mkdir(parents=True, exist_ok=True)
+    (dir_path / f"_{dir_path.name}.yaml").write_text(
+        f"wagon: {slug}\n"
+        f"description: wagon fixture for scanner tests\n"
+        f"theme: {theme}\n"
+        f"subject: agent:{slug}\n"
+        f"context: fixture\n"
+        f"action: acts\n"
+        f"goal: reach goal\n"
+        f"outcome: outcome produced\n"
+        f"produce: []\n"
+        f"consume: []\n"
+        f"wmbt: []\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty-repo baseline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_scanner_returns_empty_on_greenfield_repo(tmp_path):
+    """
+    SPEC-COACH-SCANNER-0003: Empty repo → empty detected + low_confidence.
+
+    Greenfield repos have no plan/ tree and minimal/no manifest. The
+    scanner must not raise and must return empty lists (blind prompt
+    path).
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    result = scan_existing_themes(tmp_path)
+
+    assert list(result.detected) == []
+    assert list(result.force_fits) == []
+
+
+# ---------------------------------------------------------------------------
+# Primary source — plan/**/*.yaml
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_scanner_detects_themes_from_plan_tree(tmp_path):
+    """
+    SPEC-COACH-SCANNER-0004: `theme:` values in plan/ are detected.
+
+    Given a plan/ tree with three wagons tagged with three distinct
+    themes, the scanner must return all three in `.detected` (order
+    deterministic or not — only set-equality matters).
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    _write_wagon(tmp_path / "plan" / "qualify_leads", "qualify-leads", "qualification")
+    _write_wagon(tmp_path / "plan" / "secure_ops", "secure-ops", "security")
+    _write_wagon(tmp_path / "plan" / "manage_versions", "manage-versions", "operations")
+
+    result = scan_existing_themes(tmp_path)
+
+    assert set(result.detected) == {"qualification", "security", "operations"}
+
+
+@pytest.mark.platform
+def test_scanner_deduplicates_repeated_themes(tmp_path):
+    """
+    SPEC-COACH-SCANNER-0005: Repeated `theme:` values appear once.
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    _write_wagon(tmp_path / "plan" / "q1", "qualify-leads", "qualification")
+    _write_wagon(tmp_path / "plan" / "q2", "extract-qualification", "qualification")
+    _write_wagon(tmp_path / "plan" / "q3", "handle-webhooks", "qualification")
+
+    result = scan_existing_themes(tmp_path)
+
+    assert list(result.detected).count("qualification") == 1, (
+        f"Scanner must dedupe themes, got: {result.detected}"
+    )
+
+
+@pytest.mark.platform
+def test_scanner_ignores_files_outside_plan_tree(tmp_path):
+    """
+    SPEC-COACH-SCANNER-0006: Only `plan/**/*.yaml` is primary source.
+
+    Random YAML files elsewhere in the repo (e.g. CI configs, GitHub
+    Actions) that happen to contain a `theme:` key must NOT leak into
+    the detected list.
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    (tmp_path / ".github" / "workflows" / "ci.yaml").write_text(
+        "name: ci\n"
+        "theme: bogus-from-ci\n"
+        "jobs: {}\n"
+    )
+
+    result = scan_existing_themes(tmp_path)
+
+    assert "bogus-from-ci" not in result.detected, (
+        f"Scanner leaked non-plan/ YAML content into detected: "
+        f"{result.detected}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Secondary source — low-confidence candidates from repo metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_scanner_separates_low_confidence_from_detected(tmp_path):
+    """
+    SPEC-COACH-SCANNER-0007: Low-confidence candidates do not leak.
+
+    When the scanner picks up candidate tokens from top-level dir
+    names or `pyproject.toml`/`package.json` keywords, they land in
+    `.low_confidence` — never in `.detected` — so the prompt can
+    present them as suggestions rather than pre-selections.
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    # No plan/ tree — scanner must not hallucinate detections.
+    (tmp_path / "authentication").mkdir()
+    (tmp_path / "observability").mkdir()
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nkeywords = ["qualification", "security"]\n'
+    )
+
+    result = scan_existing_themes(tmp_path)
+
+    assert list(result.detected) == [], (
+        f"Low-confidence candidates must not leak into detected, "
+        f"got: {result.detected}"
+    )
+    assert result.low_confidence, (
+        "Expected at least one low-confidence candidate from repo metadata"
+    )
+
+
+@pytest.mark.platform
+def test_scanner_finds_low_confidence_from_pyproject_keywords(tmp_path):
+    """
+    SPEC-COACH-SCANNER-0008: pyproject.toml keywords seed low-confidence.
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\n'
+        'name = "demo"\n'
+        'keywords = ["qualification", "operations"]\n'
+    )
+
+    result = scan_existing_themes(tmp_path)
+
+    lc = set(result.low_confidence)
+    assert "qualification" in lc or "operations" in lc, (
+        f"Expected pyproject keywords in low_confidence, got: {lc}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Force-fit heuristic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_scanner_flags_force_fit_authenticate_users_vs_commons(tmp_path):
+    """
+    SPEC-COACH-SCANNER-0009: Force-fit heuristic catches the canonical case.
+
+    Wagon slug tokens (`authenticate`, `users`) do not overlap with the
+    `commons` theme's semantic synonyms. The scanner must surface this
+    as a force-fit candidate so the operator can choose to re-tag.
+
+    Reference case from issue body Problem Statement:
+        > security wagons force-fit into `commons` because no default
+        > theme matches "authenticate / guard / protect".
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    _write_wagon(
+        tmp_path / "plan" / "authenticate_users",
+        "authenticate-users",
+        "commons",
+    )
+
+    result = scan_existing_themes(tmp_path)
+
+    slugs = [ff.wagon if hasattr(ff, "wagon") else ff.get("wagon") for ff in result.force_fits]
+    assert "authenticate-users" in slugs, (
+        f"Force-fit heuristic must flag `authenticate-users` tagged "
+        f"`commons`. force_fits returned: {result.force_fits}"
+    )
+
+
+@pytest.mark.platform
+def test_scanner_does_not_flag_semantically_aligned_wagon(tmp_path):
+    """
+    SPEC-COACH-SCANNER-0010: Aligned wagon/theme pairs are NOT flagged.
+
+    `authenticate-users` tagged `security` is a natural fit and must
+    not appear in force_fits (otherwise the signal is noise).
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    _write_wagon(
+        tmp_path / "plan" / "authenticate_users",
+        "authenticate-users",
+        "security",
+    )
+
+    result = scan_existing_themes(tmp_path)
+
+    slugs = [ff.wagon if hasattr(ff, "wagon") else ff.get("wagon") for ff in result.force_fits]
+    assert "authenticate-users" not in slugs, (
+        f"Semantically aligned wagon (security) must NOT be flagged as "
+        f"force-fit. force_fits returned: {result.force_fits}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration — scanner output consumable by custom prompt flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_scan_result_is_iterable_on_all_fields(tmp_path):
+    """
+    SPEC-COACH-SCANNER-0011: ScanResult exposes iterable collections.
+
+    The prompt layer iterates over `result.detected`, `result.low_confidence`,
+    and `result.force_fits`. Each must be an iterable (list or tuple)
+    regardless of whether detections exist.
+    """
+    from atdd.coach.utils.theme_scanner import scan_existing_themes
+
+    result = scan_existing_themes(tmp_path)
+
+    # Should not raise TypeError — each field must be iterable.
+    assert list(iter(result.detected)) == list(result.detected)
+    assert list(iter(result.low_confidence)) == list(result.low_confidence)
+    assert list(iter(result.force_fits)) == list(result.force_fits)

--- a/src/atdd/planner/conventions/artifact-naming.convention.yaml
+++ b/src/atdd/planner/conventions/artifact-naming.convention.yaml
@@ -69,10 +69,10 @@ naming_pattern:
 
   components:
     theme:
-      definition: "Top-level architectural theme grouping related artifacts"
-      format: "lowercase, no separators"
+      definition: "Top-level architectural theme grouping related artifacts. Kebab-case. Built-in defaults (commons, mechanic, scenario, match, sensory, player, league, audience, monetization, partnership) may be overridden via the `themes:` block in `.atdd/config.yaml`. Runtime validation resolves the effective digit-to-name map via `get_theme_map(config)` (atdd.coach.utils.theme_map); JSON Schema enforces kebab-case shape only. See issue #291 / Decision #2."
+      format: "kebab-case (^[a-z][a-z0-9-]*$)"
       multiplicity: "Required, exactly 1"
-      examples: ["commons", "match", "mechanic", "sensory", "player", "partnership", "scenario"]
+      examples: ["commons", "match", "mechanic", "sensory", "player", "partnership", "scenario", "qualification", "security", "operations"]
 
     category:
       definition: "Hierarchical path segments navigating down the resource tree"

--- a/src/atdd/planner/schemas/train.schema.json
+++ b/src/atdd/planner/schemas/train.schema.json
@@ -44,18 +44,8 @@
       "minItems": 1,
       "items": {
         "type": "string",
-        "enum": [
-          "commons",
-          "mechanic",
-          "scenario",
-          "match",
-          "sensory",
-          "player",
-          "league",
-          "audience",
-          "monetization",
-          "partnership"
-        ]
+        "pattern": "^[a-z][a-z0-9-]*$",
+        "description": "Kebab-case theme name. Built-in defaults (commons, mechanic, scenario, match, sensory, player, league, audience, monetization, partnership) may be overridden via the `themes` block in `.atdd/config.yaml`. Runtime validation resolves the effective map via `get_theme_map(config)` from `atdd.coach.utils.theme_map`."
       }
     },
     "primary_wagon": {

--- a/src/atdd/planner/schemas/wagon.schema.json
+++ b/src/atdd/planner/schemas/wagon.schema.json
@@ -40,8 +40,8 @@
     },
     "theme": {
       "type": "string",
-      "enum": ["mechanic","scenario","match","sensory","player","league","audience","monetization","partnership","commons"],
-      "description": "High-level category to group related wagons for navigation and reporting."
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "description": "High-level category to group related wagons for navigation and reporting. Kebab-case string. Built-in defaults (commons, mechanic, scenario, match, sensory, player, league, audience, monetization, partnership) may be overridden via the `themes` block in `.atdd/config.yaml`. Runtime validation resolves the effective map via `get_theme_map(config)` from `atdd.coach.utils.theme_map`."
     },
 
     "subject": {

--- a/src/atdd/planner/validators/test_custom_themes.py
+++ b/src/atdd/planner/validators/test_custom_themes.py
@@ -1,0 +1,256 @@
+"""
+Platform tests: Custom theme support via `.atdd/config.yaml`.
+
+Issue: #291 (feat(planner): support custom themes via .atdd/config.yaml)
+Phase: RED — these tests FAIL on current main.
+Gate: GT-010a
+
+Validates that consumer repos can declare custom theme names in
+`.atdd/config.yaml` under a `themes:` block, and that the planner's
+theme_map resolves digit → theme by merging hardcoded defaults with
+user overrides.
+
+URN: test:planner:custom-themes:config-load-merge
+
+Acceptance (from issue body, Phase 1 deliverables):
+- `.atdd/config.yaml` with `themes: {"1": "qualification"}` is parsed
+  and merged into theme_map.
+- A wagon with `theme: "qualification"` passes runtime validation when
+  config declares it.
+- Train `1001-*` resolves to theme `"qualification"` (not `"mechanic"`)
+  when override is active.
+- Unmapped digits fall back to built-in defaults.
+
+Target module (Phase 2 / GREEN): `atdd.coach.utils.theme_map`
+- `DEFAULT_THEME_MAP`: dict of 10 built-in digit→theme mappings
+- `get_theme_map(config: dict) -> dict`: merge helper (overrides win)
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module import guard — the helper does not yet exist (Phase 2 deliverable).
+# ImportError is the expected RED failure until `theme_map.py` is created.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_theme_map_module_is_importable():
+    """
+    SPEC-PLANNER-THEMES-0001: `atdd.coach.utils.theme_map` module exists.
+
+    The custom-theme feature promises a single source of truth for the
+    digit→theme mapping. The module must be importable; the import itself
+    is the smoke test that the helper was created.
+    """
+    from atdd.coach.utils import theme_map  # noqa: F401
+
+
+@pytest.mark.platform
+def test_default_theme_map_exposes_ten_builtin_themes():
+    """
+    SPEC-PLANNER-THEMES-0002: DEFAULT_THEME_MAP contains the 10 built-ins.
+
+    Digits 0-9 must map to the canonical ATDD-toolkit built-in theme
+    names. Changing these is a breaking (MAJOR) change and is out of
+    scope for #291.
+    """
+    from atdd.coach.utils.theme_map import DEFAULT_THEME_MAP
+
+    expected = {
+        "0": "commons",
+        "1": "mechanic",
+        "2": "scenario",
+        "3": "match",
+        "4": "sensory",
+        "5": "player",
+        "6": "league",
+        "7": "audience",
+        "8": "monetization",
+        "9": "partnership",
+    }
+    assert DEFAULT_THEME_MAP == expected, (
+        f"DEFAULT_THEME_MAP drift: got {DEFAULT_THEME_MAP}, "
+        f"expected {expected}. The 10 built-ins are a stable contract."
+    )
+
+
+@pytest.mark.platform
+def test_get_theme_map_returns_defaults_when_no_config():
+    """
+    SPEC-PLANNER-THEMES-0003: Empty config yields the default 10 themes.
+
+    Backward compatibility: existing consumer repos with no `themes:`
+    block in `.atdd/config.yaml` must continue to receive the original
+    10 built-in theme mappings unchanged.
+    """
+    from atdd.coach.utils.theme_map import get_theme_map
+
+    result = get_theme_map({})
+
+    assert result["0"] == "commons"
+    assert result["1"] == "mechanic"
+    assert result["9"] == "partnership"
+    assert len(result) == 10, (
+        f"Expected 10 digit keys in merged map, got {len(result)}"
+    )
+
+
+@pytest.mark.platform
+def test_get_theme_map_applies_single_override():
+    """
+    SPEC-PLANNER-THEMES-0004: Override wins over default for matching digit.
+
+    Consumer declares `themes: {"1": "qualification"}` → digit 1 resolves
+    to "qualification" (not the built-in "mechanic"). Unmapped digits
+    retain their defaults (Decision #5: unmapped digits fall back).
+    """
+    from atdd.coach.utils.theme_map import get_theme_map
+
+    config = {"themes": {"1": "qualification"}}
+    merged = get_theme_map(config)
+
+    assert merged["1"] == "qualification", (
+        f"Override for digit '1' should yield 'qualification', "
+        f"got '{merged['1']}'"
+    )
+    assert merged["0"] == "commons", "Digit 0 unmapped → should fall back"
+    assert merged["2"] == "scenario", "Digit 2 unmapped → should fall back"
+    assert merged["9"] == "partnership", "Digit 9 unmapped → should fall back"
+
+
+@pytest.mark.platform
+def test_get_theme_map_applies_multiple_overrides():
+    """
+    SPEC-PLANNER-THEMES-0005: Multiple overrides compose correctly.
+
+    The pluggy B2B-fintech case (issue origin) declares 3 overrides:
+    digit 1 → qualification, digit 2 → security, digit 3 → operations.
+    All three must land in the merged map; digits 4-9 fall back.
+    """
+    from atdd.coach.utils.theme_map import get_theme_map
+
+    config = {
+        "themes": {
+            "1": "qualification",
+            "2": "security",
+            "3": "operations",
+        }
+    }
+    merged = get_theme_map(config)
+
+    assert merged["1"] == "qualification"
+    assert merged["2"] == "security"
+    assert merged["3"] == "operations"
+    assert merged["0"] == "commons", "Digit 0 untouched → commons"
+    assert merged["4"] == "sensory", "Digit 4 untouched → sensory"
+
+
+@pytest.mark.platform
+def test_get_theme_map_accepts_integer_digit_keys():
+    """
+    SPEC-PLANNER-THEMES-0006: Integer and string digit keys both work.
+
+    YAML parsers may emit integer keys for bare digit tokens. The helper
+    must normalize integer keys (1) to string keys ("1") so downstream
+    code (which always uses string digits from train_id[0]) sees a
+    consistent shape.
+    """
+    from atdd.coach.utils.theme_map import get_theme_map
+
+    config = {"themes": {1: "qualification", 2: "security"}}
+    merged = get_theme_map(config)
+
+    assert merged["1"] == "qualification", (
+        "Integer YAML keys must be normalized to string digits"
+    )
+    assert merged["2"] == "security"
+
+
+@pytest.mark.platform
+def test_get_theme_map_ignores_missing_themes_key():
+    """
+    SPEC-PLANNER-THEMES-0007: Config without `themes` key = pure defaults.
+
+    A real-world `.atdd/config.yaml` contains `release`, `sync`,
+    `github`, etc. The helper must tolerate the absence of the optional
+    `themes` key without raising.
+    """
+    from atdd.coach.utils.theme_map import get_theme_map
+
+    config = {
+        "version": "1.0",
+        "release": {"version_file": "pyproject.toml", "tag_prefix": "v"},
+        "sync": {"agents": ["claude"]},
+    }
+    merged = get_theme_map(config)
+
+    assert merged["0"] == "commons"
+    assert merged["1"] == "mechanic"
+    assert len(merged) == 10
+
+
+@pytest.mark.platform
+def test_get_theme_map_tolerates_none_themes_value():
+    """
+    SPEC-PLANNER-THEMES-0008: `themes: null` (or missing value) = defaults.
+
+    A YAML block with `themes:` and no body parses to None. The helper
+    must treat None identically to a missing key.
+    """
+    from atdd.coach.utils.theme_map import get_theme_map
+
+    merged = get_theme_map({"themes": None})
+
+    assert len(merged) == 10
+    assert merged["1"] == "mechanic"
+
+
+@pytest.mark.platform
+def test_get_theme_map_is_pure_does_not_mutate_input():
+    """
+    SPEC-PLANNER-THEMES-0009: Helper does not mutate caller config.
+
+    `get_theme_map` is called from multiple validators and commands;
+    a shared config dict must not accumulate side effects across calls.
+    """
+    from atdd.coach.utils.theme_map import get_theme_map
+
+    config = {"themes": {"1": "qualification"}}
+    original_themes = dict(config["themes"])
+
+    _ = get_theme_map(config)
+
+    assert config["themes"] == original_themes, (
+        "Helper must not mutate caller-owned config dict"
+    )
+
+
+@pytest.mark.platform
+def test_train_id_resolves_theme_via_merged_map():
+    """
+    SPEC-PLANNER-THEMES-0010: Train `1001-*` resolves via merged theme_map.
+
+    End-to-end expectation from Phase 1 deliverable: when config declares
+    `themes: {"1": "qualification"}`, a train whose ID starts with digit
+    1 (e.g. `1001-qualify-lead-standard`) must resolve to theme
+    "qualification", not the built-in "mechanic".
+
+    This is the regression-proof check that existing call sites
+    (inventory.py L142, registry.py L1016, test_train_validation.py
+    L75) are rewired through `get_theme_map`.
+    """
+    from atdd.coach.utils.theme_map import get_theme_map
+
+    config = {"themes": {"1": "qualification"}}
+    theme_map = get_theme_map(config)
+
+    train_id = "1001-qualify-lead-standard"
+    first_digit = train_id[0]
+    resolved_theme = theme_map[first_digit]
+
+    assert resolved_theme == "qualification", (
+        f"Train '{train_id}' under override config should resolve to "
+        f"'qualification', got '{resolved_theme}'. This indicates the "
+        f"merge is not being applied at the digit→theme resolution site."
+    )

--- a/src/atdd/planner/validators/test_custom_themes_schema.py
+++ b/src/atdd/planner/validators/test_custom_themes_schema.py
@@ -1,0 +1,284 @@
+"""
+Platform tests: wagon.schema.json + train.schema.json theme pattern.
+
+Issue: #291 (feat(planner): support custom themes via .atdd/config.yaml)
+Phase: RED — these tests FAIL on current main.
+Gate: GT-010c
+
+Validates that the planner JSON Schemas relax the hardcoded `enum` on
+the `theme` field (wagon) and `themes.items` (train) to an open
+kebab-case string pattern `^[a-z][a-z0-9-]*$` (Decision #2: dynamic
+enums are impossible in static JSON Schema, so runtime validation
+handles theme-map merging and the schema only enforces shape).
+
+URN: test:planner:custom-themes:schema-pattern
+
+Acceptance:
+- `wagon.schema.json` `theme` is type=string with pattern, NOT enum.
+- `train.schema.json` `themes.items` is type=string with pattern,
+  NOT enum.
+- A wagon with `theme: "qualification"` passes schema validation.
+- A wagon with `theme: "UPPER"` or `theme: "1bad"` still fails (shape).
+- The 10 built-in theme names still pass (backward compatible).
+
+Target change (Phase 2 / GREEN):
+- `src/atdd/planner/schemas/wagon.schema.json` L43: enum → pattern.
+- `src/atdd/planner/schemas/train.schema.json` L47-58: enum → pattern.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.utils.repo import find_repo_root
+
+
+REPO_ROOT = find_repo_root()
+SCHEMAS_DIR = REPO_ROOT / "src" / "atdd" / "planner" / "schemas"
+WAGON_SCHEMA = SCHEMAS_DIR / "wagon.schema.json"
+TRAIN_SCHEMA = SCHEMAS_DIR / "train.schema.json"
+
+THEME_NAME_PATTERN = r"^[a-z][a-z0-9-]*$"
+
+BUILTIN_THEMES = [
+    "commons",
+    "mechanic",
+    "scenario",
+    "match",
+    "sensory",
+    "player",
+    "league",
+    "audience",
+    "monetization",
+    "partnership",
+]
+
+CUSTOM_THEMES = ["qualification", "security", "operations", "integration"]
+
+
+# ---------------------------------------------------------------------------
+# Schema loaders
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def wagon_schema() -> dict:
+    assert WAGON_SCHEMA.exists(), f"wagon.schema.json missing at {WAGON_SCHEMA}"
+    with open(WAGON_SCHEMA) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def train_schema() -> dict:
+    assert TRAIN_SCHEMA.exists(), f"train.schema.json missing at {TRAIN_SCHEMA}"
+    with open(TRAIN_SCHEMA) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def _wagon_validator(wagon_schema):
+    jsonschema = pytest.importorskip("jsonschema")
+    return jsonschema.Draft7Validator(wagon_schema)
+
+
+@pytest.fixture(scope="module")
+def _train_validator(train_schema):
+    jsonschema = pytest.importorskip("jsonschema")
+    return jsonschema.Draft7Validator(train_schema)
+
+
+@pytest.fixture
+def minimal_wagon() -> dict:
+    """A wagon manifest shape that passes all non-theme requirements."""
+    return {
+        "wagon": "qualify-leads",
+        "description": "Qualify inbound leads via chat",
+        "subject": "agent:qualifier",
+        "context": "inbound chat session",
+        "action": "scores lead fit against ICP criteria",
+        "goal": "confirm qualified-lead status before handoff",
+        "outcome": "lead state advances to QUALIFIED or DROPPED",
+        "produce": [],
+        "consume": [],
+        "wmbt": [],
+    }
+
+
+@pytest.fixture
+def minimal_train() -> dict:
+    """A train manifest shape that passes all non-theme requirements."""
+    return {
+        "train_id": "1001-qualify-lead-standard",
+        "title": "Qualify Lead Standard",
+        "description": "Standard lead qualification flow",
+        "themes": ["qualification"],
+        "participants": ["qualify-leads"],
+        "sequence": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# wagon.schema.json `theme` field shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_wagon_theme_is_not_static_enum(wagon_schema):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0001: wagon.theme drops static enum.
+
+    Custom themes from `.atdd/config.yaml` cannot be enumerated in a
+    static JSON Schema. The enum must be removed in favor of a pattern.
+    """
+    theme_prop = wagon_schema["properties"]["theme"]
+    assert "enum" not in theme_prop, (
+        "wagon.schema.json `theme` still has a static `enum`. "
+        "It must be replaced with `pattern: ^[a-z][a-z0-9-]*$` so "
+        "custom themes declared in .atdd/config.yaml are accepted."
+    )
+
+
+@pytest.mark.platform
+def test_wagon_theme_uses_kebab_case_pattern(wagon_schema):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0002: wagon.theme has kebab-case pattern.
+    """
+    theme_prop = wagon_schema["properties"]["theme"]
+    assert theme_prop.get("type") == "string"
+    assert theme_prop.get("pattern") == THEME_NAME_PATTERN, (
+        f"wagon.schema.json `theme` pattern must be "
+        f"{THEME_NAME_PATTERN!r}, got {theme_prop.get('pattern')!r}"
+    )
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize("custom", CUSTOM_THEMES)
+def test_wagon_accepts_custom_theme_name(_wagon_validator, minimal_wagon, custom):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0003: Custom kebab-case theme accepted.
+
+    A wagon declaring `theme: qualification` (semantic domain name from
+    consumer repo) must pass schema validation so the consumer can
+    complete planner phase without being forced into a game-domain
+    default.
+    """
+    doc = {**minimal_wagon, "theme": custom}
+    errors = list(_wagon_validator.iter_errors(doc))
+    theme_errors = [e for e in errors if "theme" in "/".join(str(p) for p in e.absolute_path)]
+    assert not theme_errors, (
+        f"Custom theme '{custom}' should pass wagon schema, got: "
+        f"{[e.message for e in theme_errors]}"
+    )
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize("builtin", BUILTIN_THEMES)
+def test_wagon_still_accepts_builtin_theme(_wagon_validator, minimal_wagon, builtin):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0004: All 10 built-ins still validate.
+
+    Backward compatibility: every built-in theme name from the original
+    enum must continue to pass after the switch to pattern.
+    """
+    doc = {**minimal_wagon, "theme": builtin}
+    errors = list(_wagon_validator.iter_errors(doc))
+    theme_errors = [e for e in errors if "theme" in "/".join(str(p) for p in e.absolute_path)]
+    assert not theme_errors, (
+        f"Built-in theme '{builtin}' must still validate, got: "
+        f"{[e.message for e in theme_errors]}"
+    )
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize(
+    "bad",
+    ["UPPER", "Qualification", "1bad", "-bad", "with space", "with_under", ""],
+)
+def test_wagon_rejects_malformed_theme(_wagon_validator, minimal_wagon, bad):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0005: Shape violations rejected.
+
+    Even with the enum removed, malformed strings (UPPER, digit-start,
+    spaces, underscores) must fail the kebab-case pattern.
+    """
+    doc = {**minimal_wagon, "theme": bad}
+    errors = list(_wagon_validator.iter_errors(doc))
+    theme_errors = [e for e in errors if "theme" in "/".join(str(p) for p in e.absolute_path)]
+    assert theme_errors, (
+        f"Malformed theme '{bad!r}' must be rejected by kebab-case pattern"
+    )
+
+
+# ---------------------------------------------------------------------------
+# train.schema.json `themes.items` field shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.platform
+def test_train_themes_items_is_not_static_enum(train_schema):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0006: train.themes.items drops static enum.
+    """
+    themes_prop = train_schema["properties"]["themes"]
+    items = themes_prop.get("items", {})
+    assert "enum" not in items, (
+        "train.schema.json `themes.items` still has a static `enum`. "
+        "It must be replaced with pattern-based validation."
+    )
+
+
+@pytest.mark.platform
+def test_train_themes_items_uses_kebab_case_pattern(train_schema):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0007: train.themes.items has the pattern.
+    """
+    items = train_schema["properties"]["themes"]["items"]
+    assert items.get("type") == "string"
+    assert items.get("pattern") == THEME_NAME_PATTERN, (
+        f"train.schema.json `themes.items` pattern must be "
+        f"{THEME_NAME_PATTERN!r}, got {items.get('pattern')!r}"
+    )
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize("custom", CUSTOM_THEMES)
+def test_train_accepts_custom_theme(_train_validator, minimal_train, custom):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0008: Custom theme name validates in train.
+    """
+    doc = {**minimal_train, "themes": [custom]}
+    errors = list(_train_validator.iter_errors(doc))
+    theme_errors = [e for e in errors if "themes" in "/".join(str(p) for p in e.absolute_path)]
+    assert not theme_errors, (
+        f"Custom theme '{custom}' should pass train schema, got: "
+        f"{[e.message for e in theme_errors]}"
+    )
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize("builtin", BUILTIN_THEMES)
+def test_train_still_accepts_builtin_theme(_train_validator, minimal_train, builtin):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0009: Built-in themes still validate in train.
+    """
+    doc = {**minimal_train, "themes": [builtin]}
+    errors = list(_train_validator.iter_errors(doc))
+    theme_errors = [e for e in errors if "themes" in "/".join(str(p) for p in e.absolute_path)]
+    assert not theme_errors, (
+        f"Built-in theme '{builtin}' must still pass, got: "
+        f"{[e.message for e in theme_errors]}"
+    )
+
+
+@pytest.mark.platform
+@pytest.mark.parametrize("bad", ["UPPER", "1bad", "with space"])
+def test_train_rejects_malformed_theme(_train_validator, minimal_train, bad):
+    """
+    SPEC-PLANNER-SCHEMA-THEMES-0010: Shape violations rejected in train.
+    """
+    doc = {**minimal_train, "themes": [bad]}
+    errors = list(_train_validator.iter_errors(doc))
+    theme_errors = [e for e in errors if "themes" in "/".join(str(p) for p in e.absolute_path)]
+    assert theme_errors, (
+        f"Malformed theme '{bad!r}' must be rejected in train schema"
+    )

--- a/src/atdd/planner/validators/test_train_validation.py
+++ b/src/atdd/planner/validators/test_train_validation.py
@@ -468,24 +468,14 @@ def test_train_artifacts_exist_in_wagons(trains_registry, wagon_manifests):
 @pytest.mark.platform
 def test_registry_themes_are_valid(trains_registry):
     """
-    SPEC-TRAIN-VAL-0010: Registry theme keys match schema enum
+    SPEC-TRAIN-VAL-0010: Registry theme keys match the effective theme map
 
     Given: Train registry organized by themes
     When: Checking theme keys
-    Then: All theme keys are valid according to train.schema.json
+    Then: All theme keys are valid — either a built-in default or an
+          override declared under `themes:` in `.atdd/config.yaml` (#291).
     """
-    valid_themes = {
-        "commons",
-        "mechanic",
-        "scenario",
-        "match",
-        "sensory",
-        "player",
-        "league",
-        "audience",
-        "monetization",
-        "partnership",
-    }
+    valid_themes = set(_merged_theme_map().values())
 
     invalid_themes = []
     for theme in trains_registry.keys():

--- a/src/atdd/planner/validators/test_train_validation.py
+++ b/src/atdd/planner/validators/test_train_validation.py
@@ -29,11 +29,18 @@ from pathlib import Path
 from typing import Dict, List, Set, Tuple, Any, Optional
 
 from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.utils.config import load_atdd_config
+from atdd.coach.utils.theme_map import get_theme_map
 from atdd.coach.utils.train_spec_phase import (
     TrainSpecPhase,
     should_enforce,
     emit_phase_warning
 )
+
+
+def _merged_theme_map() -> Dict[str, str]:
+    """Merged digit→theme map for the repo under test (#291)."""
+    return get_theme_map(load_atdd_config(find_repo_root()))
 
 
 @pytest.mark.platform
@@ -72,18 +79,7 @@ def test_train_theme_matches_first_digit(trains_registry):
     When: Checking train_id first digit
     Then: First digit maps to correct theme category
     """
-    theme_map = {
-        "0": "commons",
-        "1": "mechanic",
-        "2": "scenario",
-        "3": "match",
-        "4": "sensory",
-        "5": "player",
-        "6": "league",
-        "7": "audience",
-        "8": "monetization",
-        "9": "partnership",
-    }
+    theme_map = _merged_theme_map()
 
     mismatches = []
     for theme, trains in trains_registry.items():
@@ -730,11 +726,10 @@ def test_train_theme_derived_from_group_key(trains_registry_with_groups):
         else:
             derived_theme = theme_key
 
-        # Verify derived theme is valid
-        valid_themes = {
-            "commons", "mechanic", "scenario", "match", "sensory",
-            "player", "league", "audience", "monetization", "partnership"
-        }
+        # Verify derived theme is valid — use merged theme map so
+        # consumer repos that override defaults in .atdd/config.yaml
+        # pass validation (#291).
+        valid_themes = set(_merged_theme_map().values())
 
         assert derived_theme in valid_themes, \
             f"Invalid derived theme '{derived_theme}' from group key '{theme_key}'"


### PR DESCRIPTION
Closes #291

## WMBT Sub-Issues

- [ ] #297 — wmbt:govern-lifecycle:D005 — minimize quantity of config-files-unable-to-declare-domain-specific-theme-mappings when a consumer repo in a non-game domain needs to declare themes that match its bounded contexts but .atdd/config.yaml has no schema slot for theme overrides
- [ ] #298 — wmbt:govern-lifecycle:D006 — minimize quantity of duplicated-hardcoded-theme-map-dicts-across-modules when theme_map dicts are hardcoded in inventory.py, registry.py, and test_train_validation.py blocking any config-driven override
- [ ] #299 — wmbt:govern-lifecycle:L001 — minimize effort of manual-theme-discovery-during-atdd-init when atdd init runs in a consumer repo that already contains plan/**/*.yaml files with theme: entries
- [ ] #300 — wmbt:govern-lifecycle:P001 — minimize frequency of blind-theme-prompts-that-force-game-domain-defaults-on-non-game-repos when atdd init runs interactively without a scan-first flow
- [ ] #301 — wmbt:govern-lifecycle:C001 — minimize likelihood of invalid-custom-theme-names-accepted-into-config when a consumer declares themes in .atdd/config.yaml and the validator must confirm kebab-case shape, single digit keys, and non-empty names
- [ ] #302 — wmbt:govern-lifecycle:E001 — minimize likelihood of schema-validation-failures-on-valid-custom-theme-names when a wagon or train declares a custom theme value from .atdd/config.yaml and static JSON Schema enums reject it
- [ ] #303 — wmbt:govern-lifecycle:M001 — minimize likelihood of silent-commons-digit-overrides-that-break-cross-repo-tooling when a consumer overrides digit 0 in .atdd/config.yaml themes block replacing commons with a domain-specific name

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #291 |
| Type | implementation |
| Slug | custom-themes |
| Labels | atdd-issue, atdd:REFACTOR, archetype:coach, wagon:govern-lifecycle |

---
PR created by `atdd pr`.