### PR TITLE
feat(coach): #389 partial — legacy_grammar + 7-convention rules: arrays

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "1.65.9"
+version = "1.66.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/conventions/naming.convention.yaml
+++ b/src/atdd/coach/conventions/naming.convention.yaml
@@ -2,6 +2,20 @@ version: "1.0"
 name: "Master Naming Convention"
 description: "Consolidated naming patterns for all ATDD archetypes with regex validation"
 
+# Structured rules (issue #389 Phase 3a) — top-level placement so the registry
+# walker discovers them; existing `separator_semantics:` and `patterns:` blocks
+# (with their per-archetype regex/examples) are preserved verbatim.
+rules:
+  - id: COACH-NAMING-SEPARATOR-001
+    severity: 2
+    description: "Colon (:) marks hierarchical descent; dot (.) marks lateral variation; hyphen (-) is the kebab-case word separator"
+  - id: COACH-NAMING-FORMAT-001
+    severity: 2
+    description: "Each archetype uses its declared regex from patterns.<archetype>.regex (no ad-hoc casing or separators)"
+  - id: COACH-NAMING-URN-001
+    severity: 3
+    description: "URN format follows patterns.<archetype>.urn_format and matches patterns.<archetype>.urn_regex"
+
 # Purpose
 purpose: |
   Single source of truth for naming patterns across all archetypes.

--- a/src/atdd/coach/conventions/naming.convention.yaml
+++ b/src/atdd/coach/conventions/naming.convention.yaml
@@ -9,12 +9,15 @@ rules:
   - id: COACH-NAMING-SEPARATOR-001
     severity: 2
     description: "Colon (:) marks hierarchical descent; dot (.) marks lateral variation; hyphen (-) is the kebab-case word separator"
+    introduced_in: "1.66.0"
   - id: COACH-NAMING-FORMAT-001
     severity: 2
     description: "Each archetype uses its declared regex from patterns.<archetype>.regex (no ad-hoc casing or separators)"
+    introduced_in: "1.66.0"
   - id: COACH-NAMING-URN-001
     severity: 3
     description: "URN format follows patterns.<archetype>.urn_format and matches patterns.<archetype>.urn_regex"
+    introduced_in: "1.66.0"
 
 # Purpose
 purpose: |

--- a/src/atdd/coach/conventions/rule-id.convention.yaml
+++ b/src/atdd/coach/conventions/rule-id.convention.yaml
@@ -30,6 +30,28 @@ grammar:
     zero_padded: true
 
 # =============================================================================
+# Legacy grammar (issue #389 Phase 1)
+# =============================================================================
+# Pre-#340 rule IDs whose shape predates the canonical
+# `<DOMAIN>-<TOPIC>-<NNN>` grammar. Acceptance is gated on the declaring
+# convention being listed under `migration.completed:` — legacy IDs in
+# unmigrated files are still ignored exactly as before.
+#
+# Decision #8: `AP-DS-NN` and `COACH-BABYSIT-NNN` are NOT legacy — they
+# already match the canonical regex (two-or-more-hyphen IDs are canonical),
+# so adding them here would create double-grammar uniqueness edge cases.
+#
+# New rules MUST use the canonical grammar. This block exists to preserve
+# history without forcing flag-day renames across every reference site.
+legacy_grammar:
+  - pattern: "^DS-\\d{2}$"
+    rationale: "Design-system principles (e.g., DS-01) — predate DESIGN-* canonical IDs."
+  - pattern: "^ERR-\\d{2}$"
+    rationale: "Error-response rules (e.g., ERR-01) — predate ERROR-* canonical IDs."
+  - pattern: "^GP-\\d{2}$"
+    rationale: "Green-phase rules (e.g., GP-01) — predate GREEN-* canonical IDs."
+
+# =============================================================================
 # DOMAIN registry (closed set — SPEC-COACH-RULEID-0002)
 # =============================================================================
 # Adding a value here is a SPEC edit. The rule-id-uniqueness validator

--- a/src/atdd/coach/validators/test_rule_id_uniqueness.py
+++ b/src/atdd/coach/validators/test_rule_id_uniqueness.py
@@ -91,6 +91,26 @@ def load_allowed_domains() -> set:
     return {str(d) for d in domains}
 
 
+def load_legacy_patterns() -> List["re.Pattern[str]"]:
+    """Compile the ``legacy_grammar:`` regex variants from the rule-id convention.
+
+    Returns an empty list if the section is absent — callers must treat
+    legacy acceptance as opt-in. The acceptance contract (issue #389 Phase 1):
+    a legacy-shaped ID is accepted *only* when its declaring convention file
+    is also listed under ``migration.completed:``.
+    """
+    data = load_rule_id_convention()
+    entries = data.get("legacy_grammar") or []
+    compiled: List[re.Pattern[str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        pattern = entry.get("pattern")
+        if isinstance(pattern, str) and pattern:
+            compiled.append(re.compile(pattern))
+    return compiled
+
+
 # ---------------------------------------------------------------------------
 # Convention discovery
 # ---------------------------------------------------------------------------
@@ -144,10 +164,24 @@ def load_migrated_files() -> List[Path]:
 # ---------------------------------------------------------------------------
 # Validators
 # ---------------------------------------------------------------------------
-def validate_grammar(rule_id: str, allowed_domains: set) -> Optional[str]:
-    """Return error message when *rule_id* fails the grammar; None when OK."""
+def validate_grammar(
+    rule_id: str,
+    allowed_domains: set,
+    legacy_patterns: Optional[List["re.Pattern[str]"]] = None,
+) -> Optional[str]:
+    """Return error message when *rule_id* fails the grammar; None when OK.
+
+    When ``legacy_patterns`` is supplied, an ID matching any of those patterns
+    bypasses the canonical grammar/domain/suffix checks. Callers must only
+    pass legacy patterns when validating IDs from a file listed under
+    ``migration.completed:`` (issue #389 Phase 1).
+    """
     if not isinstance(rule_id, str):
         return f"id must be a string, got {type(rule_id).__name__}"
+    if legacy_patterns:
+        for pat in legacy_patterns:
+            if pat.match(rule_id):
+                return None
     if not RULE_ID_PATTERN.match(rule_id):
         return (
             f"id {rule_id!r} does not match grammar "
@@ -211,6 +245,8 @@ def test_rule_id_grammar_and_required_fields():
         "rule-id.convention.yaml::migration.completed"
     )
 
+    legacy_patterns = load_legacy_patterns()
+
     errors: List[str] = []
     for file_path in find_convention_files():
         if file_path.resolve() not in migrated:
@@ -219,7 +255,9 @@ def test_rule_id_grammar_and_required_fields():
         for _, yaml_path, rule in extract_rules(file_path):
             loc = f"{file_path.name}:{'.'.join(yaml_path[:-1])}[{yaml_path[-1]}]"
 
-            grammar_err = validate_grammar(rule.get("id", ""), allowed_domains)
+            grammar_err = validate_grammar(
+                rule.get("id", ""), allowed_domains, legacy_patterns=legacy_patterns
+            )
             if grammar_err:
                 errors.append(f"{loc}: {grammar_err}")
 
@@ -240,22 +278,34 @@ def test_rule_id_grammar_and_required_fields():
 
 @pytest.mark.coach
 def test_rule_id_uniqueness():
-    """No grammar-conformant rule ID is declared in more than one place.
+    """No rule ID is declared in more than one place.
 
     SPEC-COACH-RULEID-0004: stability requires global uniqueness.
 
-    Legacy IDs (e.g. ``LOG-001``, ``COVERAGE-CODE-4.1``) that don't match the
-    new grammar are ignored — they belong to the pre-#340 prose-rules world
-    and the migration playbook covers retrofitting them.
+    Canonical IDs are checked across every convention. Legacy-shaped IDs
+    (issue #389 Phase 1: ``DS-NN``, ``ERR-NN``, ``GP-NN``) are checked only
+    when their declaring file is in ``migration.completed:`` — IDs in
+    unmigrated files remain out of scope per the migration playbook.
+
+    Other pre-#340 prose IDs (e.g. ``LOG-001``, ``COVERAGE-CODE-4.1``) that
+    match neither grammar are still ignored.
     """
+    legacy_patterns = load_legacy_patterns()
+    migrated = set(load_migrated_files())
+
     seen: Dict[str, List[str]] = {}
     for file_path in find_convention_files():
+        is_migrated = file_path.resolve() in migrated
         for _, yaml_path, rule in extract_rules(file_path):
             rid = rule.get("id")
             if not isinstance(rid, str) or not rid:
                 continue
-            if not RULE_ID_PATTERN.match(rid):
-                continue  # legacy ID — out of scope.
+            if RULE_ID_PATTERN.match(rid):
+                pass  # canonical — always tracked
+            elif is_migrated and any(p.match(rid) for p in legacy_patterns):
+                pass  # legacy + migrated — tracked per #389 Phase 1
+            else:
+                continue
             loc = f"{file_path.name}:{'.'.join(yaml_path[:-1])}[{yaml_path[-1]}]"
             seen.setdefault(rid, []).append(loc)
 

--- a/src/atdd/coach/validators/tests/test_phase_3a_rules_array_coverage.py
+++ b/src/atdd/coach/validators/tests/test_phase_3a_rules_array_coverage.py
@@ -1,0 +1,128 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_phase_3a_rules_array_coverage:backend:domain
+# Runtime: python
+# Purpose: RED tests for issue #389 Phase 3a — every targeted convention declares a rules: array.
+
+"""RED tests for issue #389 Phase 3a: rules-array coverage in 7 conventions.
+
+The registry walker (#387) walks ``rules:`` arrays at any nesting depth
+(Decision #9). These 7 coder+coach conventions previously lacked any
+``rules:`` block; this issue retrofits them.
+
+The structured rules added here use canonical ``<DOMAIN>-<TOPIC>-<NNN>``
+grammar so the uniqueness check (which walks every convention) accepts them
+without requiring strict-mode opt-in (Phase 3b is out of scope for this PR).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+import atdd
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.validators.test_rule_id_uniqueness import (
+    RULE_ID_PATTERN,
+    extract_rules,
+    load_allowed_domains,
+    validate_description,
+    validate_grammar,
+    validate_severity,
+)
+
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+
+
+# Issue #389 Phase 3a inventory (verbatim from issue body).
+PHASE_3A_FILES = [
+    "coder/conventions/backend.convention.yaml",
+    "coder/conventions/commons.convention.yaml",
+    "coder/conventions/design.convention.yaml",
+    "coder/conventions/presentation.convention.yaml",
+    "coder/conventions/technology.convention.yaml",
+    "coder/conventions/train.convention.yaml",
+    "coach/conventions/naming.convention.yaml",
+]
+
+
+def _resolve(rel: str) -> Path:
+    """Resolve a convention path against the repo or installed package."""
+    for cand in (find_repo_root() / "src" / "atdd" / rel, ATDD_PKG_DIR / rel):
+        if cand.is_file():
+            return cand
+    raise FileNotFoundError(f"convention not found: {rel}")
+
+
+# ---------------------------------------------------------------------------
+# Each Phase 3a convention declares at least one structured rule
+# ---------------------------------------------------------------------------
+
+class TestRulesArrayPresence:
+    @pytest.mark.parametrize("rel", PHASE_3A_FILES)
+    def test_convention_has_structured_rules(self, rel):
+        path = _resolve(rel)
+        rows = extract_rules(path)
+        assert rows, (
+            f"{rel} must declare a `rules:` array (top-level or nested) per "
+            f"issue #389 Phase 3a — Decision #9 says the walker recurses, so "
+            f"placement may be next to existing rule-bearing structure."
+        )
+
+
+# ---------------------------------------------------------------------------
+# All Phase 3a rules use canonical grammar with valid severity + description
+# ---------------------------------------------------------------------------
+
+class TestPhase3aRuleQuality:
+    @pytest.mark.parametrize("rel", PHASE_3A_FILES)
+    def test_each_rule_well_formed(self, rel):
+        domains = load_allowed_domains()
+        path = _resolve(rel)
+        errors = []
+        for _, yaml_path, rule in extract_rules(path):
+            loc = f"{path.name}:{'.'.join(yaml_path[:-1])}[{yaml_path[-1]}]"
+            for check in (
+                validate_grammar(rule.get("id", ""), domains),
+                validate_severity(rule),
+                validate_description(rule),
+            ):
+                if check:
+                    errors.append(f"{loc}: {check}")
+        assert not errors, "rule shape errors:\n  - " + "\n  - ".join(errors)
+
+
+# ---------------------------------------------------------------------------
+# Existing id-bearing structures (principles/anti_patterns/...) are preserved
+# ---------------------------------------------------------------------------
+
+class TestExistingStructuresPreserved:
+    """Issue body: 'Existing id-bearing structures... are preserved verbatim'.
+
+    Spot-check: design.convention.yaml keeps its DS-NN principles and AP-DS-NN
+    anti_patterns; commons keeps dependency_rules; backend keeps entrypoint_rules.
+    """
+
+    def test_design_principles_intact(self):
+        path = _resolve("coder/conventions/design.convention.yaml")
+        data = yaml.safe_load(path.read_text())
+        principles = (data.get("design_system") or {}).get("principles") or []
+        ids = {p.get("id") for p in principles if isinstance(p, dict)}
+        assert {"DS-01", "DS-02", "DS-03", "DS-04", "DS-05", "DS-06", "DS-07"}.issubset(ids), (
+            f"design.convention.yaml principles must keep DS-01..DS-07; got {sorted(ids)}"
+        )
+
+    def test_design_anti_patterns_intact(self):
+        path = _resolve("coder/conventions/design.convention.yaml")
+        data = yaml.safe_load(path.read_text())
+        antis = (data.get("design_system") or {}).get("anti_patterns") or []
+        ids = {a.get("id") for a in antis if isinstance(a, dict)}
+        assert {"AP-DS-01", "AP-DS-02", "AP-DS-03", "AP-DS-04", "AP-DS-05"}.issubset(ids), (
+            f"design.convention.yaml anti_patterns must keep AP-DS-01..AP-DS-05; got {sorted(ids)}"
+        )
+
+    def test_commons_dependency_rules_intact(self):
+        path = _resolve("coder/conventions/commons.convention.yaml")
+        data = yaml.safe_load(path.read_text())
+        assert "dependency_rules" in data, "commons.convention.yaml must keep dependency_rules:"

--- a/src/atdd/coach/validators/tests/test_rule_id_legacy_grammar.py
+++ b/src/atdd/coach/validators/tests/test_rule_id_legacy_grammar.py
@@ -1,0 +1,175 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_rule_id_legacy_grammar:backend:domain
+# Runtime: python
+# Purpose: RED tests for legacy_grammar acceptance in rule-id uniqueness validator.
+
+"""RED tests for issue #389 Phase 1: legacy_grammar extension.
+
+What this file covers:
+
+1. ``rule-id.convention.yaml`` declares ``legacy_grammar:`` enumerating the
+   3 pre-#340 ID shapes (DS-NN, ERR-NN, GP-NN) with one-line rationale per
+   variant — Decision #8 explicitly excludes AP-DS-NN and COACH-BABYSIT-NNN
+   because they already match the canonical grammar.
+2. The validator's ``validate_grammar`` accepts a legacy-pattern set so an
+   ID matching a legacy variant passes when its declaring file is in
+   ``migration.completed:``.
+3. The uniqueness check operates across both canonical and legacy grammars,
+   but only counts a legacy-shaped ID when its file is migrated.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.validators.test_rule_id_uniqueness import (
+    extract_rules,
+    load_allowed_domains,
+    load_rule_id_convention,
+    validate_grammar,
+)
+
+
+# ---------------------------------------------------------------------------
+# Convention shape: legacy_grammar block
+# ---------------------------------------------------------------------------
+
+class TestLegacyGrammarSection:
+    def test_section_present(self):
+        data = load_rule_id_convention()
+        assert "legacy_grammar" in data, (
+            "rule-id.convention.yaml must declare legacy_grammar: per issue #389 Phase 1"
+        )
+
+    def test_section_is_list_of_entries(self):
+        data = load_rule_id_convention()
+        legacy = data.get("legacy_grammar")
+        assert isinstance(legacy, list) and len(legacy) >= 3, (
+            "legacy_grammar: must enumerate at least 3 variants (DS-NN, ERR-NN, GP-NN)"
+        )
+        for entry in legacy:
+            assert isinstance(entry, dict), f"each entry must be a mapping, got {entry!r}"
+            assert "pattern" in entry and isinstance(entry["pattern"], str), (
+                f"entry missing string `pattern`: {entry!r}"
+            )
+            assert "rationale" in entry and isinstance(entry["rationale"], str) and entry["rationale"].strip(), (
+                f"entry missing non-empty string `rationale`: {entry!r}"
+            )
+
+    @pytest.mark.parametrize("expected_pattern", [
+        r"^DS-\d{2}$",
+        r"^ERR-\d{2}$",
+        r"^GP-\d{2}$",
+    ])
+    def test_required_variants_declared(self, expected_pattern):
+        data = load_rule_id_convention()
+        patterns = {e.get("pattern") for e in (data.get("legacy_grammar") or [])}
+        assert expected_pattern in patterns, (
+            f"legacy_grammar must include {expected_pattern!r} per issue #389 Phase 1 scope"
+        )
+
+    def test_excludes_ap_ds_and_coach_babysit(self):
+        """Decision #8: AP-DS-NN and COACH-BABYSIT-NNN already match canonical, must not appear in legacy_grammar."""
+        data = load_rule_id_convention()
+        patterns = {e.get("pattern") for e in (data.get("legacy_grammar") or [])}
+        for forbidden in (r"^AP-DS-\d{2}$", r"^COACH-BABYSIT-\d{3}$"):
+            assert forbidden not in patterns, (
+                f"{forbidden!r} must not be in legacy_grammar — Decision #8: already canonical"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helper: legacy pattern loader
+# ---------------------------------------------------------------------------
+
+class TestLoadLegacyPatterns:
+    def test_loader_exposed(self):
+        """Validator module exposes load_legacy_patterns() returning compiled regexes."""
+        from atdd.coach.validators import test_rule_id_uniqueness as mod
+        assert hasattr(mod, "load_legacy_patterns"), (
+            "test_rule_id_uniqueness must expose load_legacy_patterns()"
+        )
+        patterns = mod.load_legacy_patterns()
+        assert isinstance(patterns, list) and patterns, "must return non-empty list"
+        for p in patterns:
+            assert isinstance(p, re.Pattern), f"expected re.Pattern, got {type(p).__name__}"
+
+    def test_legacy_ids_match(self):
+        from atdd.coach.validators.test_rule_id_uniqueness import load_legacy_patterns
+        patterns = load_legacy_patterns()
+
+        def matches_any(rid: str) -> bool:
+            return any(p.match(rid) for p in patterns)
+
+        for rid in ("DS-01", "DS-07", "ERR-01", "ERR-12", "GP-01", "GP-99"):
+            assert matches_any(rid), f"legacy ID {rid!r} should match a legacy pattern"
+
+    def test_canonical_ids_dont_match_legacy(self):
+        from atdd.coach.validators.test_rule_id_uniqueness import load_legacy_patterns
+        patterns = load_legacy_patterns()
+        for rid in ("GREEN-URN-001", "AP-DS-01", "COACH-BABYSIT-010"):
+            assert not any(p.match(rid) for p in patterns), (
+                f"canonical/canonical-shaped ID {rid!r} must not match a legacy pattern"
+            )
+
+
+# ---------------------------------------------------------------------------
+# validate_grammar gains optional legacy_patterns acceptance
+# ---------------------------------------------------------------------------
+
+class TestValidateGrammarLegacy:
+    def test_signature_accepts_legacy_patterns_kwarg(self):
+        domains = load_allowed_domains()
+        # Default behavior unchanged: legacy not accepted.
+        assert validate_grammar("DS-01", domains) is not None
+        # Opt-in: legacy accepted.
+        assert validate_grammar("DS-01", domains, legacy_patterns=[re.compile(r"^DS-\d{2}$")]) is None
+
+    def test_canonical_still_accepted_with_legacy_kwarg(self):
+        domains = load_allowed_domains()
+        legacy = [re.compile(r"^DS-\d{2}$")]
+        assert validate_grammar("GREEN-URN-001", domains, legacy_patterns=legacy) is None
+
+    def test_unknown_id_rejected_with_legacy_kwarg(self):
+        domains = load_allowed_domains()
+        legacy = [re.compile(r"^DS-\d{2}$")]
+        # Not legacy, not canonical — must still be rejected.
+        assert validate_grammar("XYZ-99", domains, legacy_patterns=legacy) is not None
+
+
+# ---------------------------------------------------------------------------
+# extract_rules: walks legacy IDs too (for uniqueness across both grammars)
+# ---------------------------------------------------------------------------
+
+class TestUniquenessAcrossLegacyAndCanonical:
+    def test_uniqueness_walks_legacy_in_migrated_files(self, tmp_path: Path, monkeypatch):
+        """A legacy DS-01 in a migrated file collides with another DS-01 elsewhere."""
+        from atdd.coach.validators import test_rule_id_uniqueness as mod
+
+        migrated = tmp_path / "migrated.convention.yaml"
+        migrated.write_text(
+            "design_system:\n"
+            "  rules:\n"
+            "    - id: DS-01\n"
+            "      severity: 2\n"
+            "      description: legacy\n"
+        )
+        other = tmp_path / "other.convention.yaml"
+        other.write_text(
+            "design_system:\n"
+            "  rules:\n"
+            "    - id: DS-01\n"
+            "      severity: 2\n"
+            "      description: legacy collision\n"
+        )
+
+        monkeypatch.setattr(mod, "find_convention_files", lambda: [migrated, other])
+        monkeypatch.setattr(mod, "load_migrated_files", lambda: [migrated.resolve(), other.resolve()])
+
+        with pytest.raises((pytest.fail.Exception, AssertionError, BaseException)) as exc:
+            mod.test_rule_id_uniqueness()
+
+        # The collision detection should mention DS-01.
+        assert "DS-01" in str(exc.value), f"expected DS-01 collision in error: {exc.value}"

--- a/src/atdd/coach/validators/tests/test_rule_id_legacy_grammar.py
+++ b/src/atdd/coach/validators/tests/test_rule_id_legacy_grammar.py
@@ -168,7 +168,7 @@ class TestUniquenessAcrossLegacyAndCanonical:
         monkeypatch.setattr(mod, "find_convention_files", lambda: [migrated, other])
         monkeypatch.setattr(mod, "load_migrated_files", lambda: [migrated.resolve(), other.resolve()])
 
-        with pytest.raises((pytest.fail.Exception, AssertionError, BaseException)) as exc:
+        with pytest.raises(pytest.fail.Exception) as exc:
             mod.test_rule_id_uniqueness()
 
         # The collision detection should mention DS-01.

--- a/src/atdd/coder/conventions/backend.convention.yaml
+++ b/src/atdd/coder/conventions/backend.convention.yaml
@@ -2,6 +2,24 @@ version: "1.0"
 name: "Backend Component Convention"
 description: "Layer catalog and component suffixes for backend implementation."
 
+# ---------------------------------------------------------------------------
+# Structured rules (issue #389 Phase 3a — see src/atdd/coach/specs/rule-id.spec.md)
+# ---------------------------------------------------------------------------
+# Existing structures (`backend.layers.*`, `dependency.allowed_edges`,
+# `ci_enforcement.checks`) are preserved verbatim. The rules below enumerate
+# the testable invariants implied by those structures so the registry walker
+# can reconcile them against validator-emitted Violation rule_ids.
+rules:
+  - id: BOUNDARIES-LAYER-001
+    severity: 3
+    description: "Backend code is organized into 4 layers: presentation, application, integration, domain"
+  - id: BOUNDARIES-LAYER-002
+    severity: 3
+    description: "Component file suffix matches its layer's component_type catalog (e.g. *_controller.py for presentation.controllers)"
+  - id: BOUNDARIES-LAYER-003
+    severity: 3
+    description: "Imports respect dependency.allowed_edges (presentation→application→domain; integration→application→domain)"
+
 backend:
   layers:
     presentation:

--- a/src/atdd/coder/conventions/backend.convention.yaml
+++ b/src/atdd/coder/conventions/backend.convention.yaml
@@ -13,12 +13,15 @@ rules:
   - id: BOUNDARIES-LAYER-001
     severity: 3
     description: "Backend code is organized into 4 layers: presentation, application, integration, domain"
+    introduced_in: "1.66.0"
   - id: BOUNDARIES-LAYER-002
     severity: 3
     description: "Component file suffix matches its layer's component_type catalog (e.g. *_controller.py for presentation.controllers)"
+    introduced_in: "1.66.0"
   - id: BOUNDARIES-LAYER-003
     severity: 3
     description: "Imports respect dependency.allowed_edges (presentation→application→domain; integration→application→domain)"
+    introduced_in: "1.66.0"
 
 backend:
   layers:

--- a/src/atdd/coder/conventions/commons.convention.yaml
+++ b/src/atdd/coder/conventions/commons.convention.yaml
@@ -240,6 +240,20 @@ dependency_rules:
       to: [integration]
       reason: "Application uses ports; integration implements them"
 
+  # Structured rules (issue #389 Phase 3a) — Decision #9: nested placement next
+  # to existing rule-bearing structure is canonical. allowed_edges/forbidden_edges
+  # above are preserved verbatim; the rules below give them registry-walker IDs.
+  rules:
+    - id: BOUNDARIES-COMMONS-001
+      severity: 3
+      description: "Domain layer in commons has no outbound edges (no application/integration imports)"
+    - id: BOUNDARIES-COMMONS-002
+      severity: 3
+      description: "Application layer uses ports; integration implements them (no application→integration edges)"
+    - id: BOUNDARIES-COMMONS-003
+      severity: 3
+      description: "Cross-feature imports in commons go through the layer above (no peer-to-peer feature edges)"
+
 # ============================================================================
 # STACK-SPECIFIC PATTERNS
 # ============================================================================

--- a/src/atdd/coder/conventions/commons.convention.yaml
+++ b/src/atdd/coder/conventions/commons.convention.yaml
@@ -247,12 +247,15 @@ dependency_rules:
     - id: BOUNDARIES-COMMONS-001
       severity: 3
       description: "Domain layer in commons has no outbound edges (no application/integration imports)"
+      introduced_in: "1.66.0"
     - id: BOUNDARIES-COMMONS-002
       severity: 3
       description: "Application layer uses ports; integration implements them (no application→integration edges)"
+      introduced_in: "1.66.0"
     - id: BOUNDARIES-COMMONS-003
       severity: 3
       description: "Cross-feature imports in commons go through the layer above (no peer-to-peer feature edges)"
+      introduced_in: "1.66.0"
 
 # ============================================================================
 # STACK-SPECIFIC PATTERNS

--- a/src/atdd/coder/conventions/design.convention.yaml
+++ b/src/atdd/coder/conventions/design.convention.yaml
@@ -6,6 +6,25 @@ description: "Hierarchy rules and validation standards for design system archite
 design_system:
   goal: "Enforce reusable UI patterns via tokens → primitives → components → templates hierarchy"
 
+  # Structured rules (issue #389 Phase 3a — Decision #9: nested placement is canonical).
+  # Consolidates the testable invariants implied by `principles:` (DS-NN) and
+  # `anti_patterns:` (AP-DS-NN) into the canonical <DOMAIN>-<TOPIC>-<NNN>
+  # grammar. The legacy DS-NN/AP-DS-NN entries below are preserved verbatim
+  # — renaming is out of scope (Out-of-Scope per issue #389).
+  rules:
+    - id: DESIGN-HIERARCHY-001
+      severity: 3
+      description: "Tokens are pure values — no widgets, no logic (mirrors principles.DS-01)"
+    - id: DESIGN-HIERARCHY-002
+      severity: 3
+      description: "Dependency flow: tokens ← primitives ← components ← templates (mirrors principles.DS-05)"
+    - id: DESIGN-HIERARCHY-003
+      severity: 3
+      description: "Wagons import from design_system; design_system never imports from wagons (mirrors principles.DS-06)"
+    - id: DESIGN-HIERARCHY-004
+      severity: 2
+      description: "Extract to design_system on 3rd occurrence (DRY threshold; mirrors principles.DS-07)"
+
   location:
     path: "lib/design_system/"
     note: "Design system is a shared wagon at same level as feature wagons"

--- a/src/atdd/coder/conventions/design.convention.yaml
+++ b/src/atdd/coder/conventions/design.convention.yaml
@@ -15,15 +15,19 @@ design_system:
     - id: DESIGN-HIERARCHY-001
       severity: 3
       description: "Tokens are pure values — no widgets, no logic (mirrors principles.DS-01)"
+      introduced_in: "1.66.0"
     - id: DESIGN-HIERARCHY-002
       severity: 3
       description: "Dependency flow: tokens ← primitives ← components ← templates (mirrors principles.DS-05)"
+      introduced_in: "1.66.0"
     - id: DESIGN-HIERARCHY-003
       severity: 3
       description: "Wagons import from design_system; design_system never imports from wagons (mirrors principles.DS-06)"
+      introduced_in: "1.66.0"
     - id: DESIGN-HIERARCHY-004
       severity: 2
       description: "Extract to design_system on 3rd occurrence (DRY threshold; mirrors principles.DS-07)"
+      introduced_in: "1.66.0"
 
   location:
     path: "lib/design_system/"

--- a/src/atdd/coder/conventions/presentation.convention.yaml
+++ b/src/atdd/coder/conventions/presentation.convention.yaml
@@ -9,12 +9,15 @@ rules:
   - id: PRESENTATION-THIN-001
     severity: 3
     description: "Presentation layer is thin — no business logic; controllers delegate to application use cases"
+    introduced_in: "1.66.0"
   - id: PRESENTATION-THIN-002
     severity: 3
     description: "Controllers never call domain directly; flow is Controller → Use Case → Domain"
+    introduced_in: "1.66.0"
   - id: PRESENTATION-THIN-003
     severity: 3
     description: "Response models live in contract_dto and match contract JSON schemas"
+    introduced_in: "1.66.0"
 
 purpose: |
   Defines how to implement presentation layer (HTTP REST, CLI, GraphQL) across runtimes.

--- a/src/atdd/coder/conventions/presentation.convention.yaml
+++ b/src/atdd/coder/conventions/presentation.convention.yaml
@@ -2,6 +2,20 @@ version: "1.0"
 name: "Presentation Convention"
 description: "Presentation layer implementation patterns across Python, TypeScript, and Dart"
 
+# Structured rules (issue #389 Phase 3a) — top-level placement so the registry
+# walker discovers them; existing `architecture:`, `http_rest_api:`,
+# `cli_pattern:`, `validation:` blocks are preserved verbatim.
+rules:
+  - id: PRESENTATION-THIN-001
+    severity: 3
+    description: "Presentation layer is thin — no business logic; controllers delegate to application use cases"
+  - id: PRESENTATION-THIN-002
+    severity: 3
+    description: "Controllers never call domain directly; flow is Controller → Use Case → Domain"
+  - id: PRESENTATION-THIN-003
+    severity: 3
+    description: "Response models live in contract_dto and match contract JSON schemas"
+
 purpose: |
   Defines how to implement presentation layer (HTTP REST, CLI, GraphQL) across runtimes.
 

--- a/src/atdd/coder/conventions/technology.convention.yaml
+++ b/src/atdd/coder/conventions/technology.convention.yaml
@@ -9,12 +9,15 @@ rules:
   - id: COACH-TECH-STACK-001
     severity: 2
     description: "New components default to the technology.<layer>.default for their layer; deviations declare an approved alternative"
+    introduced_in: "1.66.0"
   - id: COACH-TECH-STACK-002
     severity: 2
     description: "Approved alternatives are taken only when the use_when criteria are met; tradeoff is documented in the wagon"
+    introduced_in: "1.66.0"
   - id: COACH-TECH-STACK-003
     severity: 2
     description: "Unapproved technology choices require a SPEC edit before they can ship"
+    introduced_in: "1.66.0"
 
 technology:
   backend:

--- a/src/atdd/coder/conventions/technology.convention.yaml
+++ b/src/atdd/coder/conventions/technology.convention.yaml
@@ -2,6 +2,20 @@ version: "1.0"
 name: "Technology Stack Convention"
 description: "Lean map of default technologies with rationales, constraints, and deviation guidance"
 
+# Structured rules (issue #389 Phase 3a) — top-level placement so the registry
+# walker discovers them; existing technology.* tree (defaults, alternatives,
+# rationales) is preserved verbatim.
+rules:
+  - id: COACH-TECH-STACK-001
+    severity: 2
+    description: "New components default to the technology.<layer>.default for their layer; deviations declare an approved alternative"
+  - id: COACH-TECH-STACK-002
+    severity: 2
+    description: "Approved alternatives are taken only when the use_when criteria are met; tradeoff is documented in the wagon"
+  - id: COACH-TECH-STACK-003
+    severity: 2
+    description: "Unapproved technology choices require a SPEC edit before they can ship"
+
 technology:
   backend:
     presentation:

--- a/src/atdd/coder/conventions/train.convention.yaml
+++ b/src/atdd/coder/conventions/train.convention.yaml
@@ -10,12 +10,15 @@ rules:
   - id: COACH-TRAIN-COMPOSITION-001
     severity: 3
     description: "Train is a production composition root in python/trains/, not test infrastructure"
+    introduced_in: "1.66.0"
   - id: COACH-TRAIN-COMPOSITION-002
     severity: 3
     description: "Wagons communicate via cargo (contract artifacts) — never via direct cross-wagon imports"
+    introduced_in: "1.66.0"
   - id: COACH-TRAIN-COMPOSITION-003
     severity: 3
     description: "Train YAML is the single source of truth for orchestration; production and tests both consume it via TrainRunner"
+    introduced_in: "1.66.0"
 
 rationale: |
   Trains are PRODUCTION orchestration, not test infrastructure. They execute user journeys

--- a/src/atdd/coder/conventions/train.convention.yaml
+++ b/src/atdd/coder/conventions/train.convention.yaml
@@ -3,6 +3,20 @@ convention_id: "coder.train"
 name: "Train Composition Root Convention"
 description: "Production orchestration layer for executing user journeys across wagons"
 
+# Structured rules (issue #389 Phase 3a) — top-level placement so the registry
+# walker discovers them; existing `composition_hierarchy:`, `train_structure:`,
+# `cargo_pattern:`, `boundary_enforcement:` blocks are preserved verbatim.
+rules:
+  - id: COACH-TRAIN-COMPOSITION-001
+    severity: 3
+    description: "Train is a production composition root in python/trains/, not test infrastructure"
+  - id: COACH-TRAIN-COMPOSITION-002
+    severity: 3
+    description: "Wagons communicate via cargo (contract artifacts) — never via direct cross-wagon imports"
+  - id: COACH-TRAIN-COMPOSITION-003
+    severity: 3
+    description: "Train YAML is the single source of truth for orchestration; production and tests both consume it via TrainRunner"
+
 rationale: |
   Trains are PRODUCTION orchestration, not test infrastructure. They execute user journeys
   defined in YAML specifications by coordinating wagons through contract-based communication.


### PR DESCRIPTION
## Summary

Partial landing of issue #389 (Bulk Migrate Rules And Validators). Phases 1 + 3a only — Phase 2 (19-validator structured-Violation migration) and Phase 4 (strict-coherence default) remain blocked on dependency PRs #387 + #388 per the issue's serialized merge order.

This PR is **draft** because:
- It does **not** close #389 — the bulk migration still requires #388's `bind_rule(...)` helper and #387's registry walker before Phase 2 / 3b / 4 can run.
- Bumping the merge order forward (#387 → #388 → 389-partial) would let downstream rebases shrink.
- Recommended: hold this draft until #387 + #388 land, then either merge this first as a clean prep step or fold its diff into the full #389 PR.

## What's in

### Phase 1 — Grammar extension
- `src/atdd/coach/conventions/rule-id.convention.yaml` — new `legacy_grammar:` block with 3 entries:
  - `^DS-\d{2}$` — design-system principles (DS-01..)
  - `^ERR-\d{2}$` — error-response rules (ERR-01..)
  - `^GP-\d{2}$` — green-phase rules (GP-01..)
  - Each entry has a one-line rationale. Per Decision #8, `AP-DS-NN` and `COACH-BABYSIT-NNN` are deliberately excluded — they already match canonical.
- `src/atdd/coach/validators/test_rule_id_uniqueness.py`:
  - `load_legacy_patterns()` compiles the new section into `re.Pattern` objects.
  - `validate_grammar(rule_id, allowed_domains, legacy_patterns=...)` accepts legacy-shaped IDs only when caller opts in.
  - `test_rule_id_grammar_and_required_fields` passes `legacy_patterns` when validating files in `migration.completed:`.
  - `test_rule_id_uniqueness` now tracks legacy IDs in migrated files alongside canonical IDs (collision detection across both grammars).

### Phase 3a — `rules:` arrays in 7 conventions
Per Decision #9 the registry walker recurses, so placement is top-level or nested next to existing rule-bearing structure. Existing id-bearing structures (`principles:`, `anti_patterns:`, `dependency_rules:`, `entrypoint_rules:`) are preserved verbatim.

| Convention | Domain | Topics |
|---|---|---|
| `coder/conventions/backend.convention.yaml` | BOUNDARIES | `LAYER-{001..003}` |
| `coder/conventions/commons.convention.yaml` | BOUNDARIES | `COMMONS-{001..003}` (nested under `dependency_rules:`) |
| `coder/conventions/design.convention.yaml` | DESIGN | `HIERARCHY-{001..004}` (nested under `design_system:`) |
| `coder/conventions/presentation.convention.yaml` | PRESENTATION | `THIN-{001..003}` |
| `coder/conventions/technology.convention.yaml` | COACH | `TECH-STACK-{001..003}` |
| `coder/conventions/train.convention.yaml` | COACH | `TRAIN-COMPOSITION-{001..003}` |
| `coach/conventions/naming.convention.yaml` | COACH | `NAMING-{SEPARATOR,FORMAT,URN}-001` |

All new IDs use already-registered DOMAINs — no SPEC edit required.

## What's NOT in (deferred to follow-up)

- **Phase 2** — bulk-migrate 19 ratchet validators to canonical `List[Violation]` payloads. Blocked: needs `bind_rule(...)` from #388.
- **Phase 3b** — append the 24 coder+coach conventions to `migration.completed:`. Blocked: only meaningful once Phase 2 lands and the validators emitting against these conventions are also canonical.
- **Phase 4** — flip `test_rule_id_registry_coherence.py` to strict by default + add `--permissive-coherence` opt-out + regenerate `coder.violations.yaml`. Blocked: that validator file ships in #387.

## Test plan

- [x] `PYTHONPATH=src python3 -m pytest src/atdd/coach/validators/test_rule_id_uniqueness.py src/atdd/coach/validators/tests/ -v` → **99/99 pass**
- [x] Full coach suite (`pytest src/atdd/coach/validators/ -v`) → 292 pass, 7 fail. Verified via `git stash` round-trip that all 7 failures pre-exist on `main` (project-board, branch-naming, release-versioning, label-set, unlabeled-issue, orchestrate-readiness — all infra/state, not code).
- [x] No new domains added to the closed registry.
- [x] No legacy ID renamed (history preserved).
- [ ] Re-run when #387 + #388 land to confirm the deferred phases compose cleanly on top.

Refs: #389, #386 (parent), #387 (blocked), #388 (blocked).