### PR TITLE
chore(coach): sync manifest with May 1 issue creations (#340-#343)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -135,3 +135,11 @@ sessions:
   status: INIT
   created: '2026-05-01'
   archived: null
+- id: '344'
+  slug: atdd-issue-must-commit-manifest-update
+  file: null
+  issue_number: 344
+  type: implementation
+  status: INIT
+  created: '2026-05-01'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -103,3 +103,35 @@ sessions:
   status: INIT
   created: '2026-04-27'
   archived: null
+- id: '340'
+  slug: structured-violations
+  file: null
+  issue_number: 340
+  type: implementation
+  status: INIT
+  created: '2026-05-01'
+  archived: null
+- id: '341'
+  slug: atdd-validate-quick-pytest-resolution
+  file: null
+  issue_number: 341
+  type: implementation
+  status: INIT
+  created: '2026-05-01'
+  archived: null
+- id: '342'
+  slug: atdd-cli-mutates-config-on-read
+  file: null
+  issue_number: 342
+  type: implementation
+  status: INIT
+  created: '2026-05-01'
+  archived: null
+- id: '343'
+  slug: orchestrate-in-pane-mode
+  file: null
+  issue_number: 343
+  type: implementation
+  status: INIT
+  created: '2026-05-01'
+  archived: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.61.1"
+version = "1.61.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary

`atdd issue <slug>` updated `.atdd/manifest.yaml` when issues #340-#343 were created on May 1 but never committed. Worktrees branched from main HEAD inherit the pre-creation manifest, breaking `atdd issue <N> --sync-wmbts` in those worktrees.

This is a **stopgap commit** — it catches the manifest up so any worktree branched from main sees all four issues, unblocking the May 1 parallel wave (#340/#341/#342/#343).

The underlying CLI bug (the toolkit should commit its own manifest writes atomically) is tracked as #344 — this PR does NOT close #344.

## Test plan

- [ ] CI passes
- [ ] In a fresh worktree branched from main after this lands, `atdd issue 343 --sync-wmbts` succeeds
- [ ] `git diff main HEAD` shows only manifest entries for #340/#341/#342/#343 (no other side-effects)

Refs: #344