### PR TITLE
feat(coach): #409 — repo rule discovery CLI (atdd rules + atdd urn rule listings)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.4.3"
+version = "3.4.5"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -1311,6 +1311,120 @@ Phase descriptions:
         help="Maximum depth for subgraph (-1 for unlimited)"
     )
 
+    # atdd urn rules — list every repo-derived rule grouped by parent URN
+    urn_rules_parser = urn_subparsers.add_parser(
+        "rules",
+        help="List all repo rules derived from plan/ acceptances",
+    )
+    urn_rules_parser.add_argument(
+        "--format", "-f",
+        type=str,
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    # atdd urn wmbt-rules <wmbt-urn>
+    urn_wmbt_rules_parser = urn_subparsers.add_parser(
+        "wmbt-rules",
+        help="List repo rules derived from a WMBT URN",
+    )
+    urn_wmbt_rules_parser.add_argument(
+        "wmbt_urn",
+        type=str,
+        help="WMBT URN (e.g. wmbt:govern-lifecycle:D010)",
+    )
+    urn_wmbt_rules_parser.add_argument(
+        "--format", "-f",
+        type=str,
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    # atdd urn train-rules <train-urn>
+    urn_train_rules_parser = urn_subparsers.add_parser(
+        "train-rules",
+        help="List repo rules derived from a train URN",
+    )
+    urn_train_rules_parser.add_argument(
+        "train_urn",
+        type=str,
+        help="Train URN (e.g. train:0001-self-compliance-validate)",
+    )
+    urn_train_rules_parser.add_argument(
+        "--format", "-f",
+        type=str,
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    # ----- atdd rules {show,where,grep} (substrate spec v12 §9.2 — issue #409) -----
+    rules_parser = subparsers.add_parser(
+        "rules",
+        help="Inspect the merged rule registry (toolkit + repo-derived)",
+        description=(
+            "Inspect rules registered in the merged registry. Combines "
+            "toolkit conventions and repo-derived acceptance rules from plan/."
+        ),
+    )
+    rules_subparsers = rules_parser.add_subparsers(
+        dest="rules_command",
+        help="rules commands",
+    )
+
+    rules_show_parser = rules_subparsers.add_parser(
+        "show",
+        help="Print the bound RuleMetadata for a rule-id",
+    )
+    rules_show_parser.add_argument(
+        "rule_id",
+        type=str,
+        help="Canonical rule-id or legacy alias",
+    )
+    rules_show_parser.add_argument(
+        "--format", "-f",
+        type=str,
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    rules_where_parser = rules_subparsers.add_parser(
+        "where",
+        help="Print the rule's source path and YAML location",
+    )
+    rules_where_parser.add_argument(
+        "rule_id",
+        type=str,
+        help="Canonical rule-id or legacy alias",
+    )
+    rules_where_parser.add_argument(
+        "--format", "-f",
+        type=str,
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    rules_grep_parser = rules_subparsers.add_parser(
+        "grep",
+        help="Filter rule-ids/descriptions by regex",
+    )
+    rules_grep_parser.add_argument(
+        "pattern",
+        type=str,
+        help="Regex matched against rule_id and description",
+    )
+    rules_grep_parser.add_argument(
+        "--format", "-f",
+        type=str,
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
     # ----- Legacy flag-based arguments (deprecated, kept for backwards compatibility) -----
 
     # Repository root override (not deprecated - still useful)
@@ -1894,9 +2008,36 @@ Phase descriptions:
                 families=args.families,
                 max_depth=args.depth,
             )
+        elif args.urn_command in ("rules", "wmbt-rules", "train-rules"):
+            from atdd.coach.commands.rules import RepoRulesListing
+
+            listing = RepoRulesListing()
+            if args.urn_command == "rules":
+                return listing.list_all_repo_rules(format=args.format)
+            if args.urn_command == "wmbt-rules":
+                return listing.list_rules_for_wmbt(
+                    args.wmbt_urn, format=args.format
+                )
+            return listing.list_rules_for_train(
+                args.train_urn, format=args.format
+            )
         else:
             urn_parser.print_help()
             return 0
+
+    # atdd rules {show,where,grep}
+    elif args.command == "rules":
+        from atdd.coach.commands.rules import RulesCommand
+
+        rules_cmd = RulesCommand()
+        if args.rules_command == "show":
+            return rules_cmd.show(args.rule_id, format=args.format)
+        if args.rules_command == "where":
+            return rules_cmd.where(args.rule_id, format=args.format)
+        if args.rules_command == "grep":
+            return rules_cmd.grep(args.pattern, format=args.format)
+        rules_parser.print_help()
+        return 0
 
     # ----- Handle deprecated flag-based commands -----
 

--- a/src/atdd/coach/commands/rules.py
+++ b/src/atdd/coach/commands/rules.py
@@ -1,0 +1,296 @@
+# URN: component:govern-lifecycle:enforcement-substrate:rules_cli:backend:application
+# Runtime: python
+# Purpose: CLI command handler for `atdd rules {show,where,grep}` and the repo-rule listing peers under `atdd urn`.
+
+"""``atdd rules`` and ``atdd urn {rules,wmbt-rules,train-rules}`` handlers.
+
+Substrate spec v12 §9.2 — surface the merged rule registry to humans.
+
+Three ``atdd rules`` subcommands:
+
+* ``atdd rules show <rule-id>`` — print the bound ``RuleMetadata`` (toolkit
+  or repo).
+* ``atdd rules where <rule-id>`` — print the rule's source path (and YAML
+  location for repo rules — the ``acceptance_urn`` it was derived from).
+* ``atdd rules grep <pattern>`` — list every rule whose id or description
+  matches the regex.
+
+Three ``atdd urn`` listing peers (Track-A landing surface; Issue #414
+renames ``atdd urn`` to ``atdd repo`` wholesale):
+
+* ``atdd urn rules`` — every repo rule, grouped by parent URN.
+* ``atdd urn wmbt-rules <wmbt-urn>`` — rules derived from one WMBT.
+* ``atdd urn train-rules <train-urn>`` — rules derived from one train.
+
+Implementation iterates the merged registry exposed by
+``atdd.coach.utils.rule_binding.iter_rules`` so toolkit conventions and
+repo-derived acceptance rules appear through one path (#408 walker).
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from atdd.coach.utils.rule_binding import (
+    AmbiguousRuleError,
+    RuleMetadata,
+    RuleNotInRegistryError,
+    bind_rule,
+    iter_rules,
+)
+
+
+def _meta_to_dict(meta: RuleMetadata) -> dict:
+    """Render ``RuleMetadata`` as a JSON-serializable dict.
+
+    ``source_path`` is a ``Path`` and ``aliases`` is a tuple — neither
+    serializes via the default encoder, so cast both. ``fix_hint_ref``
+    is a derived property, not a dataclass field, so add it explicitly.
+    """
+    out = asdict(meta)
+    out["source_path"] = str(meta.source_path)
+    out["aliases"] = list(meta.aliases)
+    out["fix_hint_ref"] = meta.fix_hint_ref
+    return out
+
+
+def _print_metadata_text(meta: RuleMetadata) -> None:
+    """Render a single ``RuleMetadata`` in human-readable form."""
+    print(f"rule_id:           {meta.rule_id}")
+    print(f"severity:          {meta.severity}")
+    print(f"description:       {meta.description}")
+    print(f"disposition:       {meta.disposition}")
+    print(f"recipe:            {meta.recipe}")
+    print(f"introduced_in:     {meta.introduced_in}")
+    print(f"validator:         {meta.validator}")
+    print(f"fix_hint_ref:      {meta.fix_hint_ref}")
+    print(f"fix_hint:          {meta.fix_hint}")
+    if meta.aliases:
+        print(f"aliases:           {', '.join(meta.aliases)}")
+    print(f"source_path:       {meta.source_path}")
+    # Substrate-added discriminator / authoring context fields. Print only
+    # the ones that are populated so toolkit rules (None on every field)
+    # stay terse.
+    substrate_fields = [
+        ("acceptance_urn", meta.acceptance_urn),
+        ("wmbt_urn", meta.wmbt_urn),
+        ("train_urn", meta.train_urn),
+        ("security_urn", meta.security_urn),
+        ("feature_urn", meta.feature_urn),
+        ("phase", meta.phase),
+        ("harness_type", meta.harness_type),
+        ("harness_category", meta.harness_category),
+        ("signal_metric", meta.signal_metric),
+        ("signal_threshold", meta.signal_threshold),
+        ("given", meta.given),
+        ("when", meta.when),
+        ("then", meta.then),
+        ("author", meta.author),
+        ("created", meta.created),
+    ]
+    populated = [(k, v) for (k, v) in substrate_fields if v is not None]
+    if populated:
+        print()
+        print("Substrate context:")
+        for key, value in populated:
+            print(f"  {key:<18} {value}")
+
+
+class RulesCommand:
+    """Handler for ``atdd rules {show,where,grep}``.
+
+    Stateless — the registry walker is cached at the rule_binding layer.
+    """
+
+    def show(self, rule_id: str, format: str = "text") -> int:
+        """Print the bound ``RuleMetadata`` for *rule_id*.
+
+        Resolves through ``bind_rule`` so canonical ids and legacy aliases
+        both work. Exits non-zero when the rule is unregistered or
+        ambiguous (declared in two places — a registry-level fault, not a
+        user fault, but surfaced here so the CLI is honest about it).
+        """
+        try:
+            meta = bind_rule(rule_id)
+        except RuleNotInRegistryError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        except AmbiguousRuleError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
+        if format == "json":
+            print(json.dumps(_meta_to_dict(meta), indent=2))
+        else:
+            _print_metadata_text(meta)
+        return 0
+
+    def where(self, rule_id: str, format: str = "text") -> int:
+        """Print the rule's source path (and YAML location, if applicable).
+
+        For toolkit rules the YAML location is the ``*.convention.yaml``
+        path. For repo-derived rules (Track-A walker) the source path is
+        the WMBT or train YAML, AND the ``acceptance_urn`` discriminator
+        is printed so callers can grep the file for the matching block.
+        """
+        try:
+            meta = bind_rule(rule_id)
+        except RuleNotInRegistryError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        except AmbiguousRuleError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
+        if format == "json":
+            output = {
+                "rule_id": meta.rule_id,
+                "source_path": str(meta.source_path),
+                "acceptance_urn": meta.acceptance_urn,
+            }
+            print(json.dumps(output, indent=2))
+        else:
+            print(f"rule_id:        {meta.rule_id}")
+            print(f"source_path:    {meta.source_path}")
+            if meta.acceptance_urn is not None:
+                print(f"acceptance_urn: {meta.acceptance_urn}")
+        return 0
+
+    def grep(self, pattern: str, format: str = "text") -> int:
+        """List rules whose id or description matches *pattern* (regex)."""
+        try:
+            regex = re.compile(pattern)
+        except re.error as exc:
+            print(f"Error: invalid regex {pattern!r}: {exc}", file=sys.stderr)
+            return 1
+
+        matches: List[RuleMetadata] = []
+        for meta in iter_rules():
+            if regex.search(meta.rule_id) or regex.search(meta.description or ""):
+                matches.append(meta)
+
+        if format == "json":
+            print(json.dumps(
+                [_meta_to_dict(m) for m in matches], indent=2
+            ))
+            return 0 if matches else 1
+
+        if not matches:
+            print(f"No rules matched pattern {pattern!r}.")
+            return 1
+        for meta in matches:
+            print(f"{meta.rule_id}")
+            if meta.description:
+                print(f"    {meta.description}")
+        print()
+        print(f"Total: {len(matches)} rule(s) matched.")
+        return 0
+
+
+def _filter_repo_rules(rules: Iterable[RuleMetadata]) -> List[RuleMetadata]:
+    """Return only repo-derived rules from *rules* (archetype=='repo')."""
+    return [m for m in rules if m.rule_id.startswith("repo.")]
+
+
+def _print_repo_rule_line(meta: RuleMetadata, indent: int = 2) -> None:
+    """Render ``rule_id`` (+ optional acceptance URN) for repo-rule listings."""
+    pad = " " * indent
+    print(f"{pad}{meta.rule_id}")
+    if meta.acceptance_urn:
+        print(f"{pad}  └─ {meta.acceptance_urn}")
+
+
+class RepoRulesListing:
+    """Handler for the repo-rule listing peers under ``atdd urn``.
+
+    Lives next to ``RulesCommand`` rather than inside ``URNCommand`` so
+    the consumer (the CLI dispatcher) can hold one rule-aware command.
+    Issue #414 renames ``atdd urn`` to ``atdd repo`` wholesale; this
+    handler carries over unchanged.
+    """
+
+    def list_all_repo_rules(self, format: str = "text") -> int:
+        """``atdd urn rules`` — every repo rule, grouped by parent URN."""
+        repo_rules = _filter_repo_rules(iter_rules())
+
+        if format == "json":
+            print(json.dumps(
+                [_meta_to_dict(m) for m in repo_rules], indent=2
+            ))
+            return 0
+
+        if not repo_rules:
+            print("No repo rules derived from plan/.")
+            return 0
+
+        # Group by parent: WMBT URN if present, else train URN, else "<unknown>".
+        groups: dict = {}
+        for meta in repo_rules:
+            parent = meta.wmbt_urn or meta.train_urn or "<unknown>"
+            groups.setdefault(parent, []).append(meta)
+
+        for parent in sorted(groups.keys()):
+            metas = sorted(groups[parent], key=lambda m: m.rule_id)
+            print(f"{parent} ({len(metas)} rule{'s' if len(metas) != 1 else ''}):")
+            for meta in metas:
+                _print_repo_rule_line(meta)
+            print()
+        print(f"Total: {len(repo_rules)} repo rule(s) across {len(groups)} parent(s).")
+        return 0
+
+    def list_rules_for_wmbt(self, wmbt_urn: str, format: str = "text") -> int:
+        """``atdd urn wmbt-rules <wmbt-urn>`` — rules derived from one WMBT."""
+        if not wmbt_urn.startswith("wmbt:"):
+            print(
+                f"Error: expected WMBT URN starting with 'wmbt:', got {wmbt_urn!r}",
+                file=sys.stderr,
+            )
+            return 1
+
+        matches = [
+            m for m in _filter_repo_rules(iter_rules()) if m.wmbt_urn == wmbt_urn
+        ]
+
+        if format == "json":
+            print(json.dumps([_meta_to_dict(m) for m in matches], indent=2))
+            return 0 if matches else 1
+
+        if not matches:
+            print(f"No repo rules derived from {wmbt_urn}.")
+            return 1
+        print(f"{wmbt_urn} ({len(matches)} rule(s)):")
+        for meta in sorted(matches, key=lambda m: m.rule_id):
+            _print_repo_rule_line(meta)
+        return 0
+
+    def list_rules_for_train(self, train_urn: str, format: str = "text") -> int:
+        """``atdd urn train-rules <train-urn>`` — rules derived from one train."""
+        if not train_urn.startswith("train:"):
+            print(
+                f"Error: expected train URN starting with 'train:', got {train_urn!r}",
+                file=sys.stderr,
+            )
+            return 1
+
+        matches = [
+            m for m in _filter_repo_rules(iter_rules()) if m.train_urn == train_urn
+        ]
+
+        if format == "json":
+            print(json.dumps([_meta_to_dict(m) for m in matches], indent=2))
+            return 0 if matches else 1
+
+        if not matches:
+            print(f"No repo rules derived from {train_urn}.")
+            return 1
+        print(f"{train_urn} ({len(matches)} rule(s)):")
+        for meta in sorted(matches, key=lambda m: m.rule_id):
+            _print_repo_rule_line(meta)
+        return 0
+
+
+__all__ = ["RulesCommand", "RepoRulesListing"]

--- a/src/atdd/coach/commands/rules.py
+++ b/src/atdd/coach/commands/rules.py
@@ -116,10 +116,10 @@ class RulesCommand:
         """
         try:
             meta = bind_rule(rule_id)
-        except RuleNotInRegistryError as exc:
+        except RuleNotInRegistryError as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
             print(f"Error: {exc}", file=sys.stderr)
             return 1
-        except AmbiguousRuleError as exc:
+        except AmbiguousRuleError as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
             print(f"Error: {exc}", file=sys.stderr)
             return 1
 
@@ -139,10 +139,10 @@ class RulesCommand:
         """
         try:
             meta = bind_rule(rule_id)
-        except RuleNotInRegistryError as exc:
+        except RuleNotInRegistryError as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
             print(f"Error: {exc}", file=sys.stderr)
             return 1
-        except AmbiguousRuleError as exc:
+        except AmbiguousRuleError as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
             print(f"Error: {exc}", file=sys.stderr)
             return 1
 
@@ -164,7 +164,7 @@ class RulesCommand:
         """List rules whose id or description matches *pattern* (regex)."""
         try:
             regex = re.compile(pattern)
-        except re.error as exc:
+        except re.error as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
             print(f"Error: invalid regex {pattern!r}: {exc}", file=sys.stderr)
             return 1
 

--- a/src/atdd/coach/commands/tests/test_rules_cli.py
+++ b/src/atdd/coach/commands/tests/test_rules_cli.py
@@ -1,0 +1,436 @@
+# URN: urn:atdd:test:coach:commands:rules_cli
+# Issue: #409
+
+"""Unit tests for ``atdd rules`` and the ``atdd urn`` repo-rule listings.
+
+Substrate spec v12 §9.2 — surface the merged rule registry to humans.
+
+Coverage:
+
+* ``atdd rules show <rule-id>`` (toolkit + repo, alias resolution, JSON,
+  unknown-id error path).
+* ``atdd rules where <rule-id>`` (source path + acceptance URN).
+* ``atdd rules grep <pattern>`` (id-match, description-match, no-match).
+* ``atdd urn rules`` (lists every repo rule, grouped by parent).
+* ``atdd urn wmbt-rules <wmbt-urn>`` (single-WMBT filter).
+* ``atdd urn train-rules <train-urn>`` (single-train filter).
+
+The fixture builds a tmp-path consumer repo with two WMBT acceptances and
+one train acceptance, then drives the registry through
+``clear_cache(override_repo_root=...)`` so the tests are hermetic from the
+toolkit's own ``plan/`` tree.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+
+pytestmark = [pytest.mark.platform]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    from atdd.coach.utils.rule_binding import clear_cache
+
+    clear_cache()
+    yield
+    clear_cache()
+
+
+_WMBT_D010 = """
+    urn: "wmbt:govern-lifecycle:D010"
+    step: "define"
+    direction: "minimize"
+    dimension: "quantity"
+    object_of_control: "duplicated-hardcoded-theme-map-dicts-across-modules"
+    context_clarifier: "fixture mirroring D010.yaml"
+    lens: "functional.sustainability"
+    statement: "minimize duplicated hardcoded theme_map literals"
+    acceptances:
+      - identity:
+          urn: "acc:govern-lifecycle:D010-UNIT-001-single-source-theme-map-helper"
+          id: "AC-UNIT-001"
+          purpose: "A single get_theme_map(config) helper replaces every hardcoded theme_map dict"
+          phase: "GREEN"
+        harness:
+          type: "unit"
+          category: "backend"
+        given:
+          abstract: ["coach/utils/theme_map.py exposes get_theme_map(config)"]
+        when:
+          abstract: "A grep for hardcoded theme_map dict literals runs across src/atdd"
+        then:
+          abstract:
+            - "No theme_map dict literal appears outside coach/utils/theme_map.py"
+        signal:
+          metric: "hardcoded_theme_map_literal_count"
+          threshold: 0
+"""
+
+
+_WMBT_D001 = """
+    urn: "wmbt:foo-wagon:D001"
+    step: "define"
+    direction: "minimize"
+    dimension: "quantity"
+    object_of_control: "thing"
+    context_clarifier: "ctx"
+    lens: "functional.sustainability"
+    statement: "stmt"
+    acceptances:
+      - identity:
+          urn: "acc:foo-wagon:D001-HTTP-007-readability-slug"
+          purpose: "HTTP harness acceptance for grammar coverage"
+          phase: "RED"
+        harness: { type: http }
+"""
+
+
+_TRAIN_FIXTURE = """
+    train_id: "0001-self-compliance-validate"
+    title: "Self-compliance validation train"
+    description: "Fixture train carrying acceptances for the rules CLI test."
+    themes: ["commons"]
+    participants: ["wagon:govern-lifecycle"]
+    sequence:
+      - step: 1
+        intent: "validate the toolkit against itself"
+        from: "system:external"
+        to: "wagon:govern-lifecycle"
+        artifact: "atdd:self-validate"
+    acceptances:
+      - identity:
+          urn: "acc:0001-self-compliance-validate:idempotent-on-retry"
+          purpose: "Re-running the train with the same idempotency key is idempotent"
+          phase: "SMOKE"
+        harness:
+          type: "e2e"
+        signal:
+          metric: "duplicate_side_effects_on_retry"
+          threshold: 0
+"""
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dedent(body).lstrip(), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def fixture_repo(tmp_path: Path) -> Path:
+    """A tmp-path consumer repo seeded with WMBT + train acceptances.
+
+    Layout:
+      plan/govern_lifecycle/D010.yaml   (signal mode — `theme_map` rule)
+      plan/foo_wagon/D001.yaml          (harness-only http acceptance)
+      plan/_trains/0001-self-compliance-validate.yaml (train acceptance)
+    """
+    (tmp_path / "plan").mkdir()
+    (tmp_path / "plan" / "_trains").mkdir()
+    _write(tmp_path / "plan" / "govern_lifecycle" / "D010.yaml", _WMBT_D010)
+    _write(tmp_path / "plan" / "foo_wagon" / "D001.yaml", _WMBT_D001)
+    _write(
+        tmp_path / "plan" / "_trains" / "0001-self-compliance-validate.yaml",
+        _TRAIN_FIXTURE,
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def seeded_registry(fixture_repo: Path):
+    """Point the rule registry at the fixture repo and yield it for assertions.
+
+    The override stays in effect for the duration of one test so every
+    ``RulesCommand`` / ``RepoRulesListing`` call resolves against the
+    fixture. Reset via the autouse ``_reset_cache``.
+    """
+    from atdd.coach.utils.rule_binding import clear_cache
+
+    clear_cache(override_repo_root=fixture_repo)
+    return fixture_repo
+
+
+# ---------------------------------------------------------------------------
+# atdd rules show
+# ---------------------------------------------------------------------------
+def test_rules_show_returns_repo_metadata_text(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``atdd rules show`` prints the bound RuleMetadata for a repo rule."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().show("repo.govern-lifecycle.D010-acc-unit-001")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "rule_id:" in out
+    assert "repo.govern-lifecycle.D010-acc-unit-001" in out
+    assert "severity:" in out
+    assert "disposition:       strict" in out
+    assert "acceptance_urn" in out
+    assert "wmbt:govern-lifecycle:D010" in out
+
+
+def test_rules_show_emits_json_when_requested(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``--format json`` produces a parseable RuleMetadata payload."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().show(
+        "repo.govern-lifecycle.D010-acc-unit-001", format="json"
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["rule_id"] == "repo.govern-lifecycle.D010-acc-unit-001"
+    assert payload["severity"] == 4
+    assert payload["disposition"] == "strict"
+    assert payload["wmbt_urn"] == "wmbt:govern-lifecycle:D010"
+    assert payload["acceptance_urn"].startswith("acc:govern-lifecycle:D010-UNIT-001")
+    # source_path serializes as string (not Path).
+    assert isinstance(payload["source_path"], str)
+    assert payload["source_path"].endswith("D010.yaml")
+
+
+def test_rules_show_unknown_id_returns_nonzero_with_stderr(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """An unregistered rule-id surfaces as exit-1 with a message on stderr."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().show("does.not.exist")
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "not declared in any convention" in captured.err
+    # stdout stays clean — the message is for human eyes via stderr.
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# atdd rules where
+# ---------------------------------------------------------------------------
+def test_rules_where_prints_source_path_and_acceptance_urn(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``atdd rules where`` surfaces the YAML source + the derived acc URN."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().where("repo.govern-lifecycle.D010-acc-unit-001")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "source_path:" in out
+    assert str(seeded_registry / "plan" / "govern_lifecycle" / "D010.yaml") in out
+    assert "acceptance_urn:" in out
+    assert "acc:govern-lifecycle:D010-UNIT-001-single-source-theme-map-helper" in out
+
+
+def test_rules_where_json_keys_are_minimal(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """JSON output for ``where`` carries the three pointers — no kitchen sink."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().where(
+        "repo.govern-lifecycle.D010-acc-unit-001", format="json"
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload.keys()) == {"rule_id", "source_path", "acceptance_urn"}
+    assert payload["rule_id"] == "repo.govern-lifecycle.D010-acc-unit-001"
+    assert payload["source_path"].endswith("D010.yaml")
+
+
+# ---------------------------------------------------------------------------
+# atdd rules grep
+# ---------------------------------------------------------------------------
+def test_rules_grep_matches_description_substring(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Grep filters by description text — the canonical acceptance criterion."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().grep("theme_map")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "repo.govern-lifecycle.D010-acc-unit-001" in out
+
+
+def test_rules_grep_matches_rule_id(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Grep also matches against rule-id, not just description."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().grep(r"D010-acc-unit")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "repo.govern-lifecycle.D010-acc-unit-001" in out
+    # Train rule id has no D010 in it — must NOT match.
+    assert "repo.0001-self-compliance-validate.acc-idempotent-on-retry" not in out
+
+
+def test_rules_grep_no_match_returns_nonzero(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """No match returns exit-1 (grep convention) with a friendly text line."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().grep("zzz_no_such_token_zzz")
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "No rules matched" in out
+
+
+def test_rules_grep_invalid_regex_returns_nonzero(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """A malformed regex surfaces a clear error (not a stack trace)."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().grep("(unclosed")
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "invalid regex" in err
+
+
+# ---------------------------------------------------------------------------
+# atdd urn rules — list every repo rule, grouped by parent URN
+# ---------------------------------------------------------------------------
+def test_urn_rules_lists_every_repo_rule_grouped_by_parent(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``atdd urn rules`` shows every repo-derived rule across WMBT + train."""
+    from atdd.coach.commands.rules import RepoRulesListing
+
+    rc = RepoRulesListing().list_all_repo_rules()
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Every fixture rule appears.
+    assert "repo.govern-lifecycle.D010-acc-unit-001" in out
+    assert "repo.foo-wagon.D001-acc-http-007" in out
+    assert "repo.0001-self-compliance-validate.acc-idempotent-on-retry" in out
+    # Grouped by parent URN.
+    assert "wmbt:govern-lifecycle:D010" in out
+    assert "wmbt:foo-wagon:D001" in out
+    assert "train:0001-self-compliance-validate" in out
+
+
+def test_urn_rules_json_serializes_list(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """JSON output is a flat list of RuleMetadata dicts."""
+    from atdd.coach.commands.rules import RepoRulesListing
+
+    rc = RepoRulesListing().list_all_repo_rules(format="json")
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload, list)
+    assert len(payload) == 3
+    rule_ids = {entry["rule_id"] for entry in payload}
+    assert rule_ids == {
+        "repo.govern-lifecycle.D010-acc-unit-001",
+        "repo.foo-wagon.D001-acc-http-007",
+        "repo.0001-self-compliance-validate.acc-idempotent-on-retry",
+    }
+
+
+# ---------------------------------------------------------------------------
+# atdd urn wmbt-rules <wmbt-urn>
+# ---------------------------------------------------------------------------
+def test_urn_wmbt_rules_filters_to_one_wmbt(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Filtering by WMBT URN returns only that WMBT's derived rules."""
+    from atdd.coach.commands.rules import RepoRulesListing
+
+    rc = RepoRulesListing().list_rules_for_wmbt("wmbt:govern-lifecycle:D010")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "repo.govern-lifecycle.D010-acc-unit-001" in out
+    # Other parents must not leak in.
+    assert "repo.foo-wagon.D001-acc-http-007" not in out
+    assert "repo.0001-self-compliance-validate.acc-idempotent-on-retry" not in out
+
+
+def test_urn_wmbt_rules_unknown_wmbt_returns_nonzero(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """An unrecognized WMBT URN reports zero matches with exit-1."""
+    from atdd.coach.commands.rules import RepoRulesListing
+
+    rc = RepoRulesListing().list_rules_for_wmbt("wmbt:nobody:Z999")
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "No repo rules derived from wmbt:nobody:Z999" in out
+
+
+def test_urn_wmbt_rules_rejects_non_wmbt_urn(
+    capsys: pytest.CaptureFixture[str],
+):
+    """A URN that isn't ``wmbt:...`` is rejected before the registry walk."""
+    from atdd.coach.commands.rules import RepoRulesListing
+
+    rc = RepoRulesListing().list_rules_for_wmbt("train:foo")
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "expected WMBT URN" in err
+
+
+# ---------------------------------------------------------------------------
+# atdd urn train-rules <train-urn>
+# ---------------------------------------------------------------------------
+def test_urn_train_rules_filters_to_one_train(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Filtering by train URN returns only that train's derived rules."""
+    from atdd.coach.commands.rules import RepoRulesListing
+
+    rc = RepoRulesListing().list_rules_for_train(
+        "train:0001-self-compliance-validate"
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "repo.0001-self-compliance-validate.acc-idempotent-on-retry" in out
+    # WMBT-derived rules don't leak into a train query.
+    assert "repo.govern-lifecycle.D010-acc-unit-001" not in out
+
+
+def test_urn_train_rules_rejects_non_train_urn(
+    capsys: pytest.CaptureFixture[str],
+):
+    """A URN that isn't ``train:...`` is rejected before the registry walk."""
+    from atdd.coach.commands.rules import RepoRulesListing
+
+    rc = RepoRulesListing().list_rules_for_train("wmbt:foo:D001")
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "expected train URN" in err
+
+
+# ---------------------------------------------------------------------------
+# iter_rules public API smoke test (exposed for #409 §9.2)
+# ---------------------------------------------------------------------------
+def test_iter_rules_emits_each_canonical_rule_once(seeded_registry: Path):
+    """``iter_rules`` is the public peer of ``_get_registry`` — yields canonicals."""
+    from atdd.coach.utils.rule_binding import iter_rules
+
+    rules = list(iter_rules())
+    rule_ids = [m.rule_id for m in rules]
+    # Repo rules from the fixture appear exactly once.
+    repo_ids = [rid for rid in rule_ids if rid.startswith("repo.")]
+    assert len(repo_ids) == 3
+    assert set(repo_ids) == {
+        "repo.govern-lifecycle.D010-acc-unit-001",
+        "repo.foo-wagon.D001-acc-http-007",
+        "repo.0001-self-compliance-validate.acc-idempotent-on-retry",
+    }
+    # No duplicates anywhere.
+    assert len(set(rule_ids)) == len(rule_ids)

--- a/src/atdd/coach/utils/rule_binding.py
+++ b/src/atdd/coach/utils/rule_binding.py
@@ -850,6 +850,48 @@ def get_canonical_id(rule_id: str) -> str:
     return bind_rule(rule_id).rule_id
 
 
+def iter_rules() -> Iterable[RuleMetadata]:
+    """Yield every canonically-registered rule in the merged registry.
+
+    Walks the same registry that ``bind_rule`` resolves against — so the
+    iterator surfaces both toolkit-convention rules (via
+    ``find_convention_files``) and repo-derived rules (via
+    ``find_repo_rules``). Aliases are skipped; only the canonical id of
+    each rule is yielded once.
+
+    The iterator is the public peer of the underscored ``_get_registry``
+    helper. ``atdd rules`` and ``atdd urn rules`` consume it (issue #409).
+
+    Order: ascending by ``rule_id``. Stable across calls within a process
+    (the registry is cached) but not across processes (file discovery
+    order can shift if conventions are added or moved).
+
+    Yields:
+        ``RuleMetadata`` for each canonical rule. Ambiguous rules
+        (declared in two convention files) are silently elided here —
+        ``bind_rule`` is the place those failures surface.
+    """
+    registry = _get_registry()
+    seen: set = set()
+    for rule_id in sorted(registry.keys()):
+        matches = registry.get(rule_id, [])
+        if not matches:
+            continue
+        # ``registry`` includes alias entries pointing at the canonical
+        # ``RuleMetadata``. Yield each canonical metadata exactly once by
+        # gating on its own ``rule_id`` (the canonical id, not the lookup
+        # key — which may be an alias).
+        canonical_meta = matches[0]
+        if canonical_meta.rule_id in seen:
+            continue
+        if rule_id != canonical_meta.rule_id:
+            # This entry is the alias-row; skip — the canonical row will
+            # appear separately in the sorted walk.
+            continue
+        seen.add(canonical_meta.rule_id)
+        yield canonical_meta
+
+
 __all__ = [
     "AmbiguousAliasError",
     "AmbiguousRuleError",
@@ -862,4 +904,5 @@ __all__ = [
     "find_convention_files",
     "find_repo_rules",
     "get_canonical_id",
+    "iter_rules",
 ]


### PR DESCRIPTION
Closes #409

## Summary

Implements §9.2 of the substrate spec — repo rule discovery CLI.

- New `atdd rules` surface with three subcommands:
  - `atdd rules show <rule-id>` — prints the bound `RuleMetadata` (text or JSON)
  - `atdd rules where <rule-id>` — prints source path + acceptance URN
  - `atdd rules grep <pattern>` — regex filter over rule-ids and descriptions
- New repo-rule listings under the existing `atdd urn` parent (these will move with `atdd urn → atdd repo` in #414):
  - `atdd urn rules` — every repo rule, grouped by parent URN
  - `atdd urn wmbt-rules <wmbt-urn>` — rules derived from a WMBT
  - `atdd urn train-rules <train-urn>` — rules derived from a train
- Public `iter_rules() -> Iterable[RuleMetadata]` peer added to `rule_binding.py` (`__all__` updated). It yields every canonical rule across the merged registry — toolkit conventions and #408's repo-derived acceptances both surface through one path.

All commands route through the existing `bind_rule` / `_get_registry` machinery, so toolkit rules and repo-derived acceptance rules appear transparently.

## Acceptance criteria (issue #409)

- ✅ `atdd urn rules` lists all derived rules from `plan/`
- ✅ `atdd urn wmbt-rules wmbt:govern-lifecycle:D010` lists D010-derived rules
- ✅ `atdd rules show repo.govern-lifecycle.D010-acc-unit-001` returns full RuleMetadata
- ✅ `atdd rules grep "theme_map"` returns the rule
- ✅ Unit tests for each subcommand (17 tests total)

## Test plan

- [x] `pytest src/atdd/coach/commands/tests/test_rules_cli.py` — 17 passed
- [x] `pytest src/atdd/coach/utils/tests/test_rule_binding.py src/atdd/coach/utils/tests/test_repo_rule_walker.py` — 27 passed (no regression)
- [x] `pytest src/atdd/coder/validators/test_no_silent_exception_swallowing_python.py` — passes (suppress markers added to mirror URNCommand)
- [x] Manual smoke: every CLI flow exits 0 on hit / 1 on miss
- [x] Version bump 3.4.3 → 3.4.5 (skips 3.4.4 to avoid collision with concurrent PRs)

## Notes

Pre-existing failures in `test_release_versioning`, `test_open_issue_compliance`, `test_C002_project_board`, `test_required_label_set`, `test_unlabeled_open_issues`, and `test_issue_validation` are unrelated to this PR — they reproduce on `origin/main` and depend on post-merge tag + manifest registration.