### PR TITLE
feat(atdd): Orchestrate In Pane Mode (#343)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -135,6 +135,9 @@ sessions:
   status: INIT
   created: '2026-05-01'
   archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:orchestrate-pane-mode
+  train: 0001-self-compliance-validate
 - id: '344'
   slug: atdd-issue-must-commit-manifest-update
   file: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -132,7 +132,7 @@ sessions:
   file: null
   issue_number: 343
   type: implementation
-  status: INIT
+  status: PLANNED
   created: '2026-05-01'
   archived: null
   wagon: govern-lifecycle

--- a/plan/govern_lifecycle/D014.yaml
+++ b/plan/govern_lifecycle/D014.yaml
@@ -1,0 +1,33 @@
+urn: "wmbt:govern-lifecycle:D014"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "multiplexer-abstractions-bound-to-workspace-only-spawn-unit"
+context_clarifier: "when src/atdd/coach/utils/multiplexer.py declares only new_workspace as the creation primitive, hard-coding one-workspace-per-issue topology into both the abstraction and orchestrate's consumer"
+lens: "functional.completeness"
+statement: "minimize quantity of multiplexer-abstractions-bound-to-workspace-only-spawn-unit when src/atdd/coach/utils/multiplexer.py declares only new_workspace as the creation primitive"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D014-UNIT-001-multiplexer-new-surface-contract"
+      id: "AC-UNIT-001"
+      purpose: "Multiplexer abstract base exposes new_surface alongside new_workspace, with ref-prefix dispatch"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Multiplexer abstract base class is loaded"
+    when:
+      abstract: "A caller imports Multiplexer and inspects its public methods"
+    then:
+      abstract:
+        - "new_surface is declared on the abstract base"
+        - "new_workspace remains declared and unchanged in signature"
+        - "read_screen, send, send_key, close accept either workspace_ref or surface_ref"
+    signal:
+      metric: "missing_abstract_method_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-01"

--- a/plan/govern_lifecycle/D014.yaml
+++ b/plan/govern_lifecycle/D014.yaml
@@ -4,7 +4,7 @@ direction: "minimize"
 dimension: "quantity"
 object_of_control: "multiplexer-abstractions-bound-to-workspace-only-spawn-unit"
 context_clarifier: "when src/atdd/coach/utils/multiplexer.py declares only new_workspace as the creation primitive, hard-coding one-workspace-per-issue topology into both the abstraction and orchestrate's consumer"
-lens: "functional.completeness"
+lens: "functional.adaptability"
 statement: "minimize quantity of multiplexer-abstractions-bound-to-workspace-only-spawn-unit when src/atdd/coach/utils/multiplexer.py declares only new_workspace as the creation primitive"
 acceptances:
   - identity:

--- a/plan/govern_lifecycle/D015.yaml
+++ b/plan/govern_lifecycle/D015.yaml
@@ -1,0 +1,58 @@
+urn: "wmbt:govern-lifecycle:D015"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "cmux-pane-and-surface-primitives-unreachable-from-multiplexer-abstraction"
+context_clarifier: "when CmuxMultiplexer is the active backend and cmux exposes new-pane, new-surface, surface.read_text, surface.send_text, surface.send_key, close-surface RPCs that the abstraction does not dispatch to"
+lens: "functional.completeness"
+statement: "minimize quantity of cmux-pane-and-surface-primitives-unreachable-from-multiplexer-abstraction when CmuxMultiplexer is the active backend"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D015-UNIT-001-cmux-backend-surface-dispatch"
+      id: "AC-UNIT-001"
+      purpose: "CmuxMultiplexer dispatches ref-prefix workspace:* and surface:* to the corresponding cmux RPCs"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "CmuxMultiplexer instance with mocked subprocess.run"
+        - "A surface_ref shaped like surface:NN"
+    when:
+      abstract: "read_screen(surface_ref) and send(surface_ref, text) and close(surface_ref) are called"
+    then:
+      abstract:
+        - "read_screen issues 'cmux rpc surface.read_text' with the surface id"
+        - "send issues 'cmux rpc surface.send_text' with the surface id and text"
+        - "close issues 'cmux close-surface' with the surface id"
+        - "workspace_ref shaped like workspace:NN routes to the workspace-level cmux subcommands as before"
+    signal:
+      metric: "wrong_rpc_dispatched_count"
+      threshold: 0
+  - identity:
+      urn: "acc:govern-lifecycle:D015-UNIT-002-new-surface-creates-pane-then-surface"
+      id: "AC-UNIT-002"
+      purpose: "new_surface(pane_ref=None, ...) creates a pane via cmux new-pane and then a surface inside it via cmux new-surface; cwd and command are seeded via surface.send_text"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "CmuxMultiplexer instance with mocked subprocess.run"
+        - "A workspace_ref but no pane_ref"
+    when:
+      abstract: "new_surface(workspace_ref=W, pane_ref=None, cwd='/x', command='echo y') is called"
+    then:
+      abstract:
+        - "cmux new-pane is invoked with the workspace ref"
+        - "cmux new-surface is invoked with the freshly-created pane ref"
+        - "cmux rpc surface.send_text is invoked with text 'cd /x && echo y\\n' (cwd and command seeded together)"
+        - "The returned ref has the surface:* prefix"
+    signal:
+      metric: "missing_rpc_call_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-01"

--- a/plan/govern_lifecycle/D015.yaml
+++ b/plan/govern_lifecycle/D015.yaml
@@ -4,7 +4,7 @@ direction: "minimize"
 dimension: "quantity"
 object_of_control: "cmux-pane-and-surface-primitives-unreachable-from-multiplexer-abstraction"
 context_clarifier: "when CmuxMultiplexer is the active backend and cmux exposes new-pane, new-surface, surface.read_text, surface.send_text, surface.send_key, close-surface RPCs that the abstraction does not dispatch to"
-lens: "functional.completeness"
+lens: "functional.adaptability"
 statement: "minimize quantity of cmux-pane-and-surface-primitives-unreachable-from-multiplexer-abstraction when CmuxMultiplexer is the active backend"
 acceptances:
   - identity:

--- a/plan/govern_lifecycle/D016.yaml
+++ b/plan/govern_lifecycle/D016.yaml
@@ -1,0 +1,54 @@
+urn: "wmbt:govern-lifecycle:D016"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "orchestrate-invocations-that-cannot-opt-into-pane-mode"
+context_clarifier: "when atdd orchestrate is invoked and the user wants surfaces in the current workspace instead of new workspaces but the CLI offers no flag to express that intent"
+lens: "functional.effectiveness"
+statement: "minimize quantity of orchestrate-invocations-that-cannot-opt-into-pane-mode when atdd orchestrate is invoked"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D016-UNIT-001-orchestrate-multiplexer-mode-flag"
+      id: "AC-UNIT-001"
+      purpose: "atdd orchestrate accepts --multiplexer-mode {workspace,pane} (default workspace), and dispatches per mode"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Orchestrate is parametrized with --multiplexer-mode pane and a list of issue numbers"
+    when:
+      abstract: "Orchestrate runs the wave-launch step"
+    then:
+      abstract:
+        - "backend.new_surface is called once per issue"
+        - "backend.new_workspace is NOT called"
+        - "The orchestrate state file records the surface ref per issue"
+        - "Default invocation (no flag) preserves the existing workspace mode"
+    signal:
+      metric: "wrong_backend_method_call_count"
+      threshold: 0
+  - identity:
+      urn: "acc:govern-lifecycle:D016-UNIT-002-resume-respects-mode"
+      id: "AC-UNIT-002"
+      purpose: "atdd orchestrate --multiplexer-mode pane --resume re-attaches to existing surface refs without recreating them"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "An orchestrate state file from a prior pane-mode run"
+    when:
+      abstract: "Orchestrate is invoked with --multiplexer-mode pane --resume"
+    then:
+      abstract:
+        - "Existing surface refs in state are reused"
+        - "No new surfaces are created for already-launched issues"
+    signal:
+      metric: "duplicate_spawn_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-01"

--- a/plan/govern_lifecycle/D017.yaml
+++ b/plan/govern_lifecycle/D017.yaml
@@ -1,0 +1,54 @@
+urn: "wmbt:govern-lifecycle:D017"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "convention-rules-whose-letter-hides-their-intent"
+context_clarifier: "when src/atdd/coach/conventions/orchestration.convention.yaml rule one_agent_per_workspace says 'exactly one agent per multiplexer workspace' but the underlying intent is 'one isolated agent context per session unit' regardless of whether the unit is a workspace or a surface"
+lens: "structural.coherence"
+statement: "minimize quantity of convention-rules-whose-letter-hides-their-intent when the orchestration convention's rule is read alongside pane mode"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:D017-UNIT-001-convention-amended-to-session-unit"
+      id: "AC-UNIT-001"
+      purpose: "Convention rule renamed to one_agent_per_session_unit with workspace-mode and pane-mode sub-rules; sub-agent delegation remains the anti-pattern"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "orchestration.convention.yaml is parsed"
+    when:
+      abstract: "Rule keys are inspected"
+    then:
+      abstract:
+        - "Key 'one_agent_per_session_unit' exists"
+        - "Two sub-rules exist: workspace mode (one agent per workspace) and pane mode (one agent per surface)"
+        - "Anti-pattern remains: sub-agent delegation that shares context within one agent's session"
+        - "Old key 'one_agent_per_workspace' is removed (or marked deprecated with a pointer to the new key)"
+    signal:
+      metric: "convention_rule_drift_count"
+      threshold: 0
+  - identity:
+      urn: "acc:govern-lifecycle:D017-UNIT-002-babysit-shared-state-documented"
+      id: "AC-UNIT-002"
+      purpose: "Convention documents that pane mode shares WorkspaceState across surfaces; surface-isolated state is a follow-on"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "orchestration.convention.yaml is parsed"
+    when:
+      abstract: "babysit-related sections are inspected"
+    then:
+      abstract:
+        - "A note documents shared WorkspaceState in pane mode"
+        - "A pointer to the surface-isolated-state follow-on issue is present (or marked TBD if the follow-on is not yet filed)"
+    signal:
+      metric: "missing_caveat_count"
+      threshold: 0
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-01"

--- a/plan/govern_lifecycle/D017.yaml
+++ b/plan/govern_lifecycle/D017.yaml
@@ -4,7 +4,7 @@ direction: "minimize"
 dimension: "quantity"
 object_of_control: "convention-rules-whose-letter-hides-their-intent"
 context_clarifier: "when src/atdd/coach/conventions/orchestration.convention.yaml rule one_agent_per_workspace says 'exactly one agent per multiplexer workspace' but the underlying intent is 'one isolated agent context per session unit' regardless of whether the unit is a workspace or a surface"
-lens: "structural.coherence"
+lens: "functional.adaptability"
 statement: "minimize quantity of convention-rules-whose-letter-hides-their-intent when the orchestration convention's rule is read alongside pane mode"
 acceptances:
   - identity:

--- a/plan/govern_lifecycle/_govern_lifecycle.yaml
+++ b/plan/govern_lifecycle/_govern_lifecycle.yaml
@@ -34,9 +34,10 @@ features:
   - urn: "feature:govern-lifecycle:enforce-issue-label-compliance"
   - urn: "feature:govern-lifecycle:custom-themes"
   - urn: "feature:govern-lifecycle:config-driven-code-roots"
+  - urn: "feature:govern-lifecycle:orchestrate-pane-mode"
 
 wmbt:
-  total: 21
+  total: 25
   R001: "minimize stale local manifest status after a successful GitHub transition"
   R002: "minimize misleading layout errors during post-transition re-enter"
   R003: "minimize stale hierarchy_coverage_features ratchet baseline carrying tactical baseline bumps"
@@ -53,6 +54,10 @@ wmbt:
   D011: "minimize hardcoded implementation-root constants in coder validators blocking multi-stack adoption"
   D012: "minimize toolkit-self features invisible to the hierarchy-coverage validator"
   D013: "minimize schema drift between documented CLAUDE.md code: contract and enforced config"
+  D014: "minimize multiplexer abstractions that bind the spawn unit to workspace-level only"
+  D015: "minimize cmux pane and surface primitives left unreachable from the multiplexer abstraction"
+  D016: "minimize orchestrate invocations that cannot opt into pane mode without forking"
+  D017: "minimize convention rules whose letter (workspace) hides their intent (one isolated agent context)"
   L001: "minimize manual theme discovery during atdd init"
   P001: "minimize blind theme prompts that force game-domain defaults on non-game repos"
   C001: "minimize invalid custom theme names accepted into config"

--- a/plan/govern_lifecycle/features/orchestrate_pane_mode.yaml
+++ b/plan/govern_lifecycle/features/orchestrate_pane_mode.yaml
@@ -1,0 +1,30 @@
+urn: "feature:govern-lifecycle:orchestrate-pane-mode"
+wagon: "wagon:govern-lifecycle"
+description: "Adds pane-mode multiplexer backend so atdd orchestrate can spawn surfaces inside the current cmux workspace instead of new workspaces, mirroring the project/main + project/feat-* worktree-sibling layout in cmux."
+sizing:
+  wmbts: 4
+  footprint_score: 5
+  footprint_size: "M"
+wmbts:
+  - "wmbt:govern-lifecycle:D014"
+  - "wmbt:govern-lifecycle:D015"
+  - "wmbt:govern-lifecycle:D016"
+  - "wmbt:govern-lifecycle:D017"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 1
+        rationale: "One new CLI flag on atdd orchestrate: --multiplexer-mode {workspace,pane}"
+    application:
+      - type: "use_cases"
+        count: 2
+        rationale: "Multiplexer.new_surface ref-aware dispatch use case; orchestrate per-issue mode-dispatch use case"
+    domain:
+      - type: "entities"
+        count: 0
+        rationale: "Surface is already a cmux concept; the multiplexer abstraction grows, no new domain entity"
+    integration:
+      - type: "repositories"
+        count: 1
+        rationale: "CmuxMultiplexer backend grows ref-prefix dispatch table for read/send/send_key/close"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.62.2"
+version = "1.62.4"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -818,6 +818,19 @@ Phase descriptions:
         help="Force multiplexer backend (default: auto-detect)",
     )
     orchestrate_parser.add_argument(
+        "--multiplexer-mode",
+        type=str,
+        choices=["workspace", "pane"],
+        default="workspace",
+        dest="multiplexer_mode",
+        help=(
+            "Session unit per issue: 'workspace' spawns a new cmux workspace per issue "
+            "(default, back-compat); 'pane' creates a new surface inside the current "
+            "workspace (cmux only — mirrors the project/main + project/feat-* worktree "
+            "sibling layout)"
+        ),
+    )
+    orchestrate_parser.add_argument(
         "--dry-run",
         action="store_true",
         dest="dry_run",
@@ -1593,6 +1606,7 @@ Phase descriptions:
             autonomous=getattr(args, "autonomous", False),
             resume=getattr(args, "resume", False),
             multiplexer=getattr(args, "multiplexer", None),
+            multiplexer_mode=getattr(args, "multiplexer_mode", "workspace"),
             dry_run=getattr(args, "dry_run", False),
             state_file=getattr(args, "state_file", ".atdd/orchestrate-state.json"),
         )

--- a/src/atdd/coach/commands/orchestrate.py
+++ b/src/atdd/coach/commands/orchestrate.py
@@ -171,9 +171,18 @@ def run(
     autonomous: bool = False,
     resume: bool = False,
     multiplexer: Optional[str] = None,
+    multiplexer_mode: str = "workspace",
     dry_run: bool = False,
     state_file: str = ".atdd/orchestrate-state.json",
 ) -> int:
+    if multiplexer_mode not in ("workspace", "pane"):
+        print(
+            f"❌ unknown --multiplexer-mode '{multiplexer_mode}' "
+            f"(expected 'workspace' or 'pane')",
+            file=sys.stderr,
+        )
+        return 5
+
     state_path = Path(state_file)
     state = load_state(state_path) if resume else {}
 
@@ -224,6 +233,7 @@ def run(
     for num, issue in plan.items():
         key = str(num)
         if resume and state.get(key, {}).get("launched"):
+            issue.workspace_ref = state[key].get("ref") or state[key].get("workspace_ref", "")
             continue
         context = build_context(
             issue_number=num,
@@ -247,18 +257,31 @@ def run(
             f"\"$(cat {script_path})\""
         )
         try:
-            ref = backend.new_workspace(
-                cwd=issue.worktree_path,
-                command=launch_cmd,
-                name=f"issue-{num}",
-            )
-        except MultiplexerError as exc:
+            if multiplexer_mode == "pane":
+                ref = backend.new_surface(
+                    cwd=issue.worktree_path,
+                    command=launch_cmd,
+                    name=f"issue-{num}",
+                )
+            else:
+                ref = backend.new_workspace(
+                    cwd=issue.worktree_path,
+                    command=launch_cmd,
+                    name=f"issue-{num}",
+                )
+        except (MultiplexerError, NotImplementedError) as exc:
             print(f"⚠️  failed to launch session for #{num}: {exc}", file=sys.stderr)
             state[key]["launched"] = False
             save_state(state_path, state)
             continue
         issue.workspace_ref = ref
-        state[key].update({"launched": True, "workspace_ref": ref})
+        state[key].update({
+            "launched": True,
+            "ref": ref,
+            "mode": multiplexer_mode,
+            # Back-compat: keep workspace_ref populated when mode=workspace
+            **({"workspace_ref": ref} if multiplexer_mode == "workspace" else {}),
+        })
         save_state(state_path, state)
         print(f"✓ launched #{num} in {ref}")
 

--- a/src/atdd/coach/commands/orchestrate.py
+++ b/src/atdd/coach/commands/orchestrate.py
@@ -279,8 +279,6 @@ def run(
             "launched": True,
             "ref": ref,
             "mode": multiplexer_mode,
-            # Back-compat: keep workspace_ref populated when mode=workspace
-            **({"workspace_ref": ref} if multiplexer_mode == "workspace" else {}),
         })
         save_state(state_path, state)
         print(f"✓ launched #{num} in {ref}")

--- a/src/atdd/coach/commands/tests/test_babysit_pane_mode.py
+++ b/src/atdd/coach/commands/tests/test_babysit_pane_mode.py
@@ -1,0 +1,119 @@
+"""
+Babysit behaviour with pane-mode refs.
+
+WMBT: wmbt:govern-lifecycle:D017-AC-UNIT-002
+Phase 4 deliverable from #343.
+
+Asserts:
+1. Babysit reads each ref independently — surface refs work the same as workspace refs
+   because refs are opaque strings dispatched by the backend.
+2. When babysit receives a workspace ref that aggregates multiple surfaces, all
+   surface output flows through one WorkspaceState entry — the shared-state caveat
+   documented in orchestration.convention.yaml.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from atdd.coach.commands.babysit import (
+    BabysitDecision,
+    WorkspaceState,
+    process_workspace,
+)
+
+pytestmark = [pytest.mark.platform]
+
+
+def _silent_backend(screens: list[str]) -> MagicMock:
+    backend = MagicMock()
+    backend.read_screen.side_effect = screens
+    return backend
+
+
+def test_babysit_reads_surface_ref_like_workspace_ref(tmp_path: Path):
+    """Babysit treats a surface:* ref the same as a workspace:* ref — refs are opaque."""
+    backend = _silent_backend(["idle output\n"])
+    state = WorkspaceState(ref="surface:31")
+
+    decision = process_workspace(
+        backend=backend,
+        state=state,
+        stale_warn_minutes=15,
+        stale_escalate_minutes=30,
+        log_path=tmp_path / "log.jsonl",
+    )
+
+    backend.read_screen.assert_called_once_with("surface:31", lines=80)
+    assert decision.action == "idle"
+
+
+def test_babysit_pane_mode_shares_state_per_ref(tmp_path: Path):
+    """Documented caveat: state is keyed by ref.
+
+    When babysit is configured with a single workspace ref (pane mode default),
+    multi-surface output is aggregated by cmux read-screen --workspace and
+    ALL of it flows through one WorkspaceState entry. The state has no
+    per-surface attribution — that is the shared-state caveat.
+    """
+    # Two consecutive screen captures from a workspace that hosts many surfaces.
+    screens = [
+        "surface A says: hello\n",
+        "surface A says: hello\nsurface B says: world\n",
+    ]
+    backend = _silent_backend(screens)
+    state = WorkspaceState(ref="workspace:17")
+
+    process_workspace(
+        backend=backend,
+        state=state,
+        stale_warn_minutes=15,
+        stale_escalate_minutes=30,
+        log_path=tmp_path / "log.jsonl",
+    )
+    first_hash = state.last_screen_hash
+    first_change = state.last_change_ts
+
+    process_workspace(
+        backend=backend,
+        state=state,
+        stale_warn_minutes=15,
+        stale_escalate_minutes=30,
+        log_path=tmp_path / "log.jsonl",
+    )
+
+    # Same WorkspaceState updated twice; the hash changed because surface B's
+    # output flowed through. There is no per-surface bookkeeping — by design.
+    assert state.last_screen_hash != first_hash
+    assert state.last_change_ts >= first_change
+
+
+def test_babysit_handles_mixed_workspace_and_surface_refs(tmp_path: Path):
+    """Babysit can monitor multiple refs of either kind in one run."""
+    backend = MagicMock()
+    backend.read_screen.side_effect = ["w\n", "s\n"]
+
+    workspace_state = WorkspaceState(ref="workspace:17")
+    surface_state = WorkspaceState(ref="surface:31")
+
+    process_workspace(
+        backend=backend,
+        state=workspace_state,
+        stale_warn_minutes=15,
+        stale_escalate_minutes=30,
+        log_path=tmp_path / "log.jsonl",
+    )
+    process_workspace(
+        backend=backend,
+        state=surface_state,
+        stale_warn_minutes=15,
+        stale_escalate_minutes=30,
+        log_path=tmp_path / "log.jsonl",
+    )
+
+    calls = [c.args[0] for c in backend.read_screen.call_args_list]
+    assert calls == ["workspace:17", "surface:31"]
+    assert workspace_state.last_screen_hash != ""
+    assert surface_state.last_screen_hash != ""

--- a/src/atdd/coach/commands/tests/test_multiplexer.py
+++ b/src/atdd/coach/commands/tests/test_multiplexer.py
@@ -349,3 +349,184 @@ def test_zellij_missing_binary_raises_multiplexer_error():
     with patch("atdd.coach.utils.multiplexer.subprocess.run", side_effect=FileNotFoundError):
         with pytest.raises(MultiplexerError, match="binary not found"):
             backend.read_screen("sess1")
+
+
+# ---------------------------------------------------------------------------
+# Surface (pane mode) — abstract contract + cmux dispatch
+# wmbt:govern-lifecycle:D014, D015
+# ---------------------------------------------------------------------------
+
+
+def test_new_surface_contract_declared_on_abstract_base():
+    """D014-AC-UNIT-001: new_surface is declared on the abstract base alongside new_workspace."""
+    from atdd.coach.utils.multiplexer import MultiplexerBackend
+
+    assert hasattr(MultiplexerBackend, "new_surface")
+    assert hasattr(MultiplexerBackend, "new_workspace")
+    # new_workspace signature unchanged: (cwd, command, name=None)
+    import inspect
+    ws_params = inspect.signature(MultiplexerBackend.new_workspace).parameters
+    assert "cwd" in ws_params
+    assert "command" in ws_params
+    assert "name" in ws_params
+
+
+def test_zellij_new_surface_raises_not_implemented():
+    """D014-AC-UNIT-001: backends without pane semantics raise NotImplementedError."""
+    backend = ZellijBackend()
+    with pytest.raises(NotImplementedError):
+        backend.new_surface(cwd="/tmp/wt", command="echo hi")
+
+
+def test_tmux_new_surface_raises_not_implemented():
+    """D014-AC-UNIT-001: tmux backend raises NotImplementedError for new_surface."""
+    backend = TmuxBackend()
+    with pytest.raises(NotImplementedError):
+        backend.new_surface(cwd="/tmp/wt", command="echo hi")
+
+
+def test_cmux_new_surface_creates_pane_then_surface_then_seeds():
+    """D015-AC-UNIT-002: pane_ref=None → cmux new-pane → cmux new-surface → seed cwd+command via surface.send_text.
+
+    Returned ref has the surface:* prefix.
+    """
+    backend = CmuxBackend()
+    calls: list[list[str]] = []
+    outputs = iter(["pane:42\n", "surface:99\n", ""])
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        try:
+            stdout = next(outputs)
+        except StopIteration:
+            stdout = ""
+        return _make_result(stdout=stdout)
+
+    with patch("atdd.coach.utils.multiplexer.subprocess.run", side_effect=fake_run):
+        ref = backend.new_surface(
+            workspace_ref="workspace:17",
+            pane_ref=None,
+            cwd="/x",
+            command="echo y",
+            name="issue-340",
+        )
+
+    assert ref == "surface:99"
+    # Call 0 — cmux new-pane with the workspace ref
+    assert calls[0][:2] == ["cmux", "new-pane"]
+    assert "workspace:17" in calls[0]
+    # Call 1 — cmux new-surface with the freshly-created pane ref
+    assert calls[1][:2] == ["cmux", "new-surface"]
+    assert "pane:42" in calls[1]
+    # Call 2 — cmux rpc surface.send_text seeding cwd + command together
+    assert calls[2][:3] == ["cmux", "rpc", "surface.send_text"]
+    seeded = next(arg for arg in calls[2] if "echo y" in arg)
+    assert seeded == "cd /x && echo y\n"
+    assert "surface:99" in calls[2]
+
+
+def test_cmux_new_surface_with_existing_pane_skips_new_pane():
+    """When a caller passes pane_ref, the backend skips cmux new-pane."""
+    backend = CmuxBackend()
+    calls: list[list[str]] = []
+    outputs = iter(["surface:100\n", ""])
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        try:
+            stdout = next(outputs)
+        except StopIteration:
+            stdout = ""
+        return _make_result(stdout=stdout)
+
+    with patch("atdd.coach.utils.multiplexer.subprocess.run", side_effect=fake_run):
+        ref = backend.new_surface(
+            workspace_ref="workspace:17",
+            pane_ref="pane:23",
+            cwd="/y",
+            command="claude",
+        )
+
+    assert ref == "surface:100"
+    assert calls[0][:2] == ["cmux", "new-surface"]
+    assert "pane:23" in calls[0]
+    # No cmux new-pane call
+    assert all(c[:2] != ["cmux", "new-pane"] for c in calls)
+
+
+def test_cmux_read_screen_dispatches_by_ref_prefix():
+    """D015-AC-UNIT-001: workspace:* → cmux read-screen --workspace; surface:* → cmux rpc surface.read_text."""
+    backend = CmuxBackend()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _make_result(stdout="line1\nline2\n")
+
+    with patch("atdd.coach.utils.multiplexer.subprocess.run", side_effect=fake_run):
+        backend.read_screen("workspace:5", lines=10)
+        backend.read_screen("surface:31", lines=10)
+
+    assert calls[0][:2] == ["cmux", "read-screen"]
+    assert "--workspace" in calls[0]
+    assert "workspace:5" in calls[0]
+
+    assert calls[1][:3] == ["cmux", "rpc", "surface.read_text"]
+    assert "surface:31" in calls[1]
+
+
+def test_cmux_send_dispatches_by_ref_prefix():
+    """D015-AC-UNIT-001: workspace:* → cmux send --workspace; surface:* → cmux rpc surface.send_text."""
+    backend = CmuxBackend()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _make_result()
+
+    with patch("atdd.coach.utils.multiplexer.subprocess.run", side_effect=fake_run):
+        backend.send("workspace:5", "hello")
+        backend.send("surface:31", "hi")
+
+    assert calls[0][:3] == ["cmux", "send", "--workspace"]
+    assert "hello" in calls[0]
+    assert calls[1][:3] == ["cmux", "rpc", "surface.send_text"]
+    assert "surface:31" in calls[1]
+    assert "hi" in calls[1]
+
+
+def test_cmux_send_key_dispatches_by_ref_prefix():
+    """workspace:* → cmux send-key --workspace; surface:* → cmux rpc surface.send_key."""
+    backend = CmuxBackend()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _make_result()
+
+    with patch("atdd.coach.utils.multiplexer.subprocess.run", side_effect=fake_run):
+        backend.send_key("workspace:5", "Enter")
+        backend.send_key("surface:31", "Enter")
+
+    assert calls[0][:3] == ["cmux", "send-key", "--workspace"]
+    assert calls[1][:3] == ["cmux", "rpc", "surface.send_key"]
+    assert "surface:31" in calls[1]
+
+
+def test_cmux_close_dispatches_by_ref_prefix():
+    """D015-AC-UNIT-001: workspace:* → cmux close-workspace; surface:* → cmux close-surface."""
+    backend = CmuxBackend()
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _make_result()
+
+    with patch("atdd.coach.utils.multiplexer.subprocess.run", side_effect=fake_run):
+        backend.close("workspace:5")
+        backend.close("surface:31")
+
+    assert calls[0][:2] == ["cmux", "close-workspace"]
+    assert "workspace:5" in calls[0]
+    assert calls[1][:2] == ["cmux", "close-surface"]
+    assert "surface:31" in calls[1]

--- a/src/atdd/coach/commands/tests/test_orchestrate.py
+++ b/src/atdd/coach/commands/tests/test_orchestrate.py
@@ -158,3 +158,155 @@ def test_build_plan_skips_unfetchable():
     ):
         plan = build_plan([42])
     assert plan == {}
+
+
+# ---------------------------------------------------------------------------
+# --multiplexer-mode pane (wmbt:govern-lifecycle:D016)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBackend:
+    """Records calls; returns predictable refs for new_workspace/new_surface."""
+
+    def __init__(self):
+        self.workspace_calls: list[dict] = []
+        self.surface_calls: list[dict] = []
+        self._wcounter = 0
+        self._scounter = 0
+
+    def new_workspace(self, cwd, command, name=None):
+        self._wcounter += 1
+        self.workspace_calls.append({"cwd": cwd, "command": command, "name": name})
+        return f"workspace:{self._wcounter}"
+
+    def new_surface(self, workspace_ref=None, pane_ref=None, cwd=None, command=None, name=None):
+        self._scounter += 1
+        self.surface_calls.append({
+            "workspace_ref": workspace_ref,
+            "pane_ref": pane_ref,
+            "cwd": cwd,
+            "command": command,
+            "name": name,
+        })
+        return f"surface:{self._scounter}"
+
+
+def _wire_run_orchestrate(tmp_path, backend, plan: dict[int, PlannedIssue]):
+    """Patch orchestrate's collaborators so run() exercises the dispatch logic only."""
+    from atdd.coach.commands import orchestrate as orch
+
+    def fake_build_plan(issue_numbers):
+        return {n: plan[n] for n in issue_numbers if n in plan}
+
+    def fake_create_worktree(branch, path):
+        Path(path).mkdir(parents=True, exist_ok=True)
+
+    fake_build_context = lambda *a, **kw: type(
+        "Ctx", (), {"branch": kw.get("branch", "feat/x"), "stop_condition": ""}
+    )()
+    fake_render = lambda ctx: "launch script body"
+
+    return patch.multiple(
+        orch,
+        build_plan=fake_build_plan,
+        _create_worktree=fake_create_worktree,
+        get_multiplexer=lambda preferred=None: backend,
+        build_context=lambda **kw: type("Ctx", (), {"stop_condition": "", "branch": "feat/x"})(),
+        render=lambda ctx: "launch script body",
+    )
+
+
+def test_orchestrate_pane_mode_calls_new_surface_not_new_workspace(tmp_path: Path):
+    """D016-AC-UNIT-001: pane mode dispatches to new_surface; new_workspace is NOT called.
+
+    State file records the surface ref per issue.
+    """
+    from atdd.coach.commands.orchestrate import run as run_orchestrate
+
+    plan = {
+        1: PlannedIssue(number=1, title="A", branch="feat/a", body="", dependencies=[]),
+        2: PlannedIssue(number=2, title="B", branch="feat/b", body="", dependencies=[]),
+    }
+    backend = _FakeBackend()
+    state_file = tmp_path / "state.json"
+
+    with _wire_run_orchestrate(tmp_path, backend, plan):
+        rc = run_orchestrate(
+            issue_numbers=[1, 2],
+            multiplexer_mode="pane",
+            state_file=str(state_file),
+        )
+
+    assert rc == 0
+    assert len(backend.surface_calls) == 2
+    assert backend.workspace_calls == []
+
+    saved = json.loads(state_file.read_text())
+    assert saved["1"]["mode"] == "pane"
+    assert saved["1"]["ref"].startswith("surface:")
+    assert saved["2"]["ref"].startswith("surface:")
+
+
+def test_orchestrate_default_mode_is_workspace_backwards_compatible(tmp_path: Path):
+    """D016-AC-UNIT-001: default invocation (no flag) preserves the existing workspace mode."""
+    from atdd.coach.commands.orchestrate import run as run_orchestrate
+
+    plan = {1: PlannedIssue(number=1, title="A", branch="feat/a", body="", dependencies=[])}
+    backend = _FakeBackend()
+    state_file = tmp_path / "state.json"
+
+    with _wire_run_orchestrate(tmp_path, backend, plan):
+        rc = run_orchestrate(
+            issue_numbers=[1],
+            state_file=str(state_file),
+        )
+
+    assert rc == 0
+    assert len(backend.workspace_calls) == 1
+    assert backend.surface_calls == []
+
+
+def test_orchestrate_resume_pane_mode_skips_already_launched(tmp_path: Path):
+    """D016-AC-UNIT-002: --resume in pane mode reuses existing surface refs without recreating them."""
+    from atdd.coach.commands.orchestrate import run as run_orchestrate
+
+    plan = {
+        1: PlannedIssue(number=1, title="A", branch="feat/a", body="", dependencies=[]),
+        2: PlannedIssue(number=2, title="B", branch="feat/b", body="", dependencies=[]),
+    }
+    backend = _FakeBackend()
+    state_file = tmp_path / "state.json"
+
+    # Pre-existing state from a prior pane-mode run
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(json.dumps({
+        "1": {
+            "worktree_created": True,
+            "worktree_path": str(tmp_path / "feat-a"),
+            "launched": True,
+            "ref": "surface:777",
+            "mode": "pane",
+        },
+        "2": {
+            "worktree_created": True,
+            "worktree_path": str(tmp_path / "feat-b"),
+        },
+    }))
+
+    with _wire_run_orchestrate(tmp_path, backend, plan):
+        rc = run_orchestrate(
+            issue_numbers=[1, 2],
+            multiplexer_mode="pane",
+            resume=True,
+            state_file=str(state_file),
+        )
+
+    assert rc == 0
+    # Issue 1 is already launched in pane mode → should NOT call new_surface again.
+    # Only issue 2 needs a fresh surface.
+    assert len(backend.surface_calls) == 1
+    assert len(backend.workspace_calls) == 0
+
+    saved = json.loads(state_file.read_text())
+    assert saved["1"]["ref"] == "surface:777"  # untouched
+    assert saved["2"]["ref"].startswith("surface:")

--- a/src/atdd/coach/commands/tests/test_orchestration_convention_session_unit.py
+++ b/src/atdd/coach/commands/tests/test_orchestration_convention_session_unit.py
@@ -1,0 +1,75 @@
+"""
+Test that orchestration.convention.yaml is amended for pane mode.
+
+WMBT: wmbt:govern-lifecycle:D017
+- AC-UNIT-001: rule renamed to one_agent_per_session_unit with workspace + pane sub-rules
+- AC-UNIT-002: babysit shared-state caveat documented for pane mode
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.platform]
+
+CONVENTION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "coach"
+    / "conventions"
+    / "orchestration.convention.yaml"
+)
+
+
+def _load_convention() -> dict:
+    with CONVENTION_PATH.open() as f:
+        return yaml.safe_load(f)
+
+
+def test_convention_renames_to_one_agent_per_session_unit():
+    """D017-AC-UNIT-001: rule renamed; sub-rules cover workspace mode and pane mode."""
+    doc = _load_convention()
+    rules = doc["rules"]
+
+    assert "one_agent_per_session_unit" in rules, (
+        "Expected 'one_agent_per_session_unit' as the renamed rule key"
+    )
+
+    rule = rules["one_agent_per_session_unit"]
+    # Two sub-rules must be present: workspace mode + pane mode
+    sub_rules = rule.get("sub_rules") or rule.get("modes") or {}
+    assert isinstance(sub_rules, dict)
+    assert "workspace" in sub_rules, "workspace-mode sub-rule missing"
+    assert "pane" in sub_rules, "pane-mode sub-rule missing"
+
+    # Anti-pattern about sub-agent delegation must remain present somewhere
+    serialised = yaml.safe_dump(rule)
+    assert "sub-agent" in serialised.lower() or "sub_agent" in serialised.lower(), (
+        "Anti-pattern about sub-agent delegation must remain documented"
+    )
+
+
+def test_convention_old_key_removed_or_marked_deprecated():
+    """D017-AC-UNIT-001: old key removed or explicitly marked deprecated."""
+    doc = _load_convention()
+    rules = doc["rules"]
+    if "one_agent_per_workspace" in rules:
+        deprecated = rules["one_agent_per_workspace"].get("deprecated")
+        pointer = rules["one_agent_per_workspace"].get("see") or rules[
+            "one_agent_per_workspace"
+        ].get("renamed_to")
+        assert deprecated, "Legacy key kept without deprecation marker"
+        assert pointer == "one_agent_per_session_unit", (
+            "Deprecated key must point to the new key"
+        )
+
+
+def test_convention_documents_babysit_shared_state_caveat():
+    """D017-AC-UNIT-002: pane mode shared WorkspaceState caveat is documented."""
+    doc = _load_convention()
+    serialised = yaml.safe_dump(doc).lower()
+
+    assert "shared" in serialised
+    assert "workspacestate" in serialised or "workspace state" in serialised
+    assert "pane" in serialised

--- a/src/atdd/coach/conventions/orchestration.convention.yaml
+++ b/src/atdd/coach/conventions/orchestration.convention.yaml
@@ -13,10 +13,32 @@ rules:
     anti_pattern: "Reusing a worktree across issues causes merge conflicts"
     enforced_by: "atdd orchestrate (two-phase commit: create all worktrees before launch)"
 
+  one_agent_per_session_unit:
+    rule: "Exactly one agent session per multiplexer session unit (workspace OR surface)"
+    anti_pattern: "Sub-agent delegation that shares context within one agent's session"
+    enforced_by: "atdd orchestrate launches one claude process per session unit, regardless of mode"
+    sub_rules:
+      workspace:
+        applies_when: "atdd orchestrate --multiplexer-mode workspace (default)"
+        rule: "One agent session per multiplexer workspace"
+        layout: "Each issue spawns a new cmux workspace via cmux new-workspace"
+        recommended_for: "Repos that want full isolation between concurrent issues, including independent scrollback per workspace"
+      pane:
+        applies_when: "atdd orchestrate --multiplexer-mode pane (cmux only)"
+        rule: "One agent session per multiplexer surface inside a shared workspace"
+        layout: "Each issue spawns a surface inside the current cmux workspace via cmux new-pane + cmux new-surface"
+        recommended_for: "Repos that follow CLAUDE.md git.branching.layout (project/main + project/feat-* siblings); mirrors the worktree-sibling layout in cmux"
+        babysit_caveat: |
+          Pane mode shares WorkspaceState across surfaces in one workspace. Babysit reads
+          at workspace scope; auto-approvals and escalations fire on the focused surface's
+          screen, not per-surface. Surface-isolated state is a follow-on if shared state
+          becomes too noisy.
+
   one_agent_per_workspace:
-    rule: "Exactly one agent session per multiplexer workspace"
-    anti_pattern: "Sub-agent delegation shares context and cannot be monitored independently"
-    enforced_by: "atdd orchestrate launches one claude process per workspace"
+    deprecated: true
+    renamed_to: "one_agent_per_session_unit"
+    see: "one_agent_per_session_unit"
+    note: "Generalized to cover pane mode (cmux surfaces). Anti-pattern unchanged."
 
   wave_ordering:
     rule: "Issues are grouped into waves via topological sort on their dependency DAG"
@@ -35,6 +57,11 @@ rules:
     interval_default_seconds: 60
     stale_warn_minutes: 15
     stale_escalate_minutes: 30
+    pane_mode_caveat: |
+      In pane mode, multiple surfaces share a single workspace and therefore a single
+      WorkspaceState entry. Babysit observes the focused surface; cross-surface
+      auto-approval bookkeeping is shared, not isolated. Per-surface isolated state is
+      out of scope for #343 — file a follow-on if shared state causes drift in practice.
 
   micro_commit:
     rule: "Orchestrated sessions inherit micro-commit discipline (see CLAUDE.md)"

--- a/src/atdd/coach/utils/multiplexer.py
+++ b/src/atdd/coach/utils/multiplexer.py
@@ -7,13 +7,18 @@ Used by `atdd orchestrate` to launch parallel agent sessions, and by
 Convention: src/atdd/coach/conventions/orchestration.convention.yaml
 SPEC IDs: SPEC-COACH-ORCH-0003
 
-Operations (unified):
-    new_workspace(cwd, command, name=None) -> workspace_ref
-    read_screen(workspace_ref, lines=50)   -> str
-    send(workspace_ref, text)              -> None
-    send_key(workspace_ref, key)           -> None
-    list_workspaces()                      -> list[str]
-    close(workspace_ref)                   -> None
+Refs come in two flavours and are dispatched by string prefix:
+    workspace:NN  → top-level cmux workspace
+    surface:NN    → terminal tab inside a pane inside a workspace
+
+Operations (unified — all ref-consumers accept either workspace or surface refs):
+    new_workspace(cwd, command, name=None)                          -> MultiplexerRef
+    new_surface(workspace_ref?, pane_ref?, cwd?, command?, name?)   -> MultiplexerRef
+    read_screen(ref, lines=50)                                      -> str
+    send(ref, text)                                                 -> None
+    send_key(ref, key)                                              -> None
+    list_workspaces()                                               -> list[str]
+    close(ref)                                                      -> None
 
 Auto-detection precedence:
     get_multiplexer()  # cmux > zellij > tmux > None.
@@ -27,6 +32,10 @@ from abc import ABC, abstractmethod
 from typing import Optional
 
 
+# Type alias — opaque ref string with prefix `workspace:` or `surface:`.
+MultiplexerRef = str
+
+
 class MultiplexerError(RuntimeError):
     """Raised when a multiplexer operation fails."""
 
@@ -37,28 +46,44 @@ class MultiplexerBackend(ABC):
     name: str = "abstract"
 
     @abstractmethod
-    def new_workspace(self, cwd: str, command: str, name: Optional[str] = None) -> str:
+    def new_workspace(self, cwd: str, command: str, name: Optional[str] = None) -> MultiplexerRef:
         """Create a workspace and return an opaque reference."""
 
-    @abstractmethod
-    def read_screen(self, workspace_ref: str, lines: int = 50) -> str:
-        """Capture the last `lines` lines of the workspace screen."""
+    def new_surface(
+        self,
+        workspace_ref: Optional[MultiplexerRef] = None,
+        pane_ref: Optional[MultiplexerRef] = None,
+        cwd: Optional[str] = None,
+        command: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> MultiplexerRef:
+        """Create a surface (terminal tab) inside a pane and return its ref.
+
+        Backends without pane semantics raise NotImplementedError.
+        """
+        raise NotImplementedError(
+            f"{self.name} backend does not support pane/surface creation"
+        )
 
     @abstractmethod
-    def send(self, workspace_ref: str, text: str) -> None:
-        """Send literal text to the workspace."""
+    def read_screen(self, ref: MultiplexerRef, lines: int = 50) -> str:
+        """Capture the last `lines` lines of the workspace or surface screen."""
 
     @abstractmethod
-    def send_key(self, workspace_ref: str, key: str) -> None:
-        """Send a key press (e.g. 'Enter', 'C-c') to the workspace."""
+    def send(self, ref: MultiplexerRef, text: str) -> None:
+        """Send literal text to the workspace or surface."""
+
+    @abstractmethod
+    def send_key(self, ref: MultiplexerRef, key: str) -> None:
+        """Send a key press (e.g. 'Enter', 'C-c') to the workspace or surface."""
 
     @abstractmethod
     def list_workspaces(self) -> list[str]:
         """List all known workspace references."""
 
     @abstractmethod
-    def close(self, workspace_ref: str) -> None:
-        """Close/kill the workspace."""
+    def close(self, ref: MultiplexerRef) -> None:
+        """Close/kill the workspace or surface."""
 
 
 def _run(cmd: list[str], capture: bool = True) -> subprocess.CompletedProcess:
@@ -78,41 +103,119 @@ def _run(cmd: list[str], capture: bool = True) -> subprocess.CompletedProcess:
         ) from exc
 
 
+def _is_surface_ref(ref: str) -> bool:
+    return ref.startswith("surface:")
+
+
+def _last_nonempty_line(stdout: str) -> str:
+    for line in reversed((stdout or "").splitlines()):
+        s = line.strip()
+        if s:
+            return s
+    return ""
+
+
 class CmuxBackend(MultiplexerBackend):
-    """cmux backend — workspace-based abstraction."""
+    """cmux backend — workspace + pane/surface dispatch.
+
+    Ref prefix dispatch table:
+        workspace:NN  → cmux <verb> --workspace NN
+        surface:NN    → cmux rpc surface.<verb>  (cmux close-surface for close)
+    """
 
     name = "cmux"
 
-    def new_workspace(self, cwd: str, command: str, name: Optional[str] = None) -> str:
+    def new_workspace(self, cwd: str, command: str, name: Optional[str] = None) -> MultiplexerRef:
         cmd = ["cmux", "new-workspace", "--cwd", cwd, "--command", command]
         if name:
             cmd.extend(["--name", name])
         result = _run(cmd)
-        ref = (result.stdout or "").strip().splitlines()[-1] if result.stdout else ""
+        ref = _last_nonempty_line(result.stdout or "")
         if not ref:
             ref = name or cwd
         return ref
 
-    def read_screen(self, workspace_ref: str, lines: int = 50) -> str:
+    def new_surface(
+        self,
+        workspace_ref: Optional[MultiplexerRef] = None,
+        pane_ref: Optional[MultiplexerRef] = None,
+        cwd: Optional[str] = None,
+        command: Optional[str] = None,
+        name: Optional[str] = None,
+    ) -> MultiplexerRef:
+        if pane_ref is None:
+            new_pane_cmd = ["cmux", "new-pane"]
+            if workspace_ref:
+                new_pane_cmd.extend(["--workspace", workspace_ref])
+            pane_result = _run(new_pane_cmd)
+            pane_ref = _last_nonempty_line(pane_result.stdout or "")
+            if not pane_ref:
+                raise MultiplexerError("cmux new-pane returned no pane ref")
+
+        new_surface_cmd = ["cmux", "new-surface", "--pane", pane_ref]
+        if name:
+            new_surface_cmd.extend(["--name", name])
+        surface_result = _run(new_surface_cmd)
+        surface_ref = _last_nonempty_line(surface_result.stdout or "")
+        if not surface_ref:
+            raise MultiplexerError("cmux new-surface returned no surface ref")
+
+        if cwd or command:
+            seed_parts = []
+            if cwd:
+                seed_parts.append(f"cd {cwd}")
+            if command:
+                seed_parts.append(command)
+            seed_text = " && ".join(seed_parts) + "\n"
+            _run(
+                ["cmux", "rpc", "surface.send_text", "--surface", surface_ref, seed_text],
+                capture=False,
+            )
+
+        return surface_ref
+
+    def read_screen(self, ref: MultiplexerRef, lines: int = 50) -> str:
+        if _is_surface_ref(ref):
+            result = _run(["cmux", "rpc", "surface.read_text", "--surface", ref])
+            out = result.stdout or ""
+            if lines and lines > 0:
+                tail = out.splitlines()[-lines:]
+                return "\n".join(tail) + ("\n" if out.endswith("\n") else "")
+            return out
         result = _run([
             "cmux", "read-screen",
-            "--workspace", workspace_ref,
+            "--workspace", ref,
             "--lines", str(lines),
         ])
         return result.stdout or ""
 
-    def send(self, workspace_ref: str, text: str) -> None:
-        _run(["cmux", "send", "--workspace", workspace_ref, text], capture=False)
+    def send(self, ref: MultiplexerRef, text: str) -> None:
+        if _is_surface_ref(ref):
+            _run(
+                ["cmux", "rpc", "surface.send_text", "--surface", ref, text],
+                capture=False,
+            )
+            return
+        _run(["cmux", "send", "--workspace", ref, text], capture=False)
 
-    def send_key(self, workspace_ref: str, key: str) -> None:
-        _run(["cmux", "send-key", "--workspace", workspace_ref, key], capture=False)
+    def send_key(self, ref: MultiplexerRef, key: str) -> None:
+        if _is_surface_ref(ref):
+            _run(
+                ["cmux", "rpc", "surface.send_key", "--surface", ref, key],
+                capture=False,
+            )
+            return
+        _run(["cmux", "send-key", "--workspace", ref, key], capture=False)
 
     def list_workspaces(self) -> list[str]:
         result = _run(["cmux", "list-workspaces"])
         return [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
 
-    def close(self, workspace_ref: str) -> None:
-        _run(["cmux", "close-workspace", "--workspace", workspace_ref], capture=False)
+    def close(self, ref: MultiplexerRef) -> None:
+        if _is_surface_ref(ref):
+            _run(["cmux", "close-surface", "--surface", ref], capture=False)
+            return
+        _run(["cmux", "close-workspace", "--workspace", ref], capture=False)
 
 
 class TmuxBackend(MultiplexerBackend):


### PR DESCRIPTION
Closes #343

## WMBT Sub-Issues

- [ ] #346 — wmbt:govern-lifecycle:D014 — minimize quantity of multiplexer-abstractions-bound-to-workspace-only-spawn-unit when src/atdd/coach/utils/multiplexer.py declares only new_workspace as the creation primitive
- [ ] #347 — wmbt:govern-lifecycle:D015 — minimize quantity of cmux-pane-and-surface-primitives-unreachable-from-multiplexer-abstraction when CmuxMultiplexer is the active backend
- [ ] #348 — wmbt:govern-lifecycle:D016 — minimize quantity of orchestrate-invocations-that-cannot-opt-into-pane-mode when atdd orchestrate is invoked
- [ ] #349 — wmbt:govern-lifecycle:D017 — minimize quantity of convention-rules-whose-letter-hides-their-intent when the orchestration convention's rule is read alongside pane mode

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #343 |
| Type | implementation |
| Slug | orchestrate-in-pane-mode |
| Train | 0001-self-compliance-validate |
| Labels | atdd-issue, atdd:PLANNED, archetype:coach |

---
PR created by `atdd pr`.