### PR TITLE
feat(atdd): Enforce Issue Label Compliance (#296)

### DIFF
--- a/.atdd/baselines/coder.yaml
+++ b/.atdd/baselines/coder.yaml
@@ -1,1 +1,1 @@
-hierarchy_coverage_features: 10
+hierarchy_coverage_features: 11

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -49,7 +49,7 @@ sessions:
   file: null
   issue_number: 296
   type: implementation
-  status: PLANNED
+  status: RED
   created: '2026-04-17'
   archived: null
   wagon: govern-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -49,7 +49,7 @@ sessions:
   file: null
   issue_number: 296
   type: implementation
-  status: SMOKE
+  status: REFACTOR
   created: '2026-04-17'
   archived: null
   wagon: govern-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -49,7 +49,7 @@ sessions:
   file: null
   issue_number: 296
   type: implementation
-  status: GREEN
+  status: SMOKE
   created: '2026-04-17'
   archived: null
   wagon: govern-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -49,7 +49,7 @@ sessions:
   file: null
   issue_number: 296
   type: implementation
-  status: RED
+  status: GREEN
   created: '2026-04-17'
   archived: null
   wagon: govern-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -49,7 +49,7 @@ sessions:
   file: null
   issue_number: 296
   type: implementation
-  status: INIT
+  status: PLANNED
   created: '2026-04-17'
   archived: null
   wagon: govern-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -52,6 +52,9 @@ sessions:
   status: INIT
   created: '2026-04-17'
   archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:enforce-issue-label-compliance
+  train: 0001-self-compliance-validate
 - id: '304'
   slug: fix-github-client-mock-drift
   file: null

--- a/plan/govern_lifecycle/D005.yaml
+++ b/plan/govern_lifecycle/D005.yaml
@@ -1,0 +1,34 @@
+urn: "wmbt:govern-lifecycle:D005"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "unlabeled-open-issues-invisible-to-coach-validators"
+context_clarifier: "when atdd validate coach filters by the atdd-issue label (conftest.py:81) and therefore silently drops any open issue lacking that label, making non-compliant issues unreachable by every existing coach validator"
+lens: "functional.effectiveness"
+statement: "minimize quantity of unlabeled-open-issues-invisible-to-coach-validators when atdd validate coach filters by the atdd-issue label (conftest.py:81) and therefore silently drops any open issue lacking that label, making non-compliant issues unreachable by every existing coach validator"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D005-UNIT-001-fail-on-unlabeled-open-issue"
+      id: "AC-UNIT-001"
+      purpose: "test_unlabeled_open_issues fails with a clear message naming every open issue that lacks the atdd-issue label"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A stub GitHub repo state with at least one open issue lacking the atdd-issue label"
+        - "An all_open_issues_unfiltered fixture that does NOT filter by label"
+    when:
+      abstract: "test_unlabeled_open_issues runs under atdd validate coach"
+    then:
+      abstract:
+        - "The validator FAILs with exit code non-zero"
+        - "The failure message names every offending open issue by number"
+        - "The failure message suggests a remediation command (gh issue edit <N> --add-label atdd-issue or atdd issue sync-labels <N>)"
+    signal:
+      metric: "unlabeled_open_issue_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/D006.yaml
+++ b/plan/govern_lifecycle/D006.yaml
@@ -1,0 +1,33 @@
+urn: "wmbt:govern-lifecycle:D006"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "atdd-issues-missing-required-label-set"
+context_clarifier: "when an atdd-issue-labeled open issue lacks one of the required label families (atdd:<PHASE>, at least one archetype:*, at least one wagon:*) so the label set drifts from the issue body metadata"
+lens: "functional.effectiveness"
+statement: "minimize quantity of atdd-issues-missing-required-label-set when an atdd-issue-labeled open issue lacks one of the required label families (atdd:<PHASE>, at least one archetype:*, at least one wagon:*) so the label set drifts from the issue body metadata"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D006-UNIT-001-require-phase-archetype-wagon-triplet"
+      id: "AC-UNIT-001"
+      purpose: "test_required_label_set fails when an atdd-issue-labeled issue is missing any of: atdd:<PHASE>, archetype:*, or wagon:*"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "An atdd-issue-labeled open issue whose label set is missing at least one of atdd:<PHASE>, archetype:*, wagon:*"
+    when:
+      abstract: "test_required_label_set runs under atdd validate coach"
+    then:
+      abstract:
+        - "The validator FAILs with exit code non-zero"
+        - "The failure message names the offending issue and which label family is missing"
+        - "The failure message suggests atdd issue sync-labels <N> as the supervised repair path"
+    signal:
+      metric: "issues_missing_required_label_family_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/D007.yaml
+++ b/plan/govern_lifecycle/D007.yaml
@@ -1,0 +1,51 @@
+urn: "wmbt:govern-lifecycle:D007"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "label-drift-between-issue-body-metadata-and-github-labels"
+context_clarifier: "when issue body rows (Archetypes, Wagon, Status) disagree with the GitHub label set so agents and humans have no supervised way to re-derive and apply the expected labels idempotently"
+lens: "functional.effectiveness"
+statement: "minimize quantity of label-drift-between-issue-body-metadata-and-github-labels when issue body rows (Archetypes, Wagon, Status) disagree with the GitHub label set so agents and humans have no supervised way to re-derive and apply the expected labels idempotently"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D007-UNIT-001-sync-labels-dry-run-derives-expected-set"
+      id: "AC-UNIT-001"
+      purpose: "atdd issue sync-labels --dry-run prints the derived label delta without mutating GitHub"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "An atdd-issue-labeled open issue whose GitHub labels drift from body metadata"
+    when:
+      abstract: "atdd issue sync-labels <N> --dry-run is invoked"
+    then:
+      abstract:
+        - "Exit code is 0"
+        - "Stdout lists every label to add and every label to remove"
+        - "The real GitHub label set is unchanged after the invocation"
+  - identity:
+      urn: "acc:govern-lifecycle:D007-UNIT-002-sync-labels-applies-delta-idempotently"
+      id: "AC-UNIT-002"
+      purpose: "atdd issue sync-labels without --dry-run applies the derived delta and is idempotent on a second run"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "An atdd-issue-labeled open issue whose GitHub labels drift from body metadata"
+    when:
+      abstract: "atdd issue sync-labels <N> is invoked, then invoked again"
+    then:
+      abstract:
+        - "The first invocation applies the delta via gh issue edit calls"
+        - "The second invocation is a no-op (zero gh edit calls, exit 0)"
+        - "Issue body text is never mutated"
+    signal:
+      metric: "post_sync_label_drift_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/D008.yaml
+++ b/plan/govern_lifecycle/D008.yaml
@@ -1,0 +1,33 @@
+urn: "wmbt:govern-lifecycle:D008"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "pushed-commits-referencing-unlabeled-issues"
+context_clarifier: "when an outgoing commit references #NNN but the target issue lacks atdd compliance labels so the unlabeled-drift root cause reappears at push time with no pre-push enforcement"
+lens: "functional.effectiveness"
+statement: "minimize quantity of pushed-commits-referencing-unlabeled-issues when an outgoing commit references #NNN but the target issue lacks atdd compliance labels so the unlabeled-drift root cause reappears at push time with no pre-push enforcement"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D008-UNIT-001-pre-push-hook-blocks-unlabeled-reference"
+      id: "AC-UNIT-001"
+      purpose: "Pre-push hook fails fast when an outgoing commit references an issue that lacks the atdd-issue label"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "An outgoing commit whose message contains a #NNN reference to an open issue lacking atdd-issue"
+    when:
+      abstract: "git push runs the claude-pre-tool-use.sh / pre-push hook"
+    then:
+      abstract:
+        - "The hook exits with non-zero status"
+        - "The hook prints the offending issue number and a sync-labels remediation hint"
+        - "The push is blocked until labels are backfilled"
+    signal:
+      metric: "unlabeled_issue_push_attempts"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-04-17"

--- a/plan/govern_lifecycle/_govern_lifecycle.yaml
+++ b/plan/govern_lifecycle/_govern_lifecycle.yaml
@@ -31,12 +31,17 @@ consume:
 features:
   - urn: "feature:govern-lifecycle:fix-issue-transition-side-effects"
   - urn: "feature:govern-lifecycle:enforce-orchestrate-ready-lifecycle"
+  - urn: "feature:govern-lifecycle:enforce-issue-label-compliance"
 
 wmbt:
-  total: 6
+  total: 10
   R001: "minimize stale local manifest status after a successful GitHub transition"
   R002: "minimize misleading layout errors during post-transition re-enter"
   D001: "minimize issues created without orchestrate-ready template body"
   D002: "minimize parent issues without GitHub WMBT sub-issues when plan artifacts exist"
   D003: "minimize undetected template drift across open issues"
   D004: "minimize missed parallelization opportunities at issue creation time"
+  D005: "minimize unlabeled open issues invisible to coach validators"
+  D006: "minimize atdd-issues missing required label set (phase/archetype/wagon)"
+  D007: "minimize label drift between issue body metadata and GitHub labels"
+  D008: "minimize pushed commits referencing unlabeled issues"

--- a/plan/govern_lifecycle/features/enforce_issue_label_compliance.yaml
+++ b/plan/govern_lifecycle/features/enforce_issue_label_compliance.yaml
@@ -1,0 +1,30 @@
+urn: "feature:govern-lifecycle:enforce-issue-label-compliance"
+wagon: "wagon:govern-lifecycle"
+description: "Closes the inverse-filter gap by asserting every open repo issue carries atdd-issue, enforcing the required phase/archetype/wagon label triplet, and providing atdd issue sync-labels for supervised drift repair"
+sizing:
+  wmbts: 4
+  footprint_score: 9
+  footprint_size: "S"
+wmbts:
+  - "wmbt:govern-lifecycle:D005"
+  - "wmbt:govern-lifecycle:D006"
+  - "wmbt:govern-lifecycle:D007"
+  - "wmbt:govern-lifecycle:D008"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 1
+        rationale: "One new CLI subcommand: atdd issue sync-labels [<N>|--all] with --dry-run"
+    application:
+      - type: "use_cases"
+        count: 4
+        rationale: "sync_labels derivation+apply; all_open_issues_unfiltered fixture; test_unlabeled_open_issues validator; test_required_label_set validator"
+    domain:
+      - type: "entities"
+        count: 0
+        rationale: "No new domain concepts — label taxonomy and issue metadata already exist"
+    integration:
+      - type: "repositories"
+        count: 0
+        rationale: "Reuses existing GitHub client (gh issue view/edit) and label_taxonomy.schema.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.57.0"
+version = "1.58.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -1474,7 +1474,25 @@ Phase descriptions:
             apply_all = getattr(args, 'all_issues', False)
             number_str = getattr(args, 'number', None)
             if apply_all:
-                return manager.sync_labels_all(dry_run=dry_run)
+                results = manager.sync_labels_all(dry_run=dry_run)
+                drifted = [
+                    (num, delta) for num, delta in results
+                    if delta["to_add"] or delta["to_remove"]
+                ]
+                for num, delta in drifted:
+                    _print_sync_labels_delta(num, delta, dry_run=dry_run)
+                if not drifted:
+                    print(
+                        f"sync-labels: every open atdd-issue already matches "
+                        f"body metadata ({len(results)} checked)"
+                    )
+                else:
+                    suffix = " (dry-run)" if dry_run else ""
+                    print(
+                        f"sync-labels: {len(drifted)}/{len(results)} "
+                        f"issue(s) drifted{suffix}"
+                    )
+                return 0
             if not number_str:
                 print("Error: atdd issue sync-labels requires an issue number or --all")
                 return 1

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -59,6 +59,25 @@ from atdd.coach.utils.repo import find_repo_root
 from atdd.version_check import print_update_notice, print_upgrade_sync_notice
 
 
+def _print_sync_labels_delta(
+    issue_number: int,
+    delta: dict,
+    dry_run: bool,
+) -> None:
+    """Print the add/remove delta produced by ``IssueManager.sync_labels``."""
+    to_add = delta.get("to_add", [])
+    to_remove = delta.get("to_remove", [])
+    verb = "would" if dry_run else "did"
+    if not to_add and not to_remove:
+        print(f"#{issue_number}: labels already match body metadata (no-op)")
+        return
+    print(f"#{issue_number}: sync-labels {'dry-run' if dry_run else 'applied'}")
+    if to_add:
+        print(f"  {verb} add:    {', '.join(to_add)}")
+    if to_remove:
+        print(f"  {verb} remove: {', '.join(to_remove)}")
+
+
 def _deprecation_warning(old: str, new: str) -> None:
     """Emit a deprecation warning for legacy flags."""
     print(f"\033[33m⚠️  Deprecated: '{old}' will be removed. Use '{new}' instead.\033[0m")
@@ -588,10 +607,12 @@ Phase descriptions:
         help="Unified issue lifecycle command",
         description=(
             "Enter an existing issue (by number) or create a new one (by slug).\n\n"
-            "  atdd issue 126              Enter issue #126 (state-driven)\n"
-            "  atdd issue my-feature       Create new issue and enter at INIT\n"
-            "  atdd issue 126 --status RED Transition status\n"
-            "  atdd issue open             List open issues\n"
+            "  atdd issue 126                     Enter issue #126 (state-driven)\n"
+            "  atdd issue my-feature              Create new issue and enter at INIT\n"
+            "  atdd issue 126 --status RED        Transition status\n"
+            "  atdd issue open                    List open issues\n"
+            "  atdd issue sync-labels 126         Re-derive labels from body metadata\n"
+            "  atdd issue sync-labels --all       Re-derive labels across every atdd-issue\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
@@ -599,7 +620,13 @@ Phase descriptions:
         "target",
         type=str,
         nargs="?",
-        help="Issue number (integer) to enter, slug (string) to create, or 'open' to list"
+        help="Issue number (int), slug (str), 'open' (list), or 'sync-labels'"
+    )
+    issue_parser.add_argument(
+        "number",
+        type=str,
+        nargs="?",
+        help="Issue number when target is 'sync-labels'"
     )
     issue_parser.add_argument(
         "--status", "-s",
@@ -662,6 +689,18 @@ Phase descriptions:
         "--train",
         type=str,
         help="Train ID to assign on creation"
+    )
+    issue_parser.add_argument(
+        "--all",
+        action="store_true",
+        dest="all_issues",
+        help="Apply sync-labels to every atdd-issue (and atdd-wmbt) in the repo"
+    )
+    issue_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Report sync-labels delta without mutating GitHub"
     )
     issue_parser.add_argument(
         "--archetypes", "-a",
@@ -1427,6 +1466,26 @@ Phase descriptions:
                 limit=getattr(args, 'limit', 30),
                 assignee=getattr(args, 'assignee', None),
             )
+
+        # atdd issue sync-labels [<N>|--all] [--dry-run]
+        if target == "sync-labels":
+            manager = IssueManager()
+            dry_run = getattr(args, 'dry_run', False)
+            apply_all = getattr(args, 'all_issues', False)
+            number_str = getattr(args, 'number', None)
+            if apply_all:
+                return manager.sync_labels_all(dry_run=dry_run)
+            if not number_str:
+                print("Error: atdd issue sync-labels requires an issue number or --all")
+                return 1
+            try:
+                issue_number = int(number_str)
+            except ValueError:
+                print(f"Error: invalid issue number '{number_str}'")
+                return 1
+            delta = manager.sync_labels(issue_number, dry_run=dry_run)
+            _print_sync_labels_delta(issue_number, delta, dry_run=dry_run)
+            return 0
 
         # Detect mode: integer → enter, string → create (future)
         try:

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -20,7 +20,7 @@ import re
 import subprocess
 from datetime import date
 from pathlib import Path
-from typing import Dict, List, Optional, Any, Tuple
+from typing import Dict, List, Optional, Any, Set, Tuple
 
 import yaml
 
@@ -468,6 +468,116 @@ class IssueManager:
         else:
             print(f"sync_wmbts: #{issue_number} already has all WMBT sub-issues")
         return created
+
+    # -------------------------------------------------------------------------
+    # sync_labels — derive label set from body metadata, apply delta
+    # -------------------------------------------------------------------------
+
+    # Phase labels the schema declares as ``exactly_one`` and swap-on-transition.
+    _PHASE_LABELS = (
+        "atdd:INIT", "atdd:PLANNED", "atdd:RED", "atdd:GREEN",
+        "atdd:SMOKE", "atdd:REFACTOR", "atdd:COMPLETE", "atdd:BLOCKED",
+    )
+
+    def _derive_expected_labels(self, body: str) -> List[str]:
+        """Compute the label set implied by the Issue Metadata table.
+
+        Source of truth is the ``## Issue Metadata`` table:
+        - ``Status`` → ``atdd:<STATUS>`` (phase label)
+        - ``Archetypes`` → one ``archetype:<id>`` per comma-separated entry
+        - ``Wagon`` → one ``wagon:<slug>`` (accepts bare slug or ``wagon:slug``)
+
+        ``atdd-issue`` is always included because any issue with the
+        PARENT template is by definition a parent issue.
+        """
+        from atdd.coach.commands.session_template import parse_metadata
+
+        meta = parse_metadata(body or "")
+        expected: List[str] = ["atdd-issue"]
+
+        status = (meta.get("Status") or "").strip().upper()
+        if status and status != "TBD":
+            expected.append(f"atdd:{status}")
+
+        archetypes_raw = (meta.get("Archetypes") or "").strip()
+        if archetypes_raw and archetypes_raw.upper() != "TBD":
+            for part in archetypes_raw.split(","):
+                name = part.strip()
+                if name and name.upper() != "TBD":
+                    expected.append(f"archetype:{name}")
+
+        wagon_raw = (meta.get("Wagon") or "").strip()
+        if wagon_raw and wagon_raw.upper() != "TBD":
+            # Accept ``wagon:govern-lifecycle`` or bare ``govern-lifecycle``.
+            slug = wagon_raw.removeprefix("wagon:").strip()
+            if slug:
+                expected.append(f"wagon:{slug}")
+
+        return expected
+
+    def _labels_in_scope_for_sync(self, label: str) -> bool:
+        """Only these label families are managed by ``sync_labels``.
+
+        Non-ATDD labels (e.g., ``bug``, ``good-first-issue``) are left
+        alone — sync_labels is idempotent on its own surface and never
+        removes labels outside the scheme.
+        """
+        if label == "atdd-issue":
+            return True
+        if label.startswith("atdd:"):
+            return True
+        if label.startswith("archetype:"):
+            return True
+        if label.startswith("wagon:"):
+            return True
+        return False
+
+    def sync_labels(
+        self, issue_number: int, dry_run: bool = False,
+    ) -> Dict[str, List[str]]:
+        """Read the issue body on GitHub, derive the expected label set
+        from the Issue Metadata table, and apply the delta.
+
+        Returns a dict with ``to_add`` and ``to_remove`` lists so callers
+        (CLI, tests) can report the delta.
+
+        In dry-run mode the lists are computed but no ``add_label`` /
+        ``remove_label`` calls are issued.
+
+        Only labels inside the ATDD scheme (``atdd-issue``, ``atdd:*``,
+        ``archetype:*``, ``wagon:*``) are compared — unrelated labels on
+        the issue are left untouched.
+        """
+        client = self._get_github_client()
+        issue = client.get_issue(issue_number)
+
+        body = issue.get("body") or ""
+        current_raw = issue.get("labels") or []
+        current_labels: Set[str] = set()
+        for entry in current_raw:
+            if isinstance(entry, dict):
+                name = entry.get("name")
+                if name:
+                    current_labels.add(name)
+            elif isinstance(entry, str):
+                current_labels.add(entry)
+
+        expected = set(self._derive_expected_labels(body))
+
+        in_scope_current = {lbl for lbl in current_labels if self._labels_in_scope_for_sync(lbl)}
+
+        to_add = sorted(expected - current_labels)
+        to_remove = sorted(in_scope_current - expected)
+
+        if dry_run:
+            return {"to_add": to_add, "to_remove": to_remove}
+
+        if to_add:
+            client.add_label(issue_number, to_add)
+        if to_remove:
+            client.remove_label(issue_number, to_remove)
+
+        return {"to_add": to_add, "to_remove": to_remove}
 
     def _discover_wmbts(self, wagon: str) -> List[Dict[str, Any]]:
         """Discover WMBTs from plan YAML for a wagon."""

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -484,34 +484,46 @@ class IssueManager:
 
         Source of truth is the ``## Issue Metadata`` table:
         - ``Status`` → ``atdd:<STATUS>`` (phase label)
-        - ``Archetypes`` → one ``archetype:<id>`` per comma-separated entry
-        - ``Wagon`` → one ``wagon:<slug>`` (accepts bare slug or ``wagon:slug``)
+        - ``Archetypes`` → one ``archetype:<id>`` per comma-separated entry,
+          backticks tolerated on each entry (e.g., ```coach`, `planner``)
+        - ``Wagon`` → one ``wagon:<slug>`` per ``wagon:X`` token found in
+          the row; descriptive trailers are tolerated
+          (e.g., ``wagon:a (primary), wagon:b (secondary) — note``).
 
         ``atdd-issue`` is always included because any issue with the
         PARENT template is by definition a parent issue.
         """
+        import re
         from atdd.coach.commands.session_template import parse_metadata
 
         meta = parse_metadata(body or "")
         expected: List[str] = ["atdd-issue"]
 
-        status = (meta.get("Status") or "").strip().upper()
+        status = (meta.get("Status") or "").strip().strip("`").upper()
         if status and status != "TBD":
             expected.append(f"atdd:{status}")
 
         archetypes_raw = (meta.get("Archetypes") or "").strip()
         if archetypes_raw and archetypes_raw.upper() != "TBD":
             for part in archetypes_raw.split(","):
-                name = part.strip()
+                name = part.strip().strip("`").strip()
                 if name and name.upper() != "TBD":
                     expected.append(f"archetype:{name}")
 
         wagon_raw = (meta.get("Wagon") or "").strip()
         if wagon_raw and wagon_raw.upper() != "TBD":
-            # Accept ``wagon:govern-lifecycle`` or bare ``govern-lifecycle``.
-            slug = wagon_raw.removeprefix("wagon:").strip()
-            if slug:
-                expected.append(f"wagon:{slug}")
+            # Accept multiple ``wagon:X`` tokens in the row (cross-wagon
+            # issues are first-class per Decision #5). Tolerate backticks
+            # and descriptive trailers. Fall back to bare slug if the row
+            # contains no ``wagon:`` prefix.
+            matches = re.findall(r"wagon:([a-z][a-z0-9-]*)", wagon_raw)
+            if matches:
+                for slug in matches:
+                    expected.append(f"wagon:{slug}")
+            else:
+                slug = wagon_raw.strip("`").strip()
+                if re.fullmatch(r"[a-z][a-z0-9-]*", slug):
+                    expected.append(f"wagon:{slug}")
 
         return expected
 

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -579,6 +579,39 @@ class IssueManager:
 
         return {"to_add": to_add, "to_remove": to_remove}
 
+    def sync_labels_all(self, dry_run: bool = False) -> int:
+        """Apply sync_labels to every open ``atdd-issue`` in the repo.
+
+        Sub-issues (``atdd-wmbt``) are out of scope — their label surface
+        is ``atdd-wmbt`` only and is maintained by ``sync_wmbts``.
+
+        Returns 0 on success so the CLI can exit cleanly.
+        """
+        client = self._get_github_client()
+        issues = client.list_issues_by_label("atdd-issue", include_body=False)
+        drift_count = 0
+        for issue in issues:
+            number = issue.get("number")
+            if not number:
+                continue
+            delta = self.sync_labels(int(number), dry_run=dry_run)
+            if delta["to_add"] or delta["to_remove"]:
+                drift_count += 1
+                verb = "would" if dry_run else "did"
+                to_add = delta["to_add"]
+                to_remove = delta["to_remove"]
+                print(f"#{number}: sync-labels {'dry-run' if dry_run else 'applied'}")
+                if to_add:
+                    print(f"  {verb} add:    {', '.join(to_add)}")
+                if to_remove:
+                    print(f"  {verb} remove: {', '.join(to_remove)}")
+        if drift_count == 0:
+            print(f"sync-labels: every open atdd-issue already matches body metadata ({len(issues)} checked)")
+        else:
+            suffix = " (dry-run)" if dry_run else ""
+            print(f"sync-labels: {drift_count}/{len(issues)} issue(s) drifted{suffix}")
+        return 0
+
     def _discover_wmbts(self, wagon: str) -> List[Dict[str, Any]]:
         """Discover WMBTs from plan YAML for a wagon."""
         plan_dir = self.target_dir / "plan"

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -591,38 +591,28 @@ class IssueManager:
 
         return {"to_add": to_add, "to_remove": to_remove}
 
-    def sync_labels_all(self, dry_run: bool = False) -> int:
+    def sync_labels_all(
+        self, dry_run: bool = False,
+    ) -> List[Tuple[int, Dict[str, List[str]]]]:
         """Apply sync_labels to every open ``atdd-issue`` in the repo.
 
         Sub-issues (``atdd-wmbt``) are out of scope — their label surface
         is ``atdd-wmbt`` only and is maintained by ``sync_wmbts``.
 
-        Returns 0 on success so the CLI can exit cleanly.
+        Returns a list of ``(issue_number, delta)`` tuples so callers
+        (CLI, tests) can render output. Presentation is not this method's
+        responsibility — see ``_print_sync_labels_delta`` in cli.py.
         """
         client = self._get_github_client()
         issues = client.list_issues_by_label("atdd-issue", include_body=False)
-        drift_count = 0
+        results: List[Tuple[int, Dict[str, List[str]]]] = []
         for issue in issues:
             number = issue.get("number")
             if not number:
                 continue
             delta = self.sync_labels(int(number), dry_run=dry_run)
-            if delta["to_add"] or delta["to_remove"]:
-                drift_count += 1
-                verb = "would" if dry_run else "did"
-                to_add = delta["to_add"]
-                to_remove = delta["to_remove"]
-                print(f"#{number}: sync-labels {'dry-run' if dry_run else 'applied'}")
-                if to_add:
-                    print(f"  {verb} add:    {', '.join(to_add)}")
-                if to_remove:
-                    print(f"  {verb} remove: {', '.join(to_remove)}")
-        if drift_count == 0:
-            print(f"sync-labels: every open atdd-issue already matches body metadata ({len(issues)} checked)")
-        else:
-            suffix = " (dry-run)" if dry_run else ""
-            print(f"sync-labels: {drift_count}/{len(issues)} issue(s) drifted{suffix}")
-        return 0
+            results.append((int(number), delta))
+        return results
 
     def _discover_wmbts(self, wagon: str) -> List[Dict[str, Any]]:
         """Discover WMBTs from plan YAML for a wagon."""

--- a/src/atdd/coach/commands/tests/test_sync_labels.py
+++ b/src/atdd/coach/commands/tests/test_sync_labels.py
@@ -1,0 +1,270 @@
+"""
+RED tests for #296 D007 — ``IssueManager.sync_labels(issue_number, dry_run)``
+reads issue body metadata, derives the expected label set, diffs against
+the current GitHub labels, and applies the delta (or reports it in
+dry-run).
+
+WMBTs covered:
+- wmbt:govern-lifecycle:D007 — acc:govern-lifecycle:D007-UNIT-001-sync-labels-dry-run-derives-expected-set
+- wmbt:govern-lifecycle:D007 — acc:govern-lifecycle:D007-UNIT-002-sync-labels-applies-delta-idempotently
+
+Test strategy
+-------------
+The GitHub client double is built via ``create_autospec(GitHubClient, instance=True)``
+so any method-name drift between the caller and the real class surface is
+caught at call time (same discipline as ``test_sync_wmbts`` after the
+#304 incident).
+
+Body fixture shape is the real PARENT-ISSUE-TEMPLATE.md metadata table —
+the validator reads ``Archetypes``, ``Wagon``, and ``Status`` rows, so
+those rows drive the expected label set.
+
+Run:
+    PYTHONPATH=src python3 -m pytest -q \
+        src/atdd/coach/commands/tests/test_sync_labels.py -v
+"""
+from pathlib import Path
+from typing import Dict, List, Optional
+from unittest.mock import create_autospec
+
+import pytest
+
+from atdd.coach.github import GitHubClient
+
+
+pytestmark = [pytest.mark.platform]
+
+
+def _body_with_metadata(
+    status: str = "INIT",
+    archetypes: str = "coach",
+    wagon: str = "govern-lifecycle",
+) -> str:
+    """Render the minimum PARENT-ISSUE-TEMPLATE metadata table the
+    sync-labels derivation relies on.
+    """
+    return (
+        "## Issue Metadata\n\n"
+        "| Field | Value |\n"
+        "|-------|-------|\n"
+        "| Date | `2026-04-17` |\n"
+        f"| Status | `{status}` |\n"
+        "| Type | `implementation` (feature) |\n"
+        "| Change Class | `MINOR` |\n"
+        "| Branch | `feat/x` |\n"
+        f"| Archetypes | `{archetypes}` |\n"
+        "| Train | `0001-self-compliance-validate` |\n"
+        "| Feature | x |\n"
+        f"| Wagon | `wagon:{wagon}` |\n\n"
+        "### Dependencies\n\n- none\n"
+    )
+
+
+def _make_fake_client(
+    number: int,
+    body: str,
+    current_labels: List[str],
+) -> GitHubClient:
+    """Build a spec-enforced ``GitHubClient`` double for sync_labels tests."""
+    client = create_autospec(GitHubClient, instance=True)
+    client.get_issue.return_value = {
+        "number": number,
+        "title": "demo",
+        "state": "open",
+        "labels": [{"name": name} for name in current_labels],
+        "body": body,
+    }
+    client.add_label.return_value = None
+    client.remove_label.return_value = None
+    return client
+
+
+def _write_atdd_config(tmp_path: Path) -> None:
+    (tmp_path / ".atdd").mkdir(exist_ok=True)
+    (tmp_path / ".atdd" / "config.yaml").write_text(
+        "github:\n  repo: afokapu/atdd\n  project_number: 1\n",
+        encoding="utf-8",
+    )
+
+
+def _added_label_calls(client) -> List[List[str]]:
+    """Return the ``labels`` arg each ``add_label`` call received."""
+    return [list(call.args[1]) for call in client.add_label.call_args_list]
+
+
+def _removed_label_calls(client) -> List[List[str]]:
+    """Return the ``labels`` arg each ``remove_label`` call received."""
+    return [list(call.args[1]) for call in client.remove_label.call_args_list]
+
+
+# ---------------------------------------------------------------------------
+# D007-UNIT-001 — dry-run derives expected delta without mutating GitHub
+# ---------------------------------------------------------------------------
+
+
+def test_d007_sync_labels_dry_run_lists_missing_labels_to_add(tmp_path, monkeypatch):
+    """Dry-run reports labels that should be added (from body metadata)
+    but are not currently on GitHub.
+    """
+    from atdd.coach.commands.issue import IssueManager
+
+    _write_atdd_config(tmp_path)
+    body = _body_with_metadata(status="INIT", archetypes="coach", wagon="govern-lifecycle")
+    client = _make_fake_client(
+        number=42,
+        body=body,
+        current_labels=["atdd-issue"],  # missing phase, archetype, wagon
+    )
+
+    manager = IssueManager(target_dir=tmp_path)
+    monkeypatch.setattr(manager, "_get_github_client", lambda: client)
+
+    result = manager.sync_labels(42, dry_run=True)
+
+    expected_to_add = {"atdd:INIT", "archetype:coach", "wagon:govern-lifecycle"}
+    assert expected_to_add.issubset(set(result.get("to_add", []))), (
+        f"dry-run must list missing labels; got to_add={result.get('to_add')}"
+    )
+
+
+def test_d007_sync_labels_dry_run_does_not_mutate_github(tmp_path, monkeypatch):
+    """Dry-run must not call add_label/remove_label on the client."""
+    from atdd.coach.commands.issue import IssueManager
+
+    _write_atdd_config(tmp_path)
+    body = _body_with_metadata(status="INIT", archetypes="coach", wagon="govern-lifecycle")
+    client = _make_fake_client(number=42, body=body, current_labels=["atdd-issue"])
+
+    manager = IssueManager(target_dir=tmp_path)
+    monkeypatch.setattr(manager, "_get_github_client", lambda: client)
+
+    manager.sync_labels(42, dry_run=True)
+
+    client.add_label.assert_not_called()
+    client.remove_label.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# D007-UNIT-002 — apply + idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_d007_sync_labels_applies_add_delta(tmp_path, monkeypatch):
+    """Without dry-run, sync_labels calls add_label for every missing
+    label derived from body metadata.
+    """
+    from atdd.coach.commands.issue import IssueManager
+
+    _write_atdd_config(tmp_path)
+    body = _body_with_metadata(status="INIT", archetypes="coach", wagon="govern-lifecycle")
+    client = _make_fake_client(number=42, body=body, current_labels=["atdd-issue"])
+
+    manager = IssueManager(target_dir=tmp_path)
+    monkeypatch.setattr(manager, "_get_github_client", lambda: client)
+
+    manager.sync_labels(42, dry_run=False)
+
+    all_added = {lbl for call in _added_label_calls(client) for lbl in call}
+    assert {"atdd:INIT", "archetype:coach", "wagon:govern-lifecycle"}.issubset(all_added)
+
+
+def test_d007_sync_labels_is_idempotent_when_labels_match_body(tmp_path, monkeypatch):
+    """When GitHub labels already match the body-derived set, sync_labels
+    is a no-op — zero add/remove calls.
+    """
+    from atdd.coach.commands.issue import IssueManager
+
+    _write_atdd_config(tmp_path)
+    body = _body_with_metadata(status="INIT", archetypes="coach", wagon="govern-lifecycle")
+    client = _make_fake_client(
+        number=42,
+        body=body,
+        current_labels=["atdd-issue", "atdd:INIT", "archetype:coach", "wagon:govern-lifecycle"],
+    )
+
+    manager = IssueManager(target_dir=tmp_path)
+    monkeypatch.setattr(manager, "_get_github_client", lambda: client)
+
+    result = manager.sync_labels(42, dry_run=False)
+
+    client.add_label.assert_not_called()
+    client.remove_label.assert_not_called()
+    assert result.get("to_add", []) == []
+    assert result.get("to_remove", []) == []
+
+
+def test_d007_sync_labels_removes_stale_phase_label(tmp_path, monkeypatch):
+    """When the body declares ``Status: PLANNED`` but GitHub still carries
+    ``atdd:INIT``, sync_labels must remove the stale phase label and add
+    the body-declared one (phase labels are ``exactly_one`` per the
+    label_taxonomy schema swap_rule).
+    """
+    from atdd.coach.commands.issue import IssueManager
+
+    _write_atdd_config(tmp_path)
+    body = _body_with_metadata(status="PLANNED", archetypes="coach", wagon="govern-lifecycle")
+    client = _make_fake_client(
+        number=42,
+        body=body,
+        current_labels=[
+            "atdd-issue", "atdd:INIT",
+            "archetype:coach", "wagon:govern-lifecycle",
+        ],
+    )
+
+    manager = IssueManager(target_dir=tmp_path)
+    monkeypatch.setattr(manager, "_get_github_client", lambda: client)
+
+    manager.sync_labels(42, dry_run=False)
+
+    all_removed = {lbl for call in _removed_label_calls(client) for lbl in call}
+    all_added = {lbl for call in _added_label_calls(client) for lbl in call}
+    assert "atdd:INIT" in all_removed
+    assert "atdd:PLANNED" in all_added
+
+
+def test_d007_sync_labels_never_mutates_issue_body(tmp_path, monkeypatch):
+    """sync_labels touches only the label surface; the issue body is
+    never rewritten via edit_issue / body-changing gh calls.
+    """
+    from atdd.coach.commands.issue import IssueManager
+
+    _write_atdd_config(tmp_path)
+    body = _body_with_metadata(status="INIT", archetypes="coach", wagon="govern-lifecycle")
+    client = _make_fake_client(number=42, body=body, current_labels=["atdd-issue"])
+
+    manager = IssueManager(target_dir=tmp_path)
+    monkeypatch.setattr(manager, "_get_github_client", lambda: client)
+
+    manager.sync_labels(42, dry_run=False)
+
+    # The autospec ensures only real GitHubClient methods are callable.
+    # Assert the body-mutation surface (create_issue, any method with
+    # 'body' in its kwargs) was NOT invoked.
+    client.create_issue.assert_not_called()
+
+
+def test_d007_sync_labels_supports_multiple_archetypes(tmp_path, monkeypatch):
+    """Comma-separated ``Archetypes`` row (e.g., ``coach, contracts``)
+    produces ``archetype:coach`` and ``archetype:contracts`` in the
+    expected set — cross-cutting issues are first-class per Decision #5
+    in #296.
+    """
+    from atdd.coach.commands.issue import IssueManager
+
+    _write_atdd_config(tmp_path)
+    body = _body_with_metadata(
+        status="INIT",
+        archetypes="coach, contracts",
+        wagon="govern-lifecycle",
+    )
+    client = _make_fake_client(number=42, body=body, current_labels=["atdd-issue"])
+
+    manager = IssueManager(target_dir=tmp_path)
+    monkeypatch.setattr(manager, "_get_github_client", lambda: client)
+
+    result = manager.sync_labels(42, dry_run=True)
+
+    to_add = set(result.get("to_add", []))
+    assert "archetype:coach" in to_add
+    assert "archetype:contracts" in to_add

--- a/src/atdd/coach/github.py
+++ b/src/atdd/coach/github.py
@@ -503,9 +503,10 @@ class GitHubClient:
         results: Dict[str, Any] = {}
 
         def _fetch_issues():
-            """Fetch both open atdd-issue and complete issues via REST."""
+            """Fetch open atdd-issue, complete, and unfiltered-open issues via REST."""
             results["issues"] = self.list_issues_by_label("atdd-issue")
             results["complete_issues"] = self.list_issues_by_label("atdd:COMPLETE")
+            results["all_open_issues"] = self.list_all_open_issues()
 
         def _fetch_project_data():
             """Fetch project fields + all items in one GraphQL call."""
@@ -596,6 +597,28 @@ class GitHubClient:
     # -------------------------------------------------------------------------
     # Issue queries
     # -------------------------------------------------------------------------
+
+    def list_all_open_issues(
+        self, include_body: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """List *all* open issues, unfiltered by label.
+
+        Used by the label-compliance validator (#296 D005) which asserts
+        every open issue carries ``atdd-issue``. The regular
+        ``list_issues_by_label`` path pre-filters and therefore cannot see
+        unlabeled drift.
+        """
+        fields = "number,title,labels,state"
+        if include_body:
+            fields += ",body"
+        output = self._run_gh([
+            "issue", "list",
+            "--repo", self.repo,
+            "--state", "open",
+            "--json", fields,
+            "--limit", "500",
+        ])
+        return json.loads(output) if output else []
 
     def list_issues_by_label(
         self, label: str, include_body: bool = True,

--- a/src/atdd/coach/validators/conftest.py
+++ b/src/atdd/coach/validators/conftest.py
@@ -56,8 +56,9 @@ def _github_prefetch(github_client):
         try:
             results.update(github_client.prefetch_validator_data())
         except Exception as e:
-            for key in ("issues", "complete_issues", "project_fields",
-                        "project_items", "sub_issues", "closed_sub_issues"):
+            for key in ("issues", "complete_issues", "all_open_issues",
+                        "project_fields", "project_items", "sub_issues",
+                        "closed_sub_issues"):
                 results.setdefault(key, e)
 
     def _fetch_branch_protection():
@@ -95,6 +96,22 @@ def github_complete_issues(_github_prefetch):
         pytest.skip(f"Cannot query GitHub: {data}")
     if not data:
         pytest.skip("No COMPLETE issues found")
+    return data
+
+
+@pytest.fixture(scope="session")
+def all_open_issues_unfiltered(_github_prefetch):
+    """All open repo issues, unfiltered by label (from prefetch cache).
+
+    Counterpart to ``github_issues`` (which filters by ``atdd-issue``).
+    Required by #296 D005 — the inverse-filter validator needs to see
+    unlabeled issues that the default prefetch drops.
+    """
+    data = _github_prefetch.get("all_open_issues")
+    if isinstance(data, Exception):
+        pytest.skip(f"Cannot query GitHub: {data}")
+    if data is None:
+        pytest.skip("No open issues in prefetch cache")
     return data
 
 

--- a/src/atdd/coach/validators/test_required_label_set.py
+++ b/src/atdd/coach/validators/test_required_label_set.py
@@ -1,0 +1,212 @@
+"""
+RED tests for #296 D006 — assert every ``atdd-issue``-labeled open issue
+carries the required label triplet: one ``atdd:<PHASE>``, at least one
+``archetype:*``, and at least one ``wagon:*``.
+
+WMBT covered:
+- wmbt:govern-lifecycle:D006 — acc:govern-lifecycle:D006-UNIT-001-require-phase-archetype-wagon-triplet
+
+Why this validator exists
+-------------------------
+``atdd issue <slug>`` applies the full triplet on creation, but nothing
+re-checks after: labels drift when humans edit them manually, when a
+phase transition partially fails, or when label taxonomy evolves. The
+issue body metadata (Archetypes, Wagon, Status rows) is the source of
+truth; the label set must mirror it.
+
+The PHASE set is pinned to the label taxonomy schema
+(``atdd/coach/schemas/label_taxonomy.schema.json``) rather than a local
+constant so that any taxonomy extension (e.g., ``atdd:ADOPT`` from #260)
+flows through automatically.
+
+Run:
+    PYTHONPATH=src python3 -m pytest -q \
+        src/atdd/coach/validators/test_required_label_set.py -v
+"""
+
+from typing import Dict, List, Tuple
+
+import pytest
+
+
+_ISSUE_LABEL = "atdd-issue"
+
+_PHASE_LABELS: Tuple[str, ...] = (
+    "atdd:INIT",
+    "atdd:PLANNED",
+    "atdd:RED",
+    "atdd:GREEN",
+    "atdd:SMOKE",
+    "atdd:REFACTOR",
+    "atdd:COMPLETE",
+    "atdd:BLOCKED",
+)
+
+
+def _labels_of(issue: Dict) -> List[str]:
+    """Return label names from a GitHub issue dict."""
+    raw = issue.get("labels") or []
+    out: List[str] = []
+    for entry in raw:
+        if isinstance(entry, dict):
+            name = entry.get("name")
+            if name:
+                out.append(name)
+        elif isinstance(entry, str):
+            out.append(entry)
+    return out
+
+
+def _missing_label_families(labels: List[str]) -> List[str]:
+    """Return the names of missing required label families for a single issue.
+
+    Families:
+    - ``atdd:<PHASE>``   — exactly one from the canonical phase set.
+    - ``archetype:*``    — one or more.
+    - ``wagon:*``        — one or more.
+    """
+    missing: List[str] = []
+    if not any(label in _PHASE_LABELS for label in labels):
+        missing.append("atdd:<PHASE>")
+    if not any(label.startswith("archetype:") for label in labels):
+        missing.append("archetype:*")
+    if not any(label.startswith("wagon:") for label in labels):
+        missing.append("wagon:*")
+    return missing
+
+
+def _find_issues_missing_required_labels(issues: List[Dict]) -> List[str]:
+    """Return one drift message per ``atdd-issue``-labeled issue whose
+    label set is missing any required family.
+
+    Non-``atdd-issue`` issues are out of scope — they are caught by the
+    inverse-filter validator (``test_unlabeled_open_issues``) instead.
+    """
+    messages: List[str] = []
+    for issue in issues:
+        if str(issue.get("state", "open")).lower() != "open":
+            continue
+        labels = _labels_of(issue)
+        if _ISSUE_LABEL not in labels:
+            continue
+        missing = _missing_label_families(labels)
+        if not missing:
+            continue
+        number = issue.get("number", "<unknown>")
+        title = issue.get("title", "")
+        messages.append(
+            f"  #{number}: {title!r} missing required label families: "
+            f"{missing}"
+        )
+    return messages
+
+
+@pytest.mark.coach
+def test_atdd_issues_have_required_label_triplet(github_issues):
+    """D006: Every ``atdd-issue``-labeled open issue must carry one
+    ``atdd:<PHASE>`` label, at least one ``archetype:*`` label, and at
+    least one ``wagon:*`` label.
+
+    Given: Open issues carrying the ``atdd-issue`` label (from the
+           existing ``github_issues`` prefetch fixture — this validator
+           audits the *completeness* of labels on issues that are already
+           in scope, complementing ``test_unlabeled_open_issues`` which
+           audits *inclusion* of the issue itself).
+    When:  Walking each issue's label set.
+    Then:  Any issue missing a required family is a hard failure naming
+           the issue number and the missing families.
+    """
+    drift = _find_issues_missing_required_labels(list(github_issues))
+    if drift:
+        pytest.fail(
+            f"\n\n{len(drift)} atdd-issue(s) missing required label families:\n\n"
+            + "\n".join(drift)
+            + "\n\nFix: `atdd issue sync-labels <N>` reads body metadata "
+            "(Archetypes, Wagon, Status rows) and applies the derived "
+            "label set idempotently."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the pure helpers — no GitHub API required.
+# ---------------------------------------------------------------------------
+
+
+def test_missing_families_reports_all_three_when_only_atdd_issue_present():
+    """An issue carrying only ``atdd-issue`` is missing the full triplet."""
+    missing = _missing_label_families([_ISSUE_LABEL])
+    assert set(missing) == {"atdd:<PHASE>", "archetype:*", "wagon:*"}
+
+
+def test_missing_families_reports_phase_only_when_archetype_and_wagon_present():
+    """An issue missing only ``atdd:<PHASE>`` reports exactly that family."""
+    missing = _missing_label_families([_ISSUE_LABEL, "archetype:coach", "wagon:govern-lifecycle"])
+    assert missing == ["atdd:<PHASE>"]
+
+
+def test_missing_families_accepts_any_valid_phase_label():
+    """Any of the canonical phase labels satisfies the PHASE family."""
+    for phase in _PHASE_LABELS:
+        missing = _missing_label_families([_ISSUE_LABEL, phase, "archetype:coach", "wagon:x"])
+        assert missing == [], f"{phase} should satisfy atdd:<PHASE> family"
+
+
+def test_missing_families_empty_for_complete_label_set():
+    """A full triplet (plus ``atdd-issue``) is compliant."""
+    labels = [_ISSUE_LABEL, "atdd:INIT", "archetype:coach", "wagon:govern-lifecycle"]
+    assert _missing_label_families(labels) == []
+
+
+def test_missing_families_allows_multiple_archetypes_and_wagons():
+    """Issues spanning multiple archetypes/wagons (e.g., cross-cutting
+    changes like #291) remain compliant — the validator asserts ≥1,
+    not exactly 1.
+    """
+    labels = [
+        _ISSUE_LABEL, "atdd:INIT",
+        "archetype:coach", "archetype:contracts",
+        "wagon:govern-lifecycle", "wagon:define-plans",
+    ]
+    assert _missing_label_families(labels) == []
+
+
+def test_find_drift_skips_non_atdd_issue_items():
+    """Issues without ``atdd-issue`` are out of scope for this validator —
+    the inverse-filter validator (``test_unlabeled_open_issues``) handles
+    them.
+    """
+    issues = [{
+        "number": 501,
+        "title": "plain",
+        "state": "open",
+        "labels": [{"name": "bug"}],
+    }]
+    assert _find_issues_missing_required_labels(issues) == []
+
+
+def test_find_drift_skips_closed_issues():
+    """Closed issues are terminal — label drift there is historical noise."""
+    issues = [{
+        "number": 123,
+        "title": "closed-partial",
+        "state": "closed",
+        "labels": [{"name": _ISSUE_LABEL}],
+    }]
+    assert _find_issues_missing_required_labels(issues) == []
+
+
+def test_find_drift_names_issue_and_missing_families_in_message():
+    """Failure messages pinpoint both the issue number and the missing
+    families so operators can act without re-deriving context.
+    """
+    issues = [{
+        "number": 291,
+        "title": "custom themes",
+        "state": "open",
+        "labels": [{"name": _ISSUE_LABEL}, {"name": "atdd:INIT"}],
+    }]
+    drift = _find_issues_missing_required_labels(issues)
+    assert len(drift) == 1
+    assert "#291" in drift[0]
+    assert "archetype:*" in drift[0]
+    assert "wagon:*" in drift[0]

--- a/src/atdd/coach/validators/test_unlabeled_open_issues.py
+++ b/src/atdd/coach/validators/test_unlabeled_open_issues.py
@@ -1,0 +1,174 @@
+"""
+RED tests for #296 D005 — assert every open repo issue carries the
+``atdd-issue`` label so coach validators never silently drop
+non-compliant issues.
+
+WMBT covered:
+- wmbt:govern-lifecycle:D005 — acc:govern-lifecycle:D005-UNIT-001-fail-on-unlabeled-open-issue
+
+Why this validator exists
+-------------------------
+Every existing coach validator filters by ``atdd-issue`` as a precondition
+(see ``conftest.py::github_issues`` — "All open issues with atdd-issue
+label"). An issue created outside ``atdd issue <slug>`` (web UI,
+``gh issue create``) lands without labels and becomes invisible to every
+downstream check: the prefetch cache drops it, and ``atdd validate coach``
+returns PASS on a repo state that is demonstrably non-compliant. #291
+sat unlabeled from creation until manually audited, and zero validator
+flagged it.
+
+This validator inverts the filter: it walks **all** open repo issues
+(unfiltered) via the new ``all_open_issues_unfiltered`` fixture, and
+fails hard when any one of them is missing ``atdd-issue``.
+
+Run:
+    PYTHONPATH=src python3 -m pytest -q \
+        src/atdd/coach/validators/test_unlabeled_open_issues.py -v
+"""
+
+from typing import Dict, List
+
+import pytest
+
+
+_REQUIRED_LABEL = "atdd-issue"
+
+
+def _labels_of(issue: Dict) -> List[str]:
+    """Return label names from a GitHub issue dict.
+
+    Accepts both the ``[{name: "..."}, ...]`` REST shape and the flat
+    ``["...", ...]`` convenience shape some stubs use.
+    """
+    raw = issue.get("labels") or []
+    out: List[str] = []
+    for entry in raw:
+        if isinstance(entry, dict):
+            name = entry.get("name")
+            if name:
+                out.append(name)
+        elif isinstance(entry, str):
+            out.append(entry)
+    return out
+
+
+def _find_unlabeled_open_issues(issues: List[Dict]) -> List[str]:
+    """Return one drift message per open issue missing ``atdd-issue``.
+
+    Caller must pass **unfiltered** open issues (i.e., do NOT pre-filter
+    by the ``atdd-issue`` label — that's the bug this validator exists
+    to catch).
+    """
+    messages: List[str] = []
+    for issue in issues:
+        if issue.get("state", "open") != "open":
+            continue
+        labels = _labels_of(issue)
+        if _REQUIRED_LABEL in labels:
+            continue
+        number = issue.get("number", "<unknown>")
+        title = issue.get("title", "")
+        messages.append(f"  #{number}: {title!r} lacks '{_REQUIRED_LABEL}' label")
+    return messages
+
+
+@pytest.mark.coach
+def test_no_open_issues_lack_atdd_issue_label(all_open_issues_unfiltered):
+    """D005: Every open repo issue must carry the ``atdd-issue`` label so
+    it is visible to every coach validator.
+
+    Given: The full set of open GitHub issues in the configured repo,
+           unfiltered by label (via the ``all_open_issues_unfiltered``
+           fixture that bypasses the default ``atdd-issue`` prefetch
+           filter).
+    When:  Walking each issue's label set.
+    Then:  Any issue missing ``atdd-issue`` is a hard failure, naming the
+           issue number and suggesting a remediation command.
+    """
+    drift = _find_unlabeled_open_issues(list(all_open_issues_unfiltered))
+    if drift:
+        pytest.fail(
+            f"\n\n{len(drift)} open issue(s) lack the '{_REQUIRED_LABEL}' label "
+            f"and are invisible to every coach validator:\n\n"
+            + "\n".join(drift)
+            + "\n\nFix: `atdd issue sync-labels <N>` (preferred, reads body metadata) "
+            "or `gh issue edit <N> --add-label atdd-issue` (manual fallback)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the pure helper — no GitHub API required.
+# ---------------------------------------------------------------------------
+
+
+def test_find_unlabeled_flags_issue_with_empty_labels():
+    """An open issue with ``labels: []`` is flagged as unlabeled."""
+    issues = [{"number": 291, "title": "feat: custom themes", "state": "open", "labels": []}]
+    drift = _find_unlabeled_open_issues(issues)
+    assert len(drift) == 1
+    assert "#291" in drift[0]
+    assert _REQUIRED_LABEL in drift[0]
+
+
+def test_find_unlabeled_flags_issue_missing_atdd_issue_among_other_labels():
+    """An open issue carrying other labels but not ``atdd-issue`` is flagged."""
+    issues = [{
+        "number": 42,
+        "title": "rogue issue",
+        "state": "open",
+        "labels": [{"name": "bug"}, {"name": "needs-triage"}],
+    }]
+    drift = _find_unlabeled_open_issues(issues)
+    assert len(drift) == 1
+    assert "#42" in drift[0]
+
+
+def test_find_unlabeled_ignores_properly_labeled_issue():
+    """An open issue carrying ``atdd-issue`` is not flagged."""
+    issues = [{
+        "number": 296,
+        "title": "compliant",
+        "state": "open",
+        "labels": [{"name": _REQUIRED_LABEL}, {"name": "atdd:INIT"}],
+    }]
+    assert _find_unlabeled_open_issues(issues) == []
+
+
+def test_find_unlabeled_ignores_closed_issues():
+    """Closed issues are out of scope — retroactive labeling of closed
+    state adds noise without signal.
+    """
+    issues = [{
+        "number": 123,
+        "title": "closed-rogue",
+        "state": "closed",
+        "labels": [],
+    }]
+    assert _find_unlabeled_open_issues(issues) == []
+
+
+def test_find_unlabeled_accepts_flat_string_labels_shape():
+    """Helper tolerates the ``labels: ["foo", "bar"]`` convenience shape
+    used by some stubs and prefetch caches.
+    """
+    issues = [{
+        "number": 7,
+        "title": "string-labels",
+        "state": "open",
+        "labels": ["atdd-issue", "atdd:INIT"],
+    }]
+    assert _find_unlabeled_open_issues(issues) == []
+
+
+def test_find_unlabeled_walks_multiple_issues_independently():
+    """Drift is reported per issue; compliant issues are not included."""
+    issues = [
+        {"number": 1, "title": "ok",    "state": "open", "labels": [{"name": "atdd-issue"}]},
+        {"number": 2, "title": "rogue", "state": "open", "labels": []},
+        {"number": 3, "title": "ok",    "state": "open", "labels": [{"name": "atdd-issue"}]},
+        {"number": 4, "title": "rogue", "state": "open", "labels": [{"name": "bug"}]},
+    ]
+    drift = _find_unlabeled_open_issues(issues)
+    assert len(drift) == 2
+    assert any("#2" in m for m in drift)
+    assert any("#4" in m for m in drift)

--- a/src/atdd/coach/validators/test_unlabeled_open_issues.py
+++ b/src/atdd/coach/validators/test_unlabeled_open_issues.py
@@ -33,6 +33,12 @@ import pytest
 
 _REQUIRED_LABEL = "atdd-issue"
 
+# WMBT sub-issues carry ``atdd-wmbt`` instead of ``atdd-issue`` — they are
+# first-class ATDD-tracked but a different shape (required_label_set does
+# not apply to them). Either label satisfies the "is-ATDD-tracked" check.
+_WMBT_LABEL = "atdd-wmbt"
+_ATDD_TRACKED_LABELS = frozenset({_REQUIRED_LABEL, _WMBT_LABEL})
+
 
 def _labels_of(issue: Dict) -> List[str]:
     """Return label names from a GitHub issue dict.
@@ -53,7 +59,11 @@ def _labels_of(issue: Dict) -> List[str]:
 
 
 def _find_unlabeled_open_issues(issues: List[Dict]) -> List[str]:
-    """Return one drift message per open issue missing ``atdd-issue``.
+    """Return one drift message per open issue not tracked by ATDD.
+
+    An issue is "tracked" when it carries either ``atdd-issue`` (parent
+    issue) or ``atdd-wmbt`` (WMBT sub-issue). Any other open issue — no
+    labels, or labels unrelated to ATDD — is drift.
 
     Caller must pass **unfiltered** open issues (i.e., do NOT pre-filter
     by the ``atdd-issue`` label — that's the bug this validator exists
@@ -64,7 +74,7 @@ def _find_unlabeled_open_issues(issues: List[Dict]) -> List[str]:
         if str(issue.get("state", "open")).lower() != "open":
             continue
         labels = _labels_of(issue)
-        if _REQUIRED_LABEL in labels:
+        if any(lbl in _ATDD_TRACKED_LABELS for lbl in labels):
             continue
         number = issue.get("number", "<unknown>")
         title = issue.get("title", "")
@@ -130,6 +140,20 @@ def test_find_unlabeled_ignores_properly_labeled_issue():
         "title": "compliant",
         "state": "open",
         "labels": [{"name": _REQUIRED_LABEL}, {"name": "atdd:INIT"}],
+    }]
+    assert _find_unlabeled_open_issues(issues) == []
+
+
+def test_find_unlabeled_ignores_wmbt_sub_issues():
+    """WMBT sub-issues carry ``atdd-wmbt`` instead of ``atdd-issue`` —
+    they are first-class ATDD-tracked and must not be flagged by the
+    inverse-filter validator.
+    """
+    issues = [{
+        "number": 312,
+        "title": "wmbt:govern-lifecycle:D005 — ...",
+        "state": "open",
+        "labels": [{"name": _WMBT_LABEL}],
     }]
     assert _find_unlabeled_open_issues(issues) == []
 

--- a/src/atdd/coach/validators/test_unlabeled_open_issues.py
+++ b/src/atdd/coach/validators/test_unlabeled_open_issues.py
@@ -61,7 +61,7 @@ def _find_unlabeled_open_issues(issues: List[Dict]) -> List[str]:
     """
     messages: List[str] = []
     for issue in issues:
-        if issue.get("state", "open") != "open":
+        if str(issue.get("state", "open")).lower() != "open":
             continue
         labels = _labels_of(issue)
         if _REQUIRED_LABEL in labels:


### PR DESCRIPTION
Closes #296

## WMBT Sub-Issues

- [ ] #312 — wmbt:govern-lifecycle:D005 — minimize quantity of unlabeled-open-issues-invisible-to-coach-validators when atdd validate coach filters by the atdd-issue label (conftest.py:81) and therefore silently drops any open issue lacking that label, making non-compliant issues unreachable by every existing coach validator
- [ ] #313 — wmbt:govern-lifecycle:D006 — minimize quantity of atdd-issues-missing-required-label-set when an atdd-issue-labeled open issue lacks one of the required label families (atdd:<PHASE>, at least one archetype:*, at least one wagon:*) so the label set drifts from the issue body metadata
- [ ] #314 — wmbt:govern-lifecycle:D007 — minimize quantity of label-drift-between-issue-body-metadata-and-github-labels when issue body rows (Archetypes, Wagon, Status) disagree with the GitHub label set so agents and humans have no supervised way to re-derive and apply the expected labels idempotently
- [ ] #315 — wmbt:govern-lifecycle:D008 — minimize quantity of pushed-commits-referencing-unlabeled-issues when an outgoing commit references #NNN but the target issue lacks atdd compliance labels so the unlabeled-drift root cause reappears at push time with no pre-push enforcement

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #296 |
| Type | implementation |
| Slug | enforce-issue-label-compliance |
| Train | 0001-self-compliance-validate |
| Labels | atdd-issue, atdd:REFACTOR, archetype:coach, wagon:govern-lifecycle |

---
PR created by `atdd pr`.