### PR TITLE
fix(coach): gate config_themes/init_themes_prompt/rule_id_uniqueness validators to toolkit-installed path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.63.4"
+version = "1.63.5"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/validators/test_config_themes.py
+++ b/src/atdd/coach/validators/test_config_themes.py
@@ -31,13 +31,14 @@ from pathlib import Path
 
 import pytest
 
-from atdd.coach.utils.repo import find_repo_root
+import atdd
 
 
-REPO_ROOT = find_repo_root()
-CONFIG_SCHEMA_PATH = (
-    REPO_ROOT / "src" / "atdd" / "coach" / "schemas" / "config.schema.json"
-)
+# Anchor schema lookup to the installed atdd package, not the consumer repo
+# root. find_repo_root() returns the *consumer* repo (no src/atdd/ inside),
+# which broke validate-coach in any pip-installed scenario.
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+CONFIG_SCHEMA_PATH = ATDD_PKG_DIR / "coach" / "schemas" / "config.schema.json"
 
 
 @pytest.fixture(scope="module")

--- a/src/atdd/coach/validators/test_init_themes_prompt.py
+++ b/src/atdd/coach/validators/test_init_themes_prompt.py
@@ -240,8 +240,8 @@ def test_custom_mode_output_validates_against_config_schema(tmp_path):
     jsonschema = pytest.importorskip("jsonschema")
     import json
 
+    import atdd
     from atdd.coach.commands.initializer import Initializer
-    from atdd.coach.utils.repo import find_repo_root
 
     # Seed scanner input so custom mode has something to return.
     plan_dir = tmp_path / "plan" / "secure_ops"
@@ -264,9 +264,10 @@ def test_custom_mode_output_validates_against_config_schema(tmp_path):
     themes = initializer._prompt_themes("custom", repo_root=tmp_path)
     assert isinstance(themes, dict) and themes, "custom mode yielded no mapping"
 
-    schema_path = (
-        find_repo_root() / "src" / "atdd" / "coach" / "schemas" / "config.schema.json"
-    )
+    # Anchor to the installed atdd package; find_repo_root() points at the
+    # consumer repo, which has no src/atdd/ tree.
+    pkg_dir = Path(atdd.__file__).resolve().parent
+    schema_path = pkg_dir / "coach" / "schemas" / "config.schema.json"
     with open(schema_path) as f:
         schema = json.load(f)
     validator = jsonschema.Draft7Validator(schema)

--- a/src/atdd/coach/validators/test_rule_id_uniqueness.py
+++ b/src/atdd/coach/validators/test_rule_id_uniqueness.py
@@ -120,9 +120,17 @@ def load_migrated_files() -> List[Path]:
     repo_root = find_repo_root()
     resolved: List[Path] = []
     for rel in completed:
-        # Try repo root first (editable install / checkout), then package dir.
+        # Migration paths are written as `src/atdd/<rest>`. Resolve against:
+        #   1. consumer / toolkit-self repo root (editable install / checkout)
+        #   2. installed package dir, stripping the `src/atdd/` prefix so paths
+        #      land at e.g. `<site-packages>/atdd/<rest>` for pip installs
+        #   3. legacy two-up-from-pkg fallback for older repo layouts
+        pkg_relative = (
+            rel[len("src/atdd/"):] if rel.startswith("src/atdd/") else rel
+        )
         candidates = [
             repo_root / rel,
+            ATDD_PKG_DIR / pkg_relative,
             ATDD_PKG_DIR.parent.parent / rel,
         ]
         for cand in candidates:


### PR DESCRIPTION
## Summary

Three coach validators looked up toolkit-internal assets (config schema, migrated convention paths) under `find_repo_root() / src/atdd/...`. In a consumer repo `find_repo_root()` returns the *consumer's* root, which has no `src/atdd/` tree, so the lookups raised `FileNotFoundError` on every `atdd validate coach` run after the toolkit was pip-installed.

This PR re-anchors those lookups to the installed `atdd` package directory (`Path(atdd.__file__).parent`) — the same fix shape used previously in #272, #276, #239, #329 (gate dogfood / toolkit-internal logic to package-relative paths).

## Failing surfaces before this fix

- `src/atdd/coach/validators/test_config_themes.py` — **12 cases**, all failing at module import:
  ```
  FileNotFoundError: [Errno 2] No such file or directory:
    '<consumer-repo>/src/atdd/coach/schemas/config.schema.json'
  ```
- `src/atdd/coach/validators/test_init_themes_prompt.py::test_custom_mode_output_validates_against_config_schema` — same `FileNotFoundError` on the schema lookup inside the test body.
- `src/atdd/coach/validators/test_rule_id_uniqueness.py::test_rule_id_grammar_and_required_fields` — `assert migrated` fires because every candidate in `load_migrated_files()` resolved against paths that don't exist in pip-installed scenarios:
  ```
  AssertionError: no migrated convention files declared in
    rule-id.convention.yaml::migration.completed
  ```

## Root cause

`find_repo_root()` is designed to return the **consumer** repo (the repo running `atdd validate ...`). It walks up from `cwd` looking for `.atdd/manifest.yaml`, `plan/ + contracts/`, or `.git/`. Consumer repos have no `src/atdd/` — that path only exists inside the toolkit checkout itself.

These three validators forgot the toolkit-vs-consumer distinction and tried to read schemas/conventions that live with the *toolkit code*, not in the consumer's tree.

## Canonical recipe applied

Two patterns mirror the precedent fixes:

1. **Schema lookups** (config_themes, init_themes_prompt) → resolve against the installed package:
   ```python
   import atdd
   ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
   CONFIG_SCHEMA_PATH = ATDD_PKG_DIR / \"coach\" / \"schemas\" / \"config.schema.json\"
   ```

2. **Migration-path resolution** (rule_id_uniqueness `load_migrated_files`) → add a third resolution candidate that strips the `src/atdd/` prefix from `migration.completed` paths so they land at `<site-packages>/atdd/<rest>` in pip installs. Repo-root and legacy two-up-from-pkg candidates are preserved for editable / toolkit-self / older-layout checkouts:
   ```python
   pkg_relative = (
       rel[len(\"src/atdd/\"):] if rel.startswith(\"src/atdd/\") else rel
   )
   candidates = [
       repo_root / rel,                  # editable / toolkit-self
       ATDD_PKG_DIR / pkg_relative,      # pip-installed (NEW)
       ATDD_PKG_DIR.parent.parent / rel, # legacy fallback
   ]
   ```

## Diff scope

3 files, +20/-10:

- `src/atdd/coach/validators/test_config_themes.py`
- `src/atdd/coach/validators/test_init_themes_prompt.py`
- `src/atdd/coach/validators/test_rule_id_uniqueness.py`

No production code touched. No utility helpers changed. The `find_repo_root` utility itself is left as-is — its behavior is correct; it's the validator callers that were misusing it.

## Verification

- **Toolkit-self** (this worktree's cwd): `33/33 passed in 0.64s`
- **Simulated consumer**: ran the three validator files from a fresh `mktemp -d` + `git init` cwd (so `find_repo_root()` lands outside the toolkit checkout), with `PYTHONPATH` pointed at the toolkit's `src/`. Result: `33/33 passed in 0.61s`.

## Precedent fixes referenced

- #272 — gate dogfood fixture tests to atdd source repo
- #276 — same pattern, composition_completeness fixtures
- #239 — repo-root vs package-dir resolution
- #329 — installed-package path discipline

## Release gate

PATCH-class change. Version bumped 1.63.4 → 1.63.5 in the final commit on this branch.

## Test plan

- [x] `pytest src/atdd/coach/validators/test_config_themes.py src/atdd/coach/validators/test_init_themes_prompt.py src/atdd/coach/validators/test_rule_id_uniqueness.py` passes in toolkit-self cwd
- [x] Same three files pass when invoked from a non-toolkit cwd (simulated consumer repo)
- [ ] CI green
- [ ] After merge: tag `v1.63.5` on the merge commit, push tags