### PR TITLE
feat(coach): #416 — phase-driven dispatch for repo rules (substrate Track-F)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.5.0"
+version = "3.5.5"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/specs/phase-dispatch.spec.md
+++ b/src/atdd/coach/specs/phase-dispatch.spec.md
@@ -1,0 +1,186 @@
+# SPEC-COACH-PHASE-DISPATCH
+
+> **Title**: Coach phase-driven dispatch for repo rules
+> **Issue**: #416 (substrate Track-F, wave-s2)
+> **Spec source**: `docs/specs/atdd-repo-substrate-spec-v12.md` §8.1 (Tier-1 dispatch per phase)
+> **Companion**: coach v6 §6.5 (phase-validator selection)
+> **Status**: ratified — implementation lives in
+> `src/atdd/coach/utils/phase_dispatch.py`.
+
+## 1. Background
+
+Pre-substrate, `atdd validate <phase>` dispatched by toolkit *archetype*
+(`planner | tester | coder | coach`). Coach v6 §6.5 introduces
+*phase-driven* dispatch — the validator set executed at a coach session
+depends on the lifecycle phase the agent is in (`RED | GREEN | SMOKE |
+REFACTOR`) rather than which archetype owns the rule.
+
+The substrate adds repo-derived rules to the registry: WMBT acceptances,
+train acceptances, and security rules whose `bound_acceptance_urn`
+resolves to one of the former. Each repo rule carries an
+`identity.phase` value populated onto `RuleMetadata.phase` by the
+walker. This spec pins how coach selects validators per phase against
+that field.
+
+This spec covers the substrate-side selection logic only — the runtime
+emission of `Violation` records is the concern of the three substrate
+runners (#411 harness, #412 metric, #422 security). Those runners emit
+violations based on outcome regardless of coach phase; **coach is the
+sole interpreter**.
+
+## 2. Validator-set formula
+
+For a coach session entering phase **X**, the active validator set is:
+
+```
+S(X) =
+    { toolkit validators whose archetype gates X }                  # existing behavior
+  ∪ { repo rules where RuleMetadata.phase == X }                    # §8.1 paragraph 3
+  ∪ { repo rules where RuleMetadata.phase == "GREEN", if X == RED } # §8.1 paragraph 5 — RED expects red
+  ∪ {                                                               # §8.1 paragraph 4 — REFACTOR sweep
+        every rule (toolkit or repo) where
+          RuleMetadata.disposition == "strict",
+        if X == "REFACTOR"
+    }
+```
+
+The substrate's selection helper —
+`atdd.coach.utils.phase_dispatch.select_validator_set(phase, registry)` —
+returns the union of the second, third, and fourth sets (the toolkit
+`archetype` selection stays in `atdd validate`). Coach merges the two
+when assembling the run list.
+
+### 2.1 Source-kind irrelevance
+
+The selection reads `RuleMetadata.phase` directly. It does **not** care
+whether the rule originated from a WMBT acceptance, a train acceptance,
+a security rule, or a `*.convention.yaml` toolkit rule. Phase is the
+canonical dispatch field per §8.1.
+
+### 2.2 Security-rule dispatch (§8.1 line 584)
+
+Security rules registered via #422 carry a populated
+`RuleMetadata.bound_acceptance_urn`. Their *own* `RuleMetadata.phase`
+is informational; dispatch reads the **bound** rule's phase instead.
+
+```
+phase_for_dispatch(rule) =
+    bind_rule(rule.bound_acceptance_urn).phase   if rule.bound_acceptance_urn is set
+    rule.phase                                   otherwise
+```
+
+This branch is implemented unconditionally so #422 (security
+registration) lands without a follow-up patch. Pre-#422 it is a no-op
+because no security rules are in the registry — every rule has
+`bound_acceptance_urn is None` so the second branch wins.
+
+When a security rule's `bound_acceptance_urn` does not resolve in the
+registry, the rule is dropped from selection — the substrate
+enforcement rule
+`security-rule-must-have-acceptance-ref-resolved` (§7.3) surfaces this
+condition at PLANNED phase, not at runtime dispatch. The selector
+treats unresolved `bound_acceptance_urn` as "skip silently."
+
+## 3. RED-vs-GREEN expectation handling
+
+A `phase: GREEN` acceptance declares the contract should pass at
+GREEN. By ATDD convention, the same acceptance should *fail* at RED
+(proving the contract exercises behavior not yet implemented). The
+substrate runners emit `Violation` records based on outcome regardless
+of phase; **coach is responsible for interpretation**:
+
+| Coach phase | Rule's `phase` | Outcome | Coach interpretation |
+|---|---|---|---|
+| RED | RED | violation | Failure (regression on RED scaffolding) |
+| RED | GREEN | violation | **Expected** — RED expects red |
+| RED | GREEN | no violation | **Regression** — the GREEN contract is already passing at RED |
+| GREEN | GREEN | violation | Failure |
+| GREEN | GREEN | no violation | Pass |
+| SMOKE | SMOKE | violation | Failure |
+| REFACTOR | any strict | violation | Regression (sweep) |
+
+The "expected vs regression" classification is coach v6 §4.1
+behavior; the substrate selector simply *includes* GREEN-phase rules at
+RED and lets coach interpret. The classification helper
+`classify_violation(coach_phase, rule)` is also exported from
+`phase_dispatch.py` for callers that need it explicitly.
+
+## 4. REFACTOR sweep semantics
+
+At REFACTOR, the selector additionally returns every rule (toolkit OR
+repo) where `RuleMetadata.disposition == "strict"`, **regardless of
+that rule's phase**. The intent is a regression check before COMPLETE:
+no strict-disposition rule is allowed to fail in REFACTOR even if its
+phase has already passed.
+
+"Both registries" in §8.1 paragraph 4 refers conceptually to
+toolkit-conventions and repo-rules. Both live in the same
+`bind_rule()` cache (`_REGISTRY_CACHE` in
+`src/atdd/coach/utils/rule_binding.py`); the selector iterates the
+unified registry via `iter_rules()`.
+
+### 4.1 Suppression markers — ineffective for repo rules
+
+Per spec §8.5, the disposition gate appends repo-rule strict failures
+unconditionally at REFACTOR. Suppression markers
+(`# atdd:suppress(repo.<rule_id>) [UNTIL=<date>]`) do not silence
+them. Toolkit-rule strict failures swept at REFACTOR retain the
+existing `assert_disposition_satisfied` semantics (toolkit conventions
+can use `# atdd:suppress(...)` for the migration debt cases that
+disposition was designed for). The selector does not introduce a new
+"REFACTOR suppression bypass"; it only includes the rules — gate
+behavior is unchanged.
+
+## 5. Example trace
+
+Fixture WMBT
+(`src/atdd/tester/validators/fixtures/phase_dispatch/mixed_phases.yaml`)
+declares three acceptances:
+
+| Acceptance | Phase | Rule-id |
+|---|---|---|
+| `acc:phase-dispatch:D001-UNIT-001-red-fixture` | RED | `repo.phase-dispatch.D001-acc-unit-001` |
+| `acc:phase-dispatch:D001-UNIT-002-green-fixture` | GREEN | `repo.phase-dispatch.D001-acc-unit-002` |
+| `acc:phase-dispatch:D001-UNIT-003-refactor-fixture` | REFACTOR | `repo.phase-dispatch.D001-acc-unit-003` |
+
+Selector behavior:
+
+| Coach phase | Selected repo rules |
+|---|---|
+| RED | { unit-001 (phase=RED), unit-002 (phase=GREEN — RED expects red) } |
+| GREEN | { unit-002 (phase=GREEN) } |
+| SMOKE | { } — no fixture rule pinned to SMOKE |
+| REFACTOR | { unit-001, unit-002, unit-003 } — all strict |
+
+The integration test
+(`test_phase_dispatch.py::test_select_validator_set_against_mixed_phases_fixture`)
+asserts this trace.
+
+## 6. Public API
+
+```python
+from atdd.coach.utils.phase_dispatch import (
+    select_validator_set,
+    classify_violation,
+    PhaseDispatchError,
+)
+
+# Returns Iterable[RuleMetadata].
+selected = select_validator_set(coach_phase="RED")
+
+# Returns "expected" | "regression" | "failure" | "pass".
+classification = classify_violation(coach_phase="RED", rule=meta, violation_emitted=True)
+```
+
+`select_validator_set` accepts an optional `registry` argument (an
+`Iterable[RuleMetadata]`) for tests; live callers pass nothing and the
+function consumes `iter_rules()` from the unified cache. Phase strings
+are case-insensitive; the function normalizes to upper-case internally
+and rejects unknown phases with `PhaseDispatchError`.
+
+## 7. Out of scope
+
+* Spawn-harness `wmbt_rules` / `train_rules` / `security_rules` blocks
+  (issue #417, §8.2).
+* Risk-score archetype breakdown (issue #418, §8.3).
+* Train scope detection at SMOKE (issue #441 prospective, §8.4).

--- a/src/atdd/coach/utils/phase_dispatch.py
+++ b/src/atdd/coach/utils/phase_dispatch.py
@@ -1,0 +1,200 @@
+# URN: component:govern-lifecycle:enforcement-substrate:phase_dispatch:backend:domain
+# Runtime: python
+# Purpose: Coach phase-driven dispatch — select repo rules by RuleMetadata.phase per spec v12 §8.1.
+
+"""Coach phase-driven validator dispatch (substrate spec v12 §8.1).
+
+See ``src/atdd/coach/specs/phase-dispatch.spec.md`` for the full
+contract. In short: at coach phase ``X``, select every repo rule whose
+``RuleMetadata.phase == X``; at ``RED`` additionally include
+``phase: GREEN`` rules ("RED expects red"); at ``REFACTOR`` additionally
+sweep every strict-disposition rule from the unified registry.
+
+Security rules (registered via #422) carry a populated
+``bound_acceptance_urn``. The selector reads the **bound** rule's phase
+for dispatch — per §8.1 line 584. Pre-#422 this branch is a no-op.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Iterator, List, Optional
+
+from atdd.coach.utils.rule_binding import (
+    RuleMetadata,
+    RuleNotInRegistryError,
+    bind_rule,
+    iter_rules,
+)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+class PhaseDispatchError(ValueError):
+    """Raised for unknown coach phases or invalid dispatch arguments."""
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+VALID_PHASES = ("RED", "GREEN", "SMOKE", "REFACTOR")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _normalize_phase(phase: str) -> str:
+    if not isinstance(phase, str) or not phase.strip():
+        raise PhaseDispatchError(
+            f"coach_phase must be a non-empty string, got {phase!r}"
+        )
+    canonical = phase.strip().upper()
+    if canonical not in VALID_PHASES:
+        raise PhaseDispatchError(
+            f"unknown coach_phase {phase!r}; expected one of {VALID_PHASES}"
+        )
+    return canonical
+
+
+def _phase_for_dispatch(rule: RuleMetadata) -> Optional[str]:
+    """Resolve the rule's effective phase for dispatch per §8.1 line 584.
+
+    Security rules carry a ``bound_acceptance_urn`` pointing at the
+    acceptance whose phase governs activation. Reads that rule's phase
+    from the registry; falls back to the rule's own ``phase`` when no
+    binding is set.
+
+    Returns ``None`` when the bound rule cannot be resolved — the
+    substrate enforcement rule
+    ``security-rule-must-have-acceptance-ref-resolved`` (§7.3) surfaces
+    this at PLANNED phase, so the selector skips silently here rather
+    than failing the whole dispatch.
+    """
+    bound = rule.bound_acceptance_urn
+    if not bound:
+        return rule.phase
+    try:
+        bound_meta = bind_rule(bound)
+    except RuleNotInRegistryError:
+        return None
+    return bound_meta.phase
+
+
+def _is_repo_rule(rule: RuleMetadata) -> bool:
+    """Identify repo-derived rules — they discriminate by archetype prefix.
+
+    Repo-walker rule-ids start with ``repo.`` (spec v12 §3.3). Toolkit
+    rules use ``coder.`` / ``coach.`` / ``tester.`` / ``planner.``. The
+    selector returns toolkit rules only when REFACTOR sweeps strict; at
+    other phases it filters to repo rules.
+    """
+    return isinstance(rule.rule_id, str) and rule.rule_id.startswith("repo.")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+def select_validator_set(
+    coach_phase: str,
+    registry: Optional[Iterable[RuleMetadata]] = None,
+) -> List[RuleMetadata]:
+    """Return the repo-rule subset active at *coach_phase* per §8.1.
+
+    Args:
+        coach_phase: One of ``RED``, ``GREEN``, ``SMOKE``, ``REFACTOR``
+            (case-insensitive).
+        registry: Optional iterable of ``RuleMetadata`` to select from.
+            When ``None``, the unified registry exposed by
+            ``iter_rules()`` is consumed.
+
+    Returns:
+        Deterministic list of selected rules, ordered by ``rule_id``.
+
+    Raises:
+        PhaseDispatchError: when ``coach_phase`` is unknown.
+
+    Selection formula (spec v12 §8.1):
+
+        S(X) = { repo rules where phase_for_dispatch(rule) == X }
+             ∪ { repo rules where phase_for_dispatch(rule) == "GREEN" if X == RED }
+             ∪ { every strict-disposition rule (toolkit or repo) if X == REFACTOR }
+    """
+    phase = _normalize_phase(coach_phase)
+    rules = list(registry) if registry is not None else list(iter_rules())
+
+    selected: List[RuleMetadata] = []
+    seen: set = set()
+
+    def _add(rule: RuleMetadata) -> None:
+        if rule.rule_id in seen:
+            return
+        seen.add(rule.rule_id)
+        selected.append(rule)
+
+    # Set 1: repo rules whose effective phase matches the coach phase.
+    # Set 2: at RED only, additionally include phase=GREEN repo rules
+    #        ("RED expects red" — §8.1 paragraph 5).
+    accepted_phases = {phase}
+    if phase == "RED":
+        accepted_phases.add("GREEN")
+
+    for rule in rules:
+        if not _is_repo_rule(rule):
+            continue
+        effective = _phase_for_dispatch(rule)
+        if effective is None:
+            continue
+        if effective.upper() in accepted_phases:
+            _add(rule)
+
+    # Set 3: REFACTOR sweep — every strict-disposition rule (toolkit OR
+    # repo) regardless of phase (§8.1 paragraph 4).
+    if phase == "REFACTOR":
+        for rule in rules:
+            if rule.disposition == "strict":
+                _add(rule)
+
+    selected.sort(key=lambda r: r.rule_id)
+    return selected
+
+
+def classify_violation(
+    coach_phase: str,
+    rule: RuleMetadata,
+    violation_emitted: bool,
+) -> str:
+    """Classify a violation outcome per coach v6 §4.1 + spec v12 §8.1 ¶5.
+
+    Returns one of:
+      - ``"expected"`` — violation at RED for a phase=GREEN rule (RED expects red).
+      - ``"regression"`` — phase=GREEN rule passes at RED (the contract is
+        already passing — coach surfaces this so the agent doesn't skip
+        the GREEN write).
+      - ``"failure"`` — violation at GREEN/SMOKE for a phase=X-matching rule.
+      - ``"pass"`` — no violation; rule is satisfied for this phase.
+    """
+    phase = _normalize_phase(coach_phase)
+    rule_phase = _phase_for_dispatch(rule)
+    rule_phase_upper = rule_phase.upper() if isinstance(rule_phase, str) else None
+
+    if phase == "RED" and rule_phase_upper == "GREEN":
+        return "expected" if violation_emitted else "regression"
+
+    return "failure" if violation_emitted else "pass"
+
+
+def iter_selected(
+    coach_phase: str,
+    registry: Optional[Iterable[RuleMetadata]] = None,
+) -> Iterator[RuleMetadata]:
+    """Streaming variant of ``select_validator_set``."""
+    yield from select_validator_set(coach_phase, registry=registry)
+
+
+__all__ = [
+    "PhaseDispatchError",
+    "VALID_PHASES",
+    "classify_violation",
+    "iter_selected",
+    "select_validator_set",
+]

--- a/src/atdd/coach/utils/tests/test_phase_dispatch.py
+++ b/src/atdd/coach/utils/tests/test_phase_dispatch.py
@@ -1,0 +1,364 @@
+# URN: urn:atdd:test:coach:utils:phase_dispatch
+# Issue: #416
+
+"""Tests for the coach phase-driven dispatcher (substrate spec v12 §8.1).
+
+Covers:
+
+* Pure-function selector against in-memory ``RuleMetadata`` lists:
+  - ``phase=X`` rules selected at coach phase X.
+  - ``phase=GREEN`` rules selected at RED ("RED expects red", §8.1 ¶5).
+  - REFACTOR sweeps every strict-disposition rule (toolkit + repo).
+  - Toolkit rules excluded outside REFACTOR.
+  - Security-rule branch: ``bound_acceptance_urn`` resolution governs
+    dispatch phase (§8.1 line 584).
+  - Determinism: result ordered by ``rule_id``.
+  - Phase normalization (case-insensitive) and unknown-phase rejection.
+* Integration test against the fixture WMBT
+  ``src/atdd/tester/validators/fixtures/phase_dispatch/mixed_phases.yaml``
+  driven through the live walker → registry path.
+* ``classify_violation`` honors §4.1 expected-vs-regression at RED.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import List
+
+import pytest
+
+from atdd.coach.utils.phase_dispatch import (
+    PhaseDispatchError,
+    classify_violation,
+    select_validator_set,
+)
+from atdd.coach.utils.rule_binding import RuleMetadata
+
+
+pytestmark = [pytest.mark.platform]
+
+
+# ---------------------------------------------------------------------------
+# In-memory fixture builders
+# ---------------------------------------------------------------------------
+def _make_rule(
+    rule_id: str,
+    *,
+    phase: str = None,
+    disposition: str = "strict",
+    bound_acceptance_urn: str = None,
+) -> RuleMetadata:
+    """Construct a minimal ``RuleMetadata`` for selector unit tests."""
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=4,
+        description=f"fixture rule {rule_id}",
+        recipe=None,
+        introduced_in=None,
+        source_path=Path("/tmp/fake.yaml"),
+        disposition=disposition,
+        validator=None,
+        fix_hint=None,
+        aliases=(),
+        phase=phase,
+        bound_acceptance_urn=bound_acceptance_urn,
+    )
+
+
+def _ids(rules: List[RuleMetadata]) -> List[str]:
+    return [r.rule_id for r in rules]
+
+
+# ---------------------------------------------------------------------------
+# Pure-function selector behavior
+# ---------------------------------------------------------------------------
+def test_green_phase_selects_only_green_repo_rules():
+    """A coach session at GREEN selects only repo rules with ``phase: GREEN``."""
+    registry = [
+        _make_rule("repo.fixture.D001-acc-unit-001", phase="RED"),
+        _make_rule("repo.fixture.D001-acc-unit-002", phase="GREEN"),
+        _make_rule("repo.fixture.D001-acc-unit-003", phase="REFACTOR"),
+    ]
+    selected = select_validator_set("GREEN", registry=registry)
+    assert _ids(selected) == ["repo.fixture.D001-acc-unit-002"]
+
+
+def test_red_phase_selects_red_and_green_rules_per_red_expects_red():
+    """At RED, both phase=RED and phase=GREEN repo rules are selected (§8.1 ¶5).
+
+    The phase=GREEN rules represent the "RED expects red" override:
+    coach exercises the GREEN contract at RED so violations confirm the
+    contract currently fails (expected at RED, not at GREEN).
+    """
+    registry = [
+        _make_rule("repo.fixture.D001-acc-unit-001", phase="RED"),
+        _make_rule("repo.fixture.D001-acc-unit-002", phase="GREEN"),
+        _make_rule("repo.fixture.D001-acc-unit-003", phase="REFACTOR"),
+    ]
+    selected = select_validator_set("RED", registry=registry)
+    assert _ids(selected) == [
+        "repo.fixture.D001-acc-unit-001",
+        "repo.fixture.D001-acc-unit-002",
+    ]
+
+
+def test_refactor_sweeps_every_strict_rule_regardless_of_phase():
+    """REFACTOR sweeps every strict-disposition rule (toolkit + repo) per §8.1 ¶4."""
+    registry = [
+        _make_rule("repo.fixture.D001-acc-unit-001", phase="RED"),
+        _make_rule("repo.fixture.D001-acc-unit-002", phase="GREEN"),
+        _make_rule("repo.fixture.D001-acc-unit-003", phase="REFACTOR"),
+        _make_rule("coder.fixture.toolkit-strict", phase=None),
+        _make_rule(
+            "coder.fixture.toolkit-advisory", phase=None, disposition="advisory"
+        ),
+    ]
+    selected = select_validator_set("REFACTOR", registry=registry)
+    # Every strict rule appears (toolkit AND repo); the advisory one
+    # does not.
+    assert _ids(selected) == [
+        "coder.fixture.toolkit-strict",
+        "repo.fixture.D001-acc-unit-001",
+        "repo.fixture.D001-acc-unit-002",
+        "repo.fixture.D001-acc-unit-003",
+    ]
+
+
+def test_smoke_phase_selects_only_smoke_repo_rules():
+    """SMOKE selects rules whose ``phase: SMOKE``, no fallback."""
+    registry = [
+        _make_rule("repo.fixture.D001-acc-unit-001", phase="RED"),
+        _make_rule("repo.fixture.D001-acc-unit-002", phase="GREEN"),
+        _make_rule("repo.fixture.D001-acc-unit-003", phase="REFACTOR"),
+        _make_rule("repo.fixture.D001-acc-unit-004", phase="SMOKE"),
+    ]
+    selected = select_validator_set("SMOKE", registry=registry)
+    assert _ids(selected) == ["repo.fixture.D001-acc-unit-004"]
+
+
+def test_toolkit_rules_excluded_outside_refactor():
+    """Toolkit-archetype rules are not selected at RED/GREEN/SMOKE.
+
+    Phase-driven dispatch surfaces *repo* rules per §8.1; toolkit rules
+    continue to be selected by archetype (handled separately by
+    ``atdd validate``). REFACTOR is the only phase that pulls toolkit
+    rules through the selector — and only when their disposition is
+    ``strict`` (sweep semantics).
+    """
+    registry = [
+        _make_rule("coder.fixture.toolkit-strict-rule", phase=None),
+        _make_rule("repo.fixture.D001-acc-unit-001", phase="GREEN"),
+    ]
+    for phase in ("RED", "GREEN", "SMOKE"):
+        selected = select_validator_set(phase, registry=registry)
+        assert all(r.rule_id.startswith("repo.") for r in selected), (
+            f"toolkit rule leaked into selection at {phase}"
+        )
+
+
+def test_unknown_phase_raises():
+    with pytest.raises(PhaseDispatchError):
+        select_validator_set("PLANNED", registry=[])
+    with pytest.raises(PhaseDispatchError):
+        select_validator_set("", registry=[])
+
+
+def test_phase_is_case_insensitive():
+    """The selector normalizes phase to upper-case internally."""
+    registry = [_make_rule("repo.fixture.D001-acc-unit-002", phase="GREEN")]
+    assert _ids(select_validator_set("green", registry=registry)) == [
+        "repo.fixture.D001-acc-unit-002"
+    ]
+    assert _ids(select_validator_set("Green", registry=registry)) == [
+        "repo.fixture.D001-acc-unit-002"
+    ]
+
+
+def test_selection_is_deterministic_and_dedup():
+    """Selected rules sort by ``rule_id`` and are deduped at REFACTOR.
+
+    A repo rule with phase=REFACTOR and disposition=strict matches both
+    set 1 (phase match) and set 3 (REFACTOR sweep). The selector emits
+    it once.
+    """
+    registry = [
+        _make_rule("repo.fixture.D001-acc-unit-002", phase="REFACTOR"),
+        _make_rule("repo.fixture.D001-acc-unit-001", phase="REFACTOR"),
+    ]
+    ids = _ids(select_validator_set("REFACTOR", registry=registry))
+    assert ids == sorted(ids)
+    assert len(ids) == len(set(ids))  # no duplicates
+
+
+# ---------------------------------------------------------------------------
+# Security-rule branch (§8.1 line 584)
+# ---------------------------------------------------------------------------
+def _security_registry():
+    """Registry mixing a bound acceptance with a security rule pointing at it."""
+    return [
+        _make_rule("repo.feature-x.D005-acc-http-001", phase="GREEN"),
+        # Security rule's own phase is intentionally *wrong* — dispatch
+        # must read the bound rule's phase, not this one.
+        _make_rule(
+            "repo.feature-x.security-rule-001",
+            phase="REFACTOR",
+            bound_acceptance_urn="repo.feature-x.D005-acc-http-001",
+        ),
+    ]
+
+
+def test_security_rule_dispatches_on_bound_acceptance_phase():
+    """A security rule's bound-acceptance phase governs dispatch (§8.1 line 584).
+
+    The bound acceptance is at GREEN, so the security rule activates at
+    GREEN even though the security rule's *own* ``phase`` claims REFACTOR.
+    """
+    from atdd.coach.utils import rule_binding as rb
+
+    rb.clear_cache()
+    registry = _security_registry()
+    # Seed the registry cache directly so bind_rule(bound_urn) resolves
+    # in the selector's ``_phase_for_dispatch`` helper.
+    rb._REGISTRY_CACHE = {meta.rule_id: [meta] for meta in registry}
+    try:
+        selected_green = _ids(select_validator_set("GREEN", registry=registry))
+        # Both rules activate at GREEN: the bound acceptance directly,
+        # the security rule via bound_acceptance_urn → GREEN.
+        assert "repo.feature-x.security-rule-001" in selected_green
+        assert "repo.feature-x.D005-acc-http-001" in selected_green
+        # At REFACTOR the strict-sweep also pulls the security rule in
+        # (it's strict-disposition); we just assert presence.
+        selected_refactor = _ids(
+            select_validator_set("REFACTOR", registry=registry)
+        )
+        assert "repo.feature-x.security-rule-001" in selected_refactor
+    finally:
+        rb.clear_cache()
+
+
+def test_security_rule_with_unresolved_binding_is_skipped():
+    """An unresolvable ``bound_acceptance_urn`` causes the rule to be skipped.
+
+    Per spec §7.3, the substrate enforcement rule
+    ``security-rule-must-have-acceptance-ref-resolved`` surfaces this at
+    PLANNED phase. The dispatch selector silently skips so a stale
+    binding does not poison runtime selection.
+    """
+    from atdd.coach.utils import rule_binding as rb
+
+    rb.clear_cache()
+    registry = [
+        _make_rule(
+            "repo.feature-x.security-rule-001",
+            phase="GREEN",
+            bound_acceptance_urn="repo.does-not-exist.acc-missing",
+        ),
+    ]
+    rb._REGISTRY_CACHE = {meta.rule_id: [meta] for meta in registry}
+    try:
+        selected = select_validator_set("GREEN", registry=registry)
+        assert _ids(selected) == []
+    finally:
+        rb.clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# Integration test against the fixture (acceptance criterion)
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def fixture_repo_with_mixed_phases(tmp_path: Path) -> Path:
+    """Stand up a stand-in repo seeded with the mixed_phases.yaml fixture.
+
+    The walker discovers WMBT YAML at ``plan/<wagon>/[DLPCEMYRK]NNN.yaml``;
+    the fixture file lives elsewhere (under ``tester/validators/fixtures/``)
+    so we copy it into the conventional layout.
+    """
+    fixture_src = (
+        Path(__file__).resolve().parents[3]
+        / "tester"
+        / "validators"
+        / "fixtures"
+        / "phase_dispatch"
+        / "mixed_phases.yaml"
+    )
+    assert fixture_src.is_file(), (
+        f"fixture missing at {fixture_src}; expected copy under "
+        f"src/atdd/tester/validators/fixtures/phase_dispatch/"
+    )
+    plan_dir = tmp_path / "plan" / "phase-dispatch"
+    plan_dir.mkdir(parents=True)
+    shutil.copy(fixture_src, plan_dir / "D001.yaml")
+    return tmp_path
+
+
+def test_select_validator_set_against_mixed_phases_fixture(
+    fixture_repo_with_mixed_phases: Path,
+):
+    """Issue #416 acceptance criterion — integration against the fixture.
+
+    A coach session at:
+      - RED      selects { unit-001, unit-002 } (RED expects red)
+      - GREEN    selects { unit-002 }
+      - SMOKE    selects { } (no fixture rule pinned to SMOKE)
+      - REFACTOR sweeps { unit-001, unit-002, unit-003 } (all strict)
+    """
+    from atdd.coach.utils import rule_binding as rb
+
+    rb.clear_cache(override_repo_root=fixture_repo_with_mixed_phases)
+    try:
+        red = _ids(select_validator_set("RED"))
+        assert red == [
+            "repo.phase-dispatch.D001-acc-unit-001",
+            "repo.phase-dispatch.D001-acc-unit-002",
+        ]
+
+        green = _ids(select_validator_set("GREEN"))
+        assert green == ["repo.phase-dispatch.D001-acc-unit-002"]
+
+        smoke = _ids(select_validator_set("SMOKE"))
+        assert smoke == []
+
+        refactor = _ids(select_validator_set("REFACTOR"))
+        # Every strict-disposition repo rule from the fixture appears.
+        # Toolkit-strict rules also appear (they are swept in REFACTOR);
+        # filter the assertion to repo-rules so the test stays hermetic
+        # against unrelated toolkit churn.
+        repo_subset = [r for r in refactor if r.startswith("repo.phase-dispatch.")]
+        assert repo_subset == [
+            "repo.phase-dispatch.D001-acc-unit-001",
+            "repo.phase-dispatch.D001-acc-unit-002",
+            "repo.phase-dispatch.D001-acc-unit-003",
+        ]
+    finally:
+        rb.clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# classify_violation — coach v6 §4.1 expected-vs-regression
+# ---------------------------------------------------------------------------
+def test_classify_violation_red_expects_red_for_green_rule():
+    """At RED, a phase=GREEN rule's violation classifies as ``expected``."""
+    rule = _make_rule("repo.fixture.D001-acc-unit-002", phase="GREEN")
+    assert classify_violation("RED", rule, violation_emitted=True) == "expected"
+
+
+def test_classify_violation_red_expects_red_no_violation_is_regression():
+    """At RED, a phase=GREEN rule passing classifies as ``regression``.
+
+    The GREEN contract is already passing at RED — coach surfaces this
+    so the agent doesn't silently skip the GREEN write.
+    """
+    rule = _make_rule("repo.fixture.D001-acc-unit-002", phase="GREEN")
+    assert classify_violation("RED", rule, violation_emitted=False) == "regression"
+
+
+def test_classify_violation_green_phase_violation_is_failure():
+    """At GREEN, a phase=GREEN rule's violation classifies as ``failure``."""
+    rule = _make_rule("repo.fixture.D001-acc-unit-002", phase="GREEN")
+    assert classify_violation("GREEN", rule, violation_emitted=True) == "failure"
+
+
+def test_classify_violation_green_phase_no_violation_is_pass():
+    rule = _make_rule("repo.fixture.D001-acc-unit-002", phase="GREEN")
+    assert classify_violation("GREEN", rule, violation_emitted=False) == "pass"

--- a/src/atdd/tester/validators/fixtures/phase_dispatch/mixed_phases.yaml
+++ b/src/atdd/tester/validators/fixtures/phase_dispatch/mixed_phases.yaml
@@ -1,0 +1,82 @@
+# Fixture: WMBT with three acceptances pinned to different phases.
+# Issue #416 — substrate Track-F coach phase dispatch.
+# Spec: docs/specs/atdd-repo-substrate-spec-v12.md §8.1
+# Companion: src/atdd/coach/specs/phase-dispatch.spec.md §5
+#
+# Consumer: src/atdd/coach/utils/tests/test_phase_dispatch.py asserts the
+# selector returns:
+#   RED      → { unit-001 (RED), unit-002 (GREEN — RED expects red) }
+#   GREEN    → { unit-002 }
+#   SMOKE    → { } (no fixture rule pinned to SMOKE)
+#   REFACTOR → { unit-001, unit-002, unit-003 } (all strict, swept)
+
+urn: "wmbt:phase-dispatch:D001"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "phase-dispatch-fixture-acceptances"
+context_clarifier: "fixture WMBT exercising coach phase dispatch across RED/GREEN/REFACTOR"
+lens: "functional.sustainability"
+statement: "minimize coach phase-dispatch ambiguity by exercising every phase pin"
+
+acceptances:
+  - identity:
+      urn: "acc:phase-dispatch:D001-UNIT-001-red-fixture"
+      id: "AC-UNIT-001"
+      purpose: "RED-phase fixture acceptance — coach selects this at RED only"
+      phase: "RED"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract: ["the registry contains a phase=RED repo rule"]
+    when:
+      abstract: "coach dispatches at RED"
+    then:
+      abstract:
+        - "select_validator_set('RED') includes this rule"
+        - "select_validator_set('GREEN') excludes this rule"
+    metadata:
+      author: "atdd:phase-dispatch-fixture"
+      created: "2026-05-06"
+
+  - identity:
+      urn: "acc:phase-dispatch:D001-UNIT-002-green-fixture"
+      id: "AC-UNIT-002"
+      purpose: "GREEN-phase fixture acceptance — coach selects this at RED (expects red) and at GREEN"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract: ["the registry contains a phase=GREEN repo rule"]
+    when:
+      abstract: "coach dispatches at RED, GREEN, or REFACTOR"
+    then:
+      abstract:
+        - "select_validator_set('RED') includes this rule (RED expects red — §8.1 ¶5)"
+        - "select_validator_set('GREEN') includes this rule"
+        - "select_validator_set('REFACTOR') includes this rule (strict sweep)"
+    metadata:
+      author: "atdd:phase-dispatch-fixture"
+      created: "2026-05-06"
+
+  - identity:
+      urn: "acc:phase-dispatch:D001-UNIT-003-refactor-fixture"
+      id: "AC-UNIT-003"
+      purpose: "REFACTOR-phase fixture acceptance — coach selects this at REFACTOR only"
+      phase: "REFACTOR"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract: ["the registry contains a phase=REFACTOR repo rule"]
+    when:
+      abstract: "coach dispatches at REFACTOR"
+    then:
+      abstract:
+        - "select_validator_set('REFACTOR') includes this rule"
+        - "select_validator_set('GREEN') excludes this rule"
+    metadata:
+      author: "atdd:phase-dispatch-fixture"
+      created: "2026-05-06"


### PR DESCRIPTION
Closes #416.

## Summary

- New module `src/atdd/coach/utils/phase_dispatch.py` exposes `select_validator_set(coach_phase)` and `classify_violation(...)` per substrate spec §8.1.
- New spec `src/atdd/coach/specs/phase-dispatch.spec.md` pins the dispatch contract (the issue calls out this NEW FILE explicitly since `atdd-coach-spec-v6.md` is referenced by the substrate spec but not in the toolkit).
- New integration fixture `src/atdd/tester/validators/fixtures/phase_dispatch/mixed_phases.yaml` — three acceptances at RED/GREEN/REFACTOR.
- 15 tests in `src/atdd/coach/utils/tests/test_phase_dispatch.py` covering pure-function selection, security-rule indirection, the integration trace, and `classify_violation` semantics.

## Selection formula (§8.1)

```
S(X) = { repo rules where phase_for_dispatch(rule) == X }
     ∪ { repo rules where phase_for_dispatch(rule) == "GREEN", if X == RED }   # RED expects red
     ∪ { every strict-disposition rule (toolkit + repo), if X == REFACTOR }    # sweep
```

`phase_for_dispatch` resolves a security rule's `bound_acceptance_urn` to the bound rule's phase (§8.1 line 584). Implemented unconditionally so #422 lands without a follow-up patch — no-op pre-#422.

## Prerequisite acknowledgement (per issue body)

The issue notes that the toolkit's `atdd validate <phase>` dispatches by archetype today, not by `RED|GREEN|SMOKE|REFACTOR`, and that `atdd-coach-spec-v6.md` is not in `src/atdd/coach/specs/`. This PR lands **(a)** — the substrate-side dispatch entry point lives at the new selector module + spec. The selector is a pure library; wiring it into a `coach phase X` runner is downstream work (issues #417/#418/etc.).

## Acceptance trace (fixture-driven integration test)

| Coach phase | Selected repo rules from `mixed_phases.yaml` |
|---|---|
| RED | { unit-001 (phase=RED), unit-002 (phase=GREEN — RED expects red) } |
| GREEN | { unit-002 } |
| SMOKE | { } |
| REFACTOR | { unit-001, unit-002, unit-003 } (all strict, swept) |

## Test plan

- [x] `python3 -m pytest src/atdd/coach/utils/tests/test_phase_dispatch.py` — 15/15 pass
- [x] `python3 -m pytest src/atdd/coach/utils/tests/` — 128/128 pass (no regressions)
- [x] `python3 -m pytest src/atdd/coach/validators/test_rule_id_uniqueness.py src/atdd/coach/validators/test_rule_id_registry_coherence.py` — registry-coherence still passes after spec/file additions
- [x] Version bumped to **3.5.5** (MINOR — new module + new public API)

## Predecessors (all merged to main)

- #407 Track A foundation (`repo` archetype + `RuleMetadata` substrate fields)
- #408 Track A walker (WMBT/train repo rule derivation)
- #412 Track D metric runner
- #419 Track G SecurityResolver
- #414 Track E CLI rename (`atdd urn` → `atdd repo`)

## Concurrent wave note

Version 3.5.5 was pre-allocated for #416. Concurrent waves: #415=3.5.1, #417=3.5.2, #418=3.5.3, #422=3.5.4, **#416=3.5.5** (this PR).