### PR TITLE
feat(coach): #420 — URN grammar validator + parent-it-belongs-to

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -189,3 +189,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:actionable-ci-feedback
   train: 0001-self-compliance-validate
+- id: '420'
+  slug: substrate-420-urn-grammar
+  file: null
+  issue_number: 420
+  type: feature
+  status: RED
+  created: '2026-05-06'
+  archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:repo-rule-substrate
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.4.0"
+version = "3.4.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/utils/graph/tests/test_urn_security_grammar.py
+++ b/src/atdd/coach/utils/graph/tests/test_urn_security_grammar.py
@@ -1,0 +1,263 @@
+# URN: test:coach:urn:security_grammar
+"""
+Coverage for spec v12 §3.2 (parent-it-belongs-to URN grammar).
+
+Issue #420 ships the ``security:<wagon>:<feature-slug>:<NNN>`` URN family
+(parent = feature, 3 tokens) plus the segment-count table that anchors the
+parent-it-belongs-to principle. These tests pin both behaviors so a future
+refactor cannot silently drift either:
+
+- The new ``URNBuilder.security`` builder, ``parse_urn`` parser, and
+  ``validate_urn`` regex round-trip every documented form (digit-string,
+  ``THREAT-N``, padded numeric, int).
+- The ``validate_grammar`` auto-detect entry point fails with a clear,
+  actionable error when a known prefix has the wrong segment count, and a
+  separate "unknown resource type" error when the prefix is not registered.
+- ``URNBuilder.SEGMENT_COUNTS`` and ``URNBuilder.PATTERNS`` stay in lockstep
+  with the spec §3.2 table — the parametrized test below guards both the
+  numeric counts and the regex segment counts at once.
+
+Naming follows filename.convention.yaml: test_{component}_{what}.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from atdd.coach.utils.graph.urn import URNBuilder
+
+
+# ---------------------------------------------------------------------------
+# security:<wagon>:<feature-slug>:<NNN> — builder + parser + validator
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityBuilder:
+    """URNBuilder.security() builds canonical 3-token security URNs."""
+
+    def test_canonical_inputs_round_trip(self):
+        urn = URNBuilder.security("auth", "session-management", "001")
+        assert urn == "security:auth:session-management:001"
+        assert URNBuilder.validate_urn(urn, "security") is True
+
+        parsed = URNBuilder.parse_urn(urn)
+        assert parsed == {
+            "type": "security",
+            "wagon_id": "auth",
+            "feature_id": "session-management",
+            "threat_seq": "001",
+        }
+
+    @pytest.mark.parametrize(
+        "given,expected",
+        [
+            ("THREAT-1", "001"),       # spec example — issue body
+            ("THREAT-42", "042"),      # spec example — issue body
+            ("THREAT-001", "001"),     # spec example — already padded
+            ("threat-7", "007"),       # case-insensitive
+            ("threat_3", "003"),       # underscore separator tolerated
+            ("THREAT123", "123"),      # no separator at all
+            ("42", "042"),             # bare digit string padded
+            ("999", "999"),            # upper bound
+            ("1", "001"),              # lower bound
+            (1, "001"),                # int input
+            (42, "042"),               # int input
+            (999, "999"),              # int input upper bound
+        ],
+    )
+    def test_threat_seq_normalization(self, given, expected):
+        urn = URNBuilder.security("auth", "session-management", given)
+        assert urn == f"security:auth:session-management:{expected}"
+
+    @pytest.mark.parametrize("bad_seq", [0, 1000, -1, "0", "1000", "THREAT-1000"])
+    def test_threat_seq_out_of_range_rejected(self, bad_seq):
+        with pytest.raises(ValueError, match="between 1 and 999"):
+            URNBuilder.security("auth", "session-management", bad_seq)
+
+    @pytest.mark.parametrize("bad_seq", ["", "abc", "THREAT-", "001a", "THREAT-x1"])
+    def test_threat_seq_malformed_rejected(self, bad_seq):
+        with pytest.raises(ValueError):
+            URNBuilder.security("auth", "session-management", bad_seq)
+
+    def test_threat_seq_bool_rejected(self):
+        # bool is a subclass of int — explicitly reject so True/False never
+        # silently round-trips to "001"/"000".
+        with pytest.raises(TypeError):
+            URNBuilder.security("auth", "session-management", True)
+
+    # Note: ``_normalize_id`` lowercases, strips leading/trailing hyphens, and
+    # collapses underscores → hyphens BEFORE the regex check. So inputs like
+    # "Auth" or "-auth" are normalized to "auth" and accepted by design. Only
+    # truly unfixable inputs (empty, leading-digit, embedded punctuation) hit
+    # the validator branch.
+    @pytest.mark.parametrize("bad_wagon", ["", "1auth", "auth!"])
+    def test_invalid_wagon_id_rejected(self, bad_wagon):
+        with pytest.raises(ValueError, match="(?i)wagon"):
+            URNBuilder.security(bad_wagon, "session-management", "001")
+
+    @pytest.mark.parametrize("bad_slug", ["", "1session", "session!"])
+    def test_invalid_feature_slug_rejected(self, bad_slug):
+        with pytest.raises(ValueError, match="(?i)feature slug"):
+            URNBuilder.security("auth", bad_slug, "001")
+
+
+# ---------------------------------------------------------------------------
+# validate_urn / parse_urn — regex pass/fail and parser symmetry
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityValidatorAndParser:
+    @pytest.mark.parametrize(
+        "good_urn",
+        [
+            "security:auth:session-management:001",
+            "security:checkout:cart-overflow:042",
+            "security:a:b:999",  # minimal slugs
+            "security:auth-service:multi-factor-auth:007",
+        ],
+    )
+    def test_valid_security_urns_pass(self, good_urn):
+        assert URNBuilder.validate_urn(good_urn, "security") is True
+        assert URNBuilder.validate_grammar(good_urn) is True
+
+    @pytest.mark.parametrize(
+        "bad_urn",
+        [
+            "security:auth:session-management",          # only 2 tokens
+            "security:auth:session-management:1",        # not zero-padded
+            "security:auth:session-management:0001",     # too many digits
+            "security:auth:session-management:abc",      # non-numeric seq
+            "security:Auth:session-management:001",      # uppercase wagon
+            "security::session-management:001",          # empty wagon
+            "security:auth::001",                        # empty feature slug
+            "security:auth:session-management:001:extra",  # 4 tokens
+        ],
+    )
+    def test_invalid_security_urns_fail_validate_urn(self, bad_urn):
+        assert URNBuilder.validate_urn(bad_urn, "security") is False
+
+    def test_parse_security_urn_returns_named_components(self):
+        parsed = URNBuilder.parse_urn(
+            "security:checkout:cart-overflow:042"
+        )
+        assert parsed["type"] == "security"
+        assert parsed["wagon_id"] == "checkout"
+        assert parsed["feature_id"] == "cart-overflow"
+        assert parsed["threat_seq"] == "042"
+
+    def test_parse_security_urn_wrong_segment_count_raises(self):
+        with pytest.raises(ValueError, match="segment count"):
+            URNBuilder.parse_urn("security:checkout:only-two-tokens")
+
+
+# ---------------------------------------------------------------------------
+# validate_grammar — parent-it-belongs-to auto-detect entry point
+# ---------------------------------------------------------------------------
+
+
+class TestValidateGrammar:
+    """The auto-detecting validator that operationalizes spec §3.2."""
+
+    def test_known_prefix_correct_segment_count_passes(self):
+        assert URNBuilder.validate_grammar("wagon:auth") is True
+        assert URNBuilder.validate_grammar("feature:auth:session") is True
+        assert URNBuilder.validate_grammar("wmbt:auth:E001") is True
+        assert URNBuilder.validate_grammar(
+            "security:auth:session-management:001"
+        ) is True
+
+    @pytest.mark.parametrize(
+        "bad_urn,expected_count",
+        [
+            # Too few tokens for the family
+            ("security:auth:only-two", 3),
+            # Too many tokens for the family
+            ("security:auth:session-management:001:extra", 3),
+            ("feature:auth:session:extra", 2),
+            ("wmbt:auth:E001:extra", 2),
+            ("wagon:auth:extra", 1),
+        ],
+    )
+    def test_known_prefix_wrong_segment_count_raises_with_named_resource(
+        self, bad_urn, expected_count
+    ):
+        prefix = bad_urn.split(":", 1)[0]
+        with pytest.raises(ValueError) as exc:
+            URNBuilder.validate_grammar(bad_urn)
+
+        msg = str(exc.value)
+        # Error must name the resource and the expected count so the user
+        # can fix it without reading the spec PDF.
+        assert prefix in msg, f"resource name missing from {msg!r}"
+        assert str(expected_count) in msg, f"expected count missing from {msg!r}"
+        assert "parent-it-belongs-to" in msg or "segment count" in msg
+
+    def test_unknown_resource_type_raises_explicit_error(self):
+        with pytest.raises(ValueError, match="unknown resource type"):
+            URNBuilder.validate_grammar("zaphod:auth:beeblebrox")
+
+    def test_malformed_urn_without_prefix_raises(self):
+        with pytest.raises(ValueError, match="(?i)malformed|prefix"):
+            URNBuilder.validate_grammar("not-a-urn-at-all")
+
+
+# ---------------------------------------------------------------------------
+# SEGMENT_COUNTS table — must stay in lockstep with PATTERNS and the spec
+# ---------------------------------------------------------------------------
+
+
+# Verbatim mirror of spec v12 §3.2 table. Each entry pairs the family name
+# with (a) the documented post-prefix token count and (b) a representative
+# canonical URN. The sample URN has to validate via the family's regex AND
+# present exactly N colon-separated tokens after the prefix — both halves of
+# the parent-it-belongs-to contract verified at once.
+#
+# When a new family is added, register it here AND in ``URNBuilder.PATTERNS``
+# / ``URNBuilder.SEGMENT_COUNTS`` — this test will fail loudly if any of the
+# three drift apart.
+SPEC_3_2_TABLE = [
+    # (resource, expected_token_count_after_prefix, sample_urn)
+    ("wagon",    1, "wagon:auth"),
+    ("train",    1, "train:0001-self-compliance-validate"),
+    ("feature",  2, "feature:auth:session-management"),
+    ("wmbt",     2, "wmbt:auth:E001"),
+    ("acc",      2, "acc:auth:E001-UNIT-001"),
+    ("security", 3, "security:auth:session-management:001"),
+]
+
+
+@pytest.mark.parametrize("resource,expected_count,sample_urn", SPEC_3_2_TABLE)
+def test_urn_segment_count_table(resource, expected_count, sample_urn):
+    """SEGMENT_COUNTS, PATTERNS, and spec §3.2 stay in lockstep."""
+    # 1. SEGMENT_COUNTS matches the spec.
+    assert URNBuilder.SEGMENT_COUNTS[resource] == expected_count, (
+        f"SEGMENT_COUNTS[{resource!r}] does not match spec §3.2"
+    )
+
+    # 2. PATTERNS has an entry for this family.
+    assert resource in URNBuilder.PATTERNS, (
+        f"{resource!r} declared in SEGMENT_COUNTS but missing from PATTERNS"
+    )
+
+    # 3. The canonical sample URN is regex-valid for this family.
+    assert URNBuilder.validate_urn(sample_urn, resource), (
+        f"sample URN {sample_urn!r} does not validate as {resource!r}"
+    )
+
+    # 4. The canonical sample URN's actual token count matches the spec.
+    actual_tokens = len(sample_urn.split(":")) - 1
+    assert actual_tokens == expected_count, (
+        f"sample URN {sample_urn!r} has {actual_tokens} tokens after prefix, "
+        f"spec §3.2 requires {expected_count}"
+    )
+
+    # 5. validate_grammar() (the auto-detect entry point) accepts the sample.
+    assert URNBuilder.validate_grammar(sample_urn) is True
+
+
+def test_segment_counts_covers_documented_families():
+    """Every family in SPEC_3_2_TABLE must be declared in SEGMENT_COUNTS."""
+    documented = {name for name, _, _ in SPEC_3_2_TABLE}
+    declared = set(URNBuilder.SEGMENT_COUNTS)
+    missing = documented - declared
+    assert not missing, f"SEGMENT_COUNTS missing spec §3.2 families: {missing}"

--- a/src/atdd/coach/utils/graph/urn.py
+++ b/src/atdd/coach/utils/graph/urn.py
@@ -35,6 +35,34 @@ URN Patterns:
               - Wagon entrypoint:    component:{wagon}:wagon:{name}:{side}:assembly
               - Train infra:         component:trains:{feature}:{name}:{side}:assembly
 
+- security:   security:{wagon}:{feature-slug}:{NNN}
+              Example: security:auth:session-management:001
+              Pattern: ^security:[a-z][a-z0-9-]*:[a-z][a-z0-9-]*:[0-9]{3}$
+              Threat-seq: zero-padded to 3 digits (e.g. THREAT-1 -> 001, THREAT-42 -> 042)
+
+Parent-it-belongs-to principle (spec v12 §3.2)
+----------------------------------------------
+Each URN takes the form ``<resource>:<parent-coordinates>:<local-id>``, where
+``<parent-coordinates>`` may require multiple colon-separated tokens depending on
+how the parent is uniquely identified. URN segment count reflects the parent's
+identification cost — it is not a fixed scheme depth. New resource families
+register one entry in ``URNBuilder.PATTERNS`` and inherit the same convention
+without re-litigating per-type rules.
+
+Per-resource segment-count table (verbatim from spec §3.2):
+
+  | Resource                                  | Parent                  | Total tokens after the prefix |
+  | ----------------------------------------- | ----------------------- | ----------------------------- |
+  | wagon:<id>                                | none                    | 1                             |
+  | train:<id>                                | none                    | 1                             |
+  | feature:<wagon>:<slug>                    | wagon (1 token)         | 2                             |
+  | wmbt:<wagon>:<wmbt-id>                    | wagon (1 token)         | 2                             |
+  | acc:<wagon>:<wmbt-id>-<harness>-<seq>     | WMBT (collapses)        | 2                             |
+  | security:<wagon>:<feature-slug>:<seq>     | feature (2 tokens)      | 3                             |
+
+The machine-readable mirror of this table is ``URNBuilder.SEGMENT_COUNTS``;
+``test_urn_segment_count_table`` parametrizes over both to keep them in lockstep.
+
 Usage:
     from utils.graph import URNBuilder
     # or
@@ -146,9 +174,25 @@ class URNBuilder:
         'table': r'^table:[a-z0-9_]+$',
         'team': r'^team:[a-z0-9-]+$',
 
+        # Security artifacts (spec v12 §3.2: parent = feature, 3 tokens)
+        'security': r'^security:[a-z][a-z0-9-]*:[a-z][a-z0-9-]*:[0-9]{3}$',
+
         # Release management
         'train': r'^train:\d{4}-[a-z0-9][a-z0-9-]*$',
         'migration': r'^migration:\d{14}_[a-z][a-z0-9_]*$',
+    }
+
+    # Per-resource segment-count table (spec v12 §3.2 parent-it-belongs-to).
+    # Token count = number of colon-separated tokens AFTER the resource prefix.
+    # Adding a new family REQUIRES adding an entry here in lockstep with PATTERNS;
+    # ``test_urn_segment_count_table`` enforces parity.
+    SEGMENT_COUNTS = {
+        'wagon':    1,  # parent: none
+        'train':    1,  # parent: none
+        'feature':  2,  # parent: wagon (1 token)
+        'wmbt':     2,  # parent: wagon (1 token)
+        'acc':      2,  # parent: WMBT collapses into local-id segment
+        'security': 3,  # parent: feature (2 tokens) + threat-seq
     }
 
     @classmethod
@@ -158,6 +202,52 @@ class URNBuilder:
         if not pattern:
             raise ValueError(f"Unknown entity type: {entity_type}")
         return bool(re.match(pattern, urn))
+
+    @classmethod
+    def validate_grammar(cls, urn: str) -> bool:
+        """Validate a URN against the parent-it-belongs-to grammar (spec §3.2).
+
+        Auto-detects the resource family from the prefix before the first
+        ``:``. Returns ``True`` if the URN matches the registered pattern for
+        that family. Raises ``ValueError`` with a clear, actionable message
+        when:
+
+        - the prefix is not a registered resource type, or
+        - the segment count does not match ``SEGMENT_COUNTS`` for that family.
+
+        This is the public entry point for the substrate spec's parent-it-
+        belongs-to principle: every ``security:`` URN is a 3-token URN; every
+        ``feature:`` URN is a 2-token URN; etc. Adding a new family means
+        registering one ``PATTERNS`` entry plus one ``SEGMENT_COUNTS`` entry,
+        not editing this method.
+        """
+        if not isinstance(urn, str) or ':' not in urn:
+            raise ValueError(f"Malformed URN (missing prefix): {urn!r}")
+
+        prefix = urn.split(':', 1)[0]
+        if prefix not in cls.PATTERNS:
+            known = ', '.join(sorted(cls.PATTERNS))
+            raise ValueError(
+                f"unknown resource type: {prefix!r} in URN {urn!r}. "
+                f"Known resource types: {known}"
+            )
+
+        # Segment-count check (parent-it-belongs-to). Only enforced for
+        # families with a declared expected count; other families (test,
+        # contract, telemetry, plan, endpoint, ...) keep their existing
+        # regex-only validation.
+        expected = cls.SEGMENT_COUNTS.get(prefix)
+        if expected is not None:
+            actual = len(urn.split(':')) - 1  # tokens AFTER the prefix
+            if actual != expected:
+                raise ValueError(
+                    f"{prefix!r} URN has wrong segment count: expected "
+                    f"{expected} token{'s' if expected != 1 else ''} after "
+                    f"'{prefix}:' per parent-it-belongs-to principle "
+                    f"(spec §3.2), got {actual} in {urn!r}"
+                )
+
+        return cls.validate_urn(urn, prefix)
 
     @classmethod
     def wagon(cls, wagon_id: str) -> str:
@@ -218,6 +308,82 @@ class URNBuilder:
             raise ValueError(f"Generated invalid feature URN: {urn}")
 
         return urn
+
+    @classmethod
+    def security(cls, wagon_id: str, feature_slug: str, threat_seq) -> str:
+        """
+        Build a security URN (spec v12 §3.2, parent = feature).
+
+        Args:
+            wagon_id: The grandparent wagon identifier
+            feature_slug: The parent feature slug (kebab-case)
+            threat_seq: Threat sequence — accepts an int (1..999), a 1-3 digit
+                string, or a ``THREAT-<n>`` style id (case-insensitive). The
+                numeric tail is zero-padded to three digits. ``THREAT-1`` -> "001",
+                ``THREAT-42`` -> "042", ``"7"`` -> "007".
+
+        Returns:
+            URN in format: security:{wagon}:{feature_slug}:{NNN}
+
+        Examples:
+            URNBuilder.security("auth", "session-management", "001")
+            -> "security:auth:session-management:001"
+
+            URNBuilder.security("auth", "session-management", "THREAT-1")
+            -> "security:auth:session-management:001"
+        """
+        wagon_id = cls._normalize_id(wagon_id)
+        feature_slug = cls._normalize_id(feature_slug)
+
+        if not re.match(r'^[a-z][a-z0-9-]*$', wagon_id):
+            raise ValueError(f"Invalid wagon ID for security: {wagon_id}")
+        if not re.match(r'^[a-z][a-z0-9-]*$', feature_slug):
+            raise ValueError(f"Invalid feature slug for security: {feature_slug}")
+
+        seq_str = cls._normalize_threat_seq(threat_seq)
+
+        urn = f"security:{wagon_id}:{feature_slug}:{seq_str}"
+
+        if not cls.validate_urn(urn, 'security'):
+            raise ValueError(f"Generated invalid security URN: {urn}")
+
+        return urn
+
+    @classmethod
+    def _normalize_threat_seq(cls, threat_seq) -> str:
+        """Normalize a threat-seq value to a zero-padded 3-digit string.
+
+        Accepts int, digit-only string, or ``THREAT-<n>`` style id
+        (case-insensitive). Rejects values whose numeric tail is <1 or >999.
+        """
+        if isinstance(threat_seq, bool):  # bool is a subclass of int; reject explicitly
+            raise TypeError("threat_seq must be an int or string, got bool")
+
+        if isinstance(threat_seq, int):
+            value = threat_seq
+        elif isinstance(threat_seq, str):
+            cleaned = threat_seq.strip()
+            if not cleaned:
+                raise ValueError("threat_seq cannot be empty")
+
+            match = re.fullmatch(r'(?i)threat[-_]?(\d+)', cleaned)
+            if match:
+                value = int(match.group(1))
+            elif re.fullmatch(r'\d+', cleaned):
+                value = int(cleaned)
+            else:
+                raise ValueError(
+                    f"Invalid threat_seq: {threat_seq!r}. Must be int, digits, or THREAT-<n>."
+                )
+        else:
+            raise TypeError(f"threat_seq must be int or string, got {type(threat_seq).__name__}")
+
+        if value < 1 or value > 999:
+            raise ValueError(
+                f"threat_seq numeric tail must be between 1 and 999 (got {value})"
+            )
+
+        return f"{value:03d}"
 
     @classmethod
     def wmbt(cls, wagon_id: str, sequence: str) -> str:
@@ -926,6 +1092,21 @@ class URNBuilder:
                 'component_name': parts[2] if len(parts) > 2 else None,
                 'side': parts[3] if len(parts) > 3 else None,
                 'layer': parts[4] if len(parts) > 4 else None
+            }
+        elif urn.startswith('security:'):
+            parts = urn[len('security:'):].split(':')
+            expected = cls.SEGMENT_COUNTS['security']
+            if len(parts) != expected:
+                raise ValueError(
+                    f"Invalid security URN segment count: expected {expected} "
+                    f"tokens after 'security:' (wagon, feature_slug, threat_seq), "
+                    f"got {len(parts)} in {urn!r}"
+                )
+            return {
+                'type': 'security',
+                'wagon_id': parts[0],
+                'feature_id': parts[1],
+                'threat_seq': parts[2],
             }
         else:
             raise ValueError(f"Unknown URN type: {urn}")


### PR DESCRIPTION
Closes #420

## Summary

Substrate Track G Workstream A item A.3 + A.4 — adds the `security:` URN family and operationalizes the spec v12 §3.2 *parent-it-belongs-to* principle.

- New URN family `security:<wagon>:<feature-slug>:<NNN>` (3 tokens, parent = feature). Threat-seq is zero-padded to 3 digits; accepts int, digit-string, or `THREAT-<n>` form (cross-coupled with #419 resolver: `THREAT-1` → `001`).
- `URNBuilder.security(wagon, feature_slug, threat_seq)` builder, `parse_urn` extension, regex registration in `URNBuilder.PATTERNS`.
- New `URNBuilder.SEGMENT_COUNTS` table — machine-readable mirror of spec §3.2. Adding a new family means adding one PATTERNS entry + one SEGMENT_COUNTS entry, never editing the validator body.
- New `URNBuilder.validate_grammar(urn)` auto-detects the resource family from the prefix and raises clear, actionable errors ("`<resource>` URN has wrong segment count: expected N tokens after '<resource>:' per parent-it-belongs-to principle (spec §3.2)" / "unknown resource type").
- Module docstring at the top of `urn.py` carries the verbatim spec §3.2 segment-count table and a paragraph explaining the principle, where every URN family is already enumerated.

## Tests

- 60 new tests in `src/atdd/coach/utils/graph/tests/test_urn_security_grammar.py` covering the builder, parser, regex validator, `validate_grammar` auto-detect, and a parametrized table-parity test that asserts `SEGMENT_COUNTS`, `PATTERNS`, and the spec §3.2 table stay in lockstep (one assertion per family — extending requires touching all three together).
- All 73 graph tests pass; URN-consumer tests (`test_urn_traceability`, `test_urn_spec_v3`, `test_urn_graph_edge_type_exclude_default`) still pass — no regressions.

## Version bump

3.3.3 → 3.4.0 (MINOR — new public builder method, new validator entry point, new URN family).

## Test plan

- [x] `pytest src/atdd/coach/utils/graph/tests/` — 73/73 pass
- [x] `URNBuilder.security("auth", "session-management", "001")` round-trips through `parse_urn` and `validate_urn`
- [x] `URNBuilder.security("auth", "session-management", "THREAT-42")` → `"security:auth:session-management:042"`
- [x] `validate_grammar("zaphod:foo")` → ValueError("unknown resource type: 'zaphod' …")
- [x] `validate_grammar("security:auth:only-two")` → ValueError naming `security` and `3`