### PR TITLE
feat(coach): enrich failure output with rule description + fix_hint (#402)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -167,3 +167,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:enforce-train-has-rendered-content
   train: 0001-self-compliance-validate
+- id: '402'
+  slug: enrich-failure-output-with-rule-content
+  file: null
+  issue_number: 402
+  type: feature
+  status: PLANNED
+  created: '2026-05-04'
+  archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:actionable-failure-output
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.0.0"
+version = "3.1.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/utils/disposition_gate.py
+++ b/src/atdd/coach/utils/disposition_gate.py
@@ -169,7 +169,9 @@ def assert_disposition_satisfied(
             disposition = _DEFAULT_DISPOSITION
 
         if disposition == "advisory":
-            advisory_blocks.append(_format_advisory_block(validator_id, rule_id, vs))
+            advisory_blocks.append(
+                _format_advisory_block(validator_id, rule_id, vs, registry)
+            )
             continue
 
         if disposition == "strict":
@@ -179,6 +181,7 @@ def assert_disposition_satisfied(
                 disposition=disposition,
                 violations=vs,
                 suppressed_count=0,
+                registry=registry,
             ))
             continue
 
@@ -201,6 +204,7 @@ def assert_disposition_satisfied(
                 disposition=disposition,
                 violations=unsuppressed,
                 suppressed_count=len(suppressed),
+                registry=registry,
             ))
 
     # Opaque violations: no rule_id ⇒ default-strict.
@@ -229,6 +233,7 @@ def _format_failure_block(
     disposition: str,
     violations: Sequence[Any],
     suppressed_count: int,
+    registry: Optional[Dict[str, RuleMetadata]] = None,
 ) -> str:
     lines = [
         f"\n  rule_id={rule_id} disposition={disposition} "
@@ -236,6 +241,11 @@ def _format_failure_block(
         + (f", {suppressed_count} suppressed" if suppressed_count else "")
         + "):",
     ]
+    meta = registry.get(rule_id) if registry else None
+    if meta and meta.description:
+        lines.append(f"    description: {meta.description.splitlines()[0]}")
+    if meta and meta.fix_hint:
+        lines.append(f"    fix_hint:    {meta.fix_hint.splitlines()[0]}")
     for v in violations:
         lines.append(_format_violation(v, disposition))
     if disposition == "suppress-and-clean":
@@ -248,10 +258,16 @@ def _format_advisory_block(
     validator_id: str,
     rule_id: str,
     violations: Sequence[Any],
+    registry: Optional[Dict[str, RuleMetadata]] = None,
 ) -> str:
     lines = [
         f"[advisory] {validator_id} {rule_id}: {len(violations)} violation(s)"
     ]
+    meta = registry.get(rule_id) if registry else None
+    if meta and meta.description:
+        lines.append(f"    description: {meta.description.splitlines()[0]}")
+    if meta and meta.fix_hint:
+        lines.append(f"    fix_hint:    {meta.fix_hint.splitlines()[0]}")
     for v in violations:
         lines.append(_format_violation(v, "advisory"))
     return "\n".join(lines)

--- a/src/atdd/coach/utils/tests/test_disposition_gate.py
+++ b/src/atdd/coach/utils/tests/test_disposition_gate.py
@@ -22,13 +22,19 @@ from atdd.coach.utils.rule_id_registry import RuleMetadata
 from atdd.coach.validators._violation import Violation
 
 
-def _meta(rule_id: str, disposition: str) -> RuleMetadata:
+def _meta(
+    rule_id: str,
+    disposition: str,
+    description: str = "fixture rule",
+    fix_hint: str | None = None,
+) -> RuleMetadata:
     return RuleMetadata(
         rule_id=rule_id,
         convention_path=Path("/dev/null"),
         severity=3,
-        description="fixture rule",
+        description=description,
         disposition=disposition,
+        fix_hint=fix_hint,
     )
 
 
@@ -263,6 +269,123 @@ def test_mixed_dispositions_routed_independently(tmp_path):
 # ---------------------------------------------------------------------------
 # Opaque legacy callers
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Enriched output: description + fix_hint surfaced from registry (issue #402)
+# ---------------------------------------------------------------------------
+
+def test_failure_includes_description_when_set(tmp_path):
+    target = _write(tmp_path / "code.py", "print('x')\n")
+    v = Violation(
+        rule_id="LOG-PRINT-001",
+        severity=3,
+        location=f"{target.name}:1",
+        detail="print() at line 1",
+    )
+    registry = {
+        "LOG-PRINT-001": _meta(
+            "LOG-PRINT-001",
+            "strict",
+            description="print() in production code is not allowed",
+        )
+    }
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        assert_disposition_satisfied(
+            validator_id="vid",
+            violations=[v],
+            registry=registry,
+            repo_root=tmp_path,
+        )
+    msg = str(excinfo.value)
+    assert "description: print() in production code is not allowed" in msg
+
+
+def test_failure_includes_fix_hint_when_set(tmp_path):
+    target = _write(tmp_path / "code.py", "print('x')\n")
+    v = Violation(
+        rule_id="LOG-PRINT-001",
+        severity=3,
+        location=f"{target.name}:1",
+        detail="print() at line 1",
+    )
+    registry = {
+        "LOG-PRINT-001": _meta(
+            "LOG-PRINT-001",
+            "suppress-and-clean",
+            description="prefer logging",
+            fix_hint="Use logging.info() instead of print().",
+        )
+    }
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        assert_disposition_satisfied(
+            validator_id="vid",
+            violations=[v],
+            registry=registry,
+            repo_root=tmp_path,
+        )
+    msg = str(excinfo.value)
+    assert "fix_hint:    Use logging.info() instead of print()." in msg
+    # Suppress-marker template still appears under suppress-and-clean
+    assert "atdd:suppress(LOG-PRINT-001)" in msg
+
+
+def test_failure_omits_fields_when_not_set(tmp_path):
+    target = _write(tmp_path / "code.py", "print('x')\n")
+    v = Violation(
+        rule_id="LOG-PRINT-001",
+        severity=3,
+        location=f"{target.name}:1",
+        detail="print() at line 1",
+    )
+    # description="" + fix_hint=None — neither line should appear.
+    registry = {
+        "LOG-PRINT-001": _meta(
+            "LOG-PRINT-001",
+            "strict",
+            description="",
+            fix_hint=None,
+        )
+    }
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        assert_disposition_satisfied(
+            validator_id="vid",
+            violations=[v],
+            registry=registry,
+            repo_root=tmp_path,
+        )
+    msg = str(excinfo.value)
+    assert "description:" not in msg
+    assert "fix_hint:" not in msg
+
+
+def test_advisory_block_includes_description_and_fix_hint(tmp_path, recwarn):
+    target = _write(tmp_path / "code.py", "x\n")
+    v = Violation(
+        rule_id="STYLE-NIT-001",
+        severity=1,
+        location=f"{target.name}:1",
+        detail="trailing whitespace",
+    )
+    registry = {
+        "STYLE-NIT-001": _meta(
+            "STYLE-NIT-001",
+            "advisory",
+            description="trailing whitespace is discouraged",
+            fix_hint="Run `ruff format` to clean up.",
+        )
+    }
+    assert_disposition_satisfied(
+        validator_id="style_nits",
+        violations=[v],
+        registry=registry,
+        repo_root=tmp_path,
+    )
+    messages = [str(w.message) for w in recwarn.list]
+    assert any(
+        "description: trailing whitespace is discouraged" in m for m in messages
+    )
+    assert any("fix_hint:    Run `ruff format` to clean up." in m for m in messages)
+
 
 def test_opaque_violations_default_strict():
     with pytest.raises(pytest.fail.Exception) as excinfo:

--- a/src/atdd/coach/validators/test_rule_validator_binding.py
+++ b/src/atdd/coach/validators/test_rule_validator_binding.py
@@ -85,16 +85,19 @@ def _build_violations() -> List[Violation]:
 
         if disposition == "documentation-only":
             if validator_field:
+                detail = (
+                    f"rule {rule_id!r} is documentation-only but carries "
+                    f"validator:{validator_field!r}; remove the validator "
+                    f"field or change the disposition."
+                )
+                if meta.description:
+                    detail += f" | rule purpose: {meta.description}"
                 violations.append(
                     Violation(
                         rule_id=_RULE.rule_id,
                         severity=_RULE.severity,
                         location=loc,
-                        detail=(
-                            f"rule {rule_id!r} is documentation-only but carries "
-                            f"validator:{validator_field!r}; remove the validator "
-                            f"field or change the disposition."
-                        ),
+                        detail=detail,
                     )
                 )
             continue
@@ -105,17 +108,20 @@ def _build_violations() -> List[Violation]:
             continue
 
         if not validator_field:
+            detail = (
+                f"rule {rule_id!r} has disposition {disposition!r} but "
+                f"declares no validator: field. Either set "
+                f"validator: '<module>::<func>' or change disposition "
+                f"to documentation-only."
+            )
+            if meta.description:
+                detail += f" | rule purpose: {meta.description}"
             violations.append(
                 Violation(
                     rule_id=_RULE.rule_id,
                     severity=_RULE.severity,
                     location=loc,
-                    detail=(
-                        f"rule {rule_id!r} has disposition {disposition!r} but "
-                        f"declares no validator: field. Either set "
-                        f"validator: '<module>::<func>' or change disposition "
-                        f"to documentation-only."
-                    ),
+                    detail=detail,
                 )
             )
             continue
@@ -127,15 +133,18 @@ def _build_violations() -> List[Violation]:
                 validator_field=validator_field,
             )
         except (ValidatorResolutionError, ValueError) as exc:
+            detail = (
+                f"rule {rule_id!r} validator {validator_field!r} could "
+                f"not be resolved: {exc}"
+            )
+            if meta.description:
+                detail += f" | rule purpose: {meta.description}"
             violations.append(
                 Violation(
                     rule_id=_RULE.rule_id,
                     severity=_RULE.severity,
                     location=loc,
-                    detail=(
-                        f"rule {rule_id!r} validator {validator_field!r} could "
-                        f"not be resolved: {exc}"
-                    ),
+                    detail=detail,
                 )
             )
             continue
@@ -144,17 +153,20 @@ def _build_violations() -> List[Violation]:
         if rule_id not in resolved.bound_rule_ids and not (
             set(meta.aliases) & resolved.bound_rule_ids
         ):
+            detail = (
+                f"rule {rule_id!r} names validator "
+                f"{validator_field!r}, but the function body never "
+                f"calls bind_rule({rule_id!r}). Found "
+                f"{sorted(resolved.bound_rule_ids)!r}."
+            )
+            if meta.description:
+                detail += f" | rule purpose: {meta.description}"
             violations.append(
                 Violation(
                     rule_id=_RULE.rule_id,
                     severity=_RULE.severity,
                     location=f"{resolved.module_path}",
-                    detail=(
-                        f"rule {rule_id!r} names validator "
-                        f"{validator_field!r}, but the function body never "
-                        f"calls bind_rule({rule_id!r}). Found "
-                        f"{sorted(resolved.bound_rule_ids)!r}."
-                    ),
+                    detail=detail,
                 )
             )
 


### PR DESCRIPTION
## Summary

- `disposition_gate.py::_format_failure_block` and `_format_advisory_block` now accept the already-loaded registry and surface each rule's canonical `description:` and `fix_hint:` above the per-violation lines (only when set; sparse conventions stay quiet).
- `test_rule_validator_binding.py::_build_violations` now suffixes each Violation `detail:` with `| rule purpose: <description>` so reverse-coherence failures explain what the rule is supposed to enforce.
- 4 new tests in `test_disposition_gate.py` cover the enriched output (description present, fix_hint present, both omitted, advisory variant).
- Version bumped 3.0.0 → 3.1.0 (MINOR — non-breaking output enhancement).

## Test plan

- [x] `pytest src/atdd/coach/utils/tests/test_disposition_gate.py -v` — 14 passed (10 existing + 4 new)
- [x] `pytest src/atdd/coach/validators/test_rule_validator_binding.py -v` — passes
- [x] Full coach suite: 769 passed; 15 pre-existing failures unrelated to this change (babysit rule_id renames + GitHub-API issue/project tests)

Closes #402