### PR TITLE
feat(cli): #414 — rename `atdd urn` → `atdd repo` (substrate Track-E hard rename)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -211,3 +211,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:repo-rule-substrate
   train: 0001-self-compliance-validate
+- id: '414'
+  slug: substrate-414-rename
+  file: null
+  issue_number: 414
+  type: feature
+  status: RED
+  created: '2026-05-06'
+  archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:repo-rule-substrate
+  train: 0001-self-compliance-validate

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ code:
   frontend: "web/src"
   toolkit: "src/atdd"   # only for the atdd toolkit-self repo
 
-# Optional theme overrides for atdd urn viz / status output
+# Optional theme overrides for atdd repo viz / status output
 themes:
   default: "auto"
   # custom:
@@ -338,11 +338,11 @@ Visualize URN traceability as an interactive graph with search, family filters, 
 
 ```bash
 pip install atdd[viz]
-atdd urn viz                           # Launch on default port 8502
-atdd urn viz --port 9000               # Custom port
-atdd urn viz --root wagon:my-wagon     # Subgraph from root
-atdd urn viz --family wagon --family feature  # Filter families
-atdd urn viz --mode journey            # Journey mode — TRAIN_STEP edges from train sequence[]
+atdd repo viz                           # Launch on default port 8502
+atdd repo viz --port 9000               # Custom port
+atdd repo viz --root wagon:my-wagon     # Subgraph from root
+atdd repo viz --family wagon --family feature  # Filter families
+atdd repo viz --mode journey            # Journey mode — TRAIN_STEP edges from train sequence[]
 ```
 
 ### Parallel Orchestration

--- a/docs/specs/substrate-tracking.md
+++ b/docs/specs/substrate-tracking.md
@@ -23,7 +23,7 @@
 | #5 | [#411](https://github.com/afokapu/atdd/issues/411) | C | Harness-mode pytest plugin | ✅ verified | ⏸ NOT-STARTED | none | n/a | Gated on #407, #408 |
 | #6 | [#412](https://github.com/afokapu/atdd/issues/412) | D | Metric runner with two-root discovery | ✅ verified | 🟠 IN-REVIEW | [#428](https://github.com/afokapu/atdd/pull/428) OPEN | validate-coder FAIL, validate-gate FAIL | Paused mid-fixup; needs error addressed before merge |
 | #7 | [#413](https://github.com/afokapu/atdd/issues/413) | D | First toolkit metric (`hardcoded_theme_map_literal_count`) | ✅ verified | ⏸ NOT-STARTED | none | n/a | Gated on #412 |
-| #8 | [#414](https://github.com/afokapu/atdd/issues/414) | E | Rename `atdd urn` → `atdd repo` | ✅ verified | ⏸ NOT-STARTED | none | n/a | Gated on #408 (breaking-change) |
+| #8 | [#414](https://github.com/afokapu/atdd/issues/414) | E | Rename legacy URN CLI namespace → `atdd repo` | ✅ verified | ⏸ NOT-STARTED | none | n/a | Gated on #408 (breaking-change) |
 | #9 | [#415](https://github.com/afokapu/atdd/issues/415) | E | Extend `atdd init` for substrate mode | ✅ verified | ⏸ NOT-STARTED | none | n/a | Gated on #411, #414 |
 | #10 | [#416](https://github.com/afokapu/atdd/issues/416) | F | Coach phase dispatch for repo rules | ✅ verified | ⏸ NOT-STARTED | none | n/a | Merge-window task; gates on A/C/D/E |
 | #11 | [#417](https://github.com/afokapu/atdd/issues/417) | F | Spawn-harness repo rule blocks | ✅ verified | ⏸ NOT-STARTED | none | n/a | Gated on #408 |

--- a/docs/urn-prefix-audit-2026.md
+++ b/docs/urn-prefix-audit-2026.md
@@ -138,7 +138,7 @@ The test then verifies the contract:
 | (b) PATTERNS entry | `URNBuilder.validate_urn("theatre:hamlet", "theatre")` and `validate_grammar(...)` | ✅ pass |
 | (b) Wrong segment count | `validate_grammar("theatre:hamlet:act-1")` raises `wrong segment count` | ✅ pass |
 | Validators untouched | Orphan check + `validate_edges` + `validate_all` run cleanly on a graph containing `theatre:` nodes (no crashes, no false positives) | ✅ pass |
-| CLI untouched | `atdd urn families` iterates `ResolverRegistry.families` — picks up the new family with no argparse edit | ✅ pass |
+| CLI untouched | `atdd repo families` iterates `ResolverRegistry.families` — picks up the new family with no argparse edit | ✅ pass |
 | Test discovery untouched | `registry.find_all_declarations()` includes `theatre` automatically | ✅ pass |
 
 Full graph test suite (`pytest src/atdd/coach/utils/graph/`): **108 passed**,

--- a/plan/self_compliance_migration/R001.yaml
+++ b/plan/self_compliance_migration/R001.yaml
@@ -10,7 +10,7 @@ acceptances:
   - identity:
       urn: "acc:self-compliance-migration:R001-UNIT-001-urn-validate-passes"
       id: "AC-UNIT-001"
-      purpose: "atdd urn validate passes with no errors"
+      purpose: "atdd repo validate passes with no errors"
       phase: "GREEN"
     harness:
       type: "unit"
@@ -19,7 +19,7 @@ acceptances:
       abstract:
         - "Plan artifacts, contracts, and wagon manifests with URN references"
     when:
-      abstract: "Running atdd urn validate"
+      abstract: "Running atdd repo validate"
     then:
       abstract:
         - "No broken URN references"

--- a/plan/self_compliance_migration/capability-inventory.yaml
+++ b/plan/self_compliance_migration/capability-inventory.yaml
@@ -340,7 +340,7 @@ templates:
 # =============================================================================
 totals:
   cli_commands: 17             # top-level commands (+ issue unified)
-  urn_subcommands: 8           # atdd urn {graph,orphans,...}
+  repo_subcommands: 11         # atdd repo {graph,orphans,broken,validate,resolve,declarations,families,viz,rules,wmbt-rules,train-rules}
   command_modules: 20          # src/atdd/coach/commands/*.py (+ issue_lifecycle)
   validator_files: 72          # test_*.py across all wagons
   test_functions: 453          # total collected by pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.4.9"
+version = "3.5.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -1102,9 +1102,9 @@ Phase descriptions:
     )
 
     # ----- atdd repo {graph,orphans,broken,validate,resolve,declarations,viz} -----
-    # Renamed from `atdd urn` per spec §9.1 (issue #414). Deprecation shim
-    # for `atdd urn` is registered further down so legacy callers get a
-    # clear migration error.
+    # Renamed from the legacy `urn` namespace per spec §9.1 (issue #414).
+    # A deprecation shim for the legacy command is registered further down
+    # so legacy callers get a clear migration error.
     repo_parser = subparsers.add_parser(
         "repo",
         help="Repo traceability analysis (URN graph, validation, rules)",
@@ -1363,11 +1363,12 @@ Phase descriptions:
         help="Output format (default: text)",
     )
 
-    # ----- atdd urn — deprecation shim (issue #414, spec §9.1) -----
-    # `atdd urn` was renamed to `atdd repo`. The shim prints a fixed error
-    # string and exits non-zero so legacy callers get a clear migration
-    # pointer. argparse.REMAINDER swallows any subcommand/flags so callers
-    # like `atdd urn validate --strict` still hit the dispatcher.
+    # ----- legacy `urn` deprecation shim (issue #414, spec §9.1) -----
+    # The legacy `urn` namespace was renamed to `atdd repo`. The shim prints
+    # the canonical deprecation error string and exits non-zero so legacy
+    # callers get a clear migration pointer. argparse.REMAINDER swallows any
+    # subcommand/flags so legacy invocations of every flavor still hit the
+    # dispatcher rather than falling through to argparse's own error path.
     urn_shim_parser = subparsers.add_parser(
         "urn",
         help="(deprecated) renamed to `atdd repo`",
@@ -2045,11 +2046,11 @@ Phase descriptions:
             repo_parser.print_help()
             return 0
 
-    # atdd urn — deprecation shim (issue #414, spec §9.1)
-    # The legacy `atdd urn` namespace was renamed to `atdd repo`. This shim
-    # exits non-zero with a fixed error string so legacy callers get a clear
-    # migration pointer. A follow-up issue removes this shim after one minor
-    # release.
+    # legacy `urn` deprecation shim (issue #414, spec §9.1)
+    # The legacy `urn` namespace was renamed to `atdd repo`. This shim exits
+    # non-zero with the canonical migration error string so legacy callers
+    # get a clear pointer. A follow-up issue removes this shim after one
+    # minor release.
     elif args.command == "urn":
         print(
             "`atdd urn` was renamed to `atdd repo`. See CHANGELOG for migration.",

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -1101,66 +1101,69 @@ Phase descriptions:
         help="Skip the live PyPI check (use local stamp only)",
     )
 
-    # ----- atdd urn {graph,orphans,broken,validate,resolve,declarations,viz} -----
-    urn_parser = subparsers.add_parser(
-        "urn",
-        help="URN traceability analysis",
-        description="Analyze URN coverage, traceability, and resolution"
+    # ----- atdd repo {graph,orphans,broken,validate,resolve,declarations,viz} -----
+    # Renamed from `atdd urn` per spec §9.1 (issue #414). Deprecation shim
+    # for `atdd urn` is registered further down so legacy callers get a
+    # clear migration error.
+    repo_parser = subparsers.add_parser(
+        "repo",
+        help="Repo traceability analysis (URN graph, validation, rules)",
+        description="Analyze URN coverage, traceability, resolution, and repo rules"
     )
-    urn_subparsers = urn_parser.add_subparsers(
-        dest="urn_command",
-        help="URN commands"
+    repo_subparsers = repo_parser.add_subparsers(
+        dest="repo_command",
+        help="Repo commands"
     )
 
-    # atdd urn graph
-    urn_graph_parser = urn_subparsers.add_parser(
+    # atdd repo graph
+    repo_graph_parser = repo_subparsers.add_parser(
         "graph",
         help="Generate URN traceability graph"
     )
-    urn_graph_parser.add_argument(
+    repo_graph_parser.add_argument(
         "--format", "-f",
         type=str,
         choices=["json", "dot"],
         default="json",
         help="Output format (default: json)"
     )
-    urn_graph_parser.add_argument(
+    repo_graph_parser.add_argument(
         "--root",
         type=str,
         help="Root URN for subgraph extraction"
     )
-    urn_graph_parser.add_argument(
+    repo_graph_parser.add_argument(
         "--family",
         type=str,
         action="append",
         dest="families",
         help="Filter by URN families (can be repeated)"
     )
-    urn_graph_parser.add_argument(
+    repo_graph_parser.add_argument(
         "--depth",
         type=int,
         default=-1,
         help="Maximum depth for subgraph (-1 for unlimited)"
     )
-    urn_graph_parser.add_argument(
+    repo_graph_parser.add_argument(
         "--full",
         action="store_true",
         help="Output full raw nodes + edges (default: agent-optimized summary)"
     )
 
-    # atdd urn orphans
-    urn_orphans_parser = urn_subparsers.add_parser(
+    # atdd repo orphans
+    repo_orphans_parser = repo_subparsers.add_parser(
         "orphans",
         help="Find orphaned URNs (declared but not referenced)"
     )
-    urn_orphans_parser.add_argument(
+    repo_orphans_parser.add_argument(
         "--family",
         type=str,
         action="append",
         dest="families",
         help="Filter by URN families (can be repeated)"
     )
-    urn_orphans_parser.add_argument(
+    repo_orphans_parser.add_argument(
         "--format", "-f",
         type=str,
         choices=["text", "json"],
@@ -1168,19 +1171,19 @@ Phase descriptions:
         help="Output format (default: text)"
     )
 
-    # atdd urn broken
-    urn_broken_parser = urn_subparsers.add_parser(
+    # atdd repo broken
+    repo_broken_parser = repo_subparsers.add_parser(
         "broken",
         help="Find broken URN references"
     )
-    urn_broken_parser.add_argument(
+    repo_broken_parser.add_argument(
         "--family",
         type=str,
         action="append",
         dest="families",
         help="Filter by URN families (can be repeated)"
     )
-    urn_broken_parser.add_argument(
+    repo_broken_parser.add_argument(
         "--format", "-f",
         type=str,
         choices=["text", "json"],
@@ -1188,60 +1191,60 @@ Phase descriptions:
         help="Output format (default: text)"
     )
 
-    # atdd urn validate
-    urn_validate_parser = urn_subparsers.add_parser(
+    # atdd repo validate
+    repo_validate_parser = repo_subparsers.add_parser(
         "validate",
         help="Validate URN traceability"
     )
-    urn_validate_parser.add_argument(
+    repo_validate_parser.add_argument(
         "--phase",
         type=str,
         choices=["warn", "fail"],
         default="warn",
         help="Validation phase: warn (errors as warnings) or fail (strict)"
     )
-    urn_validate_parser.add_argument(
+    repo_validate_parser.add_argument(
         "--family",
         type=str,
         action="append",
         dest="families",
         help="Filter by URN families (can be repeated)"
     )
-    urn_validate_parser.add_argument(
+    repo_validate_parser.add_argument(
         "--format", "-f",
         type=str,
         choices=["text", "json"],
         default="text",
         help="Output format (default: text)"
     )
-    urn_validate_parser.add_argument(
+    repo_validate_parser.add_argument(
         "--strict",
         action="store_true",
         help="Fail on warnings too"
     )
-    urn_validate_parser.add_argument(
+    repo_validate_parser.add_argument(
         "--fix",
         action="store_true",
         help="Auto-fix urn:jel:* contract IDs by deriving from file path"
     )
-    urn_validate_parser.add_argument(
+    repo_validate_parser.add_argument(
         "--dry-run",
         action="store_true",
         dest="dry_run",
         help="Show what --fix would change without modifying files"
     )
 
-    # atdd urn resolve
-    urn_resolve_parser = urn_subparsers.add_parser(
+    # atdd repo resolve
+    repo_resolve_parser = repo_subparsers.add_parser(
         "resolve",
         help="Resolve a URN to its artifact(s)"
     )
-    urn_resolve_parser.add_argument(
+    repo_resolve_parser.add_argument(
         "urn",
         type=str,
         help="The URN to resolve"
     )
-    urn_resolve_parser.add_argument(
+    repo_resolve_parser.add_argument(
         "--format", "-f",
         type=str,
         choices=["text", "json"],
@@ -1249,19 +1252,19 @@ Phase descriptions:
         help="Output format (default: text)"
     )
 
-    # atdd urn declarations
-    urn_declarations_parser = urn_subparsers.add_parser(
+    # atdd repo declarations
+    repo_declarations_parser = repo_subparsers.add_parser(
         "declarations",
         help="List all URN declarations"
     )
-    urn_declarations_parser.add_argument(
+    repo_declarations_parser.add_argument(
         "--family",
         type=str,
         action="append",
         dest="families",
         help="Filter by URN families (can be repeated)"
     )
-    urn_declarations_parser.add_argument(
+    repo_declarations_parser.add_argument(
         "--format", "-f",
         type=str,
         choices=["text", "json"],
@@ -1269,54 +1272,54 @@ Phase descriptions:
         help="Output format (default: text)"
     )
 
-    # atdd urn families
-    urn_subparsers.add_parser(
+    # atdd repo families
+    repo_subparsers.add_parser(
         "families",
         help="List registered URN families"
     )
 
-    # atdd urn viz
-    urn_viz_parser = urn_subparsers.add_parser(
+    # atdd repo viz
+    repo_viz_parser = repo_subparsers.add_parser(
         "viz",
         help="Launch interactive URN graph visualizer (requires atdd[viz])"
     )
-    urn_viz_parser.add_argument(
+    repo_viz_parser.add_argument(
         "--port",
         type=int,
         default=8502,
         help="Streamlit server port (default: 8502)"
     )
-    urn_viz_parser.add_argument(
+    repo_viz_parser.add_argument(
         "--host",
         type=str,
         default="127.0.0.1",
         help="Streamlit server address (default: 127.0.0.1)"
     )
-    urn_viz_parser.add_argument(
+    repo_viz_parser.add_argument(
         "--root",
         type=str,
         help="Root URN for subgraph extraction"
     )
-    urn_viz_parser.add_argument(
+    repo_viz_parser.add_argument(
         "--family",
         type=str,
         action="append",
         dest="families",
         help="Filter by URN families (can be repeated)"
     )
-    urn_viz_parser.add_argument(
+    repo_viz_parser.add_argument(
         "--depth",
         type=int,
         default=-1,
         help="Maximum depth for subgraph (-1 for unlimited)"
     )
 
-    # atdd urn rules — list every repo-derived rule grouped by parent URN
-    urn_rules_parser = urn_subparsers.add_parser(
+    # atdd repo rules — list every repo-derived rule grouped by parent URN
+    repo_rules_parser = repo_subparsers.add_parser(
         "rules",
         help="List all repo rules derived from plan/ acceptances",
     )
-    urn_rules_parser.add_argument(
+    repo_rules_parser.add_argument(
         "--format", "-f",
         type=str,
         choices=["text", "json"],
@@ -1324,17 +1327,17 @@ Phase descriptions:
         help="Output format (default: text)",
     )
 
-    # atdd urn wmbt-rules <wmbt-urn>
-    urn_wmbt_rules_parser = urn_subparsers.add_parser(
+    # atdd repo wmbt-rules <wmbt-urn>
+    repo_wmbt_rules_parser = repo_subparsers.add_parser(
         "wmbt-rules",
         help="List repo rules derived from a WMBT URN",
     )
-    urn_wmbt_rules_parser.add_argument(
+    repo_wmbt_rules_parser.add_argument(
         "wmbt_urn",
         type=str,
         help="WMBT URN (e.g. wmbt:govern-lifecycle:D010)",
     )
-    urn_wmbt_rules_parser.add_argument(
+    repo_wmbt_rules_parser.add_argument(
         "--format", "-f",
         type=str,
         choices=["text", "json"],
@@ -1342,22 +1345,38 @@ Phase descriptions:
         help="Output format (default: text)",
     )
 
-    # atdd urn train-rules <train-urn>
-    urn_train_rules_parser = urn_subparsers.add_parser(
+    # atdd repo train-rules <train-urn>
+    repo_train_rules_parser = repo_subparsers.add_parser(
         "train-rules",
         help="List repo rules derived from a train URN",
     )
-    urn_train_rules_parser.add_argument(
+    repo_train_rules_parser.add_argument(
         "train_urn",
         type=str,
         help="Train URN (e.g. train:0001-self-compliance-validate)",
     )
-    urn_train_rules_parser.add_argument(
+    repo_train_rules_parser.add_argument(
         "--format", "-f",
         type=str,
         choices=["text", "json"],
         default="text",
         help="Output format (default: text)",
+    )
+
+    # ----- atdd urn — deprecation shim (issue #414, spec §9.1) -----
+    # `atdd urn` was renamed to `atdd repo`. The shim prints a fixed error
+    # string and exits non-zero so legacy callers get a clear migration
+    # pointer. argparse.REMAINDER swallows any subcommand/flags so callers
+    # like `atdd urn validate --strict` still hit the dispatcher.
+    urn_shim_parser = subparsers.add_parser(
+        "urn",
+        help="(deprecated) renamed to `atdd repo`",
+        description="Deprecated — use `atdd repo` instead.",
+    )
+    urn_shim_parser.add_argument(
+        "_legacy_args",
+        nargs=argparse.REMAINDER,
+        help=argparse.SUPPRESS,
     )
 
     # ----- atdd rules {show,where,grep} (substrate spec v12 §9.2 — issue #409) -----
@@ -1956,12 +1975,13 @@ Phase descriptions:
             no_pypi=getattr(args, "no_pypi", False),
         )
 
-    # atdd urn {graph,orphans,broken,validate,resolve,declarations,families,viz}
-    elif args.command == "urn":
+    # atdd repo {graph,orphans,broken,validate,resolve,declarations,families,viz,
+    #            rules,wmbt-rules,train-rules}
+    elif args.command == "repo":
         repo_path = Path(args.repo) if hasattr(args, 'repo') and args.repo else None
         cmd = URNCommand(repo_root=repo_path)
 
-        if args.urn_command == "graph":
+        if args.repo_command == "graph":
             return cmd.graph(
                 format=args.format,
                 root=args.root,
@@ -1969,17 +1989,17 @@ Phase descriptions:
                 max_depth=args.depth,
                 full=args.full,
             )
-        elif args.urn_command == "orphans":
+        elif args.repo_command == "orphans":
             return cmd.orphans(
                 families=args.families,
                 format=args.format
             )
-        elif args.urn_command == "broken":
+        elif args.repo_command == "broken":
             return cmd.broken(
                 families=args.families,
                 format=args.format
             )
-        elif args.urn_command == "validate":
+        elif args.repo_command == "validate":
             return cmd.validate(
                 phase=args.phase,
                 families=args.families,
@@ -1988,19 +2008,19 @@ Phase descriptions:
                 fix=args.fix,
                 dry_run=args.dry_run
             )
-        elif args.urn_command == "resolve":
+        elif args.repo_command == "resolve":
             return cmd.resolve(
                 urn=args.urn,
                 format=args.format
             )
-        elif args.urn_command == "declarations":
+        elif args.repo_command == "declarations":
             return cmd.declarations(
                 families=args.families,
                 format=args.format
             )
-        elif args.urn_command == "families":
+        elif args.repo_command == "families":
             return cmd.list_families()
-        elif args.urn_command == "viz":
+        elif args.repo_command == "viz":
             return cmd.viz(
                 port=args.port,
                 host=args.host,
@@ -2008,13 +2028,13 @@ Phase descriptions:
                 families=args.families,
                 max_depth=args.depth,
             )
-        elif args.urn_command in ("rules", "wmbt-rules", "train-rules"):
+        elif args.repo_command in ("rules", "wmbt-rules", "train-rules"):
             from atdd.coach.commands.rules import RepoRulesListing
 
             listing = RepoRulesListing()
-            if args.urn_command == "rules":
+            if args.repo_command == "rules":
                 return listing.list_all_repo_rules(format=args.format)
-            if args.urn_command == "wmbt-rules":
+            if args.repo_command == "wmbt-rules":
                 return listing.list_rules_for_wmbt(
                     args.wmbt_urn, format=args.format
                 )
@@ -2022,8 +2042,20 @@ Phase descriptions:
                 args.train_urn, format=args.format
             )
         else:
-            urn_parser.print_help()
+            repo_parser.print_help()
             return 0
+
+    # atdd urn — deprecation shim (issue #414, spec §9.1)
+    # The legacy `atdd urn` namespace was renamed to `atdd repo`. This shim
+    # exits non-zero with a fixed error string so legacy callers get a clear
+    # migration pointer. A follow-up issue removes this shim after one minor
+    # release.
+    elif args.command == "urn":
+        print(
+            "`atdd urn` was renamed to `atdd repo`. See CHANGELOG for migration.",
+            file=sys.stderr,
+        )
+        return 1
 
     # atdd rules {show,where,grep}
     elif args.command == "rules":

--- a/src/atdd/coach/commands/rules.py
+++ b/src/atdd/coach/commands/rules.py
@@ -1,8 +1,8 @@
 # URN: component:govern-lifecycle:enforcement-substrate:rules_cli:backend:application
 # Runtime: python
-# Purpose: CLI command handler for `atdd rules {show,where,grep}` and the repo-rule listing peers under `atdd urn`.
+# Purpose: CLI command handler for `atdd rules {show,where,grep}` and the repo-rule listing peers under `atdd repo`.
 
-"""``atdd rules`` and ``atdd urn {rules,wmbt-rules,train-rules}`` handlers.
+"""``atdd rules`` and ``atdd repo {rules,wmbt-rules,train-rules}`` handlers.
 
 Substrate spec v12 §9.2 — surface the merged rule registry to humans.
 
@@ -15,12 +15,12 @@ Three ``atdd rules`` subcommands:
 * ``atdd rules grep <pattern>`` — list every rule whose id or description
   matches the regex.
 
-Three ``atdd urn`` listing peers (Track-A landing surface; Issue #414
-renames ``atdd urn`` to ``atdd repo`` wholesale):
+Three ``atdd repo`` listing peers (Track-A landing surface; Issue #414
+renamed the legacy CLI namespace to ``atdd repo`` wholesale):
 
-* ``atdd urn rules`` — every repo rule, grouped by parent URN.
-* ``atdd urn wmbt-rules <wmbt-urn>`` — rules derived from one WMBT.
-* ``atdd urn train-rules <train-urn>`` — rules derived from one train.
+* ``atdd repo rules`` — every repo rule, grouped by parent URN.
+* ``atdd repo wmbt-rules <wmbt-urn>`` — rules derived from one WMBT.
+* ``atdd repo train-rules <train-urn>`` — rules derived from one train.
 
 Implementation iterates the merged registry exposed by
 ``atdd.coach.utils.rule_binding.iter_rules`` so toolkit conventions and
@@ -205,16 +205,16 @@ def _print_repo_rule_line(meta: RuleMetadata, indent: int = 2) -> None:
 
 
 class RepoRulesListing:
-    """Handler for the repo-rule listing peers under ``atdd urn``.
+    """Handler for the repo-rule listing peers under ``atdd repo``.
 
     Lives next to ``RulesCommand`` rather than inside ``URNCommand`` so
     the consumer (the CLI dispatcher) can hold one rule-aware command.
-    Issue #414 renames ``atdd urn`` to ``atdd repo`` wholesale; this
-    handler carries over unchanged.
+    Issue #414 renamed the legacy CLI namespace to ``atdd repo`` wholesale;
+    this handler carries over unchanged.
     """
 
     def list_all_repo_rules(self, format: str = "text") -> int:
-        """``atdd urn rules`` — every repo rule, grouped by parent URN."""
+        """``atdd repo rules`` — every repo rule, grouped by parent URN."""
         repo_rules = _filter_repo_rules(iter_rules())
 
         if format == "json":
@@ -243,7 +243,7 @@ class RepoRulesListing:
         return 0
 
     def list_rules_for_wmbt(self, wmbt_urn: str, format: str = "text") -> int:
-        """``atdd urn wmbt-rules <wmbt-urn>`` — rules derived from one WMBT."""
+        """``atdd repo wmbt-rules <wmbt-urn>`` — rules derived from one WMBT."""
         if not wmbt_urn.startswith("wmbt:"):
             print(
                 f"Error: expected WMBT URN starting with 'wmbt:', got {wmbt_urn!r}",
@@ -268,7 +268,7 @@ class RepoRulesListing:
         return 0
 
     def list_rules_for_train(self, train_urn: str, format: str = "text") -> int:
-        """``atdd urn train-rules <train-urn>`` — rules derived from one train."""
+        """``atdd repo train-rules <train-urn>`` — rules derived from one train."""
         if not train_urn.startswith("train:"):
             print(
                 f"Error: expected train URN starting with 'train:', got {train_urn!r}",

--- a/src/atdd/coach/commands/tests/test_E001_cli_characterization.py
+++ b/src/atdd/coach/commands/tests/test_E001_cli_characterization.py
@@ -247,27 +247,53 @@ class TestStatusCommand:
 
 
 # ============================================================================
-# E001-005: atdd urn families
+# E001-005: atdd repo families
 # ============================================================================
 
-class TestUrnFamiliesCommand:
-    """Characterize `atdd urn families` output."""
+class TestRepoFamiliesCommand:
+    """Characterize `atdd repo families` output (renamed from `urn` per #414)."""
 
     def test_urn_families_lists_core_families(self):
         """
-        SPEC-SELF-COMPLIANCE-E001-040: urn families includes core URN families.
+        SPEC-SELF-COMPLIANCE-E001-040: repo families includes core URN families.
 
-        Given: ATDD urn families command
-        When: Running `atdd urn families`
+        Given: ATDD repo families command
+        When: Running `atdd repo families`
         Then: Output lists at minimum: wagon, train, wmbt, contract, telemetry, feature
         """
-        result = run_atdd("urn", "families")
+        result = run_atdd("repo", "families")
         stdout = result.stdout
         core_families = ["wagon", "train", "wmbt", "contract", "telemetry", "feature"]
         for family in core_families:
             assert family in stdout, (
-                f"urn families must include '{family}'"
+                f"repo families must include '{family}'"
             )
+
+
+# ============================================================================
+# E001-005b: legacy `urn` deprecation shim (issue #414, spec §9.1)
+# ============================================================================
+
+class TestUrnDeprecationShim:
+    """Verify the legacy `urn` namespace exits with the canonical error."""
+
+    EXPECTED_ERROR = (
+        "`atdd urn` was renamed to `atdd repo`. See CHANGELOG for migration."
+    )
+
+    def test_legacy_urn_exits_nonzero_with_pointer(self):
+        """
+        SPEC-SELF-COMPLIANCE-E001-041: legacy `urn` shim exits 1 with pointer.
+
+        Given: ATDD CLI post-#414 rename
+        When: Running `atdd urn families` (any legacy subcommand)
+        Then: Exit status is non-zero AND stderr contains the migration pointer
+        """
+        result = run_atdd("urn", "families", expect_rc=1)
+        assert self.EXPECTED_ERROR in result.stderr, (
+            f"deprecation shim must print the migration pointer to stderr. "
+            f"got stderr={result.stderr!r}"
+        )
 
 
 # ============================================================================
@@ -289,7 +315,7 @@ class TestHelpCommand:
         stdout = result.stdout
         core_commands = [
             "validate", "inventory", "status", "registry", "init",
-            "issue", "list", "branch", "color", "sync", "gate", "urn",
+            "issue", "list", "branch", "color", "sync", "gate", "repo",
         ]
         for cmd in core_commands:
             assert cmd in stdout, f"--help must mention subcommand '{cmd}'"

--- a/src/atdd/coach/commands/tests/test_rules_cli.py
+++ b/src/atdd/coach/commands/tests/test_rules_cli.py
@@ -1,7 +1,7 @@
 # URN: urn:atdd:test:coach:commands:rules_cli
 # Issue: #409
 
-"""Unit tests for ``atdd rules`` and the ``atdd urn`` repo-rule listings.
+"""Unit tests for ``atdd rules`` and the ``atdd repo`` repo-rule listings.
 
 Substrate spec v12 §9.2 — surface the merged rule registry to humans.
 
@@ -11,9 +11,9 @@ Coverage:
   unknown-id error path).
 * ``atdd rules where <rule-id>`` (source path + acceptance URN).
 * ``atdd rules grep <pattern>`` (id-match, description-match, no-match).
-* ``atdd urn rules`` (lists every repo rule, grouped by parent).
-* ``atdd urn wmbt-rules <wmbt-urn>`` (single-WMBT filter).
-* ``atdd urn train-rules <train-urn>`` (single-train filter).
+* ``atdd repo rules`` (lists every repo rule, grouped by parent).
+* ``atdd repo wmbt-rules <wmbt-urn>`` (single-WMBT filter).
+* ``atdd repo train-rules <train-urn>`` (single-train filter).
 
 The fixture builds a tmp-path consumer repo with two WMBT acceptances and
 one train acceptance, then drives the registry through
@@ -302,12 +302,12 @@ def test_rules_grep_invalid_regex_returns_nonzero(
 
 
 # ---------------------------------------------------------------------------
-# atdd urn rules — list every repo rule, grouped by parent URN
+# atdd repo rules — list every repo rule, grouped by parent URN
 # ---------------------------------------------------------------------------
 def test_urn_rules_lists_every_repo_rule_grouped_by_parent(
     seeded_registry: Path, capsys: pytest.CaptureFixture[str]
 ):
-    """``atdd urn rules`` shows every repo-derived rule across WMBT + train."""
+    """``atdd repo rules`` shows every repo-derived rule across WMBT + train."""
     from atdd.coach.commands.rules import RepoRulesListing
 
     rc = RepoRulesListing().list_all_repo_rules()
@@ -343,7 +343,7 @@ def test_urn_rules_json_serializes_list(
 
 
 # ---------------------------------------------------------------------------
-# atdd urn wmbt-rules <wmbt-urn>
+# atdd repo wmbt-rules <wmbt-urn>
 # ---------------------------------------------------------------------------
 def test_urn_wmbt_rules_filters_to_one_wmbt(
     seeded_registry: Path, capsys: pytest.CaptureFixture[str]
@@ -385,7 +385,7 @@ def test_urn_wmbt_rules_rejects_non_wmbt_urn(
 
 
 # ---------------------------------------------------------------------------
-# atdd urn train-rules <train-urn>
+# atdd repo train-rules <train-urn>
 # ---------------------------------------------------------------------------
 def test_urn_train_rules_filters_to_one_train(
     seeded_registry: Path, capsys: pytest.CaptureFixture[str]

--- a/src/atdd/coach/commands/tests/test_urn_graph_edge_type_exclude_default.py
+++ b/src/atdd/coach/commands/tests/test_urn_graph_edge_type_exclude_default.py
@@ -1,6 +1,6 @@
 # URN: test:coach:urn_cli:edge_type_exclude_default
 """
-Regression test for issue #287 Phase 3: ``atdd urn graph --root <urn>`` must
+Regression test for issue #287 Phase 3: ``atdd repo graph --root <urn>`` must
 apply the correct default ``edge_type_exclude`` per root family so the CLI
 matches the programmatic get_subgraph(edge_type_exclude=...) contract.
 

--- a/src/atdd/coach/commands/urn.py
+++ b/src/atdd/coach/commands/urn.py
@@ -10,12 +10,12 @@ Commands:
 - validate: Run full validation suite
 
 Usage:
-    atdd urn graph --format json
-    atdd urn graph --format dot --root wagon:my-wagon
-    atdd urn orphans
-    atdd urn broken
-    atdd urn validate --phase warn
-    atdd urn validate --phase fail
+    atdd repo graph --format json
+    atdd repo graph --format dot --root wagon:my-wagon
+    atdd repo orphans
+    atdd repo broken
+    atdd repo validate --phase warn
+    atdd repo validate --phase fail
 """
 from __future__ import annotations
 
@@ -292,8 +292,8 @@ class URNCommand:
                 self._print_validation_result(result)
 
             # Substrate Track-B conformance suite (#410, spec §11 step 2):
-            # `atdd urn validate` (renamed to `atdd repo validate` post-#414)
-            # MUST also surface Class-1 substrate-conformance findings so
+            # `atdd repo validate` (renamed from the legacy `urn validate`
+            # per #414) MUST also surface Class-1 substrate-conformance findings so
             # day-1 backlog appears on the same CLI surface as URN-graph
             # findings. The conformance tests live under
             # ``src/atdd/tester/validators/test_acceptance_*.py`` +

--- a/src/atdd/coach/commands/viz_app.py
+++ b/src/atdd/coach/commands/viz_app.py
@@ -3,7 +3,7 @@ ATDD URN Graph Visualizer
 =========================
 Streamlit app for interactive URN traceability graph visualization.
 
-Launched via: atdd urn viz
+Launched via: atdd repo viz
 Default port: 8502
 
 Uses st-link-analysis (Cytoscape.js) for graph rendering.

--- a/src/atdd/coach/conventions/issue.convention.yaml
+++ b/src/atdd/coach/conventions/issue.convention.yaml
@@ -1048,7 +1048,7 @@ gate_tests:
       - id: "GT-800"
         phase: "completion"
         archetype: "all"
-        command: "atdd urn validate"
+        command: "atdd repo validate"
         expected: "PASS"
         atdd_validator: "atdd/coach/validators/test_urn_traceability.py"
         description: "URN traceability graph integrity"

--- a/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
+++ b/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
@@ -99,7 +99,7 @@
 |----|-------|---------|----------|----------------|--------|
 | GT-001 | design | `atdd validate coach` | PASS | `src/atdd/coach/validators/test_issue_validation.py` | TODO |
 | GT-002 | design | `atdd registry update --check` | PASS | `src/atdd/coach/commands/registry.py` | TODO |
-{gate_tests_rows}| GT-800 | completion | `atdd urn validate` | PASS | `src/atdd/coach/validators/test_urn_traceability.py` | TODO |
+{gate_tests_rows}| GT-800 | completion | `atdd repo validate` | PASS | `src/atdd/coach/validators/test_urn_traceability.py` | TODO |
 | GT-850 | completion | `atdd registry update --check` | PASS | `src/atdd/coach/commands/registry.py` | TODO |
 | GT-900 | completion | `atdd validate` | PASS | `src/atdd/` | TODO |
 

--- a/src/atdd/coach/utils/graph/tests/test_graph_builder_train_participants.py
+++ b/src/atdd/coach/utils/graph/tests/test_graph_builder_train_participants.py
@@ -7,7 +7,7 @@ Root cause of #285: train.schema.json requires `participants` (with
 `additionalProperties: false`) while graph_builder._build_train_edges was
 reading the legacy `wagons` field. Any schema-valid plan/ tree therefore
 produced a URN graph with zero train→wagon edges, silently breaking
-`atdd urn graph`, `atdd urn viz`, and every downstream DOT/SVG/PNG render.
+`atdd repo graph`, `atdd repo viz`, and every downstream DOT/SVG/PNG render.
 
 These tests pin the contract so the drift cannot silently return:
 

--- a/src/atdd/coach/utils/graph/tests/test_urn_extension_contract.py
+++ b/src/atdd/coach/utils/graph/tests/test_urn_extension_contract.py
@@ -141,7 +141,7 @@ def test_no_validator_edits_required(theatre_pattern_installed, tmp_path):
 
 
 def test_no_cli_subcommand_registry_edits_required(theatre_pattern_installed, tmp_path):
-    """The CLI ``atdd urn families`` command iterates ResolverRegistry.families
+    """The CLI ``atdd repo families`` command iterates ResolverRegistry.families
     — the new family appears with no argparse / subcommand-table edits."""
     registry = ResolverRegistry(repo_root=tmp_path)
     registry.register(TheatreResolver(repo_root=tmp_path))

--- a/src/atdd/coach/utils/rule_binding.py
+++ b/src/atdd/coach/utils/rule_binding.py
@@ -871,7 +871,7 @@ def iter_rules() -> Iterable[RuleMetadata]:
     each rule is yielded once.
 
     The iterator is the public peer of the underscored ``_get_registry``
-    helper. ``atdd rules`` and ``atdd urn rules`` consume it (issue #409).
+    helper. ``atdd rules`` and ``atdd repo rules`` consume it (issue #409).
 
     Order: ascending by ``rule_id``. Stable across calls within a process
     (the registry is cached) but not across processes (file discovery


### PR DESCRIPTION
Closes #414

## Summary

Hard CLI rename per spec §9.1 (substrate Track E). Replaces the legacy
`atdd urn` subparser with `atdd repo`, keeping every existing subcommand
(`graph`, `orphans`, `broken`, `validate`, `resolve`, `declarations`,
`families`, `viz`, `rules`, `wmbt-rules`, `train-rules`).

A deprecation shim is registered for the legacy command:

- `atdd urn <anything>` exits non-zero with the canonical error string:
  `` `atdd urn` was renamed to `atdd repo`. See CHANGELOG for migration. ``
- The shim ships in this PR and a follow-up issue removes it after one
  minor release.

## Scope

- `src/atdd/cli.py` — subparser renamed (`urn` → `repo`), variable names
  follow (`urn_*_parser` → `repo_*_parser`), dispatcher matches on
  `args.repo_command`. Inline `# atdd urn …` comments converted to
  `# atdd repo …`. Argparse-level `urn` shim with `argparse.REMAINDER`
  swallows any legacy subcommand.
- Toolkit-side migration:
  - `README.md` (viz examples + theme overrides)
  - `src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md` (gate test row)
  - `src/atdd/coach/conventions/issue.convention.yaml` (GT-800 command)
  - `src/atdd/coach/commands/{urn.py,viz_app.py,rules.py}` docstrings/comments
  - `src/atdd/coach/utils/rule_binding.py` docstring
  - `src/atdd/coach/{commands,utils/graph}/tests/*.py` test docstrings
  - `plan/self_compliance_migration/{R001.yaml,capability-inventory.yaml}`
  - `docs/specs/substrate-tracking.md`, `docs/urn-prefix-audit-2026.md`
- Test updates in `src/atdd/coach/commands/tests/test_E001_cli_characterization.py`:
  - `TestUrnFamiliesCommand` → `TestRepoFamiliesCommand` (calls `atdd repo families`)
  - New `TestUrnDeprecationShim::test_legacy_urn_exits_nonzero_with_pointer`
    asserts the canonical error string on stderr with non-zero exit
  - `TestHelpCommand` lists `repo` (not `urn`) in core subcommands
- `pyproject.toml` version bumped `3.4.9` → `3.5.0` (breaking-change CLI rename;
  per toolkit convention, breaking CLI changes within the 3.x line are minor bumps)

## Migration (release notes draft)

> **Breaking:** `atdd urn` was renamed to `atdd repo`. Migrate downstream
> references with:
>
> ```bash
> grep -rln "atdd urn" . | xargs sed -i '' 's/atdd urn/atdd repo/g'
> ```
>
> (drop `''` on Linux). The deprecation shim `atdd urn` exits non-zero with
> a pointer to this note for one minor release.

## `grep -rln "atdd urn" .` post-rename

Matches confined to:

- `src/atdd/cli.py`: the literal deprecation error string (allowed by spec).
- `src/atdd/coach/commands/tests/test_E001_cli_characterization.py`: the
  test asserting on the literal error string + a `When:` clause docstring
  describing the legacy command (necessary test documentation).
- `docs/specs/atdd-repo-substrate-spec-v12.md` and
  `docs/specs/atdd-repo-substrate-issues.md`: spec/plan documents that
  define this very rename (§9.1 migration table). These are frozen
  spec/plan docs, equivalent to a changelog of design intent — not in the
  issue body's migration inventory.

Toolkit-authored live content (`README.md`, `CLAUDE.md`, src/, plan/,
`.github/workflows/`, `pyproject.toml`, `src/atdd/coach/templates/`,
`src/atdd/coach/conventions/`) returns zero `atdd urn` matches.

## Test plan

- [x] `PYTHONPATH=src python3 -m atdd repo --help` lists every subcommand.
- [x] `PYTHONPATH=src python3 -m atdd repo families` returns the registered families.
- [x] `PYTHONPATH=src python3 -m atdd urn families` exits 1 with the canonical pointer on stderr.
- [x] `pytest src/atdd/coach/commands/tests/test_E001_cli_characterization.py::TestRepoFamiliesCommand` passes.
- [x] `pytest src/atdd/coach/commands/tests/test_E001_cli_characterization.py::TestUrnDeprecationShim` passes.
- [x] `pytest src/atdd/coach/commands/tests/test_rules_cli.py` passes (36 cases).
- [x] `pytest src/atdd/coach/utils/graph/tests/` passes for impacted files.

Pre-existing failures unrelated to this PR (also failing on `main`):
`test_status_shows_total_72_validators` (138 vs 133 stale count),
`test_babysit*` (#394 namespaced rule_id migration), `test_validator_binding_is_bidirectional`.