### PR TITLE
feat(coach): #408 — derive WMBT/train repo rules from acceptance URNs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.3.0"
+version = "3.4.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.4.0"
+version = "3.4.3"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/utils/graph/resolver.py
+++ b/src/atdd/coach/utils/graph/resolver.py
@@ -410,11 +410,19 @@ class AcceptanceResolver(BaseResolver):
         )
 
     def find_declarations(self) -> List[URNDeclaration]:
-        """Find all acceptance URN declarations in WMBT files."""
+        """Find all acceptance URN declarations in WMBT and train YAML files.
+
+        WMBT acceptances live under ``plan/<wagon>/[DLPCEMYRK]NNN.yaml``.
+        Train acceptances live under ``plan/_trains/<train-id>.yaml`` (substrate
+        spec v12 §5.2). Both sources contribute ``acc:`` URN declarations.
+        """
         declarations = []
         if not self.plan_dir.exists():
             return declarations
 
+        import yaml
+
+        # WMBT acceptances: plan/<wagon>/[DLPCEMYRK]NNN.yaml
         wmbt_pattern = re.compile(r"^[DLPCEMYRK]\d{3}\.yaml$")
         for wagon_dir in self.plan_dir.iterdir():
             if not wagon_dir.is_dir() or wagon_dir.name.startswith("_"):
@@ -425,8 +433,6 @@ class AcceptanceResolver(BaseResolver):
                     continue
 
                 try:
-                    import yaml
-
                     with open(wmbt_file, "r", encoding="utf-8") as f:
                         data = yaml.safe_load(f)
                     if data and isinstance(data, dict):
@@ -438,7 +444,29 @@ class AcceptanceResolver(BaseResolver):
                                         urn=acc_urn,
                                         family=self.family,
                                         source_path=wmbt_file,
-                                        context="acceptance block",
+                                        context="WMBT acceptance block",
+                                    )
+                                )
+                except Exception:
+                    continue
+
+        # Train acceptances: plan/_trains/<train-id>.yaml
+        trains_dir = self.plan_dir / "_trains"
+        if trains_dir.is_dir():
+            for train_file in trains_dir.glob("*.yaml"):
+                try:
+                    with open(train_file, "r", encoding="utf-8") as f:
+                        data = yaml.safe_load(f)
+                    if data and isinstance(data, dict):
+                        for acc in data.get("acceptances", []) or []:
+                            acc_urn = acc.get("identity", {}).get("urn")
+                            if acc_urn and acc_urn.startswith("acc:"):
+                                declarations.append(
+                                    URNDeclaration(
+                                        urn=acc_urn,
+                                        family=self.family,
+                                        source_path=train_file,
+                                        context="train acceptance block",
                                     )
                                 )
                 except Exception:

--- a/src/atdd/coach/utils/graph/urn.py
+++ b/src/atdd/coach/utils/graph/urn.py
@@ -19,10 +19,13 @@ URN Patterns:
               Pattern: ^wmbt:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}$
               Step Codes: D=define, L=locate, P=prepare, C=confirm, E=execute, M=monitor, Y=modify, R=resolve, K=conclude
 
-- acceptance: acc:{wagon}:{wmbt_id}-{harness}-{NNN}[-{slug}]
-              Example: acc:authenticate-user:C004-E2E-019
-                       acc:maintain-ux:C004-E2E-019-user-connection
-              Pattern: ^acc:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}-(UNIT|HTTP|...)-[0-9]{3}(?:-[a-z0-9-]+)?$
+- acceptance: acc:{wagon}:{wmbt_id}-{harness}-{NNN}[-{slug}]   (WMBT shape)
+              acc:{train_id}:{acceptance-slug}                  (train shape, spec v12 §3.3)
+              Examples:
+                acc:authenticate-user:C004-E2E-019
+                acc:maintain-ux:C004-E2E-019-user-connection
+                acc:0001-self-compliance-validate:idempotent-on-retry
+              Pattern: ^acc:[a-z0-9][a-z0-9-]*:(WMBT-form|train-slug)$
 
 - component:  component:{wagon}:{feature}:{name}:{side}:{layer}
               Example: component:resolve-dilemmas:binary-choice:OptionValidator:backend:domain
@@ -138,7 +141,21 @@ class URNBuilder:
 
         # ATDD Specific
         'wmbt': r'^wmbt:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}$',
-        'acc': r'^acc:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?$',
+        # Two shapes (substrate spec v12 §3.3):
+        #   WMBT acceptance: acc:<wagon>:<WMBT-id>-<HARNESS>-<NNN>[-<slug>]
+        #   Train acceptance: acc:<train-id>:<acceptance-slug>  (free-form kebab slug)
+        # The wagon/train segment now allows a leading digit so train ids like
+        # "0001-self-compliance-validate" are accepted. WMBT alternative is
+        # listed first; train alternative requires the slug to NOT match the
+        # WMBT shape (covered by alternation order — WMBT branch consumes
+        # `[DLPCEMYRK]\d{3}-<HARNESS>-\d{3}` greedily before the train branch).
+        'acc': (
+            r'^acc:[a-z0-9][a-z0-9-]*:('
+            r'[DLPCEMYRK][0-9]{3}-(?:UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?'
+            r'|'
+            r'[a-z][a-z0-9-]*'
+            r')$'
+        ),
 
         # Resources
         'endpoint': r'^endpoint:[a-z0-9-]+\.(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\.[a-z0-9-/]+$',

--- a/src/atdd/coach/utils/rule_binding.py
+++ b/src/atdd/coach/utils/rule_binding.py
@@ -28,6 +28,7 @@ Related substrate:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
@@ -50,6 +51,17 @@ class AmbiguousRuleError(LookupError):
 
 class AmbiguousAliasError(LookupError):
     """Raised when a legacy alias collides with another rule's canonical id or alias."""
+
+
+class RepoYamlValidationError(ValueError):
+    """Raised when a repo plan/ YAML violates the substrate's structural rules.
+
+    Surfaces (a) ``disposition:`` declared in repo YAML (walker sets it per
+    spec v12 §4.4); (b) literal ``id:`` field at the top of an acceptance
+    block (rule-id is derived per §3.3 — declaring it is misleading);
+    (c) acceptance URN that fails ``URNBuilder.PATTERNS['acc']``;
+    (d) derived rule-id that fails the canonical-archetype + grammar check.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -230,27 +242,456 @@ def find_convention_files(
 
 
 # ---------------------------------------------------------------------------
+# Repo-rule walker (substrate spec v12 §3.3, §4.2, §4.3, §4.4 — issue #408)
+# ---------------------------------------------------------------------------
+# Pattern matching the WMBT-shaped acceptance body inside an `acc:` URN:
+#   <WMBT-id>-<HARNESS>-<NNN>(-<slug>)?
+# The HARNESS list mirrors URNBuilder.HARNESS_CODES.
+_WMBT_ACC_BODY_RE = re.compile(
+    r"^([DLPCEMYRK][0-9]{3})-"
+    r"(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|"
+    r"WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-"
+    r"([0-9]{3})(?:-([a-z0-9-]+))?$"
+)
+
+# Canonical rule-id grammar (mirrors
+# ``src/atdd/coach/validators/test_rule_id_uniqueness.py::RULE_ID_PATTERN``).
+# Repeated here so the walker can validate without circular-importing the
+# validator module.
+_RULE_ID_PATTERN = re.compile(
+    r"^[a-z][a-z0-9]*(-[a-z0-9]+)*\.[a-z][a-z0-9]*(-[a-z0-9]+)*\.[a-z][a-z0-9]*(-[a-z0-9]+)*$"
+)
+
+# Repo-derived rule-id grammar — looser than the toolkit grammar in the
+# rule-name segment to permit the WMBT step-letter prefix (e.g. ``D010-``)
+# that the spec example preserves verbatim. Still enforces:
+#   - archetype == "repo"
+#   - <wagon-or-train> is a kebab-case identifier (digit-leading allowed for
+#     train ids like 0001-self-compliance-validate)
+#   - rule-name body matches one of two derived shapes:
+#       (a) WMBT: ``<WMBT-id>-acc-<harness>-<NNN>``  (WMBT-id is uppercase
+#           step-letter + 3 digits; harness is lowercase)
+#       (b) Train: ``acc-<acceptance-slug>``         (kebab-case slug)
+_REPO_RULE_ID_PATTERN = re.compile(
+    r"^repo\.[a-z0-9][a-z0-9-]*\.("
+    r"[DLPCEMYRK][0-9]{3}-acc-(?:unit|http|event|ws|e2e|a11y|vis|metric|job|db|sec|load|script|widget|golden|bloc|integration|rls|edge|realtime|storage)-[0-9]{3}"
+    r"|"
+    r"acc-[a-z][a-z0-9-]*"
+    r")$"
+)
+
+
+def _yaml_path_str(parts: Tuple[object, ...]) -> str:
+    """Render a YAML key path tuple as a dotted string for error messages."""
+    return ".".join(str(p) for p in parts) if parts else "<root>"
+
+
+def _find_disposition_anywhere(
+    node, parts: Tuple[object, ...] = ()
+) -> Optional[Tuple[object, ...]]:
+    """Return the YAML path to the first ``disposition:`` key found, or None.
+
+    Repo YAML (WMBT and train acceptance files) MUST NOT declare
+    ``disposition:`` — the walker sets it to ``strict`` per spec v12 §4.4.
+    A declared ``disposition:`` is misleading because it suggests the value
+    is configurable when it is not.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "disposition":
+                return parts + (key,)
+            sub = _find_disposition_anywhere(value, parts + (key,))
+            if sub is not None:
+                return sub
+    elif isinstance(node, list):
+        for idx, item in enumerate(node):
+            sub = _find_disposition_anywhere(item, parts + (idx,))
+            if sub is not None:
+                return sub
+    return None
+
+
+def _derive_repo_rule_id(acc_urn: str) -> Tuple[str, str]:
+    """Derive ``(rule_id, parent_token)`` from an ``acc:`` URN per spec §3.3.
+
+    Returns a tuple of the canonical repo rule-id and the parent
+    wagon-or-train token. Raises ``RepoYamlValidationError`` when the URN
+    is malformed (this should already have been caught by URN validation
+    upstream — kept as a defensive belt to surface derivation bugs loudly).
+
+    Transformations (issue #408 derivation table):
+      - WMBT shape ``acc:<wagon>:<WMBT-id>-<HARNESS>-<seq>(-<slug>)?``
+        → ``repo.<wagon>.<WMBT-id>-acc-<harness>-<seq>``
+        (HARNESS lowercased; trailing slug dropped — original slug stays
+        on ``RuleMetadata.acceptance_urn``).
+      - Train shape ``acc:<train-id>:<acceptance-slug>``
+        → ``repo.<train-id>.acc-<acceptance-slug>``
+    """
+    if not isinstance(acc_urn, str) or not acc_urn.startswith("acc:"):
+        raise RepoYamlValidationError(
+            f"acc URN must start with 'acc:', got {acc_urn!r}"
+        )
+    parts = acc_urn.split(":", 2)
+    if len(parts) != 3:
+        raise RepoYamlValidationError(
+            f"acc URN must have shape 'acc:<parent>:<body>', got {acc_urn!r}"
+        )
+    _, parent, body = parts
+
+    wmbt_match = _WMBT_ACC_BODY_RE.match(body)
+    if wmbt_match:
+        wmbt_id, harness, seq, _slug = wmbt_match.groups()
+        rule_id = f"repo.{parent}.{wmbt_id}-acc-{harness.lower()}-{seq}"
+    else:
+        # Train shape: body is the acceptance slug.
+        rule_id = f"repo.{parent}.acc-{body}"
+    return rule_id, parent
+
+
+def _check_walker_invariants(acc: Dict) -> Optional[str]:
+    """Return None when the acceptance satisfies measurability + phase invariants.
+
+    Per spec v12 §4.3: each acceptance MUST declare ``identity.phase`` AND
+    EITHER ``harness.type`` (with a binding test) OR both
+    ``signal.metric`` and ``signal.threshold``. Acceptances failing either
+    invariant are silently skipped during walking — the substrate's
+    enforcement validators (Track B / Issue #410) surface the same fail
+    condition with a different rule-id, keeping the two-class-failure
+    model clean (§11).
+    """
+    identity = acc.get("identity") if isinstance(acc, dict) else None
+    if not isinstance(identity, dict) or not identity.get("phase"):
+        return "missing identity.phase"
+    harness = acc.get("harness") if isinstance(acc, dict) else None
+    has_harness = isinstance(harness, dict) and isinstance(harness.get("type"), str) and harness.get("type")
+    signal = acc.get("signal") if isinstance(acc, dict) else None
+    has_signal = (
+        isinstance(signal, dict)
+        and isinstance(signal.get("metric"), str)
+        and signal.get("metric")
+        and signal.get("threshold") is not None
+    )
+    if not has_harness and not has_signal:
+        return "missing harness.type and signal.metric+signal.threshold (one is required)"
+    return None
+
+
+def _compose_fix_hint(then_block) -> Optional[str]:
+    """Compose ``fix_hint`` from ``then.abstract`` items joined with ``; ``."""
+    if not isinstance(then_block, dict):
+        return None
+    abstract = then_block.get("abstract")
+    if isinstance(abstract, list):
+        items = [str(x).strip() for x in abstract if isinstance(x, (str, int, float)) and str(x).strip()]
+        if not items:
+            return None
+        return "; ".join(items)
+    if isinstance(abstract, str) and abstract.strip():
+        return abstract.strip()
+    return None
+
+
+def _passthrough_str(block, key) -> Optional[str]:
+    """Return ``block[key]`` when it is a non-empty string, else None."""
+    if not isinstance(block, dict):
+        return None
+    val = block.get(key)
+    if isinstance(val, (str, int, float)):
+        s = str(val).strip()
+        return s or None
+    if isinstance(val, list):
+        # Some authors pass given/when/then.abstract as list — render to string.
+        items = [str(x).strip() for x in val if isinstance(x, (str, int, float))]
+        return "; ".join(items) if items else None
+    return None
+
+
+def _passthrough_threshold(signal):
+    """Return ``signal.threshold`` as a string (preserves int/float/str)."""
+    if not isinstance(signal, dict):
+        return None
+    val = signal.get("threshold")
+    if val is None:
+        return None
+    return str(val)
+
+
+def _build_repo_rule_metadata(
+    acc: Dict,
+    file_path: Path,
+    parent_urn: Optional[str],
+    parent_kind: str,
+) -> "RuleMetadata":
+    """Construct RuleMetadata from a single repo acceptance block per §4.2.
+
+    Caller is responsible for invariant + structural validation. This helper
+    only does field population.
+    """
+    identity = acc.get("identity", {}) or {}
+    acc_urn = identity.get("urn", "")
+    rule_id, _parent_token = _derive_repo_rule_id(acc_urn)
+
+    description = ""
+    purpose = identity.get("purpose")
+    if isinstance(purpose, (str, int, float)):
+        description = str(purpose).strip()
+
+    harness = acc.get("harness") if isinstance(acc, dict) else None
+    signal = acc.get("signal") if isinstance(acc, dict) else None
+    has_signal = (
+        isinstance(signal, dict)
+        and isinstance(signal.get("metric"), str)
+        and signal.get("threshold") is not None
+    )
+
+    # Validator: signal mode → toolkit-shipped metric runner; harness-only →
+    # None (the anchored test function can't be derived statically from YAML
+    # alone — surfaced when the substrate runner machinery lands).
+    validator: Optional[str] = None
+    if has_signal:
+        validator = "test_metric_runner::test_metric_threshold_satisfied"
+
+    metadata_block = acc.get("metadata") if isinstance(acc, dict) else None
+
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=4,  # walker-set constant per §4.2
+        description=description,
+        recipe=None,  # acceptance rules have no recipe pointer (§4.2 close)
+        introduced_in=None,
+        source_path=file_path.resolve(),
+        disposition="strict",  # walker-set constant per §4.4
+        validator=validator,
+        fix_hint=_compose_fix_hint(acc.get("then")),
+        aliases=(),
+        acceptance_urn=acc_urn,
+        wmbt_urn=parent_urn if parent_kind == "wmbt" else None,
+        train_urn=parent_urn if parent_kind == "train" else None,
+        phase=identity.get("phase") if isinstance(identity.get("phase"), str) else None,
+        harness_type=_passthrough_str(harness, "type"),
+        harness_category=_passthrough_str(harness, "category"),
+        signal_metric=_passthrough_str(signal, "metric"),
+        signal_threshold=_passthrough_threshold(signal),
+        given=_passthrough_str(acc.get("given"), "abstract"),
+        when=_passthrough_str(acc.get("when"), "abstract"),
+        then=_passthrough_str(acc.get("then"), "abstract"),
+        author=_passthrough_str(metadata_block, "author"),
+        created=_passthrough_str(metadata_block, "created"),
+    )
+
+
+def _train_urn_from_file(data: Dict, train_file: Path) -> str:
+    """Derive ``train:<id>`` URN from a parent train YAML.
+
+    Train files declare ``train_id:`` rather than ``urn:``. Falls back to
+    the file stem so a missing field still produces a usable parent URN
+    (consistent with TrainResolver.find_declarations).
+    """
+    train_id = data.get("train_id") if isinstance(data, dict) else None
+    if not isinstance(train_id, str) or not train_id:
+        train_id = train_file.stem
+    return f"train:{train_id}"
+
+
+def _walk_repo_acceptance_file(
+    file_path: Path, parent_kind: str
+) -> Iterable["RuleMetadata"]:
+    """Read one repo YAML and yield RuleMetadata for each valid acceptance.
+
+    Raises ``RepoYamlValidationError`` for structural violations
+    (disposition declared, top-level ``id:`` in acceptance, malformed URN,
+    derivation produces a non-conforming rule-id). Silently skips
+    acceptances that fail the §4.3 walker invariants — those are surfaced
+    by Track B substrate validators.
+    """
+    # Defer URNBuilder import to walk-time so the module loads even when
+    # the graph package is not yet importable (avoids import cycles in
+    # validators that import rule_binding at module-import time).
+    from atdd.coach.utils.graph.urn import URNBuilder
+
+    try:
+        with open(file_path) as fh:
+            data = yaml.safe_load(fh)
+    except (OSError, yaml.YAMLError) as exc:
+        raise RepoYamlValidationError(
+            f"unreadable repo YAML at {file_path}: {exc}"
+        )
+    if not isinstance(data, dict):
+        return
+
+    # (1) Reject disposition: anywhere in the file (§4.4).
+    bad = _find_disposition_anywhere(data)
+    if bad is not None:
+        raise RepoYamlValidationError(
+            f"{file_path}: declared 'disposition:' at YAML path "
+            f"'{_yaml_path_str(bad)}' — repo YAML must not declare disposition; "
+            f"the walker sets it to 'strict' per spec v12 §4.4."
+        )
+
+    acceptances = data.get("acceptances")
+    if not isinstance(acceptances, list):
+        return
+
+    parent_urn: Optional[str]
+    if parent_kind == "wmbt":
+        urn_field = data.get("urn")
+        parent_urn = urn_field if isinstance(urn_field, str) else None
+    elif parent_kind == "train":
+        parent_urn = _train_urn_from_file(data, file_path)
+    else:
+        parent_urn = None
+
+    for idx, acc in enumerate(acceptances):
+        if not isinstance(acc, dict):
+            continue
+
+        # (2) Reject top-level id: field on the acceptance block (§3.3 —
+        # rule-id derives from identity.urn; declaring id: is misleading).
+        if "id" in acc:
+            raise RepoYamlValidationError(
+                f"{file_path}: acceptance at acceptances[{idx}] declares a "
+                f"top-level 'id:' field — rule-id is derived from identity.urn "
+                f"per spec v12 §3.3. Remove the top-level 'id:' (identity.id "
+                f"is the human-facing label and is allowed)."
+            )
+
+        identity = acc.get("identity") or {}
+        if not isinstance(identity, dict):
+            continue
+        acc_urn = identity.get("urn")
+        if not isinstance(acc_urn, str) or not acc_urn:
+            # No URN: nothing to derive. Substrate enforcement (Track B)
+            # surfaces this separately.
+            continue
+
+        # (3) Acceptance URN must match URNBuilder.PATTERNS['acc']. Per the
+        # spec, "failure of (a) is a parent-graph problem caught by
+        # `atdd repo validate`" — so the walker SKIPS malformed-URN
+        # acceptances rather than failing loud on the whole registry build.
+        # The substrate enforcement validator (Track B / Issue #410)
+        # surfaces the URN violation separately.
+        if not URNBuilder.validate_urn(acc_urn, "acc"):
+            continue
+
+        # (4) Walker invariant: phase + (harness OR signal+threshold).
+        invariant_err = _check_walker_invariants(acc)
+        if invariant_err is not None:
+            # Silent skip — substrate enforcement surfaces this separately.
+            continue
+
+        meta = _build_repo_rule_metadata(acc, file_path, parent_urn, parent_kind)
+
+        # (5) Derived rule-id must satisfy the canonical-archetype check
+        # AND match the repo-rule grammar. Failure here means a derivation
+        # bug — fail loudly with the offending URN and derivation output.
+        archetype = meta.rule_id.split(".", 1)[0]
+        canonical_archetypes = {"coder", "coach", "tester", "planner", "repo"}
+        if archetype not in canonical_archetypes:
+            raise RepoYamlValidationError(
+                f"{file_path}: derivation produced rule-id {meta.rule_id!r} "
+                f"with archetype {archetype!r} not in {sorted(canonical_archetypes)}."
+            )
+        if not _REPO_RULE_ID_PATTERN.match(meta.rule_id):
+            raise RepoYamlValidationError(
+                f"{file_path}: derivation produced rule-id {meta.rule_id!r} "
+                f"that does not match the repo-rule grammar "
+                f"(expected 'repo.<wagon|train>.(<WMBT-id>-acc-<harness>-<NNN>|"
+                f"acc-<slug>)'). Source URN: {acc_urn!r}."
+            )
+
+        yield meta
+
+
+def find_repo_rules(
+    repo_root: Optional[Path] = None,
+) -> List[Tuple[Path, "RuleMetadata"]]:
+    """Walk ``<repo>/plan/`` and derive RuleMetadata from every acceptance.
+
+    Substrate spec v12 §4.2/§4.3/§4.4 — peer to ``find_convention_files``.
+    The two walkers share a registry index but discover from disjoint
+    sources: ``find_convention_files`` finds ``*.convention.yaml`` (toolkit
+    rules), this function finds ``plan/<wagon>/[DLPCEMYRK]NNN.yaml`` (WMBT
+    acceptances) and ``plan/_trains/<train-id>.yaml`` (train acceptances).
+
+    Each acceptance contributes one ``RuleMetadata`` with:
+      - ``rule_id`` derived from ``identity.urn`` per §3.3.
+      - ``severity = 4`` (walker-set constant).
+      - ``disposition = "strict"`` (walker-set constant per §4.4).
+      - All other fields populated per §4.2.
+
+    Acceptances failing the walker invariants (missing ``identity.phase``
+    or missing both harness.type AND signal.metric+threshold) are silently
+    skipped — Track B substrate validators surface them separately.
+
+    Raises ``RepoYamlValidationError`` for structural violations:
+      - ``disposition:`` declared anywhere in repo YAML (§4.4).
+      - Literal top-level ``id:`` field on an acceptance block (§3.3).
+      - Acceptance URN failing ``URNBuilder.PATTERNS['acc']``.
+      - Derivation producing a rule-id that fails repo grammar.
+
+    Returns a list of ``(source_path, metadata)`` tuples. Order is
+    deterministic by file path.
+    """
+    from atdd.coach.utils.repo import find_repo_root as _find_repo_root
+
+    root = Path(repo_root).resolve() if repo_root is not None else _find_repo_root()
+    plan_dir = root / "plan"
+    if not plan_dir.is_dir():
+        return []
+
+    results: List[Tuple[Path, RuleMetadata]] = []
+
+    # WMBT acceptances: plan/<wagon>/[DLPCEMYRK]NNN.yaml
+    wmbt_pattern = re.compile(r"^[DLPCEMYRK]\d{3}\.yaml$")
+    for wagon_dir in sorted(plan_dir.iterdir()):
+        if not wagon_dir.is_dir() or wagon_dir.name.startswith("_"):
+            continue
+        for wmbt_file in sorted(wagon_dir.glob("*.yaml")):
+            if not wmbt_pattern.match(wmbt_file.name):
+                continue
+            for meta in _walk_repo_acceptance_file(wmbt_file, parent_kind="wmbt"):
+                results.append((wmbt_file, meta))
+
+    # Train acceptances: plan/_trains/<train-id>.yaml
+    trains_dir = plan_dir / "_trains"
+    if trains_dir.is_dir():
+        for train_file in sorted(trains_dir.glob("*.yaml")):
+            for meta in _walk_repo_acceptance_file(train_file, parent_kind="train"):
+                results.append((train_file, meta))
+
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Registry cache
 # ---------------------------------------------------------------------------
 # rule_id -> [RuleMetadata, ...] (length > 1 means ambiguous)
 _REGISTRY_CACHE: Optional[Dict[str, List[RuleMetadata]]] = None
 _OVERRIDE_ROOTS: Optional[List[Path]] = None
+_OVERRIDE_REPO_ROOT: Optional[Path] = None
 
 
-def clear_cache(*, override_roots: Optional[Iterable[Path]] = None) -> None:
+def clear_cache(
+    *,
+    override_roots: Optional[Iterable[Path]] = None,
+    override_repo_root: Optional[Path] = None,
+) -> None:
     """Drop the cached registry.
 
     Test-only hook.  Pass ``override_roots=[...]`` to seed the next
     ``bind_rule`` call against fixture conventions instead of the live
-    toolkit tree.  Pass nothing (or ``override_roots=None``) to reset to the
+    toolkit tree.  Pass ``override_repo_root=Path(...)`` to point the
+    repo-rule walker (issue #408) at a fixture ``plan/`` tree instead of
+    the live consumer repo. Pass nothing (or ``=None``) to reset to the
     default search roots.
     """
-    global _REGISTRY_CACHE, _OVERRIDE_ROOTS
+    global _REGISTRY_CACHE, _OVERRIDE_ROOTS, _OVERRIDE_REPO_ROOT
     _REGISTRY_CACHE = None
     if override_roots is None:
         _OVERRIDE_ROOTS = None
     else:
         _OVERRIDE_ROOTS = [Path(p) for p in override_roots]
+    _OVERRIDE_REPO_ROOT = Path(override_repo_root) if override_repo_root is not None else None
 
 
 def _load_registry() -> Dict[str, List[RuleMetadata]]:
@@ -333,6 +774,25 @@ def _load_registry() -> Dict[str, List[RuleMetadata]]:
                 # bind_rule(alias) resolves to the canonical rule.
                 if alias != rid:
                     registry.setdefault(alias, []).append(meta)
+
+    # Repo-rule walker (substrate spec v12 §4.2 — issue #408). Merges into
+    # the same registry index so bind_rule resolves both toolkit-convention
+    # and repo-derived rules through one path. Cross-source collisions
+    # raise AmbiguousRuleError at lookup time (existing behavior).
+    repo_root = _OVERRIDE_REPO_ROOT
+    if repo_root is None and _OVERRIDE_ROOTS is None:
+        # Live mode: walk the consumer repo's plan/ tree.
+        from atdd.coach.utils.repo import find_repo_root
+
+        repo_root = find_repo_root()
+    # When override_roots is set (test mode pointing at fixture conventions)
+    # we DO NOT also walk a live plan/ — tests must explicitly opt in by
+    # passing override_repo_root. This keeps fixture-based convention tests
+    # hermetic from the consumer repo's plan/ contents.
+    if repo_root is not None:
+        for _src_path, repo_meta in find_repo_rules(repo_root):
+            registry.setdefault(repo_meta.rule_id, []).append(repo_meta)
+
     return registry
 
 
@@ -393,11 +853,13 @@ def get_canonical_id(rule_id: str) -> str:
 __all__ = [
     "AmbiguousAliasError",
     "AmbiguousRuleError",
+    "RepoYamlValidationError",
     "RuleMetadata",
     "RuleNotInRegistryError",
     "bind_rule",
     "clear_cache",
     "extract_rules",
     "find_convention_files",
+    "find_repo_rules",
     "get_canonical_id",
 ]

--- a/src/atdd/coach/utils/tests/test_repo_rule_walker.py
+++ b/src/atdd/coach/utils/tests/test_repo_rule_walker.py
@@ -1,0 +1,413 @@
+# URN: urn:atdd:test:coach:utils:rule_binding:repo_walker
+# Issue: #408
+
+"""Unit tests for the repo-rule walker (substrate spec v12 §3.3 / §4.2 / §4.3 / §4.4).
+
+Coverage:
+
+* Rule-ID derivation from WMBT acceptance URNs (harness lowering, slug drop).
+* Rule-ID derivation from train acceptance URNs (free-form slug preserved).
+* RuleMetadata field population (severity=4, disposition=strict, fix_hint
+  composition, phase passthrough, acceptance/wmbt/train URN discriminators).
+* Walker invariant skip (missing phase, missing harness+signal).
+* Loud failure on declared ``disposition:`` and on top-level acceptance ``id:``.
+* Live integration: the walker finds at least one rule under the toolkit's
+  own ``plan/`` directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+pytestmark = [pytest.mark.platform]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    from atdd.coach.utils.rule_binding import clear_cache
+
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.fixture
+def fixture_repo(tmp_path: Path) -> Path:
+    """Create a stand-in consumer repo rooted at ``tmp_path``."""
+    (tmp_path / "plan").mkdir()
+    (tmp_path / "plan" / "_trains").mkdir()
+    return tmp_path
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(body).lstrip(), encoding="utf-8")
+    return path
+
+
+# WMBT body shared across multiple tests so each YAML is < 25 lines.
+_WMBT_D010 = """
+    urn: "wmbt:govern-lifecycle:D010"
+    step: "define"
+    direction: "minimize"
+    dimension: "quantity"
+    object_of_control: "duplicated-hardcoded-theme-map-dicts-across-modules"
+    context_clarifier: "fixture file mirroring the live D010.yaml"
+    lens: "functional.sustainability"
+    statement: "minimize duplicated hardcoded theme_map literals"
+    acceptances:
+      - identity:
+          urn: "acc:govern-lifecycle:D010-UNIT-001-single-source-theme-map-helper"
+          id: "AC-UNIT-001"
+          purpose: "A single get_theme_map(config) helper replaces every hardcoded theme_map dict in the codebase"
+          phase: "GREEN"
+        harness:
+          type: "unit"
+          category: "backend"
+        given:
+          abstract: ["coach/utils/theme_map.py exposes get_theme_map(config) returning merged defaults + overrides"]
+        when:
+          abstract: "A grep for hardcoded theme_map dict literals runs across src/atdd"
+        then:
+          abstract:
+            - "No theme_map dict literal appears outside coach/utils/theme_map.py"
+            - "inventory.py, registry.py, and test_train_validation.py import and call get_theme_map"
+            - "The helper is the single source of truth for the digit-to-theme mapping"
+        signal:
+          metric: "hardcoded_theme_map_literal_count"
+          threshold: 0
+        metadata:
+          author: "atdd:self-compliance"
+          created: "2026-04-17"
+"""
+
+
+# ---------------------------------------------------------------------------
+# WMBT-shape derivation
+# ---------------------------------------------------------------------------
+def test_walker_derives_rule_id_from_wmbt_acceptance_urn(fixture_repo: Path):
+    """WMBT acceptance URN derives to ``repo.<wagon>.<WMBT>-acc-<harness>-<seq>``.
+
+    Spec v12 §3.3 derivation: harness code lowered, trailing slug dropped,
+    WMBT step-letter prefix preserved verbatim.
+    """
+    from atdd.coach.utils.rule_binding import find_repo_rules
+
+    _write(fixture_repo / "plan" / "govern_lifecycle" / "D010.yaml", _WMBT_D010)
+
+    results = find_repo_rules(fixture_repo)
+    assert len(results) == 1
+    src, meta = results[0]
+    assert src.name == "D010.yaml"
+    assert meta.rule_id == "repo.govern-lifecycle.D010-acc-unit-001"
+
+
+def test_walker_populates_rule_metadata_from_d010(fixture_repo: Path):
+    """RuleMetadata population matches §4.2 acceptance table for the D010 fixture."""
+    from atdd.coach.utils.rule_binding import bind_rule, clear_cache
+
+    _write(fixture_repo / "plan" / "govern_lifecycle" / "D010.yaml", _WMBT_D010)
+    clear_cache(override_repo_root=fixture_repo)
+
+    meta = bind_rule("repo.govern-lifecycle.D010-acc-unit-001")
+    # Walker-set constants (§4.2 / §4.4).
+    assert meta.severity == 4
+    assert meta.disposition == "strict"
+    assert meta.recipe is None  # acceptance rules carry no recipe pointer
+    # Identity passthrough.
+    assert meta.description == (
+        "A single get_theme_map(config) helper replaces every hardcoded "
+        "theme_map dict in the codebase"
+    )
+    assert meta.phase == "GREEN"
+    # Discriminator URNs.
+    assert meta.acceptance_urn == (
+        "acc:govern-lifecycle:D010-UNIT-001-single-source-theme-map-helper"
+    )
+    assert meta.wmbt_urn == "wmbt:govern-lifecycle:D010"
+    assert meta.train_urn is None
+    # Context fields.
+    assert meta.harness_type == "unit"
+    assert meta.harness_category == "backend"
+    assert meta.signal_metric == "hardcoded_theme_map_literal_count"
+    assert meta.signal_threshold == "0"
+    assert meta.author == "atdd:self-compliance"
+    assert meta.created == "2026-04-17"
+
+
+def test_walker_composes_fix_hint_from_then_abstract(fixture_repo: Path):
+    """``fix_hint`` is ``then.abstract`` items joined with ``"; "`` (§4.2)."""
+    from atdd.coach.utils.rule_binding import bind_rule, clear_cache
+
+    _write(fixture_repo / "plan" / "govern_lifecycle" / "D010.yaml", _WMBT_D010)
+    clear_cache(override_repo_root=fixture_repo)
+
+    meta = bind_rule("repo.govern-lifecycle.D010-acc-unit-001")
+    assert meta.fix_hint == (
+        "No theme_map dict literal appears outside coach/utils/theme_map.py; "
+        "inventory.py, registry.py, and test_train_validation.py import and call get_theme_map; "
+        "The helper is the single source of truth for the digit-to-theme mapping"
+    )
+
+
+def test_walker_drops_trailing_slug_from_wmbt_urn(fixture_repo: Path):
+    """Trailing slug on WMBT acc URN is dropped from rule-id; preserved on metadata."""
+    from atdd.coach.utils.rule_binding import find_repo_rules
+
+    _write(
+        fixture_repo / "plan" / "foo_wagon" / "D001.yaml",
+        """
+        urn: "wmbt:foo-wagon:D001"
+        step: define
+        direction: minimize
+        dimension: quantity
+        object_of_control: thing
+        context_clarifier: ctx
+        lens: functional.sustainability
+        statement: stmt
+        acceptances:
+          - identity:
+              urn: "acc:foo-wagon:D001-HTTP-007-very-long-readability-slug-here"
+              purpose: "purpose"
+              phase: "RED"
+            harness: { type: http }
+        """,
+    )
+
+    results = find_repo_rules(fixture_repo)
+    assert len(results) == 1
+    _, meta = results[0]
+    assert meta.rule_id == "repo.foo-wagon.D001-acc-http-007"
+    assert meta.acceptance_urn.endswith("very-long-readability-slug-here")
+
+
+# ---------------------------------------------------------------------------
+# Train-shape derivation
+# ---------------------------------------------------------------------------
+_TRAIN_FIXTURE = """
+    train_id: "0001-self-compliance-validate"
+    title: "Self-compliance validation train"
+    description: "Fixture train carrying acceptances for the walker test."
+    themes: ["commons"]
+    participants: ["wagon:govern-lifecycle"]
+    sequence:
+      - step: 1
+        intent: "validate the toolkit against itself"
+        from: "system:external"
+        to: "wagon:govern-lifecycle"
+        artifact: "atdd:self-validate"
+    acceptances:
+      - identity:
+          urn: "acc:0001-self-compliance-validate:idempotent-on-retry"
+          purpose: "Re-running the train with the same idempotency key produces no duplicate side effects"
+          phase: "SMOKE"
+        harness:
+          type: "e2e"
+        signal:
+          metric: "duplicate_side_effects_on_retry"
+          threshold: 0
+"""
+
+
+def test_walker_derives_rule_from_train_fixture(fixture_repo: Path):
+    """Train acceptance URN derives to ``repo.<train-id>.acc-<slug>``.
+
+    Per spec v12 §3.3 second derivation row. Acceptance criterion for #408
+    relaxed from "real train YAML" to "FIXTURE train YAML" — see issue body.
+    """
+    from atdd.coach.utils.rule_binding import bind_rule, clear_cache
+
+    _write(
+        fixture_repo / "plan" / "_trains" / "0001-self-compliance-validate.yaml",
+        _TRAIN_FIXTURE,
+    )
+    clear_cache(override_repo_root=fixture_repo)
+
+    meta = bind_rule("repo.0001-self-compliance-validate.acc-idempotent-on-retry")
+    assert meta.rule_id == "repo.0001-self-compliance-validate.acc-idempotent-on-retry"
+    assert meta.severity == 4
+    assert meta.disposition == "strict"
+    assert meta.phase == "SMOKE"
+    assert meta.train_urn == "train:0001-self-compliance-validate"
+    assert meta.wmbt_urn is None
+    assert meta.harness_type == "e2e"
+    assert meta.signal_metric == "duplicate_side_effects_on_retry"
+
+
+# ---------------------------------------------------------------------------
+# Walker invariants (§4.3) — silent skip
+# ---------------------------------------------------------------------------
+def test_walker_skips_acceptance_missing_phase(fixture_repo: Path):
+    """An acceptance without ``identity.phase`` is silently dropped."""
+    from atdd.coach.utils.rule_binding import find_repo_rules
+
+    _write(
+        fixture_repo / "plan" / "wagon" / "D001.yaml",
+        """
+        urn: "wmbt:wagon:D001"
+        acceptances:
+          - identity:
+              urn: "acc:wagon:D001-UNIT-001"
+              purpose: "missing phase"
+            harness: { type: unit }
+        """,
+    )
+
+    assert find_repo_rules(fixture_repo) == []
+
+
+def test_walker_skips_acceptance_missing_harness_and_signal(fixture_repo: Path):
+    """Acceptance with neither ``harness.type`` nor ``signal.metric+threshold`` skipped."""
+    from atdd.coach.utils.rule_binding import find_repo_rules
+
+    _write(
+        fixture_repo / "plan" / "wagon" / "D002.yaml",
+        """
+        urn: "wmbt:wagon:D002"
+        acceptances:
+          - identity:
+              urn: "acc:wagon:D002-UNIT-001"
+              purpose: "no harness or signal"
+              phase: "GREEN"
+        """,
+    )
+
+    assert find_repo_rules(fixture_repo) == []
+
+
+def test_walker_accepts_signal_only_acceptance(fixture_repo: Path):
+    """Signal-mode acceptance (no harness.type) still produces a rule."""
+    from atdd.coach.utils.rule_binding import find_repo_rules
+
+    _write(
+        fixture_repo / "plan" / "wagon" / "D003.yaml",
+        """
+        urn: "wmbt:wagon:D003"
+        acceptances:
+          - identity:
+              urn: "acc:wagon:D003-METRIC-001"
+              purpose: "signal-only"
+              phase: "REFACTOR"
+            signal:
+              metric: "thing_count"
+              threshold: 0
+        """,
+    )
+
+    results = find_repo_rules(fixture_repo)
+    assert len(results) == 1
+    _, meta = results[0]
+    assert meta.harness_type is None
+    assert meta.signal_metric == "thing_count"
+    assert meta.validator == "test_metric_runner::test_metric_threshold_satisfied"
+
+
+# ---------------------------------------------------------------------------
+# Loud failures (§4.4 disposition; §3.3 forbidden id:)
+# ---------------------------------------------------------------------------
+def test_walker_rejects_disposition_field_in_repo_yaml(fixture_repo: Path):
+    """Repo YAML may not declare ``disposition:`` (walker sets it per §4.4)."""
+    from atdd.coach.utils.rule_binding import RepoYamlValidationError, find_repo_rules
+
+    bad = _write(
+        fixture_repo / "plan" / "wagon" / "D001.yaml",
+        """
+        urn: "wmbt:wagon:D001"
+        acceptances:
+          - identity:
+              urn: "acc:wagon:D001-UNIT-001"
+              purpose: "p"
+              phase: "GREEN"
+            harness: { type: unit }
+            disposition: "advisory"
+        """,
+    )
+
+    with pytest.raises(RepoYamlValidationError) as exc:
+        find_repo_rules(fixture_repo)
+    msg = str(exc.value)
+    assert str(bad) in msg
+    assert "disposition" in msg
+
+
+def test_walker_rejects_top_level_id_in_acceptance_block(fixture_repo: Path):
+    """A literal top-level ``id:`` on an acceptance entry fails registry build."""
+    from atdd.coach.utils.rule_binding import RepoYamlValidationError, find_repo_rules
+
+    bad = _write(
+        fixture_repo / "plan" / "wagon" / "D001.yaml",
+        """
+        urn: "wmbt:wagon:D001"
+        acceptances:
+          - id: "manually-set-rule-id"
+            identity:
+              urn: "acc:wagon:D001-UNIT-001"
+              purpose: "p"
+              phase: "GREEN"
+            harness: { type: unit }
+        """,
+    )
+
+    with pytest.raises(RepoYamlValidationError) as exc:
+        find_repo_rules(fixture_repo)
+    msg = str(exc.value)
+    assert str(bad) in msg
+    assert "id" in msg
+
+
+def test_walker_skips_acceptance_with_malformed_urn(fixture_repo: Path):
+    """An acceptance whose URN fails URNBuilder.PATTERNS['acc'] is skipped.
+
+    Per the spec issue text: "failure of (a) [URN pattern] is a parent-graph
+    problem caught by `atdd repo validate`" — so the walker silently skips
+    the offending acceptance instead of failing the whole registry build.
+    """
+    from atdd.coach.utils.rule_binding import find_repo_rules
+
+    _write(
+        fixture_repo / "plan" / "wagon" / "D001.yaml",
+        """
+        urn: "wmbt:wagon:D001"
+        acceptances:
+          - identity:
+              urn: "acc:wagon:D001-NOTAHARNESS-001"
+              purpose: "malformed"
+              phase: "GREEN"
+            harness: { type: unit }
+        """,
+    )
+
+    assert find_repo_rules(fixture_repo) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration against toolkit's own plan/
+# ---------------------------------------------------------------------------
+def test_walker_finds_rules_in_toolkit_self_plan():
+    """Pointing the walker at the toolkit checkout produces a non-empty registry.
+
+    Smoke check that ``find_repo_rules`` works against real ATDD plan/ data
+    rather than only fixtures. Asserts presence of both WMBT-derived rules
+    and at least one rule per known wagon directory currently shipping
+    structured acceptances.
+    """
+    from atdd.coach.utils.repo import find_repo_root
+    from atdd.coach.utils.rule_binding import find_repo_rules
+
+    repo_root = find_repo_root()
+    plan_dir = repo_root / "plan"
+    if not plan_dir.is_dir():
+        pytest.skip("no plan/ in this checkout")
+
+    results = find_repo_rules(repo_root)
+    assert len(results) > 0, "walker found no rules under live plan/"
+    rule_ids = {meta.rule_id for _src, meta in results}
+    # Every derived rule starts with the repo archetype (§3.1 / §3.3).
+    assert all(rid.startswith("repo.") for rid in rule_ids)

--- a/src/atdd/planner/conventions/train.convention.yaml
+++ b/src/atdd/planner/conventions/train.convention.yaml
@@ -191,6 +191,34 @@ numbering:
     variation_digits: "Position 2-3: Variation within category (01-99)"
     name_part: "kebab-case descriptive name"
 
+# Train-level acceptances (substrate spec v12 §5.2)
+# Optional block — when present, each acceptance contributes a derived rule
+# to the registry via the repo-rule walker (atdd.coach.utils.rule_binding.find_repo_rules).
+acceptances:
+  optional: true
+  shape: "Mirrors the WMBT acceptance shape (see planner/conventions/acceptance.convention.yaml)."
+  rule_id_derivation: "Per spec v12 §3.3: acc:<train-id>:<slug> -> repo.<train-id>.acc-<slug>"
+  required_invariants:
+    - "identity.urn matches URNBuilder.PATTERNS['acc'] (train-acceptance shape)"
+    - "identity.purpose populated (becomes RuleMetadata.description)"
+    - "identity.phase populated (RED|GREEN|SMOKE|REFACTOR)"
+    - "EITHER harness.type OR (signal.metric AND signal.threshold) populated (measurability invariant §4.3)"
+  forbidden_fields:
+    - "id: at acceptance-block top level (rule-id derives mechanically — see §3.3)"
+    - "disposition: anywhere in repo YAML (walker sets to 'strict' per §4.4)"
+  example: |
+    acceptances:
+      - identity:
+          urn: "acc:0001-self-compliance-validate:idempotent-on-retry"
+          id: "AC-SMOKE-001"
+          purpose: "Re-running the train with the same idempotency key produces no duplicate side effects"
+          phase: "SMOKE"
+        harness:
+          type: "e2e"
+        signal:
+          metric: "duplicate_side_effects_on_retry"
+          threshold: 0
+
 # URN naming pattern
 urn_naming:
   pattern: "train:{train_id}"

--- a/src/atdd/planner/schemas/train.schema.json
+++ b/src/atdd/planner/schemas/train.schema.json
@@ -188,9 +188,75 @@
       "items": {
         "$ref": "#/definitions/step"
       }
+    },
+    "acceptances": {
+      "type": "array",
+      "description": "Train-level acceptance criteria. Mirror of the WMBT acceptance shape (substrate spec v12 §5.2). Each entry contributes a derived rule to the registry via the repo-rule walker — the rule-id derives from identity.urn per §3.3, so the acceptance block MUST NOT include an id: field at the top level (the per-acceptance identity.id field is allowed for human reference).",
+      "items": {
+        "$ref": "#/definitions/acceptance"
+      }
     }
   },
   "definitions": {
+    "acceptance": {
+      "type": "object",
+      "required": ["identity"],
+      "additionalProperties": true,
+      "properties": {
+        "identity": {
+          "type": "object",
+          "required": ["urn", "purpose", "phase"],
+          "additionalProperties": true,
+          "properties": {
+            "urn": {
+              "type": "string",
+              "description": "Acceptance URN: acc:<train-id>:<acceptance-slug>"
+            },
+            "id": {
+              "type": "string",
+              "description": "Optional human-facing label (e.g. AC-SMOKE-001). NOT used for rule-id derivation."
+            },
+            "purpose": {
+              "type": "string",
+              "minLength": 5,
+              "description": "One-line statement of what this acceptance enforces (becomes RuleMetadata.description)."
+            },
+            "phase": {
+              "type": "string",
+              "enum": ["RED", "GREEN", "SMOKE", "REFACTOR"],
+              "description": "ATDD lifecycle phase the acceptance dispatches to."
+            }
+          }
+        },
+        "harness": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "type": {"type": "string"},
+            "category": {"type": "string"}
+          }
+        },
+        "given": {"type": "object"},
+        "when": {"type": "object"},
+        "then": {"type": "object"},
+        "signal": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "metric": {"type": "string"},
+            "threshold": {}
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "author": {"type": "string"},
+            "created": {"type": "string"}
+          }
+        }
+      }
+    },
     "step": {
       "type": "object",
       "required": ["step", "intent", "from", "to", "artifact"],


### PR DESCRIPTION
Closes #408.

Implements substrate Track A wave 2 (spec v12 §3.3 / §4.2 / §4.3 / §4.4):
the registry walker now derives one rule per WMBT/train acceptance, so
acceptance criteria become first-class enforcement artifacts.

## What ships

- **`find_repo_rules(repo_root)`** — peer to `find_convention_files`, in
  `src/atdd/coach/utils/rule_binding.py`. Walks
  `<repo>/plan/<wagon>/[DLPCEMYRK]NNN.yaml` (WMBT acceptances) and
  `<repo>/plan/_trains/<train-id>.yaml` (train acceptances). Each
  acceptance yields one `RuleMetadata`.
- **`_load_registry()` integration** — repo rules merge into the same
  registry index as toolkit conventions; `bind_rule()` resolves both.
  Cross-source collisions raise the existing `AmbiguousRuleError`.
- **`URNBuilder.PATTERNS['acc']` extension** — accepts the train-shape
  `acc:<train-id>:<acceptance-slug>` alongside the existing WMBT shape.
  Wagon/train segment now allows a leading digit so train ids like
  `0001-self-compliance-validate` parse.
- **`AcceptanceResolver.find_declarations`** — also walks `plan/_trains/`
  (previously skipped any directory starting with `_`).
- **`train.schema.json` + `train.convention.yaml`** — optional
  `acceptances:` block mirroring the WMBT acceptance shape.

## Rule-ID derivation (§3.3)

| Source URN                                                              | Derived rule-ID                            |
|-------------------------------------------------------------------------|--------------------------------------------|
| `acc:govern-lifecycle:D010-UNIT-001-single-source-theme-map-helper`     | `repo.govern-lifecycle.D010-acc-unit-001`  |
| `acc:0001-self-compliance-validate:idempotent-on-retry`                 | `repo.0001-self-compliance-validate.acc-idempotent-on-retry` |

WMBT shape: harness lowered (`UNIT` → `unit`), trailing slug dropped
(original slug preserved on `RuleMetadata.acceptance_urn`). Train shape:
free-form slug preserved verbatim.

## Field population (§4.2)

- `severity = 4`, `disposition = "strict"` (walker-set constants).
- `description` from `identity.purpose`.
- `fix_hint` from `then.abstract` joined with `"; "`.
- `phase` from `identity.phase`; `acceptance_urn`/`wmbt_urn`/`train_urn`
  populated by source.
- Context fields (`harness_type`, `harness_category`, `signal_metric`,
  `signal_threshold`, `given`/`when`/`then`, `author`, `created`)
  passthrough.
- `recipe = None` for acceptance rules (§4.2 close: contracts not
  implementations).

## Walker invariants (§4.3)

For each acceptance the walker checks `identity.phase` AND
(`harness.type` OR `signal.metric` + `signal.threshold`). Failures are
silently skipped — the substrate enforcement validators (Track B /
Issue #410) surface them as conformance failures separately.

## Loud failures

- `disposition:` declared anywhere in repo YAML → `RepoYamlValidationError`
  (the walker sets it per §4.4).
- Literal top-level `id:` on an acceptance block → `RepoYamlValidationError`
  (rule-id derives mechanically — declaring it is misleading).
- Derived rule-id failing canonical-archetype check or repo-rule grammar →
  `RepoYamlValidationError` (derivation bug surface).

Malformed `acc:` URNs that fail `URNBuilder.PATTERNS['acc']` are
silently skipped — per the spec this is "a parent-graph problem caught
by `atdd repo validate`", not a walker fail-loud condition.

## Tests

`src/atdd/coach/utils/tests/test_repo_rule_walker.py` — 12 cases
covering D010 derivation, fix_hint composition, slug-drop, train fixture,
walker invariant skips, loud disposition/id rejection, malformed-URN
skip, and live integration against the toolkit's own `plan/`.

## Test plan

- [x] `pytest src/atdd/coach/utils/tests/test_repo_rule_walker.py` — all 12 pass
- [x] `pytest src/atdd/coach/utils/tests/test_rule_binding.py` — 18 pass (no regressions)
- [x] `pytest src/atdd/coach/validators/test_rule_id_uniqueness.py` — passes
- [x] Live: walker finds 69 rules under the toolkit's own `plan/`
- [x] `bind_rule("repo.govern-lifecycle.D010-acc-unit-001").description` matches
- [x] `bind_rule("repo.govern-lifecycle.D010-acc-unit-001").fix_hint` matches §4.2 composition

15 pre-existing failures on main (babysit classifier, GitHub-integration
tests, release tag check) are unaffected by this PR.