### PR TITLE
fix(coach): #396 — extract pane:N/surface:N tokens from cmux OK-lines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "2.0.0"
+version = "2.0.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/utils/multiplexer.py
+++ b/src/atdd/coach/utils/multiplexer.py
@@ -26,6 +26,7 @@ Auto-detection precedence:
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 from abc import ABC, abstractmethod
@@ -115,6 +116,24 @@ def _last_nonempty_line(stdout: str) -> str:
     return ""
 
 
+def _extract_ref_token(stdout: str, prefix: str) -> str:
+    """Extract the first ``<prefix>:<N>`` token from a cmux OK-line.
+
+    cmux mutating commands (``new-pane``, ``new-split``, ``new-surface``) emit
+    a single line of the shape ``OK <ref> [<ref>...]`` where each ref is
+    ``<kind>:<integer>``. The CLI only accepts the bare ``<kind>:<integer>``
+    token as a handle — feeding back the whole OK-line is rejected with
+    "Invalid pane handle". Returns ``""`` when no matching token is present;
+    callers raise ``MultiplexerError`` so the failure surfaces clearly.
+    """
+    pattern = re.compile(rf"(?:^|\s){re.escape(prefix)}:(\d+)\b")
+    for line in (stdout or "").splitlines():
+        match = pattern.search(line)
+        if match:
+            return f"{prefix}:{match.group(1)}"
+    return ""
+
+
 class CmuxBackend(MultiplexerBackend):
     """cmux backend — workspace + pane/surface dispatch.
 
@@ -148,17 +167,21 @@ class CmuxBackend(MultiplexerBackend):
             if workspace_ref:
                 new_pane_cmd.extend(["--workspace", workspace_ref])
             pane_result = _run(new_pane_cmd)
-            pane_ref = _last_nonempty_line(pane_result.stdout or "")
+            pane_ref = _extract_ref_token(pane_result.stdout or "", "pane")
             if not pane_ref:
-                raise MultiplexerError("cmux new-pane returned no pane ref")
+                raise MultiplexerError(
+                    f"cmux new-pane returned no pane ref: {(pane_result.stdout or '').strip()!r}"
+                )
 
         new_surface_cmd = ["cmux", "new-surface", "--pane", pane_ref]
         if name:
             new_surface_cmd.extend(["--name", name])
         surface_result = _run(new_surface_cmd)
-        surface_ref = _last_nonempty_line(surface_result.stdout or "")
+        surface_ref = _extract_ref_token(surface_result.stdout or "", "surface")
         if not surface_ref:
-            raise MultiplexerError("cmux new-surface returned no surface ref")
+            raise MultiplexerError(
+                f"cmux new-surface returned no surface ref: {(surface_result.stdout or '').strip()!r}"
+            )
 
         if cwd or command:
             seed_parts = []

--- a/src/atdd/coach/utils/tests/test_multiplexer.py
+++ b/src/atdd/coach/utils/tests/test_multiplexer.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for ``atdd.coach.utils.multiplexer``.
+
+URN: urn:atdd:test:coach:utils:multiplexer
+Issue: #396
+
+Covers the cmux OK-line ref-token parser and ``CmuxBackend.new_surface``,
+which previously fed the entire ``OK surface:N pane:M workspace:K`` line
+back to ``cmux new-surface --pane <pane_ref>`` and got rejected with
+"Invalid pane handle". The fix extracts ``pane:M`` (and ``surface:N``)
+tokens by prefix.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from atdd.coach.utils.multiplexer import (
+    CmuxBackend,
+    MultiplexerError,
+    _extract_ref_token,
+)
+
+
+# ─── _extract_ref_token ───────────────────────────────────────────────────────
+
+
+class TestExtractRefToken:
+    def test_extracts_pane_token_from_ok_line(self):
+        line = "OK surface:120 pane:33 workspace:17"
+        assert _extract_ref_token(line, "pane") == "pane:33"
+
+    def test_extracts_surface_token_from_ok_line(self):
+        line = "OK surface:120 pane:33 workspace:17"
+        assert _extract_ref_token(line, "surface") == "surface:120"
+
+    def test_extracts_workspace_token_from_ok_line(self):
+        line = "OK surface:120 pane:33 workspace:17"
+        assert _extract_ref_token(line, "workspace") == "workspace:17"
+
+    def test_returns_first_match_when_multiple(self):
+        line = "OK pane:1 pane:2"
+        assert _extract_ref_token(line, "pane") == "pane:1"
+
+    def test_handles_trailing_newline(self):
+        line = "OK surface:5 pane:7 workspace:3\n"
+        assert _extract_ref_token(line, "pane") == "pane:7"
+
+    def test_handles_multiple_lines_returns_first_match(self):
+        # Real cmux output is single-line, but be tolerant of stray prefixes.
+        stdout = "some banner\nOK surface:5 pane:7 workspace:3\n"
+        assert _extract_ref_token(stdout, "surface") == "surface:5"
+
+    def test_returns_empty_when_prefix_absent(self):
+        line = "OK workspace:17"
+        assert _extract_ref_token(line, "pane") == ""
+
+    def test_returns_empty_on_blank_input(self):
+        assert _extract_ref_token("", "pane") == ""
+        assert _extract_ref_token("   \n  ", "surface") == ""
+
+    def test_does_not_match_partial_prefix(self):
+        # "subpane:9" must NOT match prefix "pane".
+        line = "OK subpane:9 workspace:1"
+        assert _extract_ref_token(line, "pane") == ""
+
+    def test_does_not_match_prefix_in_middle_of_token(self):
+        line = "OK xpane:5 workspace:1"
+        assert _extract_ref_token(line, "pane") == ""
+
+    def test_requires_numeric_id(self):
+        line = "OK pane:abc workspace:1"
+        assert _extract_ref_token(line, "pane") == ""
+
+
+# ─── CmuxBackend.new_surface integration ──────────────────────────────────────
+
+
+def _ok(stdout: str) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+class TestCmuxNewSurface:
+    def test_passes_clean_pane_ref_to_new_surface(self):
+        """new_surface must extract `pane:N` from `cmux new-pane` output and
+        pass it (not the full OK-line) to `cmux new-surface --pane ...`.
+        """
+        backend = CmuxBackend()
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, capture=True):
+            calls.append(cmd)
+            if cmd[:2] == ["cmux", "new-pane"]:
+                return _ok("OK surface:120 pane:33 workspace:17\n")
+            if cmd[:2] == ["cmux", "new-surface"]:
+                return _ok("OK surface:121 workspace:17\n")
+            return _ok("")
+
+        with patch("atdd.coach.utils.multiplexer._run", side_effect=fake_run):
+            ref = backend.new_surface(workspace_ref="workspace:17", name="issue-396")
+
+        assert ref == "surface:121"
+
+        new_pane_call = calls[0]
+        assert new_pane_call == ["cmux", "new-pane", "--workspace", "workspace:17"]
+
+        new_surface_call = calls[1]
+        assert "--pane" in new_surface_call
+        pane_arg = new_surface_call[new_surface_call.index("--pane") + 1]
+        assert pane_arg == "pane:33", (
+            f"expected clean `pane:33`, got {pane_arg!r} "
+            "(regression: full OK-line leaked through)"
+        )
+        assert "--name" in new_surface_call
+        assert new_surface_call[new_surface_call.index("--name") + 1] == "issue-396"
+
+    def test_uses_provided_pane_ref_without_creating_new_pane(self):
+        backend = CmuxBackend()
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, capture=True):
+            calls.append(cmd)
+            if cmd[:2] == ["cmux", "new-surface"]:
+                return _ok("OK surface:99 workspace:1\n")
+            return _ok("")
+
+        with patch("atdd.coach.utils.multiplexer._run", side_effect=fake_run):
+            ref = backend.new_surface(pane_ref="pane:7")
+
+        assert ref == "surface:99"
+        assert calls[0][:2] == ["cmux", "new-surface"]
+        assert "--pane" in calls[0]
+        assert calls[0][calls[0].index("--pane") + 1] == "pane:7"
+
+    def test_seeds_cwd_and_command_into_surface(self):
+        backend = CmuxBackend()
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, capture=True):
+            calls.append(cmd)
+            if cmd[:2] == ["cmux", "new-pane"]:
+                return _ok("OK surface:1 pane:2 workspace:3\n")
+            if cmd[:2] == ["cmux", "new-surface"]:
+                return _ok("OK surface:4 workspace:3\n")
+            return _ok("")
+
+        with patch("atdd.coach.utils.multiplexer._run", side_effect=fake_run):
+            ref = backend.new_surface(
+                workspace_ref="workspace:3",
+                cwd="/tmp/wt",
+                command="claude --dangerously-skip-permissions",
+            )
+
+        assert ref == "surface:4"
+        seed_call = calls[-1]
+        assert seed_call[:4] == ["cmux", "rpc", "surface.send_text", "--surface"]
+        assert seed_call[4] == "surface:4"
+        assert seed_call[5] == "cd /tmp/wt && claude --dangerously-skip-permissions\n"
+
+    def test_raises_when_pane_ref_cannot_be_extracted(self):
+        backend = CmuxBackend()
+
+        def fake_run(cmd, capture=True):
+            if cmd[:2] == ["cmux", "new-pane"]:
+                return _ok("ERROR something went wrong\n")
+            return _ok("")
+
+        with patch("atdd.coach.utils.multiplexer._run", side_effect=fake_run):
+            with pytest.raises(MultiplexerError, match="pane"):
+                backend.new_surface(workspace_ref="workspace:1")
+
+    def test_raises_when_surface_ref_cannot_be_extracted(self):
+        backend = CmuxBackend()
+
+        def fake_run(cmd, capture=True):
+            if cmd[:2] == ["cmux", "new-pane"]:
+                return _ok("OK surface:1 pane:2 workspace:3\n")
+            if cmd[:2] == ["cmux", "new-surface"]:
+                return _ok("ERROR\n")
+            return _ok("")
+
+        with patch("atdd.coach.utils.multiplexer._run", side_effect=fake_run):
+            with pytest.raises(MultiplexerError, match="surface"):
+                backend.new_surface(workspace_ref="workspace:3")


### PR DESCRIPTION
## Summary
- Adds `_extract_ref_token(stdout, prefix)` to `src/atdd/coach/utils/multiplexer.py` — pulls the first `<prefix>:<integer>` token from a cmux `OK <ref> [<ref>...]` line.
- Replaces the two `_last_nonempty_line` calls in `CmuxBackend.new_surface` so the bare `pane:N` / `surface:N` token is passed back to cmux instead of the full OK-line.
- Adds `src/atdd/coach/utils/tests/test_multiplexer.py` (16 tests) covering the helper and the `new_surface` flow with mocked `_run`.

Closes #396.

## Why
`atdd orchestrate <N> --multiplexer-mode pane` was failing 100% of the time:

```
cmux new-surface --pane OK surface:118 pane:31 workspace:17 --name issue-N failed (exit 1):
Error: Invalid pane handle: OK surface:118 pane:31 workspace:17 (expected UUID, ref like pane:1, or index)
```

Root cause: `_last_nonempty_line` returned the entire `OK surface:120 pane:33 workspace:17` line as the `pane_ref`. cmux's CLI only accepts bare `pane:N` tokens.

Discovered while launching Wave A for the ratchet-removal arc (#394/#395) — required ~5 minutes of manual `cmux new-split` + `respawn-pane` + `paste-buffer` to work around.

## Test plan
- [x] `pytest src/atdd/coach/utils/tests/test_multiplexer.py -v` → 16/16 pass
- [x] `pytest src/atdd/coach/utils/tests/` → 75/75 pass (no regressions)
- [ ] SMOKE (manual, follow-on): `atdd orchestrate <N> --multiplexer-mode pane` against live cmux — expect pane created, surface created, claude seeded