### PR TITLE
feat(coach): #407 — substrate Track A foundation (repo archetype + RuleMetadata fields)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.2.0"
+version = "3.3.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/conventions/rule-id.convention.yaml
+++ b/src/atdd/coach/conventions/rule-id.convention.yaml
@@ -24,7 +24,7 @@ grammar:
   pattern: "^[a-z][a-z0-9]*(-[a-z0-9]+)*\\.[a-z][a-z0-9]*(-[a-z0-9]+)*\\.[a-z][a-z0-9]*(-[a-z0-9]+)*$"
   description: |
     <archetype>.<convention_short_name>.<rule_name>
-    archetype ∈ {coder, coach, tester, planner}
+    archetype ∈ {coder, coach, tester, planner, repo}
     convention_short_name = filename without .convention.yaml
     rule_name = hyphenated human-readable
   separator: "."

--- a/src/atdd/coach/specs/rule-id.spec.md
+++ b/src/atdd/coach/specs/rule-id.spec.md
@@ -16,7 +16,7 @@ The grammar is closed and audited — every rule_id is namespaced under
 
 ```
 RULE_ID    ::= <archetype> "." <convention_short_name> "." <rule_name>
-archetype  ::= coder | coach | tester | planner
+archetype  ::= coder | coach | tester | planner | repo
 convention_short_name ::= <segment> ("-" <segment>)*
                          ; filename of the declaring *.convention.yaml
                          ; minus the .convention.yaml suffix

--- a/src/atdd/coach/utils/rule_binding.py
+++ b/src/atdd/coach/utils/rule_binding.py
@@ -78,6 +78,32 @@ class RuleMetadata:
             or ``None``.
         source_path: Absolute path to the convention file that declared the
             rule.  Used in ``AmbiguousRuleError`` messages.
+
+    Substrate-added fields (issue #407, spec v12 §4.1) — discriminator /
+    graph-resolution pointers and authoring context. All default to ``None``
+    so toolkit rules predating the substrate are unaffected; repo-scope rules
+    populate them on construction.
+
+        acceptance_urn: Acceptance criterion this rule enforces.
+        wmbt_urn: WMBT (What Must Be True) criterion linkage.
+        train_urn: Train (release journey) the rule belongs to.
+        security_urn: Security control / policy the rule enforces.
+        feature_urn: Feature the rule scopes to.
+        bound_acceptance_urn: Graph-resolvable URN bound at registry-load
+            time. Distinct from ``fix_hint_ref`` (a remediation pointer) and
+            from the YAML-source ``acceptance_ref`` opaque pointer string —
+            this field is the resolved URN form (per §4.1).
+        phase: ATDD lifecycle phase pin (``RED``/``GREEN``/``SMOKE``/
+            ``REFACTOR``) when applicable.
+        harness_type: Test harness type the rule expects.
+        harness_category: Coarse-grained harness category.
+        signal_metric: Telemetry metric the rule produces / consumes.
+        signal_threshold: Threshold against which ``signal_metric`` is judged.
+        given: Authoring-time precondition prose.
+        when: Authoring-time stimulus prose.
+        then: Authoring-time expectation prose.
+        author: Rule author identifier.
+        created: ISO date the rule entry was created.
     """
 
     rule_id: str
@@ -90,6 +116,22 @@ class RuleMetadata:
     validator: Optional[str] = None
     fix_hint: Optional[str] = None
     aliases: Tuple[str, ...] = ()
+    acceptance_urn: Optional[str] = None
+    wmbt_urn: Optional[str] = None
+    train_urn: Optional[str] = None
+    security_urn: Optional[str] = None
+    feature_urn: Optional[str] = None
+    bound_acceptance_urn: Optional[str] = None
+    phase: Optional[str] = None
+    harness_type: Optional[str] = None
+    harness_category: Optional[str] = None
+    signal_metric: Optional[str] = None
+    signal_threshold: Optional[str] = None
+    given: Optional[str] = None
+    when: Optional[str] = None
+    then: Optional[str] = None
+    author: Optional[str] = None
+    created: Optional[str] = None
 
     @property
     def fix_hint_ref(self) -> Optional[str]:

--- a/src/atdd/coach/utils/tests/test_rule_binding.py
+++ b/src/atdd/coach/utils/tests/test_rule_binding.py
@@ -310,3 +310,113 @@ section:
     assert file_path == path
     assert rule["id"] == "COACH-EXT-001"
     assert "section" in yaml_path
+
+
+# ---------------------------------------------------------------------------
+# Substrate fields (issue #407, spec v12 §4.1)
+# ---------------------------------------------------------------------------
+SUBSTRATE_FIELDS = (
+    # Discriminator / graph-resolution pointers.
+    "acceptance_urn",
+    "wmbt_urn",
+    "train_urn",
+    "security_urn",
+    "feature_urn",
+    "bound_acceptance_urn",
+    "phase",
+    # Authoring context.
+    "harness_type",
+    "harness_category",
+    "signal_metric",
+    "signal_threshold",
+    "given",
+    "when",
+    "then",
+    "author",
+    "created",
+)
+
+
+def test_substrate_fields_default_to_none_for_toolkit_rules():
+    """Existing toolkit rules carry None for every substrate-added field.
+
+    Asserts the non-breaking property of #407: pre-substrate convention
+    entries (which never declared substrate fields) bind cleanly with all
+    new attributes equal to None.
+    """
+    from atdd.coach.utils.rule_binding import bind_rule
+
+    meta = bind_rule("coder.logging.coach-silent-swallow")
+
+    for field_name in SUBSTRATE_FIELDS:
+        assert hasattr(meta, field_name), f"missing substrate field {field_name!r}"
+        assert getattr(meta, field_name) is None, (
+            f"toolkit rule has non-None substrate field {field_name!r}"
+        )
+
+
+def test_rule_metadata_constructable_with_all_substrate_fields():
+    """RuleMetadata accepts every substrate field as a kwarg and preserves them.
+
+    Acceptance criterion from issue #407: a unit test demonstrating
+    constructable RuleMetadata with all substrate fields populated.
+    """
+    from atdd.coach.utils.rule_binding import RuleMetadata
+
+    populated = {
+        "acceptance_urn": "urn:atdd:acceptance:repo:substrate:foo",
+        "wmbt_urn": "wmbt:repo:substrate:bar",
+        "train_urn": "urn:atdd:train:repo:substrate",
+        "security_urn": "urn:atdd:security:repo:substrate:baz",
+        "feature_urn": "urn:atdd:feature:repo:substrate:qux",
+        "bound_acceptance_urn": "urn:atdd:acceptance:repo:substrate:foo#bound",
+        "phase": "RED",
+        "harness_type": "pytest",
+        "harness_category": "unit",
+        "signal_metric": "violation_count",
+        "signal_threshold": "0",
+        "given": "a fresh registry",
+        "when": "a substrate rule binds",
+        "then": "every substrate field round-trips",
+        "author": "alec",
+        "created": "2026-05-06",
+    }
+
+    meta = RuleMetadata(
+        rule_id="repo.substrate.fixture-rule",
+        severity=3,
+        description="Fixture rule covering every substrate field",
+        recipe=None,
+        introduced_in="3.3.0",
+        source_path=Path("/tmp/fake.convention.yaml"),
+        disposition="advisory",
+        validator="test_substrate_fixture::test_substrate_fixture",
+        fix_hint="N/A — fixture only",
+        aliases=("LEGACY-SUBSTRATE-001",),
+        **populated,
+    )
+
+    assert meta.rule_id == "repo.substrate.fixture-rule"
+    assert meta.aliases == ("LEGACY-SUBSTRATE-001",)
+    for field_name, expected in populated.items():
+        assert getattr(meta, field_name) == expected
+
+
+def test_repo_archetype_passes_grammar_validator():
+    """``validate_grammar('repo.<convention>.<rule>', ...)`` returns None.
+
+    The substrate spec v12 §3.1 extension landed when ``repo`` joined the
+    canonical archetype set in
+    ``src/atdd/coach/validators/test_rule_id_uniqueness.py::validate_grammar``.
+    """
+    from atdd.coach.validators.test_rule_id_uniqueness import (
+        load_allowed_domains,
+        validate_grammar,
+    )
+
+    allowed = load_allowed_domains()
+    assert validate_grammar("repo.substrate.fixture-rule", allowed) is None
+    assert validate_grammar("repo.layout.flat-tree", allowed) is None
+    # Sanity: an unknown archetype still rejects.
+    bogus = validate_grammar("noarchetype.substrate.fixture-rule", allowed)
+    assert bogus is not None and "noarchetype" in bogus

--- a/src/atdd/coach/validators/test_rule_id_uniqueness.py
+++ b/src/atdd/coach/validators/test_rule_id_uniqueness.py
@@ -192,7 +192,7 @@ def validate_grammar(
         )
     # Canonical archetype must be one of the closed set (issue #399).
     archetype = rule_id.split(".", 1)[0]
-    canonical_archetypes = {"coder", "coach", "tester", "planner"}
+    canonical_archetypes = {"coder", "coach", "tester", "planner", "repo"}
     if archetype not in canonical_archetypes:
         return (
             f"id {rule_id!r} uses archetype {archetype!r} which is not in the "


### PR DESCRIPTION
Closes #407

## Summary
- Extend canonical archetype set to include `repo` (SPEC-COACH-RULEID-0001 §3.1):
  spec, convention prose, and the `validate_grammar` set in `test_rule_id_uniqueness.py`.
- Append substrate-only fields to `RuleMetadata` (spec v12 §4.1) after the existing
  `aliases` field: discriminator URNs (`acceptance_urn`, `wmbt_urn`, `train_urn`,
  `security_urn`, `feature_urn`, `bound_acceptance_urn`, `phase`) and authoring
  context (`harness_type`, `harness_category`, `signal_metric`, `signal_threshold`,
  `given`/`when`/`then`, `author`, `created`).
- All new fields default to `None` — frozen-dataclass field ordering preserved,
  toolkit rules unaffected. `bound_acceptance_urn` is named distinctly from
  `fix_hint_ref` and `acceptance_ref` to flag it as a graph-resolvable URN.
- Bump version 3.2.0 → 3.3.0 (MINOR — non-breaking new feature per release gate).

## Test plan
- [x] `pytest src/atdd/coach/utils/tests/test_rule_binding.py` — 15 passed (3 new)
- [x] `pytest src/atdd/coach/validators/test_rule_id_uniqueness.py` — 3 passed
- [x] `pytest src/atdd/coach/` — 779 passed (16 pre-existing GitHub-state failures
      in babysit/issue/project-board validators, unrelated to this change)
- [x] `atdd validate coder --local` — 120 passed
- [x] Acceptance criteria from #407:
  - `validate_grammar("repo.<conv>.<rule>", load_allowed_domains())` returns `None`
  - Toolkit rules' substrate fields all `None`
  - Constructable RuleMetadata with all substrate fields populated