### PR TITLE
fix(coach): #404 — auto-phase PAT swap + validator annotations

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -178,3 +178,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:actionable-failure-output
   train: 0001-self-compliance-validate
+- id: '404'
+  slug: auto-phase-pat-swap-and-validator-annotations
+  file: null
+  issue_number: 404
+  type: fix
+  status: PLANNED
+  created: '2026-05-04'
+  archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:actionable-ci-feedback
+  train: 0001-self-compliance-validate

--- a/.github/workflows/atdd-auto-phase.yml
+++ b/.github/workflows/atdd-auto-phase.yml
@@ -16,7 +16,11 @@ jobs:
       issues: write
       contents: read
       pull-requests: read
-      projects: write   # Issue #384: required for ProjectV2 sync.
+      # Issue #404: 'projects: write' removed — GITHUB_TOKEN cannot grant the
+      # account-level Projects scope, and declaring it caused preflight to
+      # reject the workflow on every run. Full ProjectV2 Status sync is now
+      # opt-in via the PROJECT_TOKEN PAT (see GH_TOKEN below); without it,
+      # IssueManager.update falls back to label-only sync.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -31,7 +35,7 @@ jobs:
 
       - name: Run atdd auto-phase
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           PYTHONPATH=src python3 -m atdd.cli auto-phase "$PR_NUMBER"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.1.0"
+version = "3.2.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"
@@ -13,6 +13,7 @@ dependencies = [
     "pyyaml",
     "pytest>=7.0",
     "pytest-xdist",
+    "pytest-github-actions-annotate-failures",
     "jsonschema",
     "pytest-html",
     "radon>=5.0",

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -1625,9 +1625,10 @@ class IssueManager:
                     raise
                 logger.warning(
                     "ProjectV2 sync denied for issue #%s; continuing with "
-                    "label-only sync. Grant the GHA token 'projects: write' "
-                    "or enable Projects access in repo Settings → Actions → "
-                    "Workflow permissions to silence this.",
+                    "label-only sync. To enable full Status-field sync, "
+                    "create a fine-grained PAT with Projects: R/W "
+                    "(https://github.com/settings/tokens?type=beta) and set "
+                    "it as the PROJECT_TOKEN repo secret — see issue #404.",
                     issue_number,
                     extra={
                         "action": "projects_access_fallback",

--- a/src/atdd/coach/commands/tests/test_issue_update_fallback.py
+++ b/src/atdd/coach/commands/tests/test_issue_update_fallback.py
@@ -122,7 +122,10 @@ def test_denied_logs_warning_with_remediation(tmp_path, caplog):
 
     warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
     assert any("ProjectV2" in m for m in warnings), warnings
-    assert any("projects: write" in m or "Workflow permissions" in m for m in warnings), warnings
+    # Issue #404 changed the remediation hint: GITHUB_TOKEN cannot grant
+    # projects:write, so the actionable upgrade path is now the optional
+    # PROJECT_TOKEN PAT, not the workflow permissions block.
+    assert any("PROJECT_TOKEN" in m for m in warnings), warnings
 
 
 # ---------------------------------------------------------------------------

--- a/src/atdd/coach/conventions/issue.convention.yaml
+++ b/src/atdd/coach/conventions/issue.convention.yaml
@@ -535,21 +535,25 @@ status:
       - OBSOLETE
     validator: "src/atdd/coach/validators/test_auto_phase_workflow_exists.py"
 
-    # Issue #384: ProjectV2 sync may be unavailable when the GHA token lacks
-    # `projects: write` (or org-level Actions policy disables Projects).
-    # `IssueManager.update` catches the narrow "Resource not accessible by
-    # integration" GitHubClientError, logs a WARNING, and continues with
-    # label-only sync via the existing `atdd:<PHASE>` swap. Non-matching
-    # GitHubClientError instances still abort.
+    # Issue #384/#404: ProjectV2 sync may be unavailable when the workflow
+    # token lacks Projects: R/W (the default GITHUB_TOKEN cannot grant the
+    # account-level Projects scope at all). `IssueManager.update` catches
+    # the narrow "Resource not accessible by integration" GitHubClientError,
+    # logs a WARNING, and continues with label-only sync via the existing
+    # `atdd:<PHASE>` swap. Non-matching GitHubClientError instances still
+    # abort. Issue #404 made full sync OPT-IN via a fine-grained PAT in
+    # PROJECT_TOKEN; default consumers run on GITHUB_TOKEN and never hit
+    # preflight failure.
     projects_access_fallback:
       enabled: true
       trigger: "GitHubClientError matching 'Resource not accessible by integration'"
       behavior: "label-only sync (atdd:<PHASE> swap); ProjectV2 fields skipped"
       log_level: "WARNING"
       remediation: |
-        Grant the GHA token `projects: write` in the workflow `permissions:`
-        block (already shipped in atdd-auto-phase.yml since #384), or enable
-        Projects access in repo Settings → Actions → Workflow permissions.
+        Set the optional PROJECT_TOKEN secret (fine-grained PAT, scope:
+        account → Projects R/W) to enable full ProjectV2 Status sync; default
+        falls back to label-only sync via the workflow's fallback expression
+        ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }} (issue #404).
       template: "src/atdd/coach/templates/workflows/atdd-auto-phase.yml"
       validator: "src/atdd/coach/commands/tests/test_issue_update_fallback.py"
 

--- a/src/atdd/coach/templates/workflows/atdd-auto-phase.yml
+++ b/src/atdd/coach/templates/workflows/atdd-auto-phase.yml
@@ -18,7 +18,11 @@ jobs:
       issues: write
       contents: read
       pull-requests: read
-      projects: write   # Issue #384: required for ProjectV2 sync.
+      # Issue #404: 'projects: write' removed — GITHUB_TOKEN cannot grant the
+      # account-level Projects scope, and declaring it caused preflight to
+      # reject the workflow on every run. Full ProjectV2 Status sync is opt-in
+      # via the PROJECT_TOKEN PAT (see GH_TOKEN below); without it,
+      # IssueManager.update falls back to label-only sync.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,6 +42,6 @@ jobs:
 
       - name: Run atdd auto-phase
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: atdd auto-phase "$PR_NUMBER"

--- a/src/atdd/coach/utils/disposition_gate.py
+++ b/src/atdd/coach/utils/disposition_gate.py
@@ -30,6 +30,8 @@ default — unregistered rules should be caught by the
 from __future__ import annotations
 
 import logging
+import os
+import sys
 import warnings
 from collections import defaultdict
 from pathlib import Path
@@ -161,6 +163,8 @@ def assert_disposition_satisfied(
 
     failures: List[str] = []
     advisory_blocks: List[str] = []
+    error_annotations: List[Any] = []
+    warning_annotations: List[Any] = []
 
     for rule_id, vs in structured.items():
         meta = registry.get(rule_id)
@@ -172,6 +176,7 @@ def assert_disposition_satisfied(
             advisory_blocks.append(
                 _format_advisory_block(validator_id, rule_id, vs, registry)
             )
+            warning_annotations.extend(vs)
             continue
 
         if disposition == "strict":
@@ -183,6 +188,7 @@ def assert_disposition_satisfied(
                 suppressed_count=0,
                 registry=registry,
             ))
+            error_annotations.extend(vs)
             continue
 
         # suppress-and-clean
@@ -206,10 +212,17 @@ def assert_disposition_satisfied(
                 suppressed_count=len(suppressed),
                 registry=registry,
             ))
+            error_annotations.extend(unsuppressed)
 
     # Opaque violations: no rule_id ⇒ default-strict.
     if opaque:
         failures.append(_format_opaque_block(validator_id, opaque))
+
+    # Issue #404: emit GH Actions ::error::/::warning:: directives so each
+    # violation surfaces as an inline annotation on the PR's "Files changed"
+    # tab. No-op outside GH Actions to keep local pytest output clean.
+    _emit_github_annotations(error_annotations, registry, level="error")
+    _emit_github_annotations(warning_annotations, registry, level="warning")
 
     for block in advisory_blocks:
         warnings.warn(block, UserWarning, stacklevel=2)
@@ -281,6 +294,100 @@ def _format_opaque_block(validator_id: str, opaque: Sequence[Any]) -> str:
     for v in opaque:
         lines.append(f"    {v}")
     return "\n".join(lines)
+
+
+def _first_line(text: Optional[str], default: str = "") -> str:
+    """Return the first non-empty line of ``text`` (or ``default``)."""
+    if not text:
+        return default
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return default
+
+
+def _sanitize_annotation_field(value: str) -> str:
+    """Strip characters that would break a GH Actions workflow command.
+
+    GitHub parses the directive as ``::error file=...,line=...,title=...::msg``;
+    embedded ``\\n``, ``::``, or ``,`` in ``title``/``file`` would corrupt the
+    parse. Replace them with safe equivalents while preserving readability.
+    """
+    return (
+        value.replace("\r", " ")
+        .replace("\n", " ")
+        .replace("::", ":")
+        .replace(",", ";")
+        .strip()
+    )
+
+
+def _sanitize_annotation_message(value: str) -> str:
+    """Strip characters that would terminate the message early."""
+    return value.replace("\r", " ").replace("\n", " ").replace("::", ":").strip()
+
+
+def _emit_github_annotations(
+    violations: Sequence[Any],
+    registry: Optional[Dict[str, RuleMetadata]],
+    *,
+    level: str = "error",
+    stream: Any = None,
+) -> None:
+    """Emit one ``::error::`` / ``::warning::`` workflow command per violation.
+
+    Issue #404. Each annotation surfaces inline on the PR's "Files changed"
+    tab at the offending ``file:line`` with the rule's description, fix_hint,
+    and the violation's detail packed into the message. No-op when the
+    process is not running under GitHub Actions (detected via the
+    ``GITHUB_ACTIONS=true`` env var) — local pytest stdout stays clean.
+
+    Args:
+        violations: Sequence of structured ``Violation`` records
+            (``rule_id`` + ``location`` + ``detail``). Opaque/dict-shaped
+            entries are skipped — they have no anchor to annotate.
+        registry: Optional registry of ``RuleMetadata`` keyed by ``rule_id``.
+            When present, ``description`` and ``fix_hint`` are pulled from
+            here to enrich the annotation message.
+        level: ``"error"`` (default) or ``"warning"``. Mirrors the
+            disposition: ``strict`` and unsuppressed ``suppress-and-clean``
+            emit ``::error::``; ``advisory`` emits ``::warning::``.
+        stream: Override the output stream (used by tests). Defaults to
+            ``sys.stdout``.
+    """
+    if not violations:
+        return
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return
+    if level not in ("error", "warning"):
+        level = "error"
+
+    out = stream if stream is not None else sys.stdout
+    for v in violations:
+        if not _looks_like_violation(v):
+            continue
+        path, line = _split_location(v.location)
+        meta = registry.get(v.rule_id) if registry else None
+        description = _first_line(meta.description if meta else None)
+        fix_hint = _first_line(meta.fix_hint if meta else None, default="see convention")
+        detail = _first_line(v.detail, default="")
+
+        params = [f"file={_sanitize_annotation_field(path)}"]
+        if line is not None:
+            params.append(f"line={line}")
+        params.append(f"title={_sanitize_annotation_field(v.rule_id)}")
+
+        message_parts: List[str] = []
+        if description:
+            message_parts.append(description)
+        message_parts.append(f"fix: {fix_hint}")
+        if detail:
+            message_parts.append(f"site: {detail}")
+        message = _sanitize_annotation_message(" | ".join(message_parts))
+
+        out.write(f"::{level} {','.join(params)}::{message}\n")
+    out.flush()
 
 
 __all__ = ["assert_disposition_satisfied"]

--- a/src/atdd/coach/utils/tests/test_disposition_gate.py
+++ b/src/atdd/coach/utils/tests/test_disposition_gate.py
@@ -396,3 +396,196 @@ def test_opaque_violations_default_strict():
         )
     assert "legacy" in str(excinfo.value)
     assert "bare string violation" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions annotations (issue #404)
+# ---------------------------------------------------------------------------
+
+def test_emits_github_annotation_on_failure(tmp_path, monkeypatch, capsys):
+    """Strict failure under GITHUB_ACTIONS=true must emit a ::error:: directive."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    target = _write(tmp_path / "code.py", "print('x')\n")
+    v = Violation(
+        rule_id="LOG-PRINT-001",
+        severity=3,
+        location=f"{target.name}:1",
+        detail="print() at line 1",
+    )
+    registry = {
+        "LOG-PRINT-001": _meta(
+            "LOG-PRINT-001",
+            "strict",
+            description="print() in production code is not allowed",
+            fix_hint="Use logging.info() instead.",
+        )
+    }
+    with pytest.raises(pytest.fail.Exception):
+        assert_disposition_satisfied(
+            validator_id="vid",
+            violations=[v],
+            registry=registry,
+            repo_root=tmp_path,
+        )
+    captured = capsys.readouterr().out
+    # Directive shape: file= + line= + title= + delimited message.
+    assert "::error " in captured
+    assert "file=code.py" in captured
+    assert "line=1" in captured
+    assert "title=LOG-PRINT-001" in captured
+    assert "print() in production code is not allowed" in captured
+    assert "fix: Use logging.info() instead." in captured
+    assert "site: print() at line 1" in captured
+
+
+def test_emits_github_warning_for_advisory(tmp_path, monkeypatch, capsys):
+    """Advisory disposition under GITHUB_ACTIONS=true emits ::warning::, not ::error::."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    target = _write(tmp_path / "code.py", "x\n")
+    v = Violation(
+        rule_id="STYLE-NIT-001",
+        severity=1,
+        location=f"{target.name}:1",
+        detail="trailing whitespace",
+    )
+    registry = {
+        "STYLE-NIT-001": _meta(
+            "STYLE-NIT-001",
+            "advisory",
+            description="trailing whitespace is discouraged",
+            fix_hint="Run `ruff format` to clean up.",
+        )
+    }
+    assert_disposition_satisfied(
+        validator_id="style_nits",
+        violations=[v],
+        registry=registry,
+        repo_root=tmp_path,
+    )
+    captured = capsys.readouterr().out
+    assert "::warning " in captured
+    assert "::error " not in captured
+    assert "title=STYLE-NIT-001" in captured
+    assert "fix: Run `ruff format` to clean up." in captured
+
+
+def test_no_annotations_outside_github_actions(tmp_path, monkeypatch, capsys):
+    """Helper is a no-op when GITHUB_ACTIONS != 'true' — local runs stay clean."""
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    target = _write(tmp_path / "code.py", "print('x')\n")
+    v = Violation(
+        rule_id="LOG-PRINT-001",
+        severity=3,
+        location=f"{target.name}:1",
+        detail="print() at line 1",
+    )
+    with pytest.raises(pytest.fail.Exception):
+        assert_disposition_satisfied(
+            validator_id="vid",
+            violations=[v],
+            registry=_registry(("LOG-PRINT-001", "strict")),
+            repo_root=tmp_path,
+        )
+    captured = capsys.readouterr().out
+    assert "::error" not in captured
+    assert "::warning" not in captured
+
+
+def test_annotation_uses_see_convention_when_fix_hint_missing(
+    tmp_path, monkeypatch, capsys
+):
+    """When the rule has no fix_hint, the annotation falls back to 'see convention'."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    target = _write(tmp_path / "code.py", "print('x')\n")
+    v = Violation(
+        rule_id="LOG-PRINT-001",
+        severity=3,
+        location=f"{target.name}:1",
+        detail="print() at line 1",
+    )
+    registry = {
+        "LOG-PRINT-001": _meta(
+            "LOG-PRINT-001",
+            "strict",
+            description="rule with no fix_hint",
+            fix_hint=None,
+        )
+    }
+    with pytest.raises(pytest.fail.Exception):
+        assert_disposition_satisfied(
+            validator_id="vid",
+            violations=[v],
+            registry=registry,
+            repo_root=tmp_path,
+        )
+    captured = capsys.readouterr().out
+    assert "fix: see convention" in captured
+
+
+def test_suppressed_violations_do_not_annotate(tmp_path, monkeypatch, capsys):
+    """A line carrying an inline suppress marker must NOT emit an annotation."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    target = _write(
+        tmp_path / "code.py",
+        "print('x')  # atdd:suppress(LOG-PRINT-001)\n",
+    )
+    v = Violation(
+        rule_id="LOG-PRINT-001",
+        severity=3,
+        location=f"{target.name}:1",
+        detail="print() in production code",
+    )
+    assert_disposition_satisfied(
+        validator_id="vid",
+        violations=[v],
+        registry=_registry(("LOG-PRINT-001", "suppress-and-clean")),
+        repo_root=tmp_path,
+    )
+    captured = capsys.readouterr().out
+    assert "::error" not in captured
+    assert "::warning" not in captured
+
+
+def test_annotation_message_strips_newlines_and_double_colons(
+    tmp_path, monkeypatch, capsys
+):
+    """``::`` and newlines in registry text would break the directive — sanitize."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    target = _write(tmp_path / "code.py", "print('x')\n")
+    v = Violation(
+        rule_id="LOG-PRINT-001",
+        severity=3,
+        location=f"{target.name}:1",
+        detail="multiline\ndetail with :: inside",
+    )
+    registry = {
+        "LOG-PRINT-001": _meta(
+            "LOG-PRINT-001",
+            "strict",
+            description="first line\nsecond line",
+            fix_hint="hint :: with marker",
+        )
+    }
+    with pytest.raises(pytest.fail.Exception):
+        assert_disposition_satisfied(
+            validator_id="vid",
+            violations=[v],
+            registry=registry,
+            repo_root=tmp_path,
+        )
+    captured = capsys.readouterr().out
+    # Exactly one annotation line emitted (no newline broke it apart).
+    annotation_lines = [
+        ln for ln in captured.splitlines() if ln.startswith("::error ")
+    ]
+    assert len(annotation_lines) == 1
+    line = annotation_lines[0]
+    # The header `::error ...::` is the only `::` we keep — message has none.
+    head, _, message = line.partition("::")
+    head, _, message = (head + "::" + message).partition(line[:7])  # noqa: F841
+    assert "\n" not in line
+    # First-line truncation: "second line" must NOT appear in annotation.
+    assert "second line" not in line
+    # Message portion (after the second `::`) must not contain `::`.
+    body = line.split("::", 2)[2]
+    assert "::" not in body

--- a/src/atdd/coach/validators/test_auto_phase_workflow_exists.py
+++ b/src/atdd/coach/validators/test_auto_phase_workflow_exists.py
@@ -87,30 +87,79 @@ def test_auto_phase_workflow_invokes_atdd_auto_phase():
     )
 
 
-def test_auto_phase_workflow_grants_projects_write():
-    """Issue #384: `permissions:` must declare `projects: write`.
+_PROJECT_TOKEN_FALLBACK_EXPR = (
+    "${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}"
+)
 
-    Without this, the GHA token is denied ProjectV2 GraphQL writes with
-    `Resource not accessible by integration`, and auto-phase silently fails
-    after computing the transition. Regression of #382's intended fix.
+
+def _job_env(wf: dict) -> dict:
+    """Extract the `env:` block from the auto-phase job's `Run atdd auto-phase` step."""
+    job = (wf.get("jobs") or {}).get("auto-phase") or {}
+    for step in job.get("steps") or []:
+        if "auto-phase" in (step.get("name") or "").lower():
+            return step.get("env") or {}
+    return {}
+
+
+def test_auto_phase_workflow_does_not_request_projects_write():
+    """Issue #404: `permissions:` must NOT declare `projects: write`.
+
+    GITHUB_TOKEN cannot grant the account-level Projects scope, so declaring
+    `projects: write` caused GitHub to reject the workflow at preflight on
+    every run (0-second 'workflow file issue' failure). The fix dropped the
+    permission and moved full ProjectV2 sync to an opt-in PROJECT_TOKEN PAT;
+    the GH_TOKEN fallback expression silently degrades to label-only sync
+    when no PAT is present.
     """
     perms = _job_permissions(_load_workflow())
-    assert perms.get("projects") == "write", (
-        "atdd-auto-phase.yml `permissions:` must declare `projects: write`. "
-        f"Found permissions={perms!r}. Issue #384."
+    assert "projects" not in perms, (
+        "atdd-auto-phase.yml `permissions:` MUST NOT declare any `projects:` "
+        "scope — GITHUB_TOKEN cannot satisfy it and preflight rejects the "
+        f"workflow. Found permissions={perms!r}. Issue #404."
     )
 
 
-def test_auto_phase_workflow_template_grants_projects_write():
-    """Issue #384: the shipped template must declare `projects: write`.
+def test_auto_phase_workflow_template_does_not_request_projects_write():
+    """Issue #404: the shipped template must not declare `projects: write` either.
 
-    Catches regressions where the template ships without ProjectV2 write
-    access; consumer repos receiving the template via `atdd init` would
-    otherwise inherit the broken permissions block on every refresh.
+    Otherwise `atdd init --force` would regress every consumer repo back to
+    the broken preflight shape.
     """
     perms = _job_permissions(_load_template())
-    assert perms.get("projects") == "write", (
+    assert "projects" not in perms, (
         "src/atdd/coach/templates/workflows/atdd-auto-phase.yml "
-        "`permissions:` must declare `projects: write`. "
-        f"Found permissions={perms!r}. Issue #384."
+        "`permissions:` MUST NOT declare any `projects:` scope. "
+        f"Found permissions={perms!r}. Issue #404."
+    )
+
+
+def test_auto_phase_workflow_uses_project_token_fallback():
+    """Issue #404: `GH_TOKEN` must use the PROJECT_TOKEN || GITHUB_TOKEN fallback.
+
+    The fallback supports both modes without per-consumer setup:
+      * with PROJECT_TOKEN set → full ProjectV2 Status-field sync.
+      * without PROJECT_TOKEN  → GITHUB_TOKEN fallback, label-only sync via
+        `IssueManager.update`'s access-denial path.
+    A hard-coded `${{ secrets.GITHUB_TOKEN }}` would lock out optional PAT
+    consumers; a hard-coded `${{ secrets.PROJECT_TOKEN }}` would break every
+    default consumer that hasn't created the PAT.
+    """
+    env = _job_env(_load_workflow())
+    gh_token = env.get("GH_TOKEN", "")
+    assert gh_token == _PROJECT_TOKEN_FALLBACK_EXPR, (
+        "atdd-auto-phase.yml `GH_TOKEN` must be "
+        f"'{_PROJECT_TOKEN_FALLBACK_EXPR}' so a PROJECT_TOKEN PAT, when set, "
+        "is preferred and GITHUB_TOKEN is the safe fallback. "
+        f"Found GH_TOKEN={gh_token!r}. Issue #404."
+    )
+
+
+def test_auto_phase_workflow_template_uses_project_token_fallback():
+    """Issue #404: the shipped template must also use the fallback expression."""
+    env = _job_env(_load_template())
+    gh_token = env.get("GH_TOKEN", "")
+    assert gh_token == _PROJECT_TOKEN_FALLBACK_EXPR, (
+        "src/atdd/coach/templates/workflows/atdd-auto-phase.yml `GH_TOKEN` "
+        f"must be '{_PROJECT_TOKEN_FALLBACK_EXPR}'. "
+        f"Found GH_TOKEN={gh_token!r}. Issue #404."
     )


### PR DESCRIPTION
## Summary

Closes #404. Two CI/notification quality fixes in one branch:

- **Phase 1 — auto-phase preflight false-failure (problem A):** drop `permissions: projects: write` (GITHUB_TOKEN cannot satisfy it; declaring it caused 30+ false-failure runs since 2026-05-03 22:48). Switch `GH_TOKEN` to `${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}` so full ProjectV2 sync becomes opt-in via PAT and default consumers fall back to label-only sync via `IssueManager.update`'s existing access-denial path.
- **Phase 2 — validator failures as inline GH Actions annotations (problem B):** disposition gate now emits `::error::` (strict + unsuppressed `suppress-and-clean`) and `::warning::` (advisory) workflow commands per `Violation`, so each violation surfaces as an inline annotation on the PR's "Files changed" tab at the offending `file:line` with description + fix_hint + detail packed in. Sanitizes `::`, `\n`, `,` so multi-line registry text doesn't break the directive. Adds `pytest-github-actions-annotate-failures` for baseline test-level annotation.
- Updates the `IssueManager.update` access-denial log to point at the optional PROJECT_TOKEN PAT setup instead of the unreachable `projects: write` / Workflow permissions guidance.
- Bumps version 3.1.0 → 3.2.0 (MINOR — non-breaking workflow shape fix + new annotation behavior + new test dep).

**Design principle:** ProjectV2 sync is OPT-IN. Default `GITHUB_TOKEN`-only consumers must work without setup. PROJECT_TOKEN is an opt-in upgrade for full Status-field sync. The CI for this PR should pass with `GITHUB_TOKEN` only because we're DROPPING the broken `projects: write` permission.

## Test plan

- [x] `pytest src/atdd/coach/validators/test_auto_phase_workflow_exists.py -v` — 8/8 pass (asserts NO `projects:` scope and the fallback expression on both deployed file + template).
- [x] `pytest src/atdd/coach/utils/tests/test_disposition_gate.py -v` — 20/20 pass (6 new tests cover error/warning emission, no-op outside GH Actions, see-convention fallback, suppressed-skip, sanitization).
- [x] `pytest src/atdd/coach/commands/tests/test_issue_update_fallback.py -v` — 6/6 pass (assertion updated to PROJECT_TOKEN remediation hint).
- [x] `pytest src/atdd/coach/` — 16 unrelated pre-existing failures (env/state-dependent: babysit classifier, project board state, release-versioning, label set, unlabeled issues — none touch files this PR modifies).
- [ ] **SMOKE (post-merge):** observe next PR-merge fires a green auto-phase run, not a 0s preflight failure.
- [ ] **SMOKE (post-merge):** trigger a deliberate disposition failure under GH Actions and confirm the inline annotation lands on the offending file:line in the "Files changed" tab.

## Pragmatic notes

If the auto-phase workflow's CI run after merge still fails, that's a separate issue (would mean `IssueManager.update`'s fallback path has a bug) — would be tracked as a follow-on.

Closes #404