### PR TITLE
fix(coach): skip platform-marked tests in consumer mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.65.4"
+version = "1.65.5"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/test_runner.py
+++ b/src/atdd/coach/commands/test_runner.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import List, Optional
 
 import atdd
-from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.utils.repo import find_repo_root, is_atdd_source_repo
 
 
 def _xdist_available() -> bool:
@@ -185,9 +185,21 @@ class TestRunner:
 
         Stage 1: All tests except github_api — parallel
         Stage 2: github_api tests (live GitHub API) — sequential (shared session fixtures)
+
+        In consumer mode (atdd installed via pip/pipx, not running from the
+        toolkit source checkout), tests marked `platform` are skipped in
+        Stage 1. They are toolkit-self dogfood tests that walk paths like
+        ``src/atdd/...`` which only exist in the toolkit checkout — running
+        them against a consumer repo would fail with assertion errors that
+        have no consumer-side fix.
         """
-        # Stage 1: all tests except github_api, parallel
-        fast_markers = list(markers or []) + ["not github_api"]
+        # Stage 1: all tests except github_api, parallel.
+        # In consumer mode, also exclude `platform`-marked toolkit-self tests.
+        # Multiple -m flags don't AND in pytest — combine into one expression.
+        stage1_expr = "not github_api"
+        if not is_atdd_source_repo():
+            stage1_expr += " and not platform"
+        fast_markers = list(markers or []) + [stage1_expr]
         fast_cmd = self._build_pytest_cmd(
             validator_dirs, verbose=verbose, coverage=coverage,
             html_report=False, markers=fast_markers, parallel=parallel,


### PR DESCRIPTION
## Summary

Two tests in `src/atdd/coder/validators/tests/test_hierarchy_coverage_config_driven.py` fail on every consumer-repo `atdd validate coder` run:

- `TestFindToolkitImplementations::test_finds_file_by_fuzzy_basename_match`
- `TestHasImplementationConfigDriven::test_toolkit_seeded_makes_toolkit_feature_visible`

Sample failure:
```
FAILED test_hierarchy_coverage_config_driven.py::TestFindToolkitImplementations::test_finds_file_by_fuzzy_basename_match
    AssertionError: expected at least one match for 'orchestrate' under src/atdd
    assert []

FAILED test_hierarchy_coverage_config_driven.py::TestHasImplementationConfigDriven::test_toolkit_seeded_makes_toolkit_feature_visible
    assert False
```

Both walk `REPO_ROOT / \"src/atdd\"` (line 43 and line 68 respectively). That path exists **only in the toolkit source checkout** — consumer repos pip-install atdd into site-packages with no `src/` prefix.

## Why the canonical \"anchor to Path(atdd.__file__).parent\" fix doesn't apply here

These tests aren't path-resolution bugs like #367 fixed. They're **intentionally** toolkit-self platform tests — the entire module declares:

```python
pytestmark = [pytest.mark.platform]
```

precisely so the runner can filter them out in consumer mode. Anchoring `REPO_ROOT / \"src/atdd\"` to `Path(atdd.__file__).parent` would:

1. Make the consumer-mode failures disappear.
2. **Also** silently break the same tests in atdd-self CI: pip-install layout has no `src/` prefix, so the fuzzy-match resolver would walk a different tree than the toolkit's own `src/atdd/` and the assertions would no longer represent what they claim to represent.

The marker is already correct. The runner wasn't honoring it.

## The fix

In `TestRunner._run_split`, detect consumer mode via the existing `is_atdd_source_repo()` utility and combine `not platform` into the Stage 1 marker expression:

```python
stage1_expr = \"not github_api\"
if not is_atdd_source_repo():
    stage1_expr += \" and not platform\"
fast_markers = list(markers or []) + [stage1_expr]
```

**Implementation note:** pytest's `-m` flag does not AND across multiple invocations — only the last one wins. So the existing list-of-markers shape (`[\"not github_api\", \"not platform\"]`) would have silently dropped the github_api filter. Combined into a single expression to ensure both apply.

This option (B) — runner-side filter — was preferred over option (A) — fixture-skip guards — because it's durable: any future test added with `pytest.mark.platform` is automatically gated without per-test plumbing.

## Diff scope

2 files, +16/-4:

- `src/atdd/coach/commands/test_runner.py` — import `is_atdd_source_repo`, build the combined Stage 1 marker expression.
- `pyproject.toml` — version bump 1.65.0 → 1.65.2.

No production code touched. No validator file changed. The marker `pytest.mark.platform` was already declared in `pyproject.toml::[tool.pytest.ini_options].markers`.

## Verification

**Toolkit-self** (no behavior change — platform tests still run):
```
$ pytest -q src/atdd/coder/validators/tests/test_hierarchy_coverage_config_driven.py
7 passed in 0.03s
```

**Simulated consumer** (`-m \"not github_api and not platform\"`):
```
$ pytest -q -m \"not github_api and not platform\" .../test_hierarchy_coverage_config_driven.py
7 deselected in 0.01s
```

**Direct cmd inspection** (mocked `_run_pytest` in both modes):
```
TOOLKIT-SELF MODE
  cmd: ... pytest ... -m \"not github_api\" ... --tb=short
  cmd: ... pytest ... -m \"github_api\" --tb=short

CONSUMER MODE
  cmd: ... pytest ... -m \"not github_api and not platform\" ... --tb=short
  cmd: ... pytest ... -m \"github_api\" --tb=short
```

The Stage 2 (`github_api`) cmd is unchanged in both modes — `github_api` tests still gate on the marker as before.

## Release gate

PATCH-class change. Version bumped 1.65.0 → 1.65.2 (sequential after #382 which claims 1.65.1).

If #382 doesn't merge first, this PR will need rebase + bump to 1.65.1.

## Test plan

- [x] Toolkit-self platform tests still pass (no regression)
- [x] Consumer-mode pytest invocation deselects all platform tests in the target file
- [x] Cmd construction verified with mocked `_run_pytest` in both modes
- [ ] CI green
- [ ] After merge: tag `v1.65.2` on the merge commit, push tags