### PR TITLE
feat(coach): #412 — substrate metric runner with two-root metric discovery

### DIFF
--- a/.atdd/baselines/validation/coach.yaml
+++ b/.atdd/baselines/validation/coach.yaml
@@ -1,5 +1,5 @@
 phase: coach
-passed_at: '2026-05-04T01:36:39.224783+00:00'
-source_hash: 65e98af922741042bb2e0932e566324cda4f872d21da5bc20d95c2c49080347d
-atdd_version: 1.65.5
+passed_at: '2026-05-06T02:18:35.885850+00:00'
+source_hash: eb7b9c76f0851e1f44fb8a0ca0dd4d1f5f5de98637bf1502824a873a8b51def5
+atdd_version: 3.2.1
 skipped_api: false

--- a/.atdd/baselines/validation/coder.yaml
+++ b/.atdd/baselines/validation/coder.yaml
@@ -1,0 +1,5 @@
+phase: coder
+passed_at: '2026-05-06T02:19:26.462592+00:00'
+source_hash: 4fbc8c38858bd6329b63ec1a02f8654ec3048213369f507cd072b366e413265c
+atdd_version: 3.2.1
+skipped_api: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.3.0"
+version = "3.4.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.4.0"
+version = "3.4.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/utils/rule_id_registry.py
+++ b/src/atdd/coach/utils/rule_id_registry.py
@@ -69,6 +69,15 @@ class RuleMetadata:
         fix_hint: Canonical remediation guidance (issue #399), or ``None``.
         aliases: Legacy ids (typically flat-grammar) this canonical rule
             supersedes (issue #399).
+        signal_metric: Substrate field (issue #407, spec v12 §4.1). Name of
+            the metric the rule's enforcement consumes; the metric runner
+            (issue #412) iterates the registry on this field. ``None`` for
+            harness-only or non-substrate rules.
+        signal_threshold: Substrate field (issue #407). Threshold scalar
+            (``int`` / ``float`` / ``bool``) the metric is judged against;
+            type is preserved verbatim from the YAML source so the metric
+            module's ``passes(value, threshold)`` call sees what the author
+            wrote. ``None`` when not set.
     """
 
     rule_id: str
@@ -82,6 +91,8 @@ class RuleMetadata:
     validator: Optional[str] = None
     fix_hint: Optional[str] = None
     aliases: Tuple[str, ...] = ()
+    signal_metric: Optional[str] = None
+    signal_threshold: object = None
 
 
 def _build_metadata(rule_id: str, raw: Dict, path: Path) -> RuleMetadata:
@@ -90,6 +101,21 @@ def _build_metadata(rule_id: str, raw: Dict, path: Path) -> RuleMetadata:
         aliases = tuple(a for a in aliases_raw if isinstance(a, str) and a)
     else:
         aliases = ()
+    signal_raw = raw.get("signal")
+    signal_metric: Optional[str] = None
+    signal_threshold: object = None
+    if isinstance(signal_raw, dict):
+        sm = signal_raw.get("metric")
+        if isinstance(sm, str) and sm:
+            signal_metric = sm
+        if "threshold" in signal_raw:
+            signal_threshold = signal_raw["threshold"]
+    else:
+        sm = raw.get("signal_metric")
+        if isinstance(sm, str) and sm:
+            signal_metric = sm
+        if "signal_threshold" in raw:
+            signal_threshold = raw["signal_threshold"]
     return RuleMetadata(
         rule_id=rule_id,
         convention_path=path,
@@ -122,6 +148,8 @@ def _build_metadata(rule_id: str, raw: Dict, path: Path) -> RuleMetadata:
             else None
         ),
         aliases=aliases,
+        signal_metric=signal_metric,
+        signal_threshold=signal_threshold,
     )
 
 

--- a/src/atdd/runners/__init__.py
+++ b/src/atdd/runners/__init__.py
@@ -1,0 +1,16 @@
+# URN: component:govern-lifecycle:enforcement-substrate:runners:backend:domain
+# Runtime: python
+# Purpose: Toolkit-shipped runners that read RuleMetadata, dispatch enforcement, and route Violations through the disposition gate.
+
+"""Substrate runners (spec v12 §4.5).
+
+Each runner consumes the rule registry built by
+``atdd.coach.utils.rule_id_registry.build_registry`` and emits violations
+through ``atdd.coach.utils.disposition_gate.assert_disposition_satisfied``.
+
+Three runners are defined by the substrate:
+
+* harness-mode  — pytest plugin (per-test rule binding); see substrate spec.
+* metric-mode   — single computation per rule (this package, ``metric_runner``).
+* security-mode — single resolution per rule (separate runner, not in this issue).
+"""

--- a/src/atdd/runners/metric_runner.py
+++ b/src/atdd/runners/metric_runner.py
@@ -1,0 +1,312 @@
+# URN: component:govern-lifecycle:enforcement-substrate:metric_runner:backend:domain
+# Runtime: python
+# Purpose: Iterate registry rules with signal_metric+threshold, dispatch metric compute()/passes(), and route Violations through the disposition gate (spec v12 §4.5).
+
+"""Metric-mode runner (issue #412, substrate spec v12 §4.5).
+
+Iterates every ``RuleMetadata`` carrying both ``signal_metric`` and
+``signal_threshold`` and:
+
+1. Looks up the metric implementation via two-root walk:
+
+   * Repo-local first  — ``<repo>/.atdd/metrics/<name>.py::compute``
+   * Toolkit fallback  — ``atdd/runners/metrics/<name>.py::compute``
+
+2. Calls ``compute(repo_root) -> int | float | bool``.
+3. Calls ``passes(value, threshold) -> bool`` from the same module.
+4. On ``passes() == False`` constructs a ``Violation`` with
+   ``rule_id`` = the registry's rule_id and ``location`` = ``"codebase"``.
+
+All violations across all rules are routed through a SINGLE
+``assert_disposition_satisfied`` call with
+``validator_id="test_metric_runner::test_metric_threshold_satisfied"``.
+The gate already groups violations by ``rule_id`` and emits one failure
+block per failing rule (verified against ``disposition_gate.py:169-216``
+at issue-authoring time).
+
+Skip rules:
+
+* ``signal_metric`` cannot be resolved in either lookup root → SILENTLY
+  SKIPPED. The conformance rule
+  ``tester.acceptance-violation.metric-implementation-must-exist`` (#410)
+  catches missing implementations at validation time; emitting a runtime
+  violation here would double-fail the same site.
+* ``signal_metric`` populated but ``signal_threshold is None`` (or vice
+  versa) → SILENTLY SKIPPED. The
+  ``tester.acceptance-violation.acceptance-must-be-measurable`` validator
+  (#410) catches the schema violation; runner does not double-emit.
+
+The metric module owns the ``passes`` semantic. The runner does NOT
+infer threshold direction from the metric name; supplying a default
+``passes`` would silently invert minimum-requirement metrics. See spec
+§4.5 lines 252-261.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from atdd.coach.utils.disposition_gate import assert_disposition_satisfied
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.utils.rule_id_registry import RuleMetadata, build_registry
+from atdd.coach.validators._violation import Violation
+
+
+_logger = logging.getLogger(__name__)
+
+
+VALIDATOR_ID = "test_metric_runner::test_metric_threshold_satisfied"
+"""Stable validator_id for every metric-runner gate call (spec §4.2)."""
+
+
+_TOOLKIT_METRICS_PKG = Path(__file__).resolve().parent / "metrics"
+"""Filesystem root of toolkit-shipped metric commons."""
+
+
+def _repo_metrics_root(repo_root: Path) -> Path:
+    return repo_root / ".atdd" / "metrics"
+
+
+def _toolkit_metrics_root() -> Path:
+    return _TOOLKIT_METRICS_PKG
+
+
+@dataclass(frozen=True)
+class MetricLookup:
+    """Resolution result for one ``signal_metric`` name.
+
+    Attributes:
+        name: The metric name as declared on the rule.
+        path: Absolute path to the metric module (``<name>.py``), or
+            ``None`` if neither root carries it.
+        module: Loaded Python module exposing ``compute`` and (optionally)
+            ``passes``. ``None`` when ``path is None`` or the module
+            failed to import / lacks ``compute``.
+        source: ``"repo"``, ``"toolkit"``, or ``None``.
+    """
+
+    name: str
+    path: Optional[Path]
+    module: Optional[ModuleType]
+    source: Optional[str]
+
+
+def discover_metric_module(
+    name: str,
+    repo_root: Path,
+    *,
+    toolkit_root: Optional[Path] = None,
+) -> MetricLookup:
+    """Resolve ``<name>`` against the two-root metric registry.
+
+    Repo-local ``<repo>/.atdd/metrics/<name>.py`` wins on collision. Falls
+    back to ``<toolkit_root>/<name>.py``. The module is imported and
+    cached at the module-spec level via ``importlib.util.spec_from_file_location``
+    so two consumers with different ``foo.py`` files don't shadow each
+    other through ``sys.modules``.
+    """
+    toolkit = toolkit_root if toolkit_root is not None else _toolkit_metrics_root()
+
+    candidates: List[tuple[str, Path]] = [
+        ("repo", _repo_metrics_root(repo_root) / f"{name}.py"),
+        ("toolkit", toolkit / f"{name}.py"),
+    ]
+
+    for source, candidate in candidates:
+        if not candidate.is_file():
+            continue
+        module = _load_module_from_path(candidate)
+        if module is None:
+            continue
+        if not callable(getattr(module, "compute", None)):
+            # Module exists but doesn't satisfy the contract; treat as
+            # absent so the conformance rule (#410) can flag it. The
+            # runner deliberately does not double-emit.
+            continue
+        return MetricLookup(name=name, path=candidate, module=module, source=source)
+
+    return MetricLookup(name=name, path=None, module=None, source=None)
+
+
+def _load_module_from_path(path: Path) -> Optional[ModuleType]:
+    """Import ``path`` as an isolated module by file location."""
+    try:
+        unique_name = f"_atdd_metric_{path.parent.name}_{path.stem}_{abs(hash(str(path.resolve())))}"
+        spec = importlib.util.spec_from_file_location(unique_name, str(path))
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception as exc:  # atdd:suppress(coder.logging.coach-silent-swallow)
+        # Import-time errors in a metric module are policed by the #410
+        # conformance rule (validation-time). The runner skips so it
+        # doesn't double-fail; the warning is for operator visibility.
+        _logger.warning(
+            "metric_runner: failed to import %s: %s",
+            path, exc,
+            extra={"metric_path": str(path), "error_type": type(exc).__name__},
+        )
+        return None
+
+
+def _select_runnable_rules(
+    registry: Dict[str, RuleMetadata],
+) -> List[RuleMetadata]:
+    """Return rules with BOTH ``signal_metric`` and ``signal_threshold`` set.
+
+    Rules with one but not the other are silently skipped — the
+    measurability validator (#410) policies the schema violation.
+    """
+    runnable: List[RuleMetadata] = []
+    for meta in registry.values():
+        if not isinstance(meta, RuleMetadata):
+            continue
+        if not meta.signal_metric:
+            continue
+        if meta.signal_threshold is None:
+            continue
+        runnable.append(meta)
+    return runnable
+
+
+def _format_metric_detail(metric: str, value: Any, threshold: Any) -> str:
+    """Spec §6 sample: ``<metric>=<value>, threshold=<threshold>``."""
+    return f"{metric}={value!r}, threshold={threshold!r}"
+
+
+def _build_violation(
+    meta: RuleMetadata,
+    value: Any,
+    threshold: Any,
+) -> Optional[Violation]:
+    """Construct the ``Violation`` record for a failing rule.
+
+    Returns ``None`` when severity is missing/non-int — those rules are
+    malformed and policed elsewhere; the runner skips defensively.
+    """
+    severity = meta.severity
+    if not isinstance(severity, int) or isinstance(severity, bool):
+        _logger.debug(
+            "metric_runner: skipping rule %s with non-int severity %r",
+            meta.rule_id, severity,
+        )
+        return None
+    if not (1 <= severity <= 5):
+        return None
+    return Violation(
+        rule_id=meta.rule_id,
+        severity=severity,
+        location="codebase",
+        detail=_format_metric_detail(
+            meta.signal_metric or "", value, threshold,
+        ),
+    )
+
+
+def collect_metric_violations(
+    registry: Dict[str, RuleMetadata],
+    repo_root: Path,
+    *,
+    toolkit_root: Optional[Path] = None,
+) -> List[Violation]:
+    """Pure function: walk the registry and collect failing-rule violations.
+
+    Separated from the gate-emission step so unit tests can inspect the
+    list directly without needing pytest.fail interception.
+    """
+    violations: List[Violation] = []
+    seen_ids: set = set()  # canonical ids may appear under both their id and aliases
+    for meta in _select_runnable_rules(registry):
+        if meta.rule_id in seen_ids:
+            continue
+        seen_ids.add(meta.rule_id)
+
+        lookup = discover_metric_module(
+            meta.signal_metric or "",
+            repo_root,
+            toolkit_root=toolkit_root,
+        )
+        if lookup.module is None:
+            # Missing implementation → silently skipped (rationale above).
+            continue
+
+        passes_fn = getattr(lookup.module, "passes", None)
+        if not callable(passes_fn):
+            # Module is missing `passes`. Same rationale as missing compute:
+            # the #410 conformance rule catches it; runtime does not double-emit.
+            continue
+
+        try:
+            value = lookup.module.compute(repo_root)
+        except Exception as exc:  # atdd:suppress(coder.logging.coach-silent-swallow)
+            _logger.warning(
+                "metric_runner: compute() raised for %s: %s",
+                meta.signal_metric, exc,
+                extra={
+                    "metric": meta.signal_metric,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            continue
+
+        try:
+            ok = passes_fn(value, meta.signal_threshold)
+        except Exception as exc:  # atdd:suppress(coder.logging.coach-silent-swallow)
+            _logger.warning(
+                "metric_runner: passes() raised for %s: %s",
+                meta.signal_metric, exc,
+                extra={
+                    "metric": meta.signal_metric,
+                    "error_type": type(exc).__name__,
+                },
+            )
+            continue
+
+        if ok:
+            continue
+
+        violation = _build_violation(meta, value, meta.signal_threshold)
+        if violation is not None:
+            violations.append(violation)
+
+    return violations
+
+
+def run_metric_runner(
+    *,
+    registry: Optional[Dict[str, RuleMetadata]] = None,
+    repo_root: Optional[Path] = None,
+    toolkit_root: Optional[Path] = None,
+) -> None:
+    """Run the metric runner and route every failure through the gate.
+
+    Single ``assert_disposition_satisfied`` call: the gate groups by
+    ``rule_id`` internally and emits one failure block per failing rule
+    (per spec §4.5 and verified against ``disposition_gate.py``). All
+    failures surface as ONE pytest failure, with one block per rule.
+    """
+    reg = registry if registry is not None else build_registry()
+    root = repo_root if repo_root is not None else find_repo_root()
+
+    violations = collect_metric_violations(reg, root, toolkit_root=toolkit_root)
+    assert_disposition_satisfied(
+        validator_id=VALIDATOR_ID,
+        violations=violations,
+        registry=reg,
+        repo_root=root,
+    )
+
+
+__all__ = [
+    "VALIDATOR_ID",
+    "MetricLookup",
+    "collect_metric_violations",
+    "discover_metric_module",
+    "run_metric_runner",
+]

--- a/src/atdd/runners/metrics/__init__.py
+++ b/src/atdd/runners/metrics/__init__.py
@@ -1,0 +1,19 @@
+# URN: component:govern-lifecycle:enforcement-substrate:metrics:backend:domain
+# Runtime: python
+# Purpose: Toolkit-shipped commons for the metric-function registry (spec v12 §4.5).
+
+"""Toolkit-shipped metric implementations.
+
+Each module under this package exposes:
+
+    def compute(repo_root: Path) -> int | float | bool: ...
+    def passes(value, threshold) -> bool: ...
+
+The metric runner (``atdd.runners.metric_runner``) discovers metrics via a
+two-root walk: a repo-local override at ``<repo>/.atdd/metrics/<name>.py``
+takes precedence over the toolkit-shipped module at
+``atdd/runners/metrics/<name>.py``.
+
+This package starts empty; toolkit commons such as ``lines_of_code`` or
+``cyclomatic_complexity`` are added as separate substrate issues.
+"""

--- a/src/atdd/runners/test_metric_runner.py
+++ b/src/atdd/runners/test_metric_runner.py
@@ -1,0 +1,24 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_metric_runner:backend:tests
+# Runtime: python
+# Purpose: Single pytest entry point for the metric-mode runner (spec v12 §4.5).
+
+"""Pytest anchor for the metric-mode runner (issue #412).
+
+Substrate spec v12 §4.5 anchors the metric runner at
+``test_metric_runner::test_metric_threshold_satisfied``. Every rule whose
+``signal.metric`` fails its ``passes(value, threshold)`` check surfaces as
+a failure block in this single pytest item, grouped by ``rule_id`` by the
+disposition gate.
+
+The implementation lives in ``atdd.runners.metric_runner.run_metric_runner``;
+this module exists so that the validator_id matches the spec literally.
+"""
+
+from __future__ import annotations
+
+from atdd.runners.metric_runner import run_metric_runner
+
+
+def test_metric_threshold_satisfied() -> None:
+    """Run every metric-mode rule and route failures through the gate."""
+    run_metric_runner()

--- a/src/atdd/runners/tests/test_metric_runner_unit.py
+++ b/src/atdd/runners/tests/test_metric_runner_unit.py
@@ -1,0 +1,500 @@
+# URN: component:govern-lifecycle:enforcement-substrate:metric_runner:backend:tests
+# Runtime: python
+# Purpose: Cover the metric runner's discovery, compute/passes, and gate-emission paths against acceptance criteria for issue #412.
+
+"""Unit tests for ``atdd.runners.metric_runner`` (issue #412).
+
+Each test builds an in-memory ``Dict[str, RuleMetadata]`` registry and
+writes fixture metric modules under ``tmp_path/.atdd/metrics`` and a
+fake toolkit metrics root. The disposition gate is exercised via the
+real ``assert_disposition_satisfied`` so the failure-block format stays
+in sync with spec §6.
+
+Acceptance criteria (issue #412):
+
+* foo metric returning 5 with threshold 0 produces a Violation.
+* Repo-local metric overrides toolkit-shipped metric of the same name.
+* Both-mode coexistence: harness + metric runners produce independent
+  gate calls (verified by directly invoking the gate twice with the
+  same rule_id and inspecting the failure output).
+* Custom ``passes(value, threshold) -> value >= threshold`` works for
+  minimum-requirement metrics.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from atdd.coach.utils.disposition_gate import assert_disposition_satisfied
+from atdd.coach.utils.rule_id_registry import RuleMetadata
+from atdd.coach.validators._violation import Violation
+from atdd.runners.metric_runner import (
+    VALIDATOR_ID,
+    collect_metric_violations,
+    discover_metric_module,
+    run_metric_runner,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _meta(
+    rule_id: str,
+    *,
+    signal_metric: str | None,
+    signal_threshold: object,
+    severity: int = 4,
+    description: str = "fixture rule",
+    fix_hint: str | None = None,
+    disposition: str = "strict",
+) -> RuleMetadata:
+    return RuleMetadata(
+        rule_id=rule_id,
+        convention_path=Path("/dev/null"),
+        severity=severity,
+        description=description,
+        disposition=disposition,
+        fix_hint=fix_hint,
+        signal_metric=signal_metric,
+        signal_threshold=signal_threshold,
+    )
+
+
+def _write_metric(root: Path, name: str, body: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    path = root / f"{name}.py"
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+# Default metric body: compute returns the bound int, passes is upper-bound.
+def _default_metric_body(value: object) -> str:
+    return f"""
+from pathlib import Path
+
+def compute(repo_root: Path):
+    return {value!r}
+
+def passes(value, threshold):
+    return value <= threshold
+""".lstrip()
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #1 — foo with compute()==5 + threshold=0 produces a Violation
+# ---------------------------------------------------------------------------
+
+def test_foo_with_value_5_and_threshold_0_produces_violation(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+
+    _write_metric(repo_root / ".atdd" / "metrics", "foo", _default_metric_body(5))
+
+    rule_id = "repo.govern-lifecycle.D010-acc-unit-001"
+    registry: Dict[str, RuleMetadata] = {
+        rule_id: _meta(
+            rule_id,
+            signal_metric="foo",
+            signal_threshold=0,
+            description="A single helper replaces every literal",
+            fix_hint="No literal appears outside the helper module",
+        ),
+    }
+
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.rule_id == rule_id
+    assert v.severity == 4
+    assert v.location == "codebase"
+    assert "foo=5" in v.detail
+    assert "threshold=0" in v.detail
+
+
+def test_run_metric_runner_routes_failure_through_gate(tmp_path):
+    """End-to-end: run_metric_runner fails pytest with one block per rule."""
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+
+    _write_metric(repo_root / ".atdd" / "metrics", "foo", _default_metric_body(5))
+
+    rule_id = "repo.govern-lifecycle.D010-acc-unit-001"
+    registry = {
+        rule_id: _meta(
+            rule_id,
+            signal_metric="foo",
+            signal_threshold=0,
+            description="A single helper replaces every literal",
+            fix_hint="No literal appears outside the helper module",
+        ),
+    }
+
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        run_metric_runner(
+            registry=registry,
+            repo_root=repo_root,
+            toolkit_root=toolkit_root,
+        )
+
+    msg = str(excinfo.value)
+    # Spec §6: failure block carries description: + fix_hint: lines.
+    assert f"validator={VALIDATOR_ID}" in msg
+    assert f"rule_id={rule_id}" in msg
+    assert "description: A single helper replaces every literal" in msg
+    assert "fix_hint:    No literal appears outside the helper module" in msg
+    assert "foo=5" in msg
+    assert "threshold=0" in msg
+
+
+def test_passing_metric_does_not_emit_violation(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+
+    # compute()==0, threshold=0 → passes (0 <= 0).
+    _write_metric(repo_root / ".atdd" / "metrics", "foo", _default_metric_body(0))
+
+    rule_id = "repo.govern-lifecycle.D010-acc-unit-001"
+    registry = {rule_id: _meta(rule_id, signal_metric="foo", signal_threshold=0)}
+
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #2 — Repo-local metric overrides toolkit-shipped metric
+# ---------------------------------------------------------------------------
+
+def test_repo_local_metric_overrides_toolkit(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+
+    # Toolkit version says 0 (passes); repo-local says 99 (fails).
+    _write_metric(toolkit_root, "shared_metric", _default_metric_body(0))
+    _write_metric(repo_root / ".atdd" / "metrics", "shared_metric", _default_metric_body(99))
+
+    lookup = discover_metric_module(
+        "shared_metric", repo_root, toolkit_root=toolkit_root,
+    )
+    assert lookup.source == "repo"
+    assert lookup.path is not None
+    assert lookup.path.parent == (repo_root / ".atdd" / "metrics").resolve() or \
+        lookup.path.parent == repo_root / ".atdd" / "metrics"
+
+    rule_id = "repo.example.override"
+    registry = {rule_id: _meta(rule_id, signal_metric="shared_metric", signal_threshold=0)}
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert len(violations) == 1
+    assert "shared_metric=99" in violations[0].detail
+
+
+def test_toolkit_metric_used_when_no_repo_local(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+
+    _write_metric(toolkit_root, "lines_of_code", _default_metric_body(7))
+
+    lookup = discover_metric_module(
+        "lines_of_code", repo_root, toolkit_root=toolkit_root,
+    )
+    assert lookup.source == "toolkit"
+
+    rule_id = "repo.example.toolkit-only"
+    registry = {rule_id: _meta(rule_id, signal_metric="lines_of_code", signal_threshold=10)}
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert violations == []  # 7 <= 10
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #4 — Custom passes for minimum-requirement metrics
+# ---------------------------------------------------------------------------
+
+_MINIMUM_REQUIREMENT_BODY = """
+from pathlib import Path
+
+def compute(repo_root: Path):
+    return 3  # only 3 samples present
+
+def passes(value, threshold):
+    return value >= threshold
+""".lstrip()
+
+
+def test_custom_passes_minimum_requirement_fails_when_below_threshold(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+
+    _write_metric(repo_root / ".atdd" / "metrics", "min_samples", _MINIMUM_REQUIREMENT_BODY)
+
+    rule_id = "repo.example.min-samples"
+    registry = {
+        rule_id: _meta(rule_id, signal_metric="min_samples", signal_threshold=5),
+    }
+    # 3 < 5 → fails the >= check → violation emitted.
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert len(violations) == 1
+    assert "min_samples=3" in violations[0].detail
+    assert "threshold=5" in violations[0].detail
+
+
+def test_custom_passes_minimum_requirement_passes_when_above_threshold(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+
+    _write_metric(repo_root / ".atdd" / "metrics", "min_samples", _MINIMUM_REQUIREMENT_BODY)
+
+    rule_id = "repo.example.min-samples"
+    # threshold 2 → 3 >= 2 → passes.
+    registry = {rule_id: _meta(rule_id, signal_metric="min_samples", signal_threshold=2)}
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Acceptance #5 — Both-mode (harness + metric) produces TWO failure blocks
+# ---------------------------------------------------------------------------
+
+def test_harness_and_metric_modes_produce_independent_gate_calls(tmp_path):
+    """Both runners route through the gate independently per spec §5.3.
+
+    They share the same ``rule_id`` and ``description``/``fix_hint`` (from
+    the registry) but distinct ``validator_id`` values. Each call surfaces
+    its own failure block.
+    """
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+
+    _write_metric(repo_root / ".atdd" / "metrics", "foo", _default_metric_body(5))
+
+    rule_id = "repo.govern-lifecycle.D010-acc-unit-001"
+    registry = {
+        rule_id: _meta(
+            rule_id,
+            signal_metric="foo",
+            signal_threshold=0,
+            description="single helper replaces every literal",
+            fix_hint="No literal outside helper module",
+        ),
+    }
+
+    # Metric mode call.
+    metric_violations = collect_metric_violations(
+        registry, repo_root, toolkit_root=toolkit_root,
+    )
+    assert len(metric_violations) == 1
+
+    with pytest.raises(pytest.fail.Exception) as metric_exc:
+        assert_disposition_satisfied(
+            validator_id=VALIDATOR_ID,
+            violations=metric_violations,
+            registry=registry,
+            repo_root=repo_root,
+        )
+    metric_msg = str(metric_exc.value)
+    assert f"validator={VALIDATOR_ID}" in metric_msg
+    assert f"rule_id={rule_id}" in metric_msg
+    assert "description: single helper replaces every literal" in metric_msg
+    assert "fix_hint:    No literal outside helper module" in metric_msg
+
+    # Harness mode call: same rule_id, different validator_id, distinct location.
+    harness_validator = "test_theme_map::test_no_hardcoded_literals"
+    harness_violation = Violation(
+        rule_id=rule_id,
+        severity=4,
+        location="src/foo.py:42",
+        detail="hardcoded literal found",
+    )
+    with pytest.raises(pytest.fail.Exception) as harness_exc:
+        assert_disposition_satisfied(
+            validator_id=harness_validator,
+            violations=[harness_violation],
+            registry=registry,
+            repo_root=repo_root,
+        )
+    harness_msg = str(harness_exc.value)
+    assert f"validator={harness_validator}" in harness_msg
+    assert f"rule_id={rule_id}" in harness_msg
+    # Same enrichment fields on both blocks.
+    assert "description: single helper replaces every literal" in harness_msg
+    assert "fix_hint:    No literal outside helper module" in harness_msg
+
+    # The two failure blocks are independent: distinct validator_ids.
+    assert VALIDATOR_ID in metric_msg
+    assert VALIDATOR_ID not in harness_msg
+    assert harness_validator in harness_msg
+    assert harness_validator not in metric_msg
+
+
+# ---------------------------------------------------------------------------
+# Skip semantics — missing impl, missing threshold, missing metric
+# ---------------------------------------------------------------------------
+
+def test_missing_metric_implementation_silently_skipped(tmp_path):
+    """Per #410 conformance rule, runtime does NOT double-emit on missing impl."""
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+    # No metric file written under either root.
+
+    rule_id = "repo.example.missing-impl"
+    registry = {rule_id: _meta(rule_id, signal_metric="ghost", signal_threshold=0)}
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert violations == []
+
+
+def test_metric_without_threshold_silently_skipped(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+    _write_metric(repo_root / ".atdd" / "metrics", "foo", _default_metric_body(5))
+
+    rule_id = "repo.example.no-threshold"
+    registry = {rule_id: _meta(rule_id, signal_metric="foo", signal_threshold=None)}
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert violations == []
+
+
+def test_threshold_without_metric_silently_skipped(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+    _write_metric(repo_root / ".atdd" / "metrics", "foo", _default_metric_body(5))
+
+    rule_id = "repo.example.no-metric"
+    registry = {rule_id: _meta(rule_id, signal_metric=None, signal_threshold=0)}
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert violations == []
+
+
+def test_module_missing_compute_silently_skipped(tmp_path):
+    """Module without compute() is treated as absent (no double-emit)."""
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+    body = """
+def passes(value, threshold):
+    return value <= threshold
+""".lstrip()
+    _write_metric(repo_root / ".atdd" / "metrics", "no_compute", body)
+
+    rule_id = "repo.example.no-compute"
+    registry = {rule_id: _meta(rule_id, signal_metric="no_compute", signal_threshold=0)}
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert violations == []
+
+
+def test_module_missing_passes_silently_skipped(tmp_path):
+    """Module without passes() is treated as absent (no double-emit)."""
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+    body = """
+from pathlib import Path
+
+def compute(repo_root: Path):
+    return 5
+""".lstrip()
+    _write_metric(repo_root / ".atdd" / "metrics", "no_passes", body)
+
+    rule_id = "repo.example.no-passes"
+    registry = {rule_id: _meta(rule_id, signal_metric="no_passes", signal_threshold=0)}
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Bool-metric conventional encoding (spec §4.5)
+# ---------------------------------------------------------------------------
+
+_BOOL_METRIC_BODY = """
+from pathlib import Path
+
+def compute(repo_root: Path):
+    return True  # violation present
+
+def passes(value, threshold):
+    return value <= threshold
+""".lstrip()
+
+
+def test_bool_metric_true_with_threshold_false_fails(tmp_path):
+    """Spec §4.5: bool metric encoding True=='violation', threshold False, default passes."""
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+    _write_metric(repo_root / ".atdd" / "metrics", "duplicate_side_effects", _BOOL_METRIC_BODY)
+
+    rule_id = "repo.example.bool-metric"
+    registry = {
+        rule_id: _meta(
+            rule_id,
+            signal_metric="duplicate_side_effects",
+            signal_threshold=False,
+        ),
+    }
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    # passes(True, False): True <= False → False → fails.
+    assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Single gate call groups multiple failures by rule_id
+# ---------------------------------------------------------------------------
+
+def test_multiple_failing_rules_emit_one_block_each(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+    _write_metric(repo_root / ".atdd" / "metrics", "alpha", _default_metric_body(5))
+    _write_metric(repo_root / ".atdd" / "metrics", "beta", _default_metric_body(7))
+
+    registry = {
+        "repo.example.alpha": _meta(
+            "repo.example.alpha", signal_metric="alpha", signal_threshold=0,
+        ),
+        "repo.example.beta": _meta(
+            "repo.example.beta", signal_metric="beta", signal_threshold=0,
+        ),
+    }
+    with pytest.raises(pytest.fail.Exception) as excinfo:
+        run_metric_runner(
+            registry=registry, repo_root=repo_root, toolkit_root=toolkit_root,
+        )
+    msg = str(excinfo.value)
+    assert "rule_id=repo.example.alpha" in msg
+    assert "rule_id=repo.example.beta" in msg
+    # Both blocks share the same validator_id (one runner, multiple rules).
+    assert msg.count(f"validator={VALIDATOR_ID}") == 2
+
+
+# ---------------------------------------------------------------------------
+# Aliased rule registered twice in the registry should not double-emit
+# ---------------------------------------------------------------------------
+
+def test_aliased_rule_emits_one_violation(tmp_path):
+    repo_root = tmp_path
+    toolkit_root = tmp_path / "_toolkit_metrics"
+    toolkit_root.mkdir()
+    _write_metric(repo_root / ".atdd" / "metrics", "foo", _default_metric_body(5))
+
+    rule_id = "repo.example.canonical"
+    meta = _meta(rule_id, signal_metric="foo", signal_threshold=0)
+    # The registry indexes both the canonical id and aliases at the same
+    # RuleMetadata; the runner must dedupe.
+    registry = {rule_id: meta, "LEGACY-FOO-001": meta}
+
+    violations = collect_metric_violations(registry, repo_root, toolkit_root=toolkit_root)
+    assert len(violations) == 1
+    assert violations[0].rule_id == rule_id


### PR DESCRIPTION
Closes #412

## Summary

Implements substrate spec v12 §4.5 metric-mode runner. The runner iterates every rule whose `RuleMetadata` carries both `signal_metric` and `signal_threshold`, looks up the metric implementation via two-root walk (repo-local `<repo>/.atdd/metrics/<name>.py` wins over toolkit-shipped `src/atdd/runners/metrics/<name>.py`), calls `compute()` and `passes()`, and routes failures through a single `assert_disposition_satisfied` call. The disposition gate groups by `rule_id` and emits one failure block per failing rule per spec §6.

- Extends `rule_id_registry.RuleMetadata` + `_build_metadata` with `signal_metric` / `signal_threshold` so `build_registry()` (consumed by the disposition gate) carries the substrate fields. `signal_threshold` is typed `object` so YAML-native types (int, bool, float) flow through unchanged.
- Adds `src/atdd/runners/` package: `metric_runner.py` (logic), `test_metric_runner.py` (pytest anchor at the spec's literal `validator_id`), and `metrics/` (toolkit metric commons, intentionally empty for now).
- Silent-skip semantics: missing metric module, missing `compute`/`passes` symbols, or missing `signal_metric`/`signal_threshold` are all routed to the #410 conformance rule at validation time — runtime never double-emits.
- Coexists with harness mode: same `rule_id`, distinct `validator_id`, two independent gate calls per dual-mode acceptance.

## Acceptance criteria coverage

- [x] foo metric returning 5 with threshold 0 produces a Violation
- [x] Repo-local metric overrides toolkit-shipped metric of the same name
- [x] Custom `passes(value, threshold) -> value >= threshold` works for minimum-requirement metrics
- [x] Both-mode acceptance produces independent failure blocks (same rule_id, distinct validator_id, both enriched with description / fix_hint)

(Missing-implementation acceptance criterion is policed by #410's conformance rule, which surfaces the missing module at validation time.)

## Test plan

- [x] `pytest src/atdd/runners/` — 17 passed
- [x] `pytest src/atdd/coach/utils/` — 101 passed (no regression)
- [x] `atdd validate coder --local` — passes
- [x] `atdd validate coach --local` — only failures are pre-existing project-board/issue-branch checks unrelated to this branch