### PR TITLE
fix(validators): 3 tests fail on Windows due to hardcoded forward-slash path separators (#295)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -54,6 +54,16 @@ sessions:
   archived: null
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:custom-themes
+- id: '295'
+  slug: fix-windows-path-compat
+  file: null
+  issue_number: 295
+  type: refactor
+  status: INIT
+  created: '2026-04-17'
+  archived: null
+  wagon: govern-lifecycle
+  train: 0001-self-compliance-validate
 - id: '296'
   slug: enforce-issue-label-compliance
   file: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.64.0"
+version = "1.64.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/validators/test_update_feature_paths.py
+++ b/src/atdd/coach/validators/test_update_feature_paths.py
@@ -88,12 +88,13 @@ def test_update_feature_implementation_paths(tmp_path):
     expected_python_path = "python/test_wagon/test_feature/"
     expected_lib_path = "lib/test_wagon/test_feature/"
 
-    assert expected_python_path in updated_data["paths"], f"Should contain {expected_python_path}"
-    assert expected_lib_path in updated_data["paths"], f"Should contain {expected_lib_path}"
+    normalized_paths = [p.replace("\\", "/") for p in updated_data["paths"]]
+    assert expected_python_path in normalized_paths, f"Should contain {expected_python_path}"
+    assert expected_lib_path in normalized_paths, f"Should contain {expected_lib_path}"
 
     # Should NOT contain paths that don't exist
-    assert "supabase/functions/test_wagon/test_feature/" not in updated_data["paths"]
-    assert "packages/test_wagon/test_feature/" not in updated_data["paths"]
+    assert "supabase/functions/test_wagon/test_feature/" not in normalized_paths
+    assert "packages/test_wagon/test_feature/" not in normalized_paths
 
     # Other fields should remain unchanged
     assert updated_data["feature"] == "test-feature"

--- a/src/atdd/coach/validators/test_validate_contract_consumers.py
+++ b/src/atdd/coach/validators/test_validate_contract_consumers.py
@@ -178,13 +178,13 @@ def test_detect_consumer_mismatches(tmp_path):
     mismatch = manifest_to_contract[0]
     assert mismatch["manifest"] == str(feature_manifest.relative_to(tmp_path))
     assert mismatch["contract"] == "contract:match:dilemma.paired"
-    assert "dilemma/paired.schema.json" in mismatch["contract_file"]
+    assert "dilemma/paired.schema.json" in mismatch["contract_file"].replace("\\", "/")
 
     # Check contract→manifest mismatch (contract lists wagon:nonexistent-wagon but no manifest declares it)
     contract_to_manifest = report["contract_to_manifest"]
     assert len(contract_to_manifest) == 1, "Should find 1 contract→manifest mismatch"
     mismatch = contract_to_manifest[0]
-    assert "ux/foundations/color.schema.json" in mismatch["contract_file"]
+    assert "ux/foundations/color.schema.json" in mismatch["contract_file"].replace("\\", "/")
     assert mismatch["consumer"] == "wagon:nonexistent-wagon"
 
     # Verify no changes were made (validation only)

--- a/src/atdd/coder/validators/tests/test_structured_logging_unit.py
+++ b/src/atdd/coder/validators/tests/test_structured_logging_unit.py
@@ -113,7 +113,7 @@ def test_consumer_mode_skips_vendored_site_packages(
         f"Expected exactly 1 violation (consumer python/ only); "
         f"got {count}: {violations}"
     )
-    assert any("python/app.py" in v for v in violations), violations
+    assert any("python/app.py" in v.replace("\\", "/") for v in violations), violations
     assert not any("site-packages" in v for v in violations), (
         f"Vendored site-packages must not be scanned: {violations}"
     )


### PR DESCRIPTION
Closes #295

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #295 |
| Type | refactor |
| Slug | fix-windows-path-compat |
| Train | 0001-self-compliance-validate |
| Labels | atdd-issue, atdd:PLANNED, archetype:coach, wagon:govern-lifecycle |

---
PR created by `atdd pr`.