### PR TITLE
feat(coach): #417 — substrate spawn-harness blocks (Track-F-spawn-harness)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -222,3 +222,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:repo-rule-substrate
   train: 0001-self-compliance-validate
+- id: '417'
+  slug: substrate-417-spawn-harness-blocks
+  file: null
+  issue_number: 417
+  type: feature
+  status: RED
+  created: '2026-05-06'
+  archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:repo-rule-substrate
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.5.0"
+version = "3.5.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/rules.py
+++ b/src/atdd/coach/commands/rules.py
@@ -86,9 +86,11 @@ def _print_metadata_text(meta: RuleMetadata) -> None:
         ("harness_category", meta.harness_category),
         ("signal_metric", meta.signal_metric),
         ("signal_threshold", meta.signal_threshold),
-        ("given", meta.given),
-        ("when", meta.when),
-        ("then", meta.then),
+        # given/when/then are tuples per spec v12 §4.1 ("full lists"); join
+        # for the text view so a multi-line clause renders on one row.
+        ("given", "; ".join(meta.given) if meta.given else None),
+        ("when", "; ".join(meta.when) if meta.when else None),
+        ("then", "; ".join(meta.then) if meta.then else None),
         ("author", meta.author),
         ("created", meta.created),
     ]

--- a/src/atdd/coach/spawn_harness/__init__.py
+++ b/src/atdd/coach/spawn_harness/__init__.py
@@ -1,0 +1,37 @@
+# URN: component:govern-lifecycle:enforcement-substrate:spawn_harness:backend:domain
+# Runtime: python
+# Purpose: Coach spawn-harness renderer that emits repo-rule blocks (wmbt/train/security) into spawn prompts per substrate spec v12 §8.2.
+
+"""Coach v6 spawn-harness — substrate extensions (issue #417).
+
+Coach v6 §7.1 spawns coder/tester subagents with a prompt that includes a
+``conventions[].rules_in_scope`` block listing toolkit convention rules in
+play for the current phase. The substrate (spec v12 §8.2) extends that
+prompt with three parallel blocks for repo-derived rules:
+
+* ``wmbt_rules:``     — WMBT acceptances whose ``RuleMetadata.phase`` matches
+                        the current coach phase.
+* ``train_rules:``    — Train acceptances whose ``RuleMetadata.phase`` matches
+                        the current coach phase.
+* ``security_rules:`` — Security rules whose BOUND acceptance's phase matches
+                        the current coach phase (full filter wires up in #422;
+                        this PR emits the block shape with a TODO).
+
+The renderer is registry-driven: callers pass a sequence of
+``RuleMetadata`` instances (typically the output of
+``rule_binding.iter_rules()`` or a hand-built fixture for tests). The
+output is YAML emitted in the spec §8.2 verbatim shape.
+"""
+from atdd.coach.spawn_harness.renderer import (
+    render_spawn_blocks,
+    render_security_rules_block,
+    render_train_rules_block,
+    render_wmbt_rules_block,
+)
+
+__all__ = [
+    "render_spawn_blocks",
+    "render_security_rules_block",
+    "render_train_rules_block",
+    "render_wmbt_rules_block",
+]

--- a/src/atdd/coach/spawn_harness/renderer.py
+++ b/src/atdd/coach/spawn_harness/renderer.py
@@ -1,0 +1,278 @@
+# URN: component:govern-lifecycle:enforcement-substrate:spawn_harness:renderer:backend:domain
+# Runtime: python
+# Purpose: Render substrate spec v12 §8.2 spawn-harness blocks (wmbt/train/security) into spawn prompts.
+
+"""Spawn-harness renderer (substrate spec v12 §8.2 — issue #417).
+
+Produces the YAML body that coach v6 §7.1 splices into spawn prompts after
+its existing ``conventions[].rules_in_scope`` block. The output is a
+verbatim match for spec §8.2 lines 600–633 modulo URN substitution.
+
+Rendering is intentionally hand-rolled (no PyYAML emit) for two reasons:
+
+* The spec example pins block ordering, key ordering inside each rule,
+  and quote-style. PyYAML's default emitter rearranges keys
+  alphabetically and adds quotes that diverge from the reviewer-eye-
+  trained shape. The hand-rolled emitter holds the example shape stable.
+* The block is glued into a larger prompt template; emitting raw text is
+  simpler than building a dict tree and post-processing PyYAML output.
+
+Field-name mapping (issue #417 — short names per spec §8.2 example):
+
+    Output key            ← RuleMetadata source
+    --------------------    -------------------------
+    purpose               ← description
+    expectations          ← then (full list, one bullet per item)
+    acceptance_urn        ← acceptance_urn        (WMBT/train rules)
+    acceptance_ref        ← bound_acceptance_urn  (security rules)
+    threat                ← description           (security rules)
+    mitigation            ← fix_hint              (security rules)
+    severity              ← severity              (security rules)
+    security_urn          ← security_urn
+
+The internal ``RuleMetadata`` field names ``bound_acceptance_urn``,
+``description``, and ``then`` never appear in the rendered output.
+"""
+from __future__ import annotations
+
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from atdd.coach.utils.rule_binding import RuleMetadata
+
+
+__all__ = [
+    "render_spawn_blocks",
+    "render_security_rules_block",
+    "render_train_rules_block",
+    "render_wmbt_rules_block",
+]
+
+
+# ---------------------------------------------------------------------------
+# Scalar emit — minimal YAML-friendly quoting
+# ---------------------------------------------------------------------------
+# YAML scalars typically don't need quoting. The exceptions for our payload
+# are strings that look like flow-style indicators or contain leading/trailing
+# whitespace. Acceptance YAML upstream is hand-authored prose, so quoting is
+# rarely necessary; when it is, double-quote with minimal escaping. Keeping
+# this aligned with the spec example (which renders most prose unquoted)
+# preserves byte-identity in the snapshot fixture.
+_YAML_DANGEROUS_PREFIXES = ("- ", "? ", ": ", "*", "&", "!", "|", ">", "%", "@", "`")
+
+
+def _emit_scalar(value: object) -> str:
+    """Render *value* as a YAML scalar.
+
+    Booleans / None / ints render unquoted. Strings render unquoted unless
+    they collide with YAML's flow indicators or contain a leading/trailing
+    space. The renderer never emits multi-line scalars (acceptance prose
+    is always single-line).
+    """
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    s = str(value)
+    if not s:
+        return '""'
+    needs_quote = (
+        s != s.strip()
+        or s.startswith(_YAML_DANGEROUS_PREFIXES)
+        or s.lower() in ("yes", "no", "true", "false", "null", "~")
+        or ": " in s
+        or s.startswith("# ")
+    )
+    if needs_quote:
+        return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return s
+
+
+def _filter_phase(rules: Iterable[RuleMetadata], phase: str) -> List[RuleMetadata]:
+    """Return rules whose ``RuleMetadata.phase`` equals *phase*."""
+    return [r for r in rules if r.phase == phase]
+
+
+def _group_by(
+    rules: Iterable[RuleMetadata], key: str
+) -> List[Tuple[str, List[RuleMetadata]]]:
+    """Group *rules* by attribute *key*, preserving first-seen order."""
+    order: List[str] = []
+    buckets: dict = {}
+    for rule in rules:
+        bucket_key = getattr(rule, key, None)
+        if not bucket_key:
+            continue
+        if bucket_key not in buckets:
+            buckets[bucket_key] = []
+            order.append(bucket_key)
+        buckets[bucket_key].append(rule)
+    return [(k, buckets[k]) for k in order]
+
+
+# ---------------------------------------------------------------------------
+# Per-rule emitters
+# ---------------------------------------------------------------------------
+def _emit_acceptance_rule(rule: RuleMetadata, *, indent: int) -> List[str]:
+    """Emit a single WMBT-or-train rule body (the ``- id: ...`` block).
+
+    Indent is the column of the leading dash. Keys inside the rule sit at
+    ``indent + 2``; ``expectations:`` bullets sit at ``indent + 4``.
+    """
+    pad = " " * indent
+    inner = " " * (indent + 2)
+    bullet_pad = " " * (indent + 4)
+    lines = [f"{pad}- id: {_emit_scalar(rule.rule_id)}"]
+    if rule.acceptance_urn:
+        lines.append(f"{inner}acceptance_urn: {_emit_scalar(rule.acceptance_urn)}")
+    lines.append(f"{inner}purpose: {_emit_scalar(rule.description)}")
+    if rule.then:
+        lines.append(f"{inner}expectations:")
+        for expectation in rule.then:
+            lines.append(f"{bullet_pad}- {_emit_scalar(expectation)}")
+    return lines
+
+
+def _emit_security_rule(rule: RuleMetadata, *, indent: int) -> List[str]:
+    """Emit a single security rule body in spec §8.2 short-name shape."""
+    pad = " " * indent
+    inner = " " * (indent + 2)
+    lines = [f"{pad}- id: {_emit_scalar(rule.rule_id)}"]
+    if rule.security_urn:
+        lines.append(f"{inner}security_urn: {_emit_scalar(rule.security_urn)}")
+    lines.append(f"{inner}threat: {_emit_scalar(rule.description)}")
+    if rule.fix_hint:
+        lines.append(f"{inner}mitigation: {_emit_scalar(rule.fix_hint)}")
+    if rule.severity is not None:
+        lines.append(f"{inner}severity: {_emit_scalar(rule.severity)}")
+    if rule.bound_acceptance_urn:
+        # Note the rename: internal `bound_acceptance_urn` → output
+        # `acceptance_ref` per issue #417 field-name pin.
+        lines.append(
+            f"{inner}acceptance_ref: {_emit_scalar(rule.bound_acceptance_urn)}"
+        )
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Block emitters — public
+# ---------------------------------------------------------------------------
+def render_wmbt_rules_block(
+    rules: Iterable[RuleMetadata], *, coach_phase: str
+) -> str:
+    """Render the ``wmbt_rules:`` block for *coach_phase*.
+
+    Filters *rules* to those carrying a ``wmbt_urn`` and a ``phase``
+    matching *coach_phase*, then groups by ``wmbt_urn`` and emits one
+    ``- wmbt_urn: ...\\n  rules:\\n  ...`` entry per WMBT.
+
+    Returns an empty string (no block, no trailing newline) when no
+    rules survive filtering.
+    """
+    eligible = [
+        r for r in _filter_phase(rules, coach_phase) if r.wmbt_urn is not None
+    ]
+    if not eligible:
+        return ""
+    lines = ["wmbt_rules:"]
+    for wmbt_urn, group in _group_by(eligible, "wmbt_urn"):
+        lines.append(f"  - wmbt_urn: {_emit_scalar(wmbt_urn)}")
+        lines.append("    rules:")
+        for rule in group:
+            lines.extend(_emit_acceptance_rule(rule, indent=6))
+    return "\n".join(lines) + "\n"
+
+
+def render_train_rules_block(
+    rules: Iterable[RuleMetadata],
+    *,
+    coach_phase: str,
+    train_scope: Sequence[str] = (),
+) -> str:
+    """Render the ``train_rules:`` block for *coach_phase*.
+
+    *train_scope* is the explicit set of train URNs in scope, supplied
+    by the caller (per issue #417 AC: full ``--scope train:<urn>,…``
+    detection lands in a separate Track-F follow-up; this renderer
+    accepts the scope set as input).
+
+    Filters *rules* to those whose ``train_urn`` is in *train_scope*
+    AND whose ``phase`` matches *coach_phase*. Groups by ``train_urn``.
+    Returns an empty string when the block would be empty.
+    """
+    if not train_scope:
+        return ""
+    scope = set(train_scope)
+    eligible = [
+        r
+        for r in _filter_phase(rules, coach_phase)
+        if r.train_urn is not None and r.train_urn in scope
+    ]
+    if not eligible:
+        return ""
+    lines = ["train_rules:"]
+    for train_urn, group in _group_by(eligible, "train_urn"):
+        lines.append(f"  - train_urn: {_emit_scalar(train_urn)}")
+        lines.append("    rules:")
+        for rule in group:
+            lines.extend(_emit_acceptance_rule(rule, indent=6))
+    return "\n".join(lines) + "\n"
+
+
+def render_security_rules_block(
+    rules: Iterable[RuleMetadata], *, coach_phase: str
+) -> str:
+    """Render the ``security_rules:`` block for *coach_phase*.
+
+    Per spec §8.1 paragraph 6 + §8.2 line 625, security rules carry no
+    ``phase`` of their own — activation is determined by the BOUND
+    acceptance's phase. Wiring that filter requires walking the
+    acceptance graph from each security rule's ``bound_acceptance_urn``
+    back to its acceptance phase.
+
+    TODO(#422): wire the bound-acceptance phase resolver. Until that
+    issue lands, this renderer emits every security rule whose
+    ``security_urn`` is populated; the caller is responsible for
+    pre-filtering. The block shape itself matches spec §8.2.
+    """
+    eligible = [r for r in rules if r.security_urn is not None]
+    if not eligible:
+        return ""
+    lines = ["security_rules:"]
+    for feature_urn, group in _group_by(eligible, "feature_urn"):
+        lines.append(f"  - feature_urn: {_emit_scalar(feature_urn)}")
+        lines.append("    rules:")
+        for rule in group:
+            lines.extend(_emit_security_rule(rule, indent=6))
+    return "\n".join(lines) + "\n"
+
+
+def render_spawn_blocks(
+    rules: Iterable[RuleMetadata],
+    *,
+    coach_phase: str,
+    train_scope: Sequence[str] = (),
+) -> str:
+    """Render all three substrate spawn-harness blocks, concatenated.
+
+    Block order: ``wmbt_rules:``, ``train_rules:``, ``security_rules:``.
+    Empty blocks are elided (no header, no separator). The output never
+    has a leading or trailing blank line. Returns an empty string when
+    no blocks would render — the coach can splice the empty result into
+    a prompt without producing a stray section.
+    """
+    rules = list(rules)
+    parts: List[str] = []
+    wmbt = render_wmbt_rules_block(rules, coach_phase=coach_phase)
+    if wmbt:
+        parts.append(wmbt)
+    train = render_train_rules_block(
+        rules, coach_phase=coach_phase, train_scope=train_scope
+    )
+    if train:
+        parts.append(train)
+    security = render_security_rules_block(rules, coach_phase=coach_phase)
+    if security:
+        parts.append(security)
+    return "".join(parts)

--- a/src/atdd/coach/spawn_harness/tests/fixtures/expected_spawn_blocks.yaml
+++ b/src/atdd/coach/spawn_harness/tests/fixtures/expected_spawn_blocks.yaml
@@ -1,0 +1,28 @@
+wmbt_rules:
+  - wmbt_urn: wmbt:govern-lifecycle:D010
+    rules:
+      - id: repo.govern-lifecycle.D010-acc-unit-001
+        acceptance_urn: acc:govern-lifecycle:D010-UNIT-001-single-source-theme-map-helper
+        purpose: A single get_theme_map(config) helper replaces every hardcoded theme_map dict in the codebase
+        expectations:
+          - No theme_map dict literal appears outside coach/utils/theme_map.py
+          - inventory.py, registry.py, and test_train_validation.py import and call get_theme_map
+          - The helper is the single source of truth for the digit-to-theme mapping
+train_rules:
+  - train_urn: train:checkout-train
+    rules:
+      - id: repo.checkout-train.acc-idempotent-on-retry
+        acceptance_urn: acc:checkout-train:idempotent-on-retry
+        purpose: Re-running the flow with the same idempotency key produces no duplicate side effects
+        expectations:
+          - Repeating a charge with the same key returns the original receipt
+          - No second downstream webhook is emitted
+security_rules:
+  - feature_urn: feature:auth:session-management
+    rules:
+      - id: repo.auth.session-management-security-001
+        security_urn: security:auth:session-management:001
+        threat: Session Hijacking — Attacker steals session token via XSS
+        mitigation: HttpOnly cookies, CSP headers
+        severity: 4
+        acceptance_ref: acc:auth:D001-SEC-001-session-protection

--- a/src/atdd/coach/spawn_harness/tests/test_renderer_unit.py
+++ b/src/atdd/coach/spawn_harness/tests/test_renderer_unit.py
@@ -1,0 +1,189 @@
+# URN: component:govern-lifecycle:enforcement-substrate:spawn_harness:tests:test_renderer_unit
+# Runtime: python
+# Purpose: Per-block unit tests for the substrate spawn-harness renderer.
+
+"""Per-block unit tests for the spawn-harness renderer (issue #417).
+
+Covers the wmbt/train/security block emitters individually, plus the
+phase-filter and train-scope-filter behavior the snapshot test does not
+exercise in isolation.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from atdd.coach.spawn_harness import (
+    render_security_rules_block,
+    render_spawn_blocks,
+    render_train_rules_block,
+    render_wmbt_rules_block,
+)
+from atdd.coach.utils.rule_binding import RuleMetadata
+
+
+def _wmbt_rule(rule_id: str, wmbt_urn: str, *, phase: str = "GREEN") -> RuleMetadata:
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=4,
+        description="purpose-line for " + rule_id,
+        recipe=None,
+        introduced_in=None,
+        source_path=Path("/fixture/plan/wagon/D001.yaml"),
+        disposition="strict",
+        validator=None,
+        fix_hint=None,
+        aliases=(),
+        acceptance_urn=f"acc:wagon:{rule_id}",
+        wmbt_urn=wmbt_urn,
+        phase=phase,
+        then=("expectation a", "expectation b"),
+    )
+
+
+def _train_rule(rule_id: str, train_urn: str, *, phase: str = "SMOKE") -> RuleMetadata:
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=4,
+        description="train purpose for " + rule_id,
+        recipe=None,
+        introduced_in=None,
+        source_path=Path("/fixture/plan/_trains/some-train.yaml"),
+        disposition="strict",
+        validator=None,
+        fix_hint=None,
+        aliases=(),
+        acceptance_urn=f"acc:some-train:{rule_id}",
+        train_urn=train_urn,
+        phase=phase,
+        then=("train expectation",),
+    )
+
+
+def _security_rule(rule_id: str, *, phase: str = "GREEN") -> RuleMetadata:
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=3,
+        description="Threat Name — threat description",
+        recipe=None,
+        introduced_in=None,
+        source_path=Path("/fixture/plan/auth/feature.yaml"),
+        disposition="strict",
+        validator=None,
+        fix_hint="mitigation prose",
+        aliases=(),
+        security_urn=f"security:auth:{rule_id}",
+        feature_urn="feature:auth:session",
+        bound_acceptance_urn="acc:auth:D001-SEC-001-bound",
+        phase=phase,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phase filtering
+# ---------------------------------------------------------------------------
+def test_wmbt_rules_filters_by_phase():
+    """Only WMBT rules whose ``phase`` matches ``coach_phase`` render."""
+    rules = [
+        _wmbt_rule("repo.w.D001-acc-unit-001", "wmbt:w:D001", phase="GREEN"),
+        _wmbt_rule("repo.w.D002-acc-unit-001", "wmbt:w:D002", phase="RED"),
+    ]
+    out = render_wmbt_rules_block(rules, coach_phase="GREEN")
+    assert "repo.w.D001-acc-unit-001" in out
+    assert "repo.w.D002-acc-unit-001" not in out
+
+
+def test_train_rules_filters_by_phase():
+    """Only train rules whose ``phase`` matches ``coach_phase`` render."""
+    rules = [
+        _train_rule("repo.t.acc-a", "train:t", phase="SMOKE"),
+        _train_rule("repo.t.acc-b", "train:t", phase="GREEN"),
+    ]
+    out = render_train_rules_block(
+        rules, coach_phase="SMOKE", train_scope=("train:t",)
+    )
+    assert "repo.t.acc-a" in out
+    assert "repo.t.acc-b" not in out
+
+
+def test_train_rules_filters_by_train_scope():
+    """Train rules outside the supplied ``train_scope`` set are dropped."""
+    rules = [
+        _train_rule("repo.a.acc-a", "train:a", phase="SMOKE"),
+        _train_rule("repo.b.acc-b", "train:b", phase="SMOKE"),
+    ]
+    out = render_train_rules_block(
+        rules, coach_phase="SMOKE", train_scope=("train:a",)
+    )
+    assert "train:a" in out
+    assert "train:b" not in out
+    assert "repo.b.acc-b" not in out
+
+
+def test_train_rules_empty_scope_renders_no_block():
+    """When the scope set is empty, the train_rules block is omitted."""
+    rules = [_train_rule("repo.t.acc-a", "train:t", phase="SMOKE")]
+    out = render_train_rules_block(rules, coach_phase="SMOKE", train_scope=())
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# Field-name pinning (short names per spec §8.2)
+# ---------------------------------------------------------------------------
+def test_wmbt_block_uses_short_field_names():
+    """Output uses ``purpose``/``expectations`` not ``description``/``then``."""
+    rules = [_wmbt_rule("repo.w.D001-acc-unit-001", "wmbt:w:D001")]
+    out = render_wmbt_rules_block(rules, coach_phase="GREEN")
+    assert "purpose:" in out
+    assert "expectations:" in out
+    assert "description:" not in out
+    # 'then:' is not used for expectations rendering.
+    assert "\n        then:" not in out
+
+
+def test_security_block_maps_bound_acceptance_to_acceptance_ref():
+    """``bound_acceptance_urn`` renders as ``acceptance_ref`` (spec §8.2)."""
+    rules = [_security_rule("repo.auth.session-management-security-001")]
+    out = render_security_rules_block(rules, coach_phase="GREEN")
+    assert "acceptance_ref: acc:auth:D001-SEC-001-bound" in out
+    assert "bound_acceptance_urn" not in out
+
+
+def test_security_block_emits_threat_mitigation_severity():
+    """Security rule rendering pins the spec-mandated short field names."""
+    rules = [_security_rule("repo.auth.session-management-security-001")]
+    out = render_security_rules_block(rules, coach_phase="GREEN")
+    assert "threat:" in out
+    assert "mitigation:" in out
+    assert "severity: 3" in out
+
+
+# ---------------------------------------------------------------------------
+# Empty-block elision
+# ---------------------------------------------------------------------------
+def test_render_spawn_blocks_omits_empty_blocks():
+    """When no rules of a kind survive filtering, the block is omitted."""
+    rules = [_wmbt_rule("repo.w.D001-acc-unit-001", "wmbt:w:D001", phase="GREEN")]
+    out = render_spawn_blocks(rules, coach_phase="GREEN", train_scope=())
+    assert "wmbt_rules:" in out
+    assert "train_rules:" not in out
+    assert "security_rules:" not in out
+
+
+def test_render_spawn_blocks_returns_empty_when_no_repo_rules():
+    """All three blocks omitted when the registry has no repo rules."""
+    out = render_spawn_blocks([], coach_phase="GREEN", train_scope=())
+    assert out == ""
+
+
+# ---------------------------------------------------------------------------
+# Expectations source — list, not joined string
+# ---------------------------------------------------------------------------
+def test_expectations_use_then_list_not_joined_string():
+    """Each ``then`` list element appears as its own bullet under expectations."""
+    rule = _wmbt_rule("repo.w.D001-acc-unit-001", "wmbt:w:D001")
+    out = render_wmbt_rules_block([rule], coach_phase="GREEN")
+    # Two expectation lines, each on its own line.
+    assert "- expectation a" in out
+    assert "- expectation b" in out
+    # The joined-string form must NOT appear.
+    assert "expectation a; expectation b" not in out

--- a/src/atdd/coach/spawn_harness/tests/test_repo_blocks_snapshot.py
+++ b/src/atdd/coach/spawn_harness/tests/test_repo_blocks_snapshot.py
@@ -1,0 +1,125 @@
+# URN: component:govern-lifecycle:enforcement-substrate:spawn_harness:tests:test_repo_blocks_snapshot
+# Runtime: python
+# Purpose: Snapshot test for substrate spec v12 §8.2 spawn-harness output.
+
+"""Snapshot test for the spawn-harness repo-rule blocks (issue #417 AC).
+
+Builds a fixture registry containing one WMBT rule, one train rule, and
+one security rule, runs ``render_spawn_blocks(rules, coach_phase=...)``,
+and diffs the YAML output against
+``fixtures/expected_spawn_blocks.yaml``. The expected output is
+byte-identical to spec §8.2 lines 600–633 modulo URN substitution.
+
+Per the issue, the renderer must:
+
+* Emit the SHORT field names from the spec example (``acceptance_ref``,
+  ``purpose``, ``expectations``, ``threat``, ``mitigation``,
+  ``severity``) NOT the RuleMetadata internal names
+  (``bound_acceptance_urn``, ``description``, ``then`` list).
+* Map ``RuleMetadata.bound_acceptance_urn`` → output ``acceptance_ref``
+  for security rules.
+* Source ``expectations:`` from the FULL ``RuleMetadata.then`` list
+  (not the joined ``fix_hint`` string).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from atdd.coach.spawn_harness import render_spawn_blocks
+from atdd.coach.utils.rule_binding import RuleMetadata
+
+
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+def _build_fixture_rules() -> list[RuleMetadata]:
+    """Return three rules (one WMBT, one train, one security) at GREEN phase."""
+    wmbt_rule = RuleMetadata(
+        rule_id="repo.govern-lifecycle.D010-acc-unit-001",
+        severity=4,
+        description=(
+            "A single get_theme_map(config) helper replaces every "
+            "hardcoded theme_map dict in the codebase"
+        ),
+        recipe=None,
+        introduced_in=None,
+        source_path=Path("/fixture/plan/govern-lifecycle/D010.yaml"),
+        disposition="strict",
+        validator=None,
+        fix_hint=None,
+        aliases=(),
+        acceptance_urn=(
+            "acc:govern-lifecycle:"
+            "D010-UNIT-001-single-source-theme-map-helper"
+        ),
+        wmbt_urn="wmbt:govern-lifecycle:D010",
+        phase="GREEN",
+        then=(
+            "No theme_map dict literal appears outside coach/utils/theme_map.py",
+            "inventory.py, registry.py, and test_train_validation.py "
+            "import and call get_theme_map",
+            "The helper is the single source of truth for the "
+            "digit-to-theme mapping",
+        ),
+    )
+
+    train_rule = RuleMetadata(
+        rule_id="repo.checkout-train.acc-idempotent-on-retry",
+        severity=4,
+        description=(
+            "Re-running the flow with the same idempotency key produces "
+            "no duplicate side effects"
+        ),
+        recipe=None,
+        introduced_in=None,
+        source_path=Path("/fixture/plan/_trains/checkout-train.yaml"),
+        disposition="strict",
+        validator=None,
+        fix_hint=None,
+        aliases=(),
+        acceptance_urn="acc:checkout-train:idempotent-on-retry",
+        train_urn="train:checkout-train",
+        phase="GREEN",
+        then=(
+            "Repeating a charge with the same key returns the original receipt",
+            "No second downstream webhook is emitted",
+        ),
+    )
+
+    security_rule = RuleMetadata(
+        rule_id="repo.auth.session-management-security-001",
+        severity=4,
+        description="Session Hijacking — Attacker steals session token via XSS",
+        recipe=None,
+        introduced_in=None,
+        source_path=Path("/fixture/plan/auth/session-management.feature.yaml"),
+        disposition="strict",
+        validator=None,
+        fix_hint="HttpOnly cookies, CSP headers",
+        aliases=(),
+        security_urn="security:auth:session-management:001",
+        feature_urn="feature:auth:session-management",
+        bound_acceptance_urn="acc:auth:D001-SEC-001-session-protection",
+        phase="GREEN",
+    )
+
+    return [wmbt_rule, train_rule, security_rule]
+
+
+def test_render_spawn_blocks_matches_expected_snapshot():
+    """``render_spawn_blocks`` produces YAML byte-identical to the fixture."""
+    rules = _build_fixture_rules()
+
+    rendered = render_spawn_blocks(
+        rules,
+        coach_phase="GREEN",
+        train_scope=("train:checkout-train",),
+    )
+
+    expected = (_FIXTURE_DIR / "expected_spawn_blocks.yaml").read_text()
+
+    assert rendered == expected, (
+        "spawn-harness output diverged from spec §8.2 fixture. "
+        "If the spec changed, regenerate fixtures/expected_spawn_blocks.yaml.\n"
+        f"--- expected ---\n{expected}\n--- got ---\n{rendered}\n"
+    )

--- a/src/atdd/coach/utils/rule_binding.py
+++ b/src/atdd/coach/utils/rule_binding.py
@@ -111,9 +111,17 @@ class RuleMetadata:
         harness_category: Coarse-grained harness category.
         signal_metric: Telemetry metric the rule produces / consumes.
         signal_threshold: Threshold against which ``signal_metric`` is judged.
-        given: Authoring-time precondition prose.
-        when: Authoring-time stimulus prose.
-        then: Authoring-time expectation prose.
+        given: Authoring-time precondition prose, full list per
+            §4.1 (one tuple element per ``given.abstract`` list item, or
+            a single-element tuple when the source is a scalar string).
+            ``None`` for toolkit rules and for repo rules whose YAML
+            omits the block.
+        when: Authoring-time stimulus prose; same shape as ``given``.
+        then: Authoring-time expectation prose; same shape as ``given``.
+            The substrate spawn-harness renderer (§8.2) consumes this as
+            the source of the ``expectations:`` block — one bullet per
+            tuple element. Distinct from ``fix_hint`` which is the
+            joined-string form for legacy display paths (§4.2).
         author: Rule author identifier.
         created: ISO date the rule entry was created.
     """
@@ -139,9 +147,9 @@ class RuleMetadata:
     harness_category: Optional[str] = None
     signal_metric: Optional[str] = None
     signal_threshold: Optional[str] = None
-    given: Optional[str] = None
-    when: Optional[str] = None
-    then: Optional[str] = None
+    given: Optional[Tuple[str, ...]] = None
+    when: Optional[Tuple[str, ...]] = None
+    then: Optional[Tuple[str, ...]] = None
     author: Optional[str] = None
     created: Optional[str] = None
 
@@ -417,6 +425,36 @@ def _passthrough_str(block, key) -> Optional[str]:
     return None
 
 
+def _passthrough_list(block, key) -> Optional[Tuple[str, ...]]:
+    """Return ``block[key]`` as a tuple of strings (preserves list structure).
+
+    Spec v12 §4.1 documents ``given/when/then`` context fields as full
+    lists. Returns:
+      * ``None`` when the block or key is missing.
+      * a single-element tuple when the source is a scalar string (so
+        legacy single-line acceptances still surface a list-shape).
+      * a tuple of stringified items when the source is a list.
+    Empty / blank-only lists collapse to ``None`` so the renderer can
+    omit the bullet block instead of emitting an empty ``expectations:``.
+    """
+    if not isinstance(block, dict):
+        return None
+    val = block.get(key)
+    if val is None:
+        return None
+    if isinstance(val, list):
+        items = tuple(
+            str(x).strip()
+            for x in val
+            if isinstance(x, (str, int, float)) and str(x).strip()
+        )
+        return items or None
+    if isinstance(val, (str, int, float)):
+        s = str(val).strip()
+        return (s,) if s else None
+    return None
+
+
 def _passthrough_threshold(signal):
     """Return ``signal.threshold`` as a string (preserves int/float/str)."""
     if not isinstance(signal, dict):
@@ -483,9 +521,9 @@ def _build_repo_rule_metadata(
         harness_category=_passthrough_str(harness, "category"),
         signal_metric=_passthrough_str(signal, "metric"),
         signal_threshold=_passthrough_threshold(signal),
-        given=_passthrough_str(acc.get("given"), "abstract"),
-        when=_passthrough_str(acc.get("when"), "abstract"),
-        then=_passthrough_str(acc.get("then"), "abstract"),
+        given=_passthrough_list(acc.get("given"), "abstract"),
+        when=_passthrough_list(acc.get("when"), "abstract"),
+        then=_passthrough_list(acc.get("then"), "abstract"),
         author=_passthrough_str(metadata_block, "author"),
         created=_passthrough_str(metadata_block, "created"),
     )

--- a/src/atdd/coach/utils/tests/test_rule_binding.py
+++ b/src/atdd/coach/utils/tests/test_rule_binding.py
@@ -375,9 +375,12 @@ def test_rule_metadata_constructable_with_all_substrate_fields():
         "harness_category": "unit",
         "signal_metric": "violation_count",
         "signal_threshold": "0",
-        "given": "a fresh registry",
-        "when": "a substrate rule binds",
-        "then": "every substrate field round-trips",
+        "given": ("a fresh registry",),
+        "when": ("a substrate rule binds",),
+        "then": (
+            "every substrate field round-trips",
+            "the renderer can consume it as a list",
+        ),
         "author": "alec",
         "created": "2026-05-06",
     }


### PR DESCRIPTION
Closes #417.

## Summary

Implements substrate spec v12 §8.2: emits the three repo-rule blocks
that coach v6 §7.1 splices into spawn prompts after its existing
`conventions[].rules_in_scope` block.

## Coach v6 spawn-harness substrate — resolution

Per the issue's prerequisite acknowledgement: live grep
`grep -rn "rules_in_scope\|spawn.harness" src/atdd/coach/` returns zero
hits. **Resolved as path (a)**: this PR ships the substrate spawn-harness
renderer module standalone (`src/atdd/coach/spawn_harness/`). The
existing `conventions[].rules_in_scope` block from coach v6 §7.1 is
**not** synthesized here — when that ramp-up issue lands, its renderer
will call `render_spawn_blocks()` to splice these substrate blocks in
after its own toolkit-rule output. The module is self-contained, has no
runtime callers yet, and ships behind no flag — it is dormant code
waiting for the coach v6 spawn-harness foreground to wire it in.

## What landed

- `src/atdd/coach/spawn_harness/renderer.py` — three block emitters +
  one orchestrator.
- `RuleMetadata.given/when/then` aligned with spec §4.1 ("full lists"):
  type changed from `Optional[str]` → `Optional[Tuple[str, ...]]`. The
  walker uses a new `_passthrough_list` helper. `fix_hint`'s legacy
  joined-string form is unchanged so the disposition-gate enriched-
  output path keeps current rendering. `atdd rules show` joins the
  tuple with `; ` for one-line text-view display.
- 11 new tests (1 snapshot + 10 unit). Snapshot output is
  byte-identical to spec §8.2 lines 600–633 modulo URN substitution.

## Field-name pin (per issue)

The renderer emits the SHORT field names from the spec example, NOT
the RuleMetadata internal names. Mapping in `renderer.py` docstring:

| Output             | RuleMetadata source                |
|---|---|
| `purpose`          | `description`                      |
| `expectations`     | `then` (full list, one bullet each) |
| `acceptance_urn`   | `acceptance_urn` (WMBT/train)      |
| `acceptance_ref`   | `bound_acceptance_urn` (security)  |
| `threat`           | `description` (security)           |
| `mitigation`       | `fix_hint` (security)              |
| `severity`         | `severity` (security)              |

## Out-of-scope (deferred to other issues)

- **§8.4 train-scope detection** (diff → wagon → train walk): the
  renderer accepts the train-URN set as a `train_scope=` argument, per
  the issue's AC. Filing as a Track-F follow-up.
- **`security_rules:` phase filter** (bound-acceptance phase resolution
  per §8.1 paragraph 6): renderer carries a `TODO(#422)` comment and
  emits every rule whose `security_urn` is populated. Filter shape
  matches §8.2.

## Test plan

- [x] `pytest src/atdd/coach/spawn_harness/tests/` — 11 pass
- [x] `pytest src/atdd/coach/utils/tests/` (rule_binding regressions) — passes
- [x] `pytest src/atdd/coach/commands/tests/test_rules_cli.py` — passes
- [x] Snapshot byte-identical to spec §8.2 lines 600–633 modulo URN substitution