### PR TITLE
feat(coach): #419 — SecurityResolver + registration + graph edges

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.2.1"
+version = "3.3.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.3.0"
+version = "3.4.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/utils/graph/graph_builder.py
+++ b/src/atdd/coach/utils/graph/graph_builder.py
@@ -753,18 +753,26 @@ class GraphBuilder:
                 artifact_path = (
                     resolution.resolved_paths[0] if resolution.resolved_paths else None
                 )
+                node_metadata = {
+                    "source_path": str(decl.source_path),
+                    "is_broken": resolution.is_broken,
+                    "resolution_error": resolution.error,
+                    "is_deterministic": resolution.is_deterministic,
+                    "is_resolved": resolution.is_resolved,
+                    "resolved_paths": [str(p) for p in resolution.resolved_paths],
+                }
+                # Surface declaration- and resolution-level metadata onto the
+                # graph node so downstream consumers (validators, viz) can
+                # read e.g. abuse_case fields without re-parsing YAMLs.
+                if getattr(decl, "metadata", None):
+                    node_metadata["declaration"] = dict(decl.metadata)
+                if getattr(resolution, "metadata", None):
+                    node_metadata["resolution"] = dict(resolution.metadata)
                 node = URNNode(
                     urn=decl.urn,
                     family=family,
                     artifact_path=artifact_path,
-                    metadata={
-                        "source_path": str(decl.source_path),
-                        "is_broken": resolution.is_broken,
-                        "resolution_error": resolution.error,
-                        "is_deterministic": resolution.is_deterministic,
-                        "is_resolved": resolution.is_resolved,
-                        "resolved_paths": [str(p) for p in resolution.resolved_paths],
-                    },
+                    metadata=node_metadata,
                 )
                 graph.add_node(node)
 
@@ -773,6 +781,7 @@ class GraphBuilder:
         self._build_produce_consume_edges(graph)
         self._build_train_edges(graph)
         self._build_component_edges(graph)
+        self._build_security_edges(graph)
         # Phase 3: pass content cache to edge builders that read files
         self._build_test_edges(graph, content_cache)
         self._build_tested_by_edges(graph, content_cache)
@@ -1127,6 +1136,81 @@ class GraphBuilder:
 
             except Exception:
                 continue
+
+    def _build_security_edges(self, graph: TraceabilityGraph) -> None:
+        """
+        Build security URN edges:
+
+        - ``feature → security`` (CONTAINS) — every resolved abuse_case is
+          contained by its parent feature.
+        - ``security → acceptance_ref`` (REFERENCES) — every abuse_case that
+          declares ``acceptance_ref`` references the named acc URN. Edges
+          are emitted regardless of whether the target acc URN resolves;
+          broken refs are flagged separately by ``find_broken``.
+        """
+        for node in list(graph.nodes.values()):
+            if node.family != "security":
+                continue
+
+            # security:{wagon}:{feature}:{NNN}
+            parts = node.urn.replace("security:", "").split(":")
+            if len(parts) != 3:
+                continue
+            wagon_id, feature_id, _seq = parts
+            feature_urn = f"feature:{wagon_id}:{feature_id}"
+
+            # feature → security (CONTAINS); add_edge auto-synthesizes missing feature node
+            graph.add_edge(
+                URNEdge(
+                    source_urn=feature_urn,
+                    target_urn=node.urn,
+                    edge_type=EdgeType.CONTAINS,
+                    metadata={"source": "abuse-case-structure"},
+                )
+            )
+
+            # security → acceptance_ref (REFERENCES). The abuse_case fields
+            # were stashed onto node.metadata['declaration'] in build().
+            decl_meta = node.metadata.get("declaration") or {}
+            acceptance_ref = decl_meta.get("acceptance_ref")
+            if not acceptance_ref or not isinstance(acceptance_ref, str):
+                continue
+
+            # If the target acc URN was not declared elsewhere, synthesize a
+            # broken target node so EdgeValidator.find_broken flags it.
+            if acceptance_ref not in graph.nodes:
+                target_resolution = self.registry.resolve(acceptance_ref)
+                graph.add_node(
+                    URNNode(
+                        urn=acceptance_ref,
+                        family=self.registry.get_family(acceptance_ref) or "unknown",
+                        artifact_path=(
+                            target_resolution.resolved_paths[0]
+                            if target_resolution.resolved_paths
+                            else None
+                        ),
+                        metadata={
+                            "source_path": str(node.metadata.get("source_path", "")),
+                            "is_broken": target_resolution.is_broken,
+                            "resolution_error": target_resolution.error,
+                            "is_deterministic": target_resolution.is_deterministic,
+                            "is_resolved": target_resolution.is_resolved,
+                            "resolved_paths": [
+                                str(p) for p in target_resolution.resolved_paths
+                            ],
+                            "synthesized_by": "abuse_case.acceptance_ref",
+                        },
+                    )
+                )
+
+            graph.add_edge(
+                URNEdge(
+                    source_urn=node.urn,
+                    target_urn=acceptance_ref,
+                    edge_type=EdgeType.REFERENCES,
+                    metadata={"source": "abuse-case-acceptance-ref"},
+                )
+            )
 
     def _build_component_edges(self, graph: TraceabilityGraph) -> None:
         """Build feature -> component (CONTAINS) edges from component URN structure."""

--- a/src/atdd/coach/utils/graph/resolver.py
+++ b/src/atdd/coach/utils/graph/resolver.py
@@ -16,6 +16,7 @@ Architecture:
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -25,6 +26,8 @@ from abc import ABC, abstractmethod
 
 from atdd.coach.utils.repo import find_repo_root
 from atdd.coach.utils.graph.urn import URNBuilder
+
+LOG = logging.getLogger(__name__)
 
 
 @dataclass
@@ -529,8 +532,12 @@ class SecurityResolver(BaseResolver):
                 feature_slug = feature_slug or fallback_path.stem.replace("_", "-")
                 wagon_dir = fallback_path.parent.parent
                 wagon_slug = wagon_slug or wagon_dir.name.replace("_", "-")
-            except Exception:
-                pass
+            except (AttributeError, IndexError) as exc:
+                LOG.warning(
+                    "SecurityResolver: could not derive wagon/feature from path %s: %s",
+                    fallback_path,
+                    exc,
+                )
         return wagon_slug, feature_slug
 
     @staticmethod
@@ -623,7 +630,12 @@ class SecurityResolver(BaseResolver):
 
             with open(feature_path, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f)
-        except Exception as exc:
+        except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+            LOG.warning(
+                "SecurityResolver: failed to parse feature file %s: %s",
+                feature_path,
+                exc,
+            )
             return URNResolution(
                 urn=urn,
                 family=self.family,

--- a/src/atdd/coach/utils/graph/resolver.py
+++ b/src/atdd/coach/utils/graph/resolver.py
@@ -39,6 +39,7 @@ class URNDeclaration:
     source_path: Path
     line_number: Optional[int] = None
     context: Optional[str] = None
+    metadata: Dict = field(default_factory=dict)
 
 
 @dataclass
@@ -60,6 +61,7 @@ class URNResolution:
     is_deterministic: bool = True
     error: Optional[str] = None
     declaration: Optional[URNDeclaration] = None
+    metadata: Dict = field(default_factory=dict)
 
     @property
     def is_resolved(self) -> bool:
@@ -445,6 +447,213 @@ class AcceptanceResolver(BaseResolver):
                     continue
 
         return declarations
+
+
+class SecurityResolver(BaseResolver):
+    """
+    Resolver for security: URNs.
+
+    Reads ``feature.yaml::security.abuse_cases[]`` and emits
+    ``security:<wagon>:<feature-slug>:<threat-seq>`` URNs.
+
+    Threat-seq is derived from ``abuse_case.id`` by stripping the
+    alphabetic prefix and zero-padding the trailing number to three digits
+    (e.g. id ``"THREAT-1"`` → seq ``"001"``; id ``"THREAT-42"`` → ``"042"``;
+    id ``"THREAT-001"`` → ``"001"``). Ids whose tail is >999 are rejected.
+    """
+
+    _ABUSE_ID_RE = re.compile(r"^([A-Z][A-Z0-9-]*)-(\d+)$")
+
+    @property
+    def family(self) -> str:
+        return "security"
+
+    @classmethod
+    def derive_threat_seq(cls, abuse_id: object) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Validate an ``abuse_case.id`` value and derive the zero-padded
+        three-digit threat sequence.
+
+        Returns ``(seq, error)``. ``seq`` is None if validation fails;
+        ``error`` is None on success.
+        """
+        if abuse_id is None:
+            return None, "abuse_case is missing required 'id' field"
+        if not isinstance(abuse_id, str) or not abuse_id.strip():
+            return None, f"abuse_case 'id' must be a non-empty string (got {abuse_id!r})"
+        match = cls._ABUSE_ID_RE.match(abuse_id.strip())
+        if not match:
+            return (
+                None,
+                (
+                    f"abuse_case id {abuse_id!r} does not match required pattern "
+                    f"^[A-Z][A-Z0-9-]*-\\d+$ (e.g. 'THREAT-001')"
+                ),
+            )
+        numeric = int(match.group(2))
+        if numeric > 999:
+            return (
+                None,
+                (
+                    f"abuse_case id {abuse_id!r} has numeric tail {numeric} which exceeds 999; "
+                    "threat-seq must fit in three digits"
+                ),
+            )
+        return f"{numeric:03d}", None
+
+    def _iter_feature_files(self):
+        """Yield every ``plan/<wagon>/features/*.yaml`` file."""
+        if not self.plan_dir.exists():
+            return
+        for feature_file in self.plan_dir.rglob("features/*.yaml"):
+            yield feature_file
+
+    @staticmethod
+    def _extract_wagon_feature_from_yaml(data: dict, fallback_path: Path) -> Tuple[Optional[str], Optional[str]]:
+        """
+        Recover (wagon_slug, feature_slug) from a feature YAML.
+
+        Prefer the canonical ``urn: feature:<wagon>:<feature>`` field; fall
+        back to the on-disk path layout ``plan/<wagon>/features/<feature>.yaml``.
+        """
+        wagon_slug = None
+        feature_slug = None
+        feature_urn = data.get("urn") if isinstance(data, dict) else None
+        if isinstance(feature_urn, str) and feature_urn.startswith("feature:"):
+            parts = feature_urn[len("feature:"):].split(":")
+            if len(parts) == 2 and all(parts):
+                wagon_slug, feature_slug = parts[0], parts[1]
+        if not wagon_slug or not feature_slug:
+            try:
+                # plan/<wagon>/features/<feature>.yaml
+                feature_slug = feature_slug or fallback_path.stem.replace("_", "-")
+                wagon_dir = fallback_path.parent.parent
+                wagon_slug = wagon_slug or wagon_dir.name.replace("_", "-")
+            except Exception:
+                pass
+        return wagon_slug, feature_slug
+
+    @staticmethod
+    def _abuse_metadata(abuse: dict) -> Dict:
+        """
+        Build a metadata dict from an abuse_case YAML block.
+
+        Preserves spec fields verbatim so downstream consumers
+        (graph nodes, validators) can read them without re-parsing.
+        """
+        keys = ("id", "name", "threat", "mitigation", "severity", "acceptance_ref")
+        return {k: abuse.get(k) for k in keys if k in abuse}
+
+    def find_declarations(self) -> List[URNDeclaration]:
+        """Find all security URN declarations across feature YAMLs."""
+        declarations: List[URNDeclaration] = []
+        if not self.plan_dir.exists():
+            return declarations
+
+        import yaml
+
+        for feature_file in self._iter_feature_files():
+            try:
+                with open(feature_file, "r", encoding="utf-8") as f:
+                    data = yaml.safe_load(f)
+            except Exception:
+                continue
+            if not isinstance(data, dict):
+                continue
+            security = data.get("security")
+            if not isinstance(security, dict):
+                continue
+            abuse_cases = security.get("abuse_cases")
+            if not isinstance(abuse_cases, list) or not abuse_cases:
+                continue
+
+            wagon_slug, feature_slug = self._extract_wagon_feature_from_yaml(data, feature_file)
+            if not wagon_slug or not feature_slug:
+                continue
+
+            for abuse in abuse_cases:
+                if not isinstance(abuse, dict):
+                    continue
+                abuse_id = abuse.get("id")
+                seq, err = self.derive_threat_seq(abuse_id)
+                if err:
+                    raise ValueError(f"{feature_file}: {err}")
+                urn = f"security:{wagon_slug}:{feature_slug}:{seq}"
+                declarations.append(
+                    URNDeclaration(
+                        urn=urn,
+                        family=self.family,
+                        source_path=feature_file,
+                        context="abuse_case",
+                        metadata=self._abuse_metadata(abuse),
+                    )
+                )
+
+        return declarations
+
+    def resolve(self, urn: str) -> URNResolution:
+        if not self.can_resolve(urn):
+            return URNResolution(urn=urn, family=self.family, error="Not a security URN")
+
+        error = self._validate_urn_format(urn)
+        if error:
+            return URNResolution(urn=urn, family=self.family, error=error)
+
+        parts = urn.replace("security:", "").split(":")
+        if len(parts) != 3:
+            return URNResolution(
+                urn=urn, family=self.family, error="Invalid security URN format"
+            )
+        wagon_slug, feature_slug, seq = parts
+
+        wagon_dir = self.plan_dir / wagon_slug.replace("-", "_")
+        feature_path = wagon_dir / "features" / f"{feature_slug.replace('-', '_')}.yaml"
+
+        if not feature_path.exists():
+            return URNResolution(
+                urn=urn,
+                family=self.family,
+                resolved_paths=[],
+                is_deterministic=False,
+                error=f"Feature file not found for security URN: {feature_path}",
+            )
+
+        try:
+            import yaml
+
+            with open(feature_path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+        except Exception as exc:
+            return URNResolution(
+                urn=urn,
+                family=self.family,
+                error=f"Failed to parse feature file {feature_path}: {exc}",
+            )
+
+        security = (data or {}).get("security") or {}
+        abuse_cases = security.get("abuse_cases") or []
+        for abuse in abuse_cases:
+            if not isinstance(abuse, dict):
+                continue
+            derived_seq, derive_err = self.derive_threat_seq(abuse.get("id"))
+            if derive_err or derived_seq != seq:
+                continue
+            return URNResolution(
+                urn=urn,
+                family=self.family,
+                resolved_paths=[feature_path],
+                is_deterministic=True,
+                error=None,
+                metadata=self._abuse_metadata(abuse),
+            )
+
+        return URNResolution(
+            urn=urn,
+            family=self.family,
+            resolved_paths=[],
+            is_deterministic=False,
+            error=f"No abuse_case with threat-seq {seq} found in {feature_path}",
+        )
 
 
 class ContractResolver(BaseResolver):
@@ -1284,6 +1493,7 @@ class ResolverRegistry:
             FeatureResolver(self.repo_root),
             WMBTResolver(self.repo_root),
             AcceptanceResolver(self.repo_root),
+            SecurityResolver(self.repo_root),
             ContractResolver(self.repo_root),
             TelemetryResolver(self.repo_root),
             TrainResolver(self.repo_root),

--- a/src/atdd/coach/utils/graph/resolver.py
+++ b/src/atdd/coach/utils/graph/resolver.py
@@ -537,6 +537,14 @@ class SecurityResolver(BaseResolver):
                     "SecurityResolver: could not derive wagon/feature from path %s: %s",
                     fallback_path,
                     exc,
+                    extra={
+                        "resolver": "security",
+                        "phase": "wagon_feature_path_fallback",
+                        "fallback_path": str(fallback_path),
+                        "wagon_slug": wagon_slug,
+                        "feature_slug": feature_slug,
+                        "exception_type": type(exc).__name__,
+                    },
                 )
         return wagon_slug, feature_slug
 
@@ -635,6 +643,16 @@ class SecurityResolver(BaseResolver):
                 "SecurityResolver: failed to parse feature file %s: %s",
                 feature_path,
                 exc,
+                extra={
+                    "resolver": "security",
+                    "phase": "resolve_yaml_load",
+                    "urn": urn,
+                    "feature_path": str(feature_path),
+                    "wagon_slug": wagon_slug,
+                    "feature_slug": feature_slug,
+                    "threat_seq": seq,
+                    "exception_type": type(exc).__name__,
+                },
             )
             return URNResolution(
                 urn=urn,

--- a/src/atdd/coach/utils/graph/tests/test_graph_builder_security_edges.py
+++ b/src/atdd/coach/utils/graph/tests/test_graph_builder_security_edges.py
@@ -1,0 +1,203 @@
+# URN: test:coach:graph_builder:security_edges
+"""
+Acceptance tests for SecurityResolver integration into GraphBuilder (#419).
+
+Covers:
+  - feature -> security CONTAINS edge per resolved abuse_case.
+  - security -> acceptance_ref REFERENCES edge per declared abuse_case.
+  - REFERENCES edge is emitted regardless of whether the target acc URN
+    resolves; broken targets are surfaced via EdgeValidator.find_broken.
+  - URNNode.metadata exposes abuse_case fields verbatim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.utils.graph.graph_builder import (
+    EdgeType,
+    GraphBuilder,
+)
+from atdd.coach.utils.graph.edge_validator import EdgeValidator, IssueType
+
+
+_ABUSE_TWO = (
+    '- id: "THREAT-001"\n'
+    '  name: "Session token leak"\n'
+    '  threat: "Attacker exfiltrates session token"\n'
+    '  mitigation: "Bind tokens to IP and rotate"\n'
+    '  severity: "high"\n'
+    '  acceptance_ref: "acc:auth:E001-HTTP-001"\n'
+    '- id: "THREAT-002"\n'
+    '  name: "Replay attack"\n'
+    '  threat: "Attacker replays captured session"\n'
+    '  mitigation: "Nonce + timestamp validation"\n'
+    '  severity: "medium"\n'
+    '  acceptance_ref: "acc:auth:E001-HTTP-002"\n'
+)
+
+
+def _write_feature(plan_dir: Path, wagon_slug: str, feature_slug: str, abuse_yaml: str) -> Path:
+    wagon_dir = plan_dir / wagon_slug.replace("-", "_")
+    features_dir = wagon_dir / "features"
+    features_dir.mkdir(parents=True, exist_ok=True)
+    feature_file = features_dir / f"{feature_slug.replace('-', '_')}.yaml"
+    indented = "\n".join(("    " + ln) if ln.strip() else ln for ln in abuse_yaml.splitlines())
+    body = (
+        f'urn: "feature:{wagon_slug}:{feature_slug}"\n'
+        f'wagon: "wagon:{wagon_slug}"\n'
+        'description: "Fixture feature for security edge tests"\n'
+        "sizing:\n"
+        "  wmbts: 0\n"
+        "  footprint_score: 1\n"
+        '  footprint_size: "S"\n'
+        "wmbts: []\n"
+        "components:\n"
+        "  backend:\n"
+        "    presentation: []\n"
+        "    application: []\n"
+        "    domain: []\n"
+        "    integration: []\n"
+        "security:\n"
+        "  abuse_cases:\n"
+    )
+    body += indented + "\n"
+    feature_file.write_text(body)
+    return feature_file
+
+
+def _write_minimal_wagon(plan_dir: Path, slug: str) -> Path:
+    """Write a minimal wagon manifest so wagon URNs resolve."""
+    wagon_dir = plan_dir / slug.replace("-", "_")
+    wagon_dir.mkdir(parents=True, exist_ok=True)
+    wagon_file = wagon_dir / f"_{slug.replace('-', '_')}.yaml"
+    wagon_file.write_text(
+        f'wagon: {slug}\n'
+        f'urn: wagon:{slug}\n'
+        'description: "Minimal wagon for security edge regression test"\n'
+        "produce: []\n"
+        "consume: []\n"
+        "wmbt:\n"
+        "  total: 0\n"
+    )
+    return wagon_file
+
+
+def _build_graph(repo_root: Path):
+    return GraphBuilder(repo_root=repo_root, use_cache=False).build()
+
+
+def test_feature_to_security_contains_edge_emitted(tmp_path):
+    """feature → security CONTAINS edge per abuse_case."""
+    plan = tmp_path / "plan"
+    _write_minimal_wagon(plan, "auth")
+    _write_feature(plan, "auth", "session-management", _ABUSE_TWO)
+
+    graph = _build_graph(tmp_path)
+
+    contains_edges = [
+        e
+        for e in graph.edges
+        if e.edge_type == EdgeType.CONTAINS
+        and e.source_urn == "feature:auth:session-management"
+        and e.target_urn.startswith("security:auth:session-management:")
+    ]
+    targets = sorted(e.target_urn for e in contains_edges)
+    assert targets == [
+        "security:auth:session-management:001",
+        "security:auth:session-management:002",
+    ]
+
+
+def test_security_to_acceptance_references_edge_emitted(tmp_path):
+    """security → acceptance_ref REFERENCES edge per declared abuse_case."""
+    plan = tmp_path / "plan"
+    _write_minimal_wagon(plan, "auth")
+    _write_feature(plan, "auth", "session-management", _ABUSE_TWO)
+
+    graph = _build_graph(tmp_path)
+
+    references = [
+        e
+        for e in graph.edges
+        if e.edge_type == EdgeType.REFERENCES
+        and e.source_urn.startswith("security:auth:session-management:")
+    ]
+    pairs = {(e.source_urn, e.target_urn) for e in references}
+    assert pairs == {
+        ("security:auth:session-management:001", "acc:auth:E001-HTTP-001"),
+        ("security:auth:session-management:002", "acc:auth:E001-HTTP-002"),
+    }
+
+
+def test_security_node_carries_abuse_case_metadata(tmp_path):
+    """URNNode.metadata['declaration'] mirrors the abuse_case fields verbatim."""
+    plan = tmp_path / "plan"
+    _write_minimal_wagon(plan, "auth")
+    _write_feature(plan, "auth", "session-management", _ABUSE_TWO)
+
+    graph = _build_graph(tmp_path)
+    node = graph.nodes["security:auth:session-management:001"]
+    decl_meta = node.metadata.get("declaration") or {}
+    assert decl_meta["id"] == "THREAT-001"
+    assert decl_meta["name"] == "Session token leak"
+    assert decl_meta["threat"] == "Attacker exfiltrates session token"
+    assert decl_meta["mitigation"] == "Bind tokens to IP and rotate"
+    assert decl_meta["severity"] == "high"
+    assert decl_meta["acceptance_ref"] == "acc:auth:E001-HTTP-001"
+
+
+def test_broken_acceptance_ref_is_flagged_by_validator(tmp_path):
+    """
+    An abuse_case whose acceptance_ref points at a non-existent acc URN
+    must produce a broken-reference issue surfaced by EdgeValidator.
+    """
+    plan = tmp_path / "plan"
+    _write_minimal_wagon(plan, "auth")
+    _write_feature(plan, "auth", "session-management", _ABUSE_TWO)
+
+    graph = _build_graph(tmp_path)
+    issues = EdgeValidator(graph).find_broken()
+    broken_acc_urns = {
+        i.urn for i in issues if i.issue_type == IssueType.BROKEN and i.urn.startswith("acc:")
+    }
+    # The acc URNs referenced in _ABUSE_TWO have no backing WMBT/feature
+    # YAML, so both should be flagged broken.
+    assert "acc:auth:E001-HTTP-001" in broken_acc_urns
+    assert "acc:auth:E001-HTTP-002" in broken_acc_urns
+
+
+def test_abuse_case_without_acceptance_ref_emits_no_references_edge(tmp_path):
+    """An abuse_case with no acceptance_ref produces only the CONTAINS edge."""
+    plan = tmp_path / "plan"
+    _write_minimal_wagon(plan, "auth")
+    _write_feature(
+        plan,
+        "auth",
+        "no-ref",
+        (
+            '- id: "THREAT-001"\n'
+            '  name: "Token leak"\n'
+            '  threat: "x"\n'
+            '  mitigation: "y"\n'
+            '  severity: "low"\n'
+        ),
+    )
+    graph = _build_graph(tmp_path)
+
+    refs = [
+        e
+        for e in graph.edges
+        if e.edge_type == EdgeType.REFERENCES and e.source_urn.startswith("security:auth:no-ref:")
+    ]
+    contains = [
+        e
+        for e in graph.edges
+        if e.edge_type == EdgeType.CONTAINS
+        and e.source_urn == "feature:auth:no-ref"
+        and e.target_urn.startswith("security:auth:no-ref:")
+    ]
+    assert refs == []
+    assert len(contains) == 1

--- a/src/atdd/coach/utils/graph/tests/test_security_resolver.py
+++ b/src/atdd/coach/utils/graph/tests/test_security_resolver.py
@@ -1,0 +1,356 @@
+# URN: test:coach:graph_security_resolver:abuse_cases
+"""
+Acceptance tests for SecurityResolver (#419).
+
+Covers:
+  - Threat-seq derivation from abuse_case.id (THREAT-1 -> 001 etc.)
+  - Strict id validation: missing/malformed/numeric-tail-too-large rejected.
+  - find_declarations() returns one URNDeclaration per abuse_case keyed
+    by source_path with context "abuse_case".
+  - URN format security:<wagon>:<feature>:<NNN>.
+  - URNResolution.metadata exposes abuse_case fields (id, name, threat,
+    mitigation, severity, acceptance_ref) verbatim from feature.yaml.
+  - find_all_declarations(['security']) on a fixture plan/ with two
+    features × three abuse_cases each returns six URNDeclaration entries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from atdd.coach.utils.graph.resolver import (
+    ResolverRegistry,
+    SecurityResolver,
+    URNDeclaration,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture builders
+# ---------------------------------------------------------------------------
+
+
+def _write_feature(
+    plan_dir: Path,
+    wagon_slug: str,
+    feature_slug: str,
+    abuse_cases_yaml: str,
+) -> Path:
+    """Write a minimal plan/<wagon>/features/<feature>.yaml with abuse_cases.
+
+    ``abuse_cases_yaml`` is the de-dented body of the ``abuse_cases`` list;
+    each line is re-indented by 4 spaces so it sits under ``abuse_cases:``.
+    """
+    wagon_dir = plan_dir / wagon_slug.replace("-", "_")
+    features_dir = wagon_dir / "features"
+    features_dir.mkdir(parents=True, exist_ok=True)
+    feature_file = features_dir / f"{feature_slug.replace('-', '_')}.yaml"
+    indented_abuse = "\n".join(
+        ("    " + line) if line.strip() else line
+        for line in abuse_cases_yaml.splitlines()
+    )
+    body = dedent(
+        f"""\
+        urn: "feature:{wagon_slug}:{feature_slug}"
+        wagon: "wagon:{wagon_slug}"
+        description: "Fixture feature for SecurityResolver tests"
+        sizing:
+          wmbts: 0
+          footprint_score: 1
+          footprint_size: "S"
+        wmbts: []
+        components:
+          backend:
+            presentation: []
+            application: []
+            domain: []
+            integration: []
+        security:
+          abuse_cases:
+        """
+    )
+    body += indented_abuse + "\n"
+    feature_file.write_text(body)
+    return feature_file
+
+
+# ---------------------------------------------------------------------------
+# derive_threat_seq
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "abuse_id,expected_seq",
+    [
+        ("THREAT-001", "001"),
+        ("THREAT-1", "001"),
+        ("THREAT-42", "042"),
+        ("THREAT-999", "999"),
+        ("ABUSE-007", "007"),
+        ("INJ-SQL-12", "012"),  # alphabetic prefix may contain hyphens/digits
+    ],
+)
+def test_derive_threat_seq_zero_pads(abuse_id, expected_seq):
+    """Valid ids zero-pad the trailing number to three digits."""
+    seq, err = SecurityResolver.derive_threat_seq(abuse_id)
+    assert err is None, f"unexpected error: {err}"
+    assert seq == expected_seq
+
+
+@pytest.mark.parametrize(
+    "bad_id",
+    [None, "", "   ", "threat-001", "THREAT", "1-001", "THREAT_001", "THREAT-001-extra"],
+)
+def test_derive_threat_seq_rejects_malformed(bad_id):
+    """Missing or malformed ids are rejected with a clear error."""
+    seq, err = SecurityResolver.derive_threat_seq(bad_id)
+    assert seq is None
+    assert err is not None
+    assert err  # message present
+
+
+def test_derive_threat_seq_rejects_tail_above_999():
+    seq, err = SecurityResolver.derive_threat_seq("THREAT-1000")
+    assert seq is None
+    assert "999" in err
+
+
+# ---------------------------------------------------------------------------
+# find_declarations
+# ---------------------------------------------------------------------------
+
+
+_ABUSE_BLOCK_TWO = (
+    '- id: "THREAT-001"\n'
+    '  name: "Session token leak"\n'
+    '  threat: "Attacker exfiltrates session token"\n'
+    '  mitigation: "Bind tokens to IP and rotate on privilege change"\n'
+    '  severity: "high"\n'
+    '  acceptance_ref: "acc:auth:E001-HTTP-001"\n'
+    '- id: "THREAT-002"\n'
+    '  name: "Replay attack"\n'
+    '  threat: "Attacker replays captured session"\n'
+    '  mitigation: "Nonce + timestamp validation"\n'
+    '  severity: "medium"\n'
+    '  acceptance_ref: "acc:auth:E001-HTTP-002"\n'
+)
+
+
+def test_find_declarations_returns_one_per_abuse_case(tmp_path):
+    plan = tmp_path / "plan"
+    feature_file = _write_feature(
+        plan,
+        wagon_slug="auth",
+        feature_slug="session-management",
+        abuse_cases_yaml=_ABUSE_BLOCK_TWO,
+    )
+
+    resolver = SecurityResolver(repo_root=tmp_path)
+    decls = resolver.find_declarations()
+
+    urns = sorted(d.urn for d in decls)
+    assert urns == [
+        "security:auth:session-management:001",
+        "security:auth:session-management:002",
+    ]
+    for d in decls:
+        assert d.family == "security"
+        assert d.context == "abuse_case"
+        assert d.source_path == feature_file
+
+
+def test_find_declarations_metadata_is_verbatim(tmp_path):
+    """
+    URNDeclaration.metadata exposes id, name, threat, mitigation, severity,
+    acceptance_ref string-equal to the YAML source.
+    """
+    plan = tmp_path / "plan"
+    _write_feature(
+        plan,
+        wagon_slug="auth",
+        feature_slug="session-management",
+        abuse_cases_yaml=_ABUSE_BLOCK_TWO,
+    )
+
+    resolver = SecurityResolver(repo_root=tmp_path)
+    decls = {d.urn: d for d in resolver.find_declarations()}
+    one = decls["security:auth:session-management:001"]
+    assert one.metadata["id"] == "THREAT-001"
+    assert one.metadata["name"] == "Session token leak"
+    assert one.metadata["threat"] == "Attacker exfiltrates session token"
+    assert one.metadata["mitigation"] == "Bind tokens to IP and rotate on privilege change"
+    assert one.metadata["severity"] == "high"
+    assert one.metadata["acceptance_ref"] == "acc:auth:E001-HTTP-001"
+
+
+def test_find_declarations_raises_on_malformed_id(tmp_path):
+    plan = tmp_path / "plan"
+    _write_feature(
+        plan,
+        wagon_slug="auth",
+        feature_slug="bad-feature",
+        abuse_cases_yaml=(
+            '- id: "lowercase-bad"\n'
+            '  name: "Bad id"\n'
+            '  threat: "x"\n'
+            '  mitigation: "y"\n'
+            '  severity: "low"\n'
+            '  acceptance_ref: "acc:auth:E001-HTTP-001"\n'
+        ),
+    )
+    resolver = SecurityResolver(repo_root=tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        resolver.find_declarations()
+    assert "lowercase-bad" in str(excinfo.value)
+
+
+def test_find_declarations_raises_on_missing_id(tmp_path):
+    plan = tmp_path / "plan"
+    _write_feature(
+        plan,
+        wagon_slug="auth",
+        feature_slug="missing-id",
+        abuse_cases_yaml=(
+            '- name: "No id"\n'
+            '  threat: "x"\n'
+            '  mitigation: "y"\n'
+            '  severity: "low"\n'
+            '  acceptance_ref: "acc:auth:E001-HTTP-001"\n'
+        ),
+    )
+    resolver = SecurityResolver(repo_root=tmp_path)
+    with pytest.raises(ValueError) as excinfo:
+        resolver.find_declarations()
+    assert "missing required 'id'" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# resolve()
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_returns_metadata_with_feature_path(tmp_path):
+    plan = tmp_path / "plan"
+    feature_file = _write_feature(
+        plan,
+        wagon_slug="auth",
+        feature_slug="session-management",
+        abuse_cases_yaml=_ABUSE_BLOCK_TWO,
+    )
+    resolver = SecurityResolver(repo_root=tmp_path)
+    res = resolver.resolve("security:auth:session-management:001")
+    assert res.is_resolved
+    assert res.is_deterministic
+    assert res.resolved_paths == [feature_file]
+    assert res.metadata["id"] == "THREAT-001"
+    assert res.metadata["acceptance_ref"] == "acc:auth:E001-HTTP-001"
+
+
+def test_resolve_unknown_seq_is_broken(tmp_path):
+    plan = tmp_path / "plan"
+    _write_feature(
+        plan,
+        wagon_slug="auth",
+        feature_slug="session-management",
+        abuse_cases_yaml=_ABUSE_BLOCK_TWO,
+    )
+    resolver = SecurityResolver(repo_root=tmp_path)
+    res = resolver.resolve("security:auth:session-management:999")
+    assert res.is_broken
+    assert res.error and "999" in res.error
+
+
+def test_resolve_invalid_format_returns_error(tmp_path):
+    resolver = SecurityResolver(repo_root=tmp_path)
+    res = resolver.resolve("security:auth:session-management:abc")
+    assert res.is_broken
+    assert res.error
+
+
+# ---------------------------------------------------------------------------
+# Registry integration
+# ---------------------------------------------------------------------------
+
+
+def test_registry_finds_security_declarations_across_two_features(tmp_path):
+    """
+    find_all_declarations(['security']) on plan/ with 2 features × 3
+    abuse_cases each returns six URNDeclaration entries with correct
+    source_path attribution.
+    """
+    plan = tmp_path / "plan"
+    abuse_three_a = (
+        '- id: "THREAT-1"\n'
+        '  name: "A1"\n'
+        '  threat: "tA1"\n'
+        '  mitigation: "mA1"\n'
+        '  severity: "low"\n'
+        '  acceptance_ref: "acc:auth:E001-HTTP-001"\n'
+        '- id: "THREAT-2"\n'
+        '  name: "A2"\n'
+        '  threat: "tA2"\n'
+        '  mitigation: "mA2"\n'
+        '  severity: "medium"\n'
+        '  acceptance_ref: "acc:auth:E001-HTTP-002"\n'
+        '- id: "THREAT-3"\n'
+        '  name: "A3"\n'
+        '  threat: "tA3"\n'
+        '  mitigation: "mA3"\n'
+        '  severity: "high"\n'
+        '  acceptance_ref: "acc:auth:E001-HTTP-003"\n'
+    )
+    abuse_three_b = (
+        '- id: "ABUSE-10"\n'
+        '  name: "B1"\n'
+        '  threat: "tB1"\n'
+        '  mitigation: "mB1"\n'
+        '  severity: "low"\n'
+        '  acceptance_ref: "acc:billing:E001-HTTP-001"\n'
+        '- id: "ABUSE-11"\n'
+        '  name: "B2"\n'
+        '  threat: "tB2"\n'
+        '  mitigation: "mB2"\n'
+        '  severity: "medium"\n'
+        '  acceptance_ref: "acc:billing:E001-HTTP-002"\n'
+        '- id: "ABUSE-12"\n'
+        '  name: "B3"\n'
+        '  threat: "tB3"\n'
+        '  mitigation: "mB3"\n'
+        '  severity: "high"\n'
+        '  acceptance_ref: "acc:billing:E001-HTTP-003"\n'
+    )
+    file_a = _write_feature(plan, "auth", "session-management", abuse_three_a)
+    file_b = _write_feature(plan, "billing", "charge-card", abuse_three_b)
+
+    registry = ResolverRegistry(repo_root=tmp_path)
+    decls_by_family = registry.find_all_declarations(["security"])
+    decls = decls_by_family["security"]
+    assert len(decls) == 6
+    sources = {d.source_path for d in decls}
+    assert sources == {file_a, file_b}
+    urns = sorted(d.urn for d in decls)
+    assert urns == [
+        "security:auth:session-management:001",
+        "security:auth:session-management:002",
+        "security:auth:session-management:003",
+        "security:billing:charge-card:010",
+        "security:billing:charge-card:011",
+        "security:billing:charge-card:012",
+    ]
+
+
+def test_registry_resolves_security_urn(tmp_path):
+    plan = tmp_path / "plan"
+    _write_feature(
+        plan,
+        wagon_slug="auth",
+        feature_slug="session-management",
+        abuse_cases_yaml=_ABUSE_BLOCK_TWO,
+    )
+    registry = ResolverRegistry(repo_root=tmp_path)
+    res = registry.resolve("security:auth:session-management:002")
+    assert res.is_resolved
+    assert res.metadata["id"] == "THREAT-002"

--- a/src/atdd/coach/utils/graph/urn.py
+++ b/src/atdd/coach/utils/graph/urn.py
@@ -139,6 +139,7 @@ class URNBuilder:
         # ATDD Specific
         'wmbt': r'^wmbt:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}$',
         'acc': r'^acc:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?$',
+        'security': r'^security:[a-z][a-z0-9-]*:[a-z][a-z0-9-]*:\d{3}$',
 
         # Resources
         'endpoint': r'^endpoint:[a-z0-9-]+\.(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\.[a-z0-9-/]+$',


### PR DESCRIPTION
Closes #419

## Summary

Implements substrate Track G Workstream A (items A.1, A.2, A.5):

- **`SecurityResolver`** in `src/atdd/coach/utils/graph/resolver.py`
  - Reads `feature.yaml::security.abuse_cases[]` across `plan/<wagon>/features/*.yaml`
  - Emits `security:<wagon>:<feature-slug>:<NNN>` URNs
  - Threat-seq derivation strips alphabetic prefix and zero-pads numeric tail to three digits (`THREAT-1` → `001`, `THREAT-42` → `042`, `THREAT-001` → `001`)
  - Rejects malformed ids (`^[A-Z][A-Z0-9-]*-\d+$`) and ids whose tail is >999 with a clear error referencing the failing feature.yaml
  - `URNDeclaration.metadata` and `URNResolution.metadata` expose `id`, `name`, `threat`, `mitigation`, `severity`, `acceptance_ref` verbatim from the YAML source
- **Registration** in `ResolverRegistry._register_default_resolvers()` so graph queries, `atdd urn validate`, `atdd urn declarations`, etc. all see security URNs
- **`security` URN pattern** added to `URNBuilder.PATTERNS`: `^security:[a-z][a-z0-9-]*:[a-z][a-z0-9-]*:\d{3}$`
- **`GraphBuilder._build_security_edges`** emits two edges per resolved abuse_case:
  - `feature → security` (`EdgeType.CONTAINS`)
  - `security → acceptance_ref` (`EdgeType.REFERENCES`), regardless of target resolution
- **Broken target detection**: when `acceptance_ref` does not resolve, a phantom node with `is_broken=True` metadata is synthesized so `EdgeValidator.find_broken()` (and `atdd urn validate`) flags it.

## Tests

- `src/atdd/coach/utils/graph/tests/test_security_resolver.py` — 24 tests covering threat-seq derivation, id validation, find_declarations, resolve, registry routing, and the 6-declaration two-feature × three-abuse-case fixture from the issue's acceptance criteria.
- `src/atdd/coach/utils/graph/tests/test_graph_builder_security_edges.py` — 5 tests covering both edge types, abuse_case metadata propagation onto graph nodes, broken-acceptance-ref detection, and the no-acceptance_ref → no REFERENCES edge case.

## Test plan

- [x] `pytest src/atdd/coach/utils/graph/tests/ -v` — 42/42 pass
- [x] `pytest src/atdd/coach/utils/` — 140/140 pass
- [x] Full `pytest src/atdd/coach/` — 805 passed; the 16 failures are pre-existing GitHub-state checks (project board, issue advancement, branch convention, babysit rule_id format) unrelated to URN graph
- [x] Sanity-loaded `from atdd.coach.utils.graph.resolver import SecurityResolver, ResolverRegistry` and confirmed `'security' in ResolverRegistry().families`

## Version

- 3.2.1 → **3.3.0** (MINOR — new `security` URN family, new resolver, new graph edge wiring)