### PR TITLE
fix(coach): test_issue_advancement skips non-lifecycle issues (tracking/meta/epic/parent)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.3.1"
+version = "3.3.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.3.0"
+version = "3.3.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/validators/test_issue_advancement.py
+++ b/src/atdd/coach/validators/test_issue_advancement.py
@@ -32,6 +32,23 @@ _STALE_PHASES = frozenset({"INIT", "PLANNED"})
 # Terminal or expected post-merge phases — no advancement expected
 _TERMINAL_PHASES = frozenset({"COMPLETE", "OBSOLETE"})
 
+# Issue labels that mark a non-lifecycle issue (parent meta-issue, tracker,
+# milestone, etc.). These don't advance through the standard 6-phase lifecycle
+# because their "advancement" is the cumulative state of their child issues,
+# not a single phase transition. PRs that reference them (e.g., a docs PR whose
+# title includes "(#406)") should not trigger advancement enforcement.
+_NON_LIFECYCLE_LABELS = frozenset({"tracking", "meta", "epic", "parent"})
+
+
+def _issue_is_non_lifecycle(issue_data: dict) -> bool:
+    """True if the issue carries a label marking it as non-lifecycle."""
+    labels = issue_data.get("labels", []) or []
+    label_names = {
+        (lbl.get("name") if isinstance(lbl, dict) else lbl)
+        for lbl in labels
+    }
+    return bool(label_names & _NON_LIFECYCLE_LABELS)
+
 
 def scan_issue_advancement(repo_root: Path) -> Tuple[int, Sequence]:
     """Scan recently merged PRs for stale linked issues.
@@ -64,6 +81,12 @@ def scan_issue_advancement(repo_root: Path) -> Tuple[int, Sequence]:
 
         # Skip terminal phases
         if phase in _TERMINAL_PHASES:
+            continue
+
+        # Skip non-lifecycle issues (tracking / meta / epic / parent).
+        # Their "advancement" is the cumulative state of child issues, not
+        # a single label transition.
+        if _issue_is_non_lifecycle(resolution["issue_data"]):
             continue
 
         if phase in _STALE_PHASES:

--- a/src/atdd/coach/validators/tests/test_issue_advancement_non_lifecycle.py
+++ b/src/atdd/coach/validators/tests/test_issue_advancement_non_lifecycle.py
@@ -1,0 +1,65 @@
+"""Tests for non-lifecycle issue skip in test_issue_advancement.
+
+A PR whose linked issue carries a `tracking` / `meta` / `epic` / `parent`
+label should NOT trigger advancement enforcement, because such issues don't
+advance through the 6-phase lifecycle — their state is the cumulative state
+of their child issues.
+"""
+from atdd.coach.validators.test_issue_advancement import (
+    _NON_LIFECYCLE_LABELS,
+    _issue_is_non_lifecycle,
+)
+
+
+class TestIssueIsNonLifecycle:
+    def test_returns_true_for_tracking_label(self):
+        issue = {"labels": [{"name": "tracking"}, {"name": "atdd:INIT"}]}
+        assert _issue_is_non_lifecycle(issue) is True
+
+    def test_returns_true_for_meta_label(self):
+        issue = {"labels": [{"name": "meta"}]}
+        assert _issue_is_non_lifecycle(issue) is True
+
+    def test_returns_true_for_epic_label(self):
+        issue = {"labels": [{"name": "epic"}]}
+        assert _issue_is_non_lifecycle(issue) is True
+
+    def test_returns_true_for_parent_label(self):
+        issue = {"labels": [{"name": "parent"}]}
+        assert _issue_is_non_lifecycle(issue) is True
+
+    def test_returns_false_for_normal_lifecycle_issue(self):
+        issue = {"labels": [{"name": "atdd:INIT"}, {"name": "archetype:coach"}]}
+        assert _issue_is_non_lifecycle(issue) is False
+
+    def test_returns_false_for_no_labels(self):
+        assert _issue_is_non_lifecycle({"labels": []}) is False
+        assert _issue_is_non_lifecycle({}) is False
+
+    def test_returns_false_for_label_with_similar_substring(self):
+        # "tracking-misc" should NOT trip the "tracking" exact match.
+        issue = {"labels": [{"name": "tracking-misc"}, {"name": "atdd:RED"}]}
+        assert _issue_is_non_lifecycle(issue) is False
+
+    def test_handles_string_labels_legacy_shape(self):
+        issue = {"labels": ["tracking"]}
+        assert _issue_is_non_lifecycle(issue) is True
+
+    def test_returns_true_when_one_of_many_labels_is_non_lifecycle(self):
+        issue = {"labels": [
+            {"name": "atdd:INIT"},
+            {"name": "tracking"},
+            {"name": "archetype:coach"},
+        ]}
+        assert _issue_is_non_lifecycle(issue) is True
+
+
+class TestNonLifecycleLabelsConst:
+    def test_includes_documented_labels(self):
+        assert _NON_LIFECYCLE_LABELS == frozenset({"tracking", "meta", "epic", "parent"})
+
+    def test_is_immutable(self):
+        # frozenset by contract — mutation should fail
+        import pytest
+        with pytest.raises((AttributeError, TypeError)):
+            _NON_LIFECYCLE_LABELS.add("foo")  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
Validator at `src/atdd/coach/validators/test_issue_advancement.py` flags merged PRs whose linked issues haven't advanced past INIT/PLANNED. Currently false-positives on **tracking / meta / epic / parent** issues, which never go through the 6-phase lifecycle — their state IS the cumulative state of their child issues.

## Incident this fixes
PR #425 (docs PR for substrate spec) was correctly merged. Its title contained `(#406)` referencing parent meta-issue #406. The validator's title-regex strategy (#4) resolved this as a 'linked issue' and flagged #406 for not being past INIT — even though #406 is a tracking issue with 17 child issues, none of which had run yet.

The same false-positive will fire for any docs/refactor PR that mentions a parent issue in its title or body.

## Fix
- New constant `_NON_LIFECYCLE_LABELS = frozenset({"tracking", "meta", "epic", "parent"})`
- New helper `_issue_is_non_lifecycle(issue_data) -> bool` — exact-match label check, supports both dict-shaped and string-shaped GitHub label payloads
- `scan_issue_advancement` now skips non-lifecycle issues alongside the existing CLOSED + terminal-phase skips

## Tests
11 new unit tests in `src/atdd/coach/validators/tests/test_issue_advancement_non_lifecycle.py`:
- Each of 4 non-lifecycle labels triggers exclusion
- Normal lifecycle issues (`atdd:INIT` + `archetype:coach` only) are NOT excluded
- Empty / missing labels safe
- Similar-substring (`tracking-misc`) does NOT exclude — exact match only
- Legacy `labels: ["tracking"]` string shape supported
- Mixed label sets work
- Constant is immutable (frozenset)

## Test plan
- [x] `pytest src/atdd/coach/validators/tests/test_issue_advancement_non_lifecycle.py -v` — 11 passing
- [ ] CI green
- [ ] After merge, manually verify on PR #425 by checking that #406 (atdd:tracking) no longer trips the validator.