### PR TITLE
feat: regression(#375): atdd-auto-phase template ships without `projects: write`, and CLI hard-fails on ProjectV2 access denial — auto-phase still unusable in CI (#384)

### DIFF
--- a/.github/workflows/atdd-auto-phase.yml
+++ b/.github/workflows/atdd-auto-phase.yml
@@ -16,6 +16,7 @@ jobs:
       issues: write
       contents: read
       pull-requests: read
+      projects: write   # Issue #384: required for ProjectV2 sync.
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.65.5"
+version = "1.65.6"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -1607,36 +1607,39 @@ class IssueManager:
             print(f"Error: Invalid issue number '{issue_id}'")
             return 1
 
+        # Issue #384: ProjectV2 sync may be denied when the GHA token lacks
+        # `projects: write` (or when the org-level Actions policy disables
+        # Projects access). The inner try catches the narrow access-denied
+        # case so the label swap below still runs (label-only sync). Any
+        # other error re-raises into the outer except for the existing
+        # user-visible abort path — no new print sites introduced.
+        projects_access_denied = False
         try:
             client = self._get_github_client()
             issue = client.get_issue(issue_number)
-        except (GitHubClientError, Exception) as e:
-            print(f"Error: {e}")
-            return 1
-
-        # Issue #384: ProjectV2 sync may be denied when the GHA token lacks
-        # `projects: write` (or when the org-level Actions policy disables
-        # Projects access). Catch the narrow access-denied case so the label
-        # swap below still runs (label-only sync). Anything else still aborts.
-        projects_access_denied = False
-        try:
-            fields = client.get_project_fields()
-            item_id = client.get_project_item_id(issue_number)
-        except GitHubClientError as e:
-            if "Resource not accessible by integration" in str(e):
+            try:
+                fields = client.get_project_fields()
+                item_id = client.get_project_item_id(issue_number)
+            except GitHubClientError as e:
+                if "Resource not accessible by integration" not in str(e):
+                    raise
                 logger.warning(
                     "ProjectV2 sync denied for issue #%s; continuing with "
                     "label-only sync. Grant the GHA token 'projects: write' "
                     "or enable Projects access in repo Settings → Actions → "
                     "Workflow permissions to silence this.",
                     issue_number,
+                    extra={
+                        "action": "projects_access_fallback",
+                        "issue": issue_number,
+                    },
                 )
                 projects_access_denied = True
                 fields = {}
                 item_id = None
-            else:
-                print(f"Error: {e}")
-                return 1
+        except (GitHubClientError, Exception) as e:
+            print(f"Error: {e}")
+            return 1
 
         if item_id is None and not projects_access_denied:
             print(f"Error: #{issue_number} not found in Project")

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -1610,13 +1610,35 @@ class IssueManager:
         try:
             client = self._get_github_client()
             issue = client.get_issue(issue_number)
-            fields = client.get_project_fields()
-            item_id = client.get_project_item_id(issue_number)
         except (GitHubClientError, Exception) as e:
             print(f"Error: {e}")
             return 1
 
-        if not item_id:
+        # Issue #384: ProjectV2 sync may be denied when the GHA token lacks
+        # `projects: write` (or when the org-level Actions policy disables
+        # Projects access). Catch the narrow access-denied case so the label
+        # swap below still runs (label-only sync). Anything else still aborts.
+        projects_access_denied = False
+        try:
+            fields = client.get_project_fields()
+            item_id = client.get_project_item_id(issue_number)
+        except GitHubClientError as e:
+            if "Resource not accessible by integration" in str(e):
+                logger.warning(
+                    "ProjectV2 sync denied for issue #%s; continuing with "
+                    "label-only sync. Grant the GHA token 'projects: write' "
+                    "or enable Projects access in repo Settings → Actions → "
+                    "Workflow permissions to silence this.",
+                    issue_number,
+                )
+                projects_access_denied = True
+                fields = {}
+                item_id = None
+            else:
+                print(f"Error: {e}")
+                return 1
+
+        if item_id is None and not projects_access_denied:
             print(f"Error: #{issue_number} not found in Project")
             return 1
 

--- a/src/atdd/coach/commands/tests/test_issue_update_fallback.py
+++ b/src/atdd/coach/commands/tests/test_issue_update_fallback.py
@@ -1,0 +1,198 @@
+"""
+Regression tests for IssueManager.update fallback when ProjectV2 access denied.
+
+Issue #384: GHA token without `projects: write` (or org-disabled Projects
+access) hard-fails the auto-phase workflow before the label swap runs. With
+the narrow try/except patch around the ProjectV2 GraphQL calls, denied access
+logs a warning and continues with label-only sync.
+
+Three branches covered:
+1. denied  — "Resource not accessible by integration" → label swap runs, rc=0
+2. granted — happy path: label swap AND ProjectV2 field updates both run
+3. other   — non-matching GitHubClientError still aborts (rc=1, no label swap)
+
+Run: PYTHONPATH=src python3 -m pytest -q \\
+     src/atdd/coach/commands/tests/test_issue_update_fallback.py -v
+"""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from atdd.coach.commands.issue import IssueManager
+from atdd.coach.github import GitHubClientError
+
+
+pytestmark = [pytest.mark.platform]
+
+
+def _setup_atdd_config(tmp_path: Path) -> Path:
+    """Create a minimal .atdd/config.yaml so _check_initialized passes."""
+    cfg_dir = tmp_path / ".atdd"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text(yaml.safe_dump({
+        "github": {"repo": "owner/repo", "project_id": "PVT_test"},
+    }))
+    return tmp_path
+
+
+def _make_issue(status: str = "RED") -> dict:
+    """Fake gh-issue dict with cleanup type (train-optional)."""
+    return {
+        "number": 384,
+        "title": "regression: auto-phase",
+        "state": "OPEN",
+        "labels": [{"name": f"atdd:{status}"}, {"name": "atdd-issue"}],
+        "body": "| Type | `cleanup` |\n",
+    }
+
+
+def _make_fields_dict() -> dict:
+    return {
+        "ATDD Status": {
+            "id": "field_status",
+            "options": {"GREEN": "opt_green", "SMOKE": "opt_smoke"},
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Branch 1: denied → label-only fallback succeeds
+# ---------------------------------------------------------------------------
+
+def test_denied_falls_back_to_label_only_via_get_project_fields(tmp_path):
+    """get_project_fields raises access-denied → label swap runs, rc=0."""
+    target = _setup_atdd_config(tmp_path)
+    mgr = IssueManager(target_dir=target)
+
+    client = MagicMock()
+    client.get_issue.return_value = _make_issue("RED")
+    client.get_project_fields.side_effect = GitHubClientError(
+        "Resource not accessible by integration"
+    )
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"):
+        rc = mgr.update("384", status="GREEN")
+
+    assert rc == 0, "denied access should fall back, not abort"
+    client.add_label.assert_called_once_with(384, ["atdd:GREEN"])
+    client.set_project_field_select.assert_not_called()
+
+
+def test_denied_falls_back_to_label_only_via_get_project_item_id(tmp_path):
+    """get_project_item_id raises access-denied → label swap runs, rc=0."""
+    target = _setup_atdd_config(tmp_path)
+    mgr = IssueManager(target_dir=target)
+
+    client = MagicMock()
+    client.get_issue.return_value = _make_issue("RED")
+    client.get_project_fields.return_value = _make_fields_dict()
+    client.get_project_item_id.side_effect = GitHubClientError(
+        "Resource not accessible by integration"
+    )
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"):
+        rc = mgr.update("384", status="GREEN")
+
+    assert rc == 0
+    client.add_label.assert_called_once_with(384, ["atdd:GREEN"])
+    client.set_project_field_select.assert_not_called()
+
+
+def test_denied_logs_warning_with_remediation(tmp_path, caplog):
+    """Warning log must include actionable remediation hint."""
+    import logging
+    caplog.set_level(logging.WARNING, logger="atdd.coach.commands.issue")
+
+    target = _setup_atdd_config(tmp_path)
+    mgr = IssueManager(target_dir=target)
+
+    client = MagicMock()
+    client.get_issue.return_value = _make_issue("RED")
+    client.get_project_fields.side_effect = GitHubClientError(
+        "Resource not accessible by integration"
+    )
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"):
+        mgr.update("384", status="GREEN")
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("ProjectV2" in m for m in warnings), warnings
+    assert any("projects: write" in m or "Workflow permissions" in m for m in warnings), warnings
+
+
+# ---------------------------------------------------------------------------
+# Branch 2: granted → both label swap and field updates run
+# ---------------------------------------------------------------------------
+
+def test_granted_runs_both_label_and_project_field(tmp_path):
+    target = _setup_atdd_config(tmp_path)
+    mgr = IssueManager(target_dir=target)
+
+    client = MagicMock()
+    client.get_issue.return_value = _make_issue("RED")
+    client.get_project_fields.return_value = _make_fields_dict()
+    client.get_project_item_id.return_value = "item_abc"
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"):
+        rc = mgr.update("384", status="GREEN")
+
+    assert rc == 0
+    client.add_label.assert_called_once_with(384, ["atdd:GREEN"])
+    client.set_project_field_select.assert_called_once_with(
+        "item_abc", "field_status", "opt_green"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Branch 3: other GitHubClientError still aborts
+# ---------------------------------------------------------------------------
+
+def test_non_matching_github_error_aborts(tmp_path, capsys):
+    """Non-access-denied GitHubClientError must still abort (rc=1)."""
+    target = _setup_atdd_config(tmp_path)
+    mgr = IssueManager(target_dir=target)
+
+    client = MagicMock()
+    client.get_issue.return_value = _make_issue("RED")
+    client.get_project_fields.side_effect = GitHubClientError(
+        "Network error: connection reset by peer"
+    )
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"):
+        rc = mgr.update("384", status="GREEN")
+
+    assert rc == 1, "unrelated GitHubClientError must not be swallowed"
+    client.add_label.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Branch 4: item_id None on access-denied does not trigger "not found" error
+# ---------------------------------------------------------------------------
+
+def test_access_denied_does_not_print_not_found_in_project(tmp_path, capsys):
+    """Sentinel flag must distinguish 'denied' from 'missing in Project'."""
+    target = _setup_atdd_config(tmp_path)
+    mgr = IssueManager(target_dir=target)
+
+    client = MagicMock()
+    client.get_issue.return_value = _make_issue("RED")
+    client.get_project_fields.side_effect = GitHubClientError(
+        "Resource not accessible by integration"
+    )
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"):
+        rc = mgr.update("384", status="GREEN")
+
+    out = capsys.readouterr().out
+    assert "not found in Project" not in out, (
+        "access-denied must not be reported as missing in Project"
+    )
+    assert rc == 0

--- a/src/atdd/coach/conventions/issue.convention.yaml
+++ b/src/atdd/coach/conventions/issue.convention.yaml
@@ -535,6 +535,24 @@ status:
       - OBSOLETE
     validator: "src/atdd/coach/validators/test_auto_phase_workflow_exists.py"
 
+    # Issue #384: ProjectV2 sync may be unavailable when the GHA token lacks
+    # `projects: write` (or org-level Actions policy disables Projects).
+    # `IssueManager.update` catches the narrow "Resource not accessible by
+    # integration" GitHubClientError, logs a WARNING, and continues with
+    # label-only sync via the existing `atdd:<PHASE>` swap. Non-matching
+    # GitHubClientError instances still abort.
+    projects_access_fallback:
+      enabled: true
+      trigger: "GitHubClientError matching 'Resource not accessible by integration'"
+      behavior: "label-only sync (atdd:<PHASE> swap); ProjectV2 fields skipped"
+      log_level: "WARNING"
+      remediation: |
+        Grant the GHA token `projects: write` in the workflow `permissions:`
+        block (already shipped in atdd-auto-phase.yml since #384), or enable
+        Projects access in repo Settings → Actions → Workflow permissions.
+      template: "src/atdd/coach/templates/workflows/atdd-auto-phase.yml"
+      validator: "src/atdd/coach/commands/tests/test_issue_update_fallback.py"
+
 # Infrastructure archetypes - what can be changed
 archetypes:
   database:

--- a/src/atdd/coach/templates/workflows/atdd-auto-phase.yml
+++ b/src/atdd/coach/templates/workflows/atdd-auto-phase.yml
@@ -18,6 +18,7 @@ jobs:
       issues: write
       contents: read
       pull-requests: read
+      projects: write   # Issue #384: required for ProjectV2 sync.
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/atdd/coach/validators/test_auto_phase_workflow_exists.py
+++ b/src/atdd/coach/validators/test_auto_phase_workflow_exists.py
@@ -18,6 +18,10 @@ from atdd.coach.utils.repo import find_repo_root
 
 REPO_ROOT = find_repo_root()
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "atdd-auto-phase.yml"
+TEMPLATE_PATH = (
+    REPO_ROOT
+    / "src" / "atdd" / "coach" / "templates" / "workflows" / "atdd-auto-phase.yml"
+)
 
 
 def _load_workflow() -> dict:
@@ -28,6 +32,21 @@ def _load_workflow() -> dict:
             "phase on PR merge."
         )
     return yaml.safe_load(WORKFLOW_PATH.read_text()) or {}
+
+
+def _load_template() -> dict:
+    if not TEMPLATE_PATH.exists():
+        pytest.skip(
+            f"Template not present at {TEMPLATE_PATH.relative_to(REPO_ROOT)} "
+            "(consumer repo without toolkit source) — deployed-file checks "
+            "still apply."
+        )
+    return yaml.safe_load(TEMPLATE_PATH.read_text()) or {}
+
+
+def _job_permissions(wf: dict) -> dict:
+    """Extract the auto-phase job's `permissions:` block."""
+    return ((wf.get("jobs") or {}).get("auto-phase") or {}).get("permissions") or {}
 
 
 def test_auto_phase_workflow_file_exists():
@@ -65,4 +84,33 @@ def test_auto_phase_workflow_invokes_atdd_auto_phase():
     assert "auto-phase" in content, (
         "atdd-auto-phase.yml must invoke `atdd auto-phase` (or "
         "`python -m atdd.cli auto-phase`) to perform the transition."
+    )
+
+
+def test_auto_phase_workflow_grants_projects_write():
+    """Issue #384: `permissions:` must declare `projects: write`.
+
+    Without this, the GHA token is denied ProjectV2 GraphQL writes with
+    `Resource not accessible by integration`, and auto-phase silently fails
+    after computing the transition. Regression of #382's intended fix.
+    """
+    perms = _job_permissions(_load_workflow())
+    assert perms.get("projects") == "write", (
+        "atdd-auto-phase.yml `permissions:` must declare `projects: write`. "
+        f"Found permissions={perms!r}. Issue #384."
+    )
+
+
+def test_auto_phase_workflow_template_grants_projects_write():
+    """Issue #384: the shipped template must declare `projects: write`.
+
+    Catches regressions where the template ships without ProjectV2 write
+    access; consumer repos receiving the template via `atdd init` would
+    otherwise inherit the broken permissions block on every refresh.
+    """
+    perms = _job_permissions(_load_template())
+    assert perms.get("projects") == "write", (
+        "src/atdd/coach/templates/workflows/atdd-auto-phase.yml "
+        "`permissions:` must declare `projects: write`. "
+        f"Found permissions={perms!r}. Issue #384."
     )


### PR DESCRIPTION
Closes #384

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #384 |

---
PR created by `atdd pr`.