### PR TITLE
feat(atdd): #415 — atdd init substrate-mode extension

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to ATDD
+
+Thanks for working on ATDD. This file documents toolkit-specific workflows
+that consumers don't need to know about.
+
+For day-to-day usage, see [README.md](README.md).
+
+## Dogfooding the substrate
+
+The ATDD repo-substrate (spec v12) is a pytest plugin that anchors test
+failures to acceptance rules in `plan/**/features/*.yaml`. It is registered
+via a `pytest11` entry-point on the toolkit's `pyproject.toml` and is
+auto-loaded in any environment where `atdd` is installed. The plugin is
+gated at runtime on `.atdd/config.yaml::repo.substrate.enabled` — it is a
+no-op for any consumer that hasn't opted in.
+
+`atdd init` decides whether to opt in by heuristic (spec v12 §9.3):
+
+| Layout | `plan/` | `src/atdd/` | Default mode |
+|---|---|---|---|
+| Greenfield consumer repo | absent | absent | `toolkit` (substrate inactive) |
+| Working consumer repo | present | absent | `consumer-repo` |
+| The toolkit's own checkout | present | present | `toolkit` |
+
+The third row is what makes dogfooding interesting: the toolkit's own
+checkout has both signals, so a bare `atdd init` correctly classifies it
+as toolkit mode and the substrate stays inert. To dogfood the substrate
+against the toolkit's own `plan/govern_lifecycle/`, run:
+
+```sh
+atdd init --consumer-repo
+```
+
+This writes the `repo:` block to `.atdd/config.yaml`:
+
+```yaml
+repo:
+  test_root: tests/
+  plan_root: plan/
+  substrate:
+    enabled: true
+    plugin: atdd.tester.substrate.plugin
+    mode: consumer-repo
+```
+
+…and on the next `pytest` run, the substrate plugin walks `tests/` for
+`# Acceptance: <urn>` headers and routes assertion failures through the
+disposition gate. To revert, run:
+
+```sh
+atdd init --toolkit
+```
+
+This removes the `repo:` block and the plugin returns to no-op mode.
+
+### Mode persistence
+
+A subsequent bare `atdd init --force` reads the existing
+`repo.substrate.mode` and stays in mode — overriding requires explicit
+`--consumer-repo` / `--toolkit`. Two consecutive
+`atdd init --consumer-repo --force` runs are idempotent; same for
+`--toolkit --force`. Mixing flags (`--consumer-repo --toolkit`) is
+rejected with a non-zero exit code.
+
+## Releasing
+
+Every PR ends with a version bump in `pyproject.toml` and a
+`v{version}` tag on the merge commit. See `CLAUDE.md::release` for the
+end-to-end protocol.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.5.0"
+version = "3.5.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"
@@ -33,6 +33,13 @@ viz = ["streamlit", "st-link-analysis"]
 
 [project.scripts]
 atdd = "atdd.cli:cli"
+
+# Substrate pytest plugin (spec v12 §7.2, §9.3 — issues #411, #415).
+# Auto-loaded by pytest whenever atdd is importable; the plugin itself
+# early-returns when `.atdd/config.yaml::repo.substrate.enabled` is unset
+# (toolkit mode), so non-substrate consumers see no behavior change.
+[project.entry-points.pytest11]
+atdd_substrate = "atdd.tester.substrate.plugin"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -501,6 +501,19 @@ Phase descriptions:
         dest="export_schemas",
         help="Export convention YAML and schema JSON files to .atdd/schemas/"
     )
+    # Substrate mode (issue #415, spec v12 §9.3) — mutually exclusive overrides.
+    init_substrate_group = init_parser.add_mutually_exclusive_group()
+    init_substrate_group.add_argument(
+        "--consumer-repo",
+        action="store_true",
+        dest="consumer_repo",
+        help="Force consumer-repo substrate mode (writes repo.* fields to .atdd/config.yaml)"
+    )
+    init_substrate_group.add_argument(
+        "--toolkit",
+        action="store_true",
+        help="Force toolkit mode (removes substrate fields; only existing toolkit init behavior)"
+    )
 
     # ----- atdd schemas --check -----
     schemas_parser = subparsers.add_parser(
@@ -1675,7 +1688,12 @@ Phase descriptions:
         initializer = ProjectInitializer()
         if args.export_schemas:
             return initializer.export_schemas()
-        return initializer.init(force=args.force, worktree_layout=args.worktree_layout)
+        return initializer.init(
+            force=args.force,
+            worktree_layout=args.worktree_layout,
+            consumer_repo=getattr(args, "consumer_repo", False),
+            toolkit=getattr(args, "toolkit", False),
+        )
 
     # atdd new <slug> — DEPRECATED, delegates to atdd issue <slug>
     elif args.command == "new":

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -69,6 +69,21 @@ Define themes now? [defaults / custom / skip]
 _THEME_MODES = frozenset({"defaults", "custom", "skip"})
 
 
+# -----------------------------------------------------------------------------
+# Substrate mode (issue #415, spec v12 §9.3)
+# -----------------------------------------------------------------------------
+# Toolkit-self vs consumer-repo is detected by heuristic, with explicit flag
+# override. The substrate's pytest plugin is registered via pytest11 entry-point
+# in pyproject.toml; the plugin checks `repo.substrate.enabled` at collect time
+# and is a no-op in toolkit mode.
+
+SUBSTRATE_MODE_CONSUMER = "consumer-repo"
+SUBSTRATE_MODE_TOOLKIT = "toolkit"
+SUBSTRATE_PLUGIN_ENTRY_POINT = "atdd.tester.substrate.plugin"
+SUBSTRATE_DEFAULT_TEST_ROOT = "tests/"
+SUBSTRATE_DEFAULT_PLAN_ROOT = "plan/"
+
+
 def slug_to_branch_name(slug: str) -> str:
     """Convert worktree directory slug to branch-style name.
 
@@ -359,17 +374,31 @@ class ProjectInitializer:
         self.manifest_file = self.atdd_config_dir / "manifest.yaml"
         self.config_file = self.atdd_config_dir / "config.yaml"
 
-    def init(self, force: bool = False, worktree_layout: bool = False) -> int:
+    def init(
+        self,
+        force: bool = False,
+        worktree_layout: bool = False,
+        consumer_repo: bool = False,
+        toolkit: bool = False,
+    ) -> int:
         """
         Bootstrap .atdd/ config and GitHub infrastructure.
 
         Args:
             force: If True, overwrite existing files.
             worktree_layout: If True, migrate repo to flat-sibling worktree layout.
+            consumer_repo: If True, force consumer-repo substrate mode (writes
+                substrate fields to .atdd/config.yaml). Mutually exclusive with
+                ``toolkit``. Spec v12 §9.3, issue #415.
+            toolkit: If True, force toolkit mode (removes substrate fields).
+                Mutually exclusive with ``consumer_repo``.
 
         Returns:
             0 on success, 1 on error.
         """
+        if consumer_repo and toolkit:
+            print("Error: --consumer-repo and --toolkit are mutually exclusive.")
+            return 1
         from atdd.coach.utils.repo import detect_worktree_layout, find_repo_root
 
         layout = detect_worktree_layout(self.target_dir)
@@ -453,6 +482,14 @@ class ProjectInitializer:
 
             # Create config.yaml
             self._create_config(force)
+
+            # Resolve substrate mode (consumer-repo vs toolkit) and write/remove
+            # the `repo:` block in .atdd/config.yaml — issue #415, spec v12 §9.3.
+            substrate_mode = self._apply_substrate_mode(
+                force_consumer=consumer_repo,
+                force_toolkit=toolkit,
+            )
+            print(f"Substrate mode: {substrate_mode}")
 
             # Prompt for workspace color if unset or default yellow
             self._prompt_workspace_color()
@@ -683,6 +720,129 @@ class ProjectInitializer:
 
         action = "Updated" if is_update else "Created"
         print(f"{action}: {self.config_file}")
+
+    # -------------------------------------------------------------------------
+    # Substrate mode (issue #415, spec v12 §9.3)
+    # -------------------------------------------------------------------------
+    def detect_substrate_mode_heuristic(self) -> str:
+        """Resolve substrate mode purely from filesystem layout.
+
+        Default heuristic per spec v12 §9.3: presence of ``plan/`` AND absence
+        of ``src/atdd/`` → consumer-repo mode. Otherwise toolkit mode.
+
+        The toolkit's own checkout has both signals, so the heuristic correctly
+        classifies it as toolkit; the override flag (`--consumer-repo`) is
+        needed only for dogfooding.
+        """
+        has_plan = (self.target_dir / "plan").is_dir()
+        has_src_atdd = (self.target_dir / "src" / "atdd").is_dir()
+        if has_plan and not has_src_atdd:
+            return SUBSTRATE_MODE_CONSUMER
+        return SUBSTRATE_MODE_TOOLKIT
+
+    def resolve_substrate_mode(
+        self,
+        force_consumer: bool = False,
+        force_toolkit: bool = False,
+    ) -> str:
+        """Resolve the substrate mode to apply on this `atdd init` run.
+
+        Precedence (high → low):
+          1. ``--toolkit`` flag
+          2. ``--consumer-repo`` flag
+          3. Existing ``repo.substrate.mode`` in ``.atdd/config.yaml``
+             (a subsequent bare `atdd init` stays in mode)
+          4. Filesystem heuristic (`plan/` ^ `src/atdd/`)
+        """
+        if force_toolkit:
+            return SUBSTRATE_MODE_TOOLKIT
+        if force_consumer:
+            return SUBSTRATE_MODE_CONSUMER
+
+        if self.config_file.exists():
+            try:
+                with open(self.config_file) as f:
+                    cfg = yaml.safe_load(f) or {}
+            except (yaml.YAMLError, OSError) as exc:
+                logger.debug("substrate mode: cannot read config %s: %s", self.config_file, exc)
+                cfg = {}
+            existing_mode = (
+                cfg.get("repo", {}).get("substrate", {}).get("mode")
+                if isinstance(cfg, dict) else None
+            )
+            if existing_mode in (SUBSTRATE_MODE_CONSUMER, SUBSTRATE_MODE_TOOLKIT):
+                return existing_mode
+
+        return self.detect_substrate_mode_heuristic()
+
+    def _apply_substrate_mode(
+        self,
+        force_consumer: bool = False,
+        force_toolkit: bool = False,
+    ) -> str:
+        """Resolve mode and write/remove the `repo:` block in `.atdd/config.yaml`.
+
+        Returns the resolved mode string for the caller to print/log.
+        """
+        mode = self.resolve_substrate_mode(force_consumer, force_toolkit)
+        if mode == SUBSTRATE_MODE_CONSUMER:
+            self._write_substrate_config()
+        else:
+            self._remove_substrate_config()
+        return mode
+
+    def _write_substrate_config(self) -> None:
+        """Write the `repo:` block to `.atdd/config.yaml` (consumer-repo mode).
+
+        Idempotent: rewriting with the same defaults yields no diff. Existing
+        non-default values for `test_root` / `plan_root` are preserved.
+        """
+        if not self.config_file.exists():
+            return
+
+        with open(self.config_file) as f:
+            cfg = yaml.safe_load(f) or {}
+        if not isinstance(cfg, dict):
+            cfg = {}
+
+        existing_repo = cfg.get("repo") if isinstance(cfg.get("repo"), dict) else {}
+        existing_substrate = (
+            existing_repo.get("substrate")
+            if isinstance(existing_repo.get("substrate"), dict) else {}
+        )
+
+        repo_block = {
+            "test_root": existing_repo.get("test_root", SUBSTRATE_DEFAULT_TEST_ROOT),
+            "plan_root": existing_repo.get("plan_root", SUBSTRATE_DEFAULT_PLAN_ROOT),
+            "substrate": {
+                "enabled": existing_substrate.get("enabled", True),
+                "plugin": existing_substrate.get("plugin", SUBSTRATE_PLUGIN_ENTRY_POINT),
+                "mode": SUBSTRATE_MODE_CONSUMER,
+            },
+        }
+
+        if cfg.get("repo") == repo_block:
+            return  # already current — no-op
+
+        cfg["repo"] = repo_block
+        with open(self.config_file, "w") as f:
+            yaml.dump(cfg, f, default_flow_style=False, sort_keys=False)
+        print(f"  Wrote substrate fields to {self.config_file}")
+
+    def _remove_substrate_config(self) -> None:
+        """Remove the `repo:` block from `.atdd/config.yaml` (toolkit mode)."""
+        if not self.config_file.exists():
+            return
+
+        with open(self.config_file) as f:
+            cfg = yaml.safe_load(f) or {}
+        if not isinstance(cfg, dict) or "repo" not in cfg:
+            return
+
+        del cfg["repo"]
+        with open(self.config_file, "w") as f:
+            yaml.dump(cfg, f, default_flow_style=False, sort_keys=False)
+        print(f"  Removed substrate fields from {self.config_file}")
 
     def _install_hooks(self, force: bool = False) -> None:
         """Install git hooks from package templates into .atdd/hooks/.

--- a/src/atdd/coach/schemas/config.schema.json
+++ b/src/atdd/coach/schemas/config.schema.json
@@ -239,6 +239,49 @@
       },
       "additionalProperties": false
     },
+    "repo": {
+      "type": "object",
+      "description": "Consumer-repo substrate settings (issue #415, spec v12 §9.3). Written by `atdd init --consumer-repo` (or by default heuristic when `plan/` exists and `src/atdd/` does not). The `--toolkit` flag removes this block.",
+      "properties": {
+        "test_root": {
+          "type": "string",
+          "description": "Path the substrate pytest plugin walks for `# Acceptance:` headers (consumed by `atdd.tester.substrate.plugin`, issue #411). Relative to repo root.",
+          "default": "tests/",
+          "examples": ["tests/", "python/tests/"]
+        },
+        "plan_root": {
+          "type": "string",
+          "description": "Walker root for AcceptanceResolver (issue #408). Relative to repo root.",
+          "default": "plan/",
+          "examples": ["plan/"]
+        },
+        "substrate": {
+          "type": "object",
+          "description": "Substrate registration metadata. Pinned schema so the plugin (#411) reads what `atdd init` (#415) writes.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Toggle for opting out without running `atdd init --toolkit`. The substrate pytest plugin checks this before scanning for anchored tests.",
+              "default": true
+            },
+            "plugin": {
+              "type": "string",
+              "description": "Entry-point id of the substrate pytest plugin. Mirrors `[project.entry-points.pytest11]` in the toolkit pyproject.toml.",
+              "default": "atdd.tester.substrate.plugin"
+            },
+            "mode": {
+              "type": "string",
+              "enum": ["consumer-repo", "toolkit"],
+              "description": "Mode resolved by `atdd init`. Subsequent bare `atdd init` reads this and stays in mode (override needs explicit --toolkit / --consumer-repo)."
+            }
+          },
+          "required": ["enabled", "plugin", "mode"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["test_root", "plan_root", "substrate"],
+      "additionalProperties": false
+    },
     "coach": {
       "type": "object",
       "description": "Coach agent validation settings",

--- a/src/atdd/coach/validators/test_init_substrate_mode.py
+++ b/src/atdd/coach/validators/test_init_substrate_mode.py
@@ -1,0 +1,329 @@
+"""
+Platform tests: `atdd init` substrate-mode extension (issue #415).
+
+Spec: docs/specs/atdd-repo-substrate-spec-v12.md §9.3
+URN: test:coach:substrate:init-mode
+
+Acceptance:
+- Heuristic: `plan/` exists AND `src/atdd/` does not → consumer-repo mode.
+  Otherwise toolkit mode (covers the live toolkit which has both signals).
+- `--consumer-repo` forces consumer-repo mode and writes substrate fields.
+- `--toolkit` forces toolkit mode and removes substrate fields.
+- Mutually exclusive flags: passing both is rejected.
+- Mode persistence: bare `atdd init --force` after a `--consumer-repo` run
+  stays in consumer-repo mode (reads existing `repo.substrate.mode`).
+- Idempotent under `--force`: two consecutive `--consumer-repo --force` runs
+  produce no diff in `.atdd/config.yaml`.
+- pytest11 entry-point is registered in pyproject.toml so the substrate
+  plugin auto-loads in consumer environments (chosen mechanism per #415).
+- pyproject.toml is the toolkit's distribution metadata; the plugin is
+  ``atdd.tester.substrate.plugin``.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = [pytest.mark.platform]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_consumer_layout(root: Path) -> None:
+    """Fixture layout that the heuristic classifies as consumer-repo."""
+    (root / "plan").mkdir(parents=True, exist_ok=True)
+    # Deliberately no src/atdd/ — heuristic key.
+
+
+def _seed_toolkit_layout(root: Path) -> None:
+    """Fixture layout that the heuristic classifies as toolkit (both signals)."""
+    (root / "plan").mkdir(parents=True, exist_ok=True)
+    (root / "src" / "atdd").mkdir(parents=True, exist_ok=True)
+
+
+def _make_initialized(root: Path) -> "Initializer":  # type: ignore[name-defined]
+    """Return a fresh Initializer with `.atdd/` already bootstrapped."""
+    from atdd.coach.commands.initializer import Initializer
+
+    init = Initializer(target_dir=root)
+    init.atdd_config_dir.mkdir(parents=True, exist_ok=True)
+    # Minimal valid config so substrate-mode helpers can read/write.
+    init._create_config(force=True)
+    return init
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_initializer_exposes_substrate_constants():
+    """Constants for mode names + plugin entry-point id exist on the module."""
+    from atdd.coach.commands import initializer
+
+    for name in (
+        "SUBSTRATE_MODE_CONSUMER",
+        "SUBSTRATE_MODE_TOOLKIT",
+        "SUBSTRATE_PLUGIN_ENTRY_POINT",
+    ):
+        assert hasattr(initializer, name), f"initializer must expose {name}"
+
+    assert initializer.SUBSTRATE_MODE_CONSUMER == "consumer-repo"
+    assert initializer.SUBSTRATE_MODE_TOOLKIT == "toolkit"
+    assert initializer.SUBSTRATE_PLUGIN_ENTRY_POINT == "atdd.tester.substrate.plugin"
+
+
+def test_initializer_exposes_resolution_methods():
+    """Resolution + apply methods are part of the Initializer surface."""
+    from atdd.coach.commands.initializer import Initializer
+
+    for name in (
+        "detect_substrate_mode_heuristic",
+        "resolve_substrate_mode",
+        "_apply_substrate_mode",
+        "_write_substrate_config",
+        "_remove_substrate_config",
+    ):
+        assert hasattr(Initializer, name), f"Initializer must define {name}"
+
+
+# ---------------------------------------------------------------------------
+# Heuristic detection (spec v12 §9.3)
+# ---------------------------------------------------------------------------
+
+
+def test_heuristic_classifies_consumer_when_only_plan_present(tmp_path):
+    """plan/ + no src/atdd/ → consumer-repo."""
+    from atdd.coach.commands.initializer import Initializer
+
+    _seed_consumer_layout(tmp_path)
+    init = Initializer(target_dir=tmp_path)
+    assert init.detect_substrate_mode_heuristic() == "consumer-repo"
+
+
+def test_heuristic_classifies_toolkit_when_both_signals_present(tmp_path):
+    """plan/ AND src/atdd/ → toolkit (the live-toolkit case)."""
+    from atdd.coach.commands.initializer import Initializer
+
+    _seed_toolkit_layout(tmp_path)
+    init = Initializer(target_dir=tmp_path)
+    assert init.detect_substrate_mode_heuristic() == "toolkit"
+
+
+def test_heuristic_classifies_toolkit_when_neither_signal_present(tmp_path):
+    """Empty repo (no plan/, no src/atdd/) → toolkit (substrate inactive)."""
+    from atdd.coach.commands.initializer import Initializer
+
+    init = Initializer(target_dir=tmp_path)
+    assert init.detect_substrate_mode_heuristic() == "toolkit"
+
+
+# ---------------------------------------------------------------------------
+# Override precedence
+# ---------------------------------------------------------------------------
+
+
+def test_consumer_repo_flag_overrides_heuristic(tmp_path):
+    """--consumer-repo wins on a layout the heuristic would call toolkit."""
+    from atdd.coach.commands.initializer import Initializer
+
+    _seed_toolkit_layout(tmp_path)
+    init = Initializer(target_dir=tmp_path)
+    assert init.resolve_substrate_mode(force_consumer=True) == "consumer-repo"
+
+
+def test_toolkit_flag_overrides_heuristic(tmp_path):
+    """--toolkit wins on a layout the heuristic would call consumer-repo."""
+    from atdd.coach.commands.initializer import Initializer
+
+    _seed_consumer_layout(tmp_path)
+    init = Initializer(target_dir=tmp_path)
+    assert init.resolve_substrate_mode(force_toolkit=True) == "toolkit"
+
+
+def test_existing_mode_in_config_overrides_heuristic(tmp_path):
+    """Bare `atdd init` after a prior `--consumer-repo` stays in mode."""
+    init = _make_initialized(tmp_path)
+    # Wipe layout signals so the heuristic would say "toolkit"
+    if (tmp_path / "plan").is_dir():
+        (tmp_path / "plan").rmdir()
+    init._write_substrate_config()  # writes mode: consumer-repo
+
+    # Bare invocation: heuristic would say "toolkit", but persisted mode wins.
+    assert init.resolve_substrate_mode() == "consumer-repo"
+
+
+def test_explicit_flag_wins_over_persisted_mode(tmp_path):
+    """`--toolkit` after a previous `--consumer-repo` flips back."""
+    init = _make_initialized(tmp_path)
+    init._write_substrate_config()
+    assert init.resolve_substrate_mode(force_toolkit=True) == "toolkit"
+
+
+def test_init_rejects_both_flags(tmp_path):
+    """`atdd init --consumer-repo --toolkit` returns non-zero."""
+    from atdd.coach.commands.initializer import Initializer
+
+    init = Initializer(target_dir=tmp_path)
+    rc = init.init(force=True, consumer_repo=True, toolkit=True)
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Config writing / removing
+# ---------------------------------------------------------------------------
+
+
+def _read_config(root: Path) -> dict:
+    return yaml.safe_load((root / ".atdd" / "config.yaml").read_text()) or {}
+
+
+def test_consumer_mode_writes_substrate_block(tmp_path):
+    """`_write_substrate_config` populates repo.test_root/plan_root/substrate."""
+    init = _make_initialized(tmp_path)
+    init._write_substrate_config()
+
+    cfg = _read_config(tmp_path)
+    assert cfg["repo"]["test_root"] == "tests/"
+    assert cfg["repo"]["plan_root"] == "plan/"
+    assert cfg["repo"]["substrate"]["enabled"] is True
+    assert cfg["repo"]["substrate"]["plugin"] == "atdd.tester.substrate.plugin"
+    assert cfg["repo"]["substrate"]["mode"] == "consumer-repo"
+
+
+def test_toolkit_mode_removes_substrate_block(tmp_path):
+    """`_remove_substrate_config` strips the `repo:` block when present."""
+    init = _make_initialized(tmp_path)
+    init._write_substrate_config()
+    assert "repo" in _read_config(tmp_path)
+
+    init._remove_substrate_config()
+    cfg = _read_config(tmp_path)
+    assert "repo" not in cfg
+
+
+def test_remove_is_no_op_when_no_repo_block(tmp_path):
+    """`_remove_substrate_config` on a fresh config is a no-op."""
+    init = _make_initialized(tmp_path)
+    before = (tmp_path / ".atdd" / "config.yaml").read_text()
+    init._remove_substrate_config()
+    after = (tmp_path / ".atdd" / "config.yaml").read_text()
+    assert before == after
+
+
+def test_consumer_force_init_idempotent(tmp_path):
+    """Two `init --consumer-repo --force` runs produce no diff on the second."""
+    from atdd.coach.commands.initializer import Initializer
+
+    _seed_consumer_layout(tmp_path)
+
+    # First run.
+    Initializer(target_dir=tmp_path).init(
+        force=True, consumer_repo=True,
+    )
+    first = (tmp_path / ".atdd" / "config.yaml").read_text()
+
+    # Second run.
+    Initializer(target_dir=tmp_path).init(
+        force=True, consumer_repo=True,
+    )
+    second = (tmp_path / ".atdd" / "config.yaml").read_text()
+
+    # toolkit.last_version is rewritten on every run with the current version,
+    # so a strict byte-for-byte equality could regress on a version bump in
+    # the same call. The substrate fields under repo: must be identical.
+    cfg_first = yaml.safe_load(first)
+    cfg_second = yaml.safe_load(second)
+    assert cfg_first.get("repo") == cfg_second.get("repo")
+    # And second equals first overall (the version is fixed during one run).
+    assert first == second
+
+
+def test_consumer_then_toolkit_force_init_removes_substrate(tmp_path):
+    """`init --consumer-repo --force` then `init --toolkit --force` cleans up."""
+    from atdd.coach.commands.initializer import Initializer
+
+    _seed_consumer_layout(tmp_path)
+
+    Initializer(target_dir=tmp_path).init(
+        force=True, consumer_repo=True,
+    )
+    assert "repo" in _read_config(tmp_path)
+
+    Initializer(target_dir=tmp_path).init(
+        force=True, toolkit=True,
+    )
+    assert "repo" not in _read_config(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# pytest11 entry-point registration
+# ---------------------------------------------------------------------------
+
+
+def test_pyproject_registers_pytest11_entry_point():
+    """`pyproject.toml` must declare the substrate plugin under pytest11."""
+    try:
+        import tomllib
+    except ImportError:  # Python < 3.11
+        import tomli as tomllib  # type: ignore[import-not-found]
+
+    # Walk up from this test file to the toolkit pyproject.toml.
+    pyproject = Path(__file__).resolve()
+    for ancestor in pyproject.parents:
+        candidate = ancestor / "pyproject.toml"
+        if candidate.is_file():
+            pyproject = candidate
+            break
+    else:
+        pytest.skip("pyproject.toml not found in any ancestor of this test")
+
+    with open(pyproject, "rb") as fh:
+        data = tomllib.load(fh)
+
+    pytest11 = (
+        data.get("project", {})
+        .get("entry-points", {})
+        .get("pytest11", {})
+    )
+    assert pytest11, (
+        "pyproject.toml must declare a [project.entry-points.pytest11] block "
+        "registering the substrate plugin per spec v12 §9.3."
+    )
+    # The substrate plugin is the entry-point we care about; allow any name.
+    assert "atdd.tester.substrate.plugin" in pytest11.values(), (
+        "pytest11 entry-point must point at atdd.tester.substrate.plugin, "
+        f"got: {pytest11!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Substrate plugin runtime gate
+# ---------------------------------------------------------------------------
+
+
+def test_substrate_plugin_disabled_in_toolkit_mode(tmp_path):
+    """`_substrate_enabled` returns False when no `repo:` block is present."""
+    from atdd.tester.substrate.plugin import _substrate_enabled
+
+    (tmp_path / ".atdd").mkdir()
+    (tmp_path / ".atdd" / "config.yaml").write_text(
+        "version: '1.0'\nrelease:\n  version_file: pyproject.toml\n"
+    )
+    assert _substrate_enabled(tmp_path) is False
+
+
+def test_substrate_plugin_enabled_after_consumer_init(tmp_path):
+    """After consumer-repo init, the runtime gate returns True."""
+    from atdd.tester.substrate.plugin import _substrate_enabled
+
+    init = _make_initialized(tmp_path)
+    init._write_substrate_config()
+
+    assert _substrate_enabled(tmp_path) is True

--- a/src/atdd/tester/substrate/plugin.py
+++ b/src/atdd/tester/substrate/plugin.py
@@ -143,6 +143,41 @@ def _read_atdd_config_test_root(repo_root: Path) -> Optional[Path]:
     return None
 
 
+def _substrate_enabled(repo_root: Path) -> bool:
+    """Return True if the substrate is enabled in `.atdd/config.yaml`.
+
+    Spec v12 §9.3 / issue #415: `atdd init --consumer-repo` writes
+    ``repo.substrate.enabled: true``; `--toolkit` removes the `repo:` block
+    entirely. The plugin is auto-loaded as a pytest11 entry-point in any
+    consumer that has atdd installed, so the runtime check on
+    ``repo.substrate.enabled`` is the authoritative on/off switch.
+    """
+    cfg = repo_root / ".atdd" / "config.yaml"
+    if not cfg.is_file():
+        return False
+    try:
+        import yaml
+
+        with open(cfg, encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+    except Exception as exc:  # atdd:suppress(coder.logging.coach-silent-swallow)
+        _logger.debug(
+            "substrate plugin: skipping malformed %s: %s",
+            cfg, exc,
+            extra={"path": str(cfg), "error_type": type(exc).__name__},
+        )
+        return False
+    if not isinstance(data, dict):
+        return False
+    repo_section = data.get("repo")
+    if not isinstance(repo_section, dict):
+        return False
+    substrate = repo_section.get("substrate")
+    if not isinstance(substrate, dict):
+        return False
+    return substrate.get("enabled") is True
+
+
 def _read_pyproject_testpaths(repo_root: Path) -> List[Path]:
     pp = repo_root / "pyproject.toml"
     if not pp.is_file():
@@ -281,6 +316,14 @@ def pytest_collection_modifyitems(
 
     repo_root = _detect_repo_root_for_session(session, config)
     if repo_root is None:
+        return
+
+    # Spec v12 §9.3 / issue #415: in toolkit mode (or any environment that
+    # never ran `atdd init --consumer-repo`), the `repo:` block is absent and
+    # the plugin must be a no-op — even though it is auto-loaded by pytest's
+    # entry-point discovery. This gate is the runtime equivalent of "plugin
+    # not registered" for non-substrate consumers.
+    if not _substrate_enabled(repo_root):
         return
 
     test_roots = _resolve_test_roots(repo_root)

--- a/src/atdd/tester/substrate/tests/test_plugin_integration.py
+++ b/src/atdd/tester/substrate/tests/test_plugin_integration.py
@@ -76,6 +76,23 @@ def _write_repo_skeleton(repo: Path) -> None:
     (repo / ".atdd" / "manifest.yaml").write_text(
         "version: '2.0'\nsessions: []\n", encoding="utf-8",
     )
+    # Per spec v12 §9.3 (issue #415), the substrate plugin is auto-loaded
+    # via a pytest11 entry-point and gated at runtime on the `repo:` block.
+    # Integration fixtures simulate a consumer-repo `atdd init --consumer-repo`
+    # by writing the same block the initializer would produce.
+    (repo / ".atdd" / "config.yaml").write_text(
+        "version: '1.0'\n"
+        "release:\n"
+        "  version_file: pyproject.toml\n"
+        "repo:\n"
+        "  test_root: tests/\n"
+        "  plan_root: plan/\n"
+        "  substrate:\n"
+        "    enabled: true\n"
+        "    plugin: atdd.tester.substrate.plugin\n"
+        "    mode: consumer-repo\n",
+        encoding="utf-8",
+    )
     (repo / "plan").mkdir(exist_ok=True)
     (repo / "tests").mkdir(exist_ok=True)
 


### PR DESCRIPTION
## Summary

Implements §9.3 of `docs/specs/atdd-repo-substrate-spec-v12.md`. `atdd init` now resolves a substrate mode at every run and writes (or strips) the `repo:` block in `.atdd/config.yaml`.

Closes #415.

## Mode resolution

Precedence (high → low):

1. `--toolkit` — force toolkit (strips substrate fields)
2. `--consumer-repo` — force consumer-repo (writes substrate fields)
3. existing `repo.substrate.mode` in `.atdd/config.yaml` (subsequent bare `atdd init` stays in mode)
4. heuristic — `plan/` exists AND `src/atdd/` does not → consumer-repo

## Registration mechanism (chosen)

The PR adds a `pytest11` entry-point in `pyproject.toml`:

```toml
[project.entry-points.pytest11]
atdd_substrate = "atdd.tester.substrate.plugin"
```

This is the **Preferred** option from issue #415. Any consumer with `atdd` installed auto-loads the plugin; the plugin itself checks `repo.substrate.enabled` at collection time and early-returns when the marker is absent. So:

- **`--consumer-repo`** writes the `repo:` block → plugin scans `tests/` for `# Acceptance:` headers → substrate-mode active.
- **`--toolkit`** removes the `repo:` block → plugin sees no marker → no-op (effectively "not registered" for that consumer).

The alternative (writing `conftest.py`) was rejected to avoid the toolkit reaching into consumer-owned territory.

## Documentation choice (chosen)

`CONTRIBUTING.md` was created (it didn't exist before) with a "Dogfooding the substrate" section that explains running `atdd init --consumer-repo` against the toolkit's own checkout.

## Acceptance criteria coverage

| Criterion | Test |
|---|---|
| Fixture with only `plan/` → consumer-repo by default | `test_heuristic_classifies_consumer_when_only_plan_present` |
| Live toolkit (`plan/` + `src/atdd/`) → toolkit by default | `test_heuristic_classifies_toolkit_when_both_signals_present` |
| `--consumer-repo` overrides on toolkit-shaped layout | `test_consumer_repo_flag_overrides_heuristic` |
| `--toolkit` reverts substrate registration | `test_consumer_then_toolkit_force_init_removes_substrate` |
| `--force` idempotent in same mode | `test_consumer_force_init_idempotent` |
| Mode persistence across bare re-runs | `test_existing_mode_in_config_overrides_heuristic` |
| Mutually exclusive flags rejected | `test_init_rejects_both_flags` |
| pytest11 entry-point registered | `test_pyproject_registers_pytest11_entry_point` |
| Plugin gated on `repo.substrate.enabled` | `test_substrate_plugin_disabled_in_toolkit_mode` + `..._enabled_after_consumer_init` |
| CONTRIBUTING.md documents dogfooding | committed in this PR |

## Test plan

- [ ] CI: `atdd validate` passes
- [ ] `PYTHONPATH=src python3 -m pytest src/atdd/coach/validators/test_init_substrate_mode.py src/atdd/tester/substrate/tests -q` → all green (verified locally: 51 passed)
- [ ] `atdd init --help` shows `--consumer-repo` / `--toolkit` flags

## Schema impact

`coach/schemas/config.schema.json` gains a `repo:` block (additionalProperties=false at the top level required this addition). Both consumer and toolkit shapes validate.

## Version

Bumps to `3.5.1` (pre-allocated for wave-S0).