### PR TITLE
feat(atdd): #449 — Validation Diagnostics Artifact

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -244,3 +244,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:repo-rule-substrate
   train: 0001-self-compliance-validate
+- id: '449'
+  slug: validation-diagnostics-artifact
+  file: null
+  issue_number: 449
+  type: implementation
+  status: PLANNED
+  created: '2026-05-06'
+  archived: null
+  wagon: null
+  feature: null
+  train: 0001-self-compliance-validate

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ coverage.xml
 
 # ATDD cache + agent-local state
 .atdd/cache/
+.atdd/diagnostics/
 .atdd/orchestration-log.jsonl
 .atdd/worker-state-*.json
 .scratch/

--- a/docs/specs/atdd-diagnostics-spec-v1.md
+++ b/docs/specs/atdd-diagnostics-spec-v1.md
@@ -1,0 +1,271 @@
+# ATDD Validation Diagnostics — Spec v1
+
+**Status**: Frozen as `schema_version: 1` (issue #449)
+**Owner**: ATDD coach
+**Consumers**: AI coding agents, CI dashboards, auto-fix tooling, PR comment bots, local human triage
+
+This document freezes the on-disk schema and stdout format for the
+validation diagnostics artifact. It is the contract that downstream
+consumers (CI, agents, auto-fix codemods) read against. Behavioral
+changes to the schema follow the [Schema versioning](#schema-versioning)
+policy below.
+
+---
+
+## Overview
+
+`atdd validate` runs pytest against the toolkit's validators and emits
+two parallel artifacts on every run:
+
+| Artifact                                              | Purpose                                       | Written when            |
+|-------------------------------------------------------|-----------------------------------------------|-------------------------|
+| `.atdd/baselines/validation/<phase>.yaml`             | Pass-proof for `--verify-baseline` (<10s CI)  | Only on pass            |
+| `.atdd/diagnostics/validation/<phase>.yaml` (**new**) | Machine-readable failure record               | Every run (pass or fail) |
+
+Diagnostics complement baselines — they are not a replacement.
+
+---
+
+## Schema (frozen for `schema_version: 1`)
+
+```yaml
+schema_version: 1
+run:
+  phase: coder                          # planner | tester | coder | coach | all
+  ran_at: "2026-05-06T13:45:00Z"        # ISO-8601 UTC, second precision
+  duration_seconds: 4.83
+  atdd_version: "3.7.0"
+  invocation: "atdd validate --local"
+  outcome:
+    passed: 426
+    failed: 27
+    skipped: 99
+    deselected: 0
+findings:
+  - validator_id: test_python_test_classes_named_correctly
+    validator_path: tester/validators/test_python_test_naming.py
+    category: naming                     # closed enum (see below)
+    severity: error                      # error | warning
+    convention_ref:
+      file: tester/conventions/filename.convention.yaml
+      anchor: test_class_pascalcase
+    summary: "5 test classes do not use PascalCase after 'Test'"
+    items:
+      - file: python/analyze_ledger/tests/test_navigate_domains.py
+        line: 42
+        column: null
+        symbol: TestL001_LoadYamlFiles
+        expected: TestL001LoadYamlFiles
+        found: TestL001_LoadYamlFiles
+        fix: "Rename TestL001_LoadYamlFiles to TestL001LoadYamlFiles"
+        extra: {}
+    raw_message: |                       # ALWAYS populated, verbatim from pytest.fail
+      Found 5 class naming violations:
+      ...
+toolkit_packaging_issues:
+  - resource: tester/validators/fixtures/train_renders_content/fail_stub/harness_output.json
+    referenced_by: [test_analyzer_fail_stub_fixture_emits_render_002]
+```
+
+### Field semantics
+
+#### `run`
+
+| Field                | Type    | Notes                                                                |
+|----------------------|---------|----------------------------------------------------------------------|
+| `phase`              | string  | One of `planner`, `tester`, `coder`, `coach`, `all`.                 |
+| `ran_at`             | string  | ISO-8601 UTC, second precision (e.g. `"2026-05-06T13:45:00Z"`).      |
+| `duration_seconds`   | number  | Wall-clock seconds, rounded to 2dp.                                  |
+| `atdd_version`       | string  | `atdd.__version__` at run time.                                      |
+| `invocation`         | string  | Best-effort recovery of `argv` ("atdd validate --local").            |
+| `outcome`            | object  | Aggregate counts. Keys: `passed`, `failed`, `skipped`, `deselected`. |
+
+#### `findings[]`
+
+One entry per failing validator. Migrated validators emit fully
+populated `items[]`; non-migrated validators emit `items: []` and
+populate `raw_message` only.
+
+| Field             | Type        | Notes                                                                 |
+|-------------------|-------------|-----------------------------------------------------------------------|
+| `validator_id`    | string      | Test function name (e.g. `test_python_test_classes_named_correctly`). |
+| `validator_path`  | string\|null| Repository-relative validator path.                                   |
+| `category`        | string      | Closed enum (see below).                                              |
+| `severity`        | string      | `error` or `warning`.                                                 |
+| `convention_ref`  | object\|absent | Pointer to backing convention rule. Absent when not provided.      |
+| `summary`         | string      | Short one-line summary. Default: first non-empty line of message.     |
+| `items[]`         | array       | Per-violation rows. May be empty (structural failure / unmigrated).   |
+| `raw_message`     | string      | **Always populated** — verbatim text passed to `pytest.fail`.         |
+
+#### `findings[].category` (closed enum)
+
+```
+naming        missing-file   contract       boundary
+hygiene       quality        train          workflow
+convention    unmigrated
+```
+
+`unmigrated` is the auto-assigned bucket when a validator failed without
+calling `fail_with_diagnostic()`. Its presence and growth/shrink rate
+should drive the next round of validator migrations.
+
+#### `findings[].items[]`
+
+| Field      | Type            | Notes                                                                       |
+|------------|-----------------|-----------------------------------------------------------------------------|
+| `file`     | string\|null    | Repo-relative file path of the offending site.                              |
+| `line`     | int\|null       | 1-based line number. Only populated for migrated validators.                |
+| `column`   | int\|null       | 1-based column. Rarely populated.                                           |
+| `symbol`   | string\|null    | The offending identifier (class, function, file path).                      |
+| `expected` | string\|null    | What the convention requires (e.g. `TestFooBar`).                           |
+| `found`    | string\|null    | What was actually found (e.g. `TestFoo_Bar`).                               |
+| `fix`      | string\|null    | One-line actionable fix (suitable for codemod prompts).                     |
+| `extra`    | object          | Free-form per-category bag (e.g. `{"reason": "too-short"}`).                |
+
+#### `toolkit_packaging_issues[]`
+
+Populated when a validator hits `FileNotFoundError` whose path resolves
+to a file under the installed `atdd/` package directory (Decision #5,
+issue #449). Detection uses `Path.resolve()` + `Path.is_relative_to()`
+— substring matching is forbidden because consumer tmp paths can
+contain the substring `atdd`.
+
+| Field           | Type     | Notes                                            |
+|-----------------|----------|--------------------------------------------------|
+| `resource`      | string   | Absolute path to the missing toolkit resource.   |
+| `referenced_by` | string[] | nodeids of every validator that hit the missing path. |
+
+---
+
+## Stdout summary (printed only when `failed > 0`)
+
+```
+=== DIAGNOSTICS (27 findings, 5 categories) ===
+[naming        ]  1 finding,  5 items
+[hygiene       ]  3 findings, 13 items
+[missing-file  ]  6 findings,  6 items
+[contract      ]  2 findings,  2 items
+[train         ] 15 findings, 15 items
+
+Top fixes (sorted by category, capped at 10):
+  python/analyze_ledger/tests/test_navigate_domains.py:42
+    Rename TestL001_LoadYamlFiles to TestL001LoadYamlFiles
+  python/analyze_ledger/tests/test_basic.py:10
+    Remove sys.path manipulation — pytest pythonpath handles this
+  ...
+
+Full diagnostics: .atdd/diagnostics/validation/coder.yaml (27 findings)
+Toolkit packaging issues: 5 (see file)
+```
+
+The format is intentionally **not** a frozen string snapshot — tests assert
+*structure* (header line, one `[<category>]` per category, `Top fixes`
+header, capped at 10 entries, footer with artifact path). See the issue
+body for rationale.
+
+---
+
+## Plugin behavior
+
+### Loading
+
+The plugin is loaded **only** by `atdd validate` via argv injection:
+
+```python
+cmd.extend(["-p", "atdd.coach.plugins.diagnostics"])
+```
+
+It MUST NOT be added to any `conftest.py` or `pytest_plugins` list — that
+would auto-load it in consumer test suites outside `atdd validate`,
+violating the v1 scope.
+
+### Hooks
+
+| Hook                         | Behavior                                                       |
+|------------------------------|----------------------------------------------------------------|
+| `pytest_sessionstart`        | Reset state, clear pending findings.                           |
+| `pytest_runtest_setup`       | Record active nodeid (for `fail_with_diagnostic`).             |
+| `pytest_runtest_logreport`   | Capture failures into findings + toolkit-packaging-issue scan. |
+| `pytest_runtest_teardown`    | Clear active nodeid.                                           |
+| `pytest_deselected`          | Tally deselected count.                                        |
+| `pytest_sessionfinish`       | Write artifact (master only) + print summary if any failures.  |
+
+### Disable conditions
+
+The plugin short-circuits (no artifact write, no stdout summary) when:
+
+1. The `ATDD_DIAGNOSTICS_DISABLED=1` env var is set. The runner sets
+   this on `atdd validate --verify-baseline` (GT-140 regression).
+2. Running on a pytest-xdist worker (`session.config.workerinput`
+   truthy). Only the master writes.
+3. The user passes `--no-diagnostics` to `atdd validate` — the runner
+   omits the `-p atdd.coach.plugins.diagnostics` argv injection
+   entirely.
+
+---
+
+## CLI
+
+```
+atdd validate [phase] [--no-diagnostics] [--diagnostics-only] [--verify-baseline]
+```
+
+| Flag                  | Behavior                                                                 |
+|-----------------------|--------------------------------------------------------------------------|
+| (default)             | Diagnostics enabled — artifact written every run.                        |
+| `--no-diagnostics`    | Suppresses artifact + stdout summary. Plugin not loaded.                 |
+| `--diagnostics-only`  | Reads + prints latest artifact in <100 ms. No pytest invocation.         |
+| `--verify-baseline`   | Existing baseline-freshness check. Diagnostics plugin is a no-op (GT-140). |
+
+---
+
+## Schema versioning
+
+The schema is frozen as `schema_version: 1`. Future evolution follows
+the policy below.
+
+### Breaking-change policy
+
+Any of the following changes bump the schema version to v2:
+
+* Removing or renaming a top-level field (`schema_version`, `run`, `findings`, `toolkit_packaging_issues`).
+* Removing or renaming a field within `run`, `findings[]`, `findings[].items[]`, or `toolkit_packaging_issues[]`.
+* Changing the type of any existing field.
+* Changing the semantics of an existing field (e.g. flipping `outcome.failed` from a count to a boolean).
+* Removing a value from the `findings[].category` enum.
+
+Additive changes (new optional fields, new categories, new severity
+values) are **minor** and do NOT bump the schema version. Consumers
+MUST tolerate unknown fields gracefully.
+
+### Emission policy
+
+The plugin writes whatever `schema_version` is baked into its own code.
+There is no config switch — to opt out of v1 emission, downstream
+consumers stop reading the artifact (or use `--no-diagnostics`). When
+the toolkit ships v2, every `atdd validate` invocation begins emitting
+v2 artifacts; consumers must check `schema_version` before parsing.
+
+### Consumer guidance
+
+Consumers MUST:
+
+1. Check `schema_version` before parsing.
+2. Degrade gracefully on unrecognized values — log and skip the
+   artifact, do not crash.
+3. Tolerate additional unknown fields (forward-compatibility).
+
+Consumers SHOULD:
+
+1. Pin against a specific schema version range in their own
+   documentation.
+2. Track the toolkit `Changelog` for schema bumps.
+
+---
+
+## References
+
+* Issue #449 — implementation tracker
+* `.atdd/baselines/validation/` — parallel pass-proof artifact
+* `src/atdd/coach/utils/disposition_gate.py` — issue #395
+  (read-only consumer for migrated quality validators)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.6.1"
+version = "3.7.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -126,6 +126,7 @@ class ATDDCoach:
         split: bool = True,
         local: bool = False,
         skip_api: bool = False,
+        no_diagnostics: bool = False,
     ) -> int:
         """Run ATDD validators."""
         if quick:
@@ -142,6 +143,7 @@ class ATDDCoach:
             split=split,
             local=local,
             markers=markers,
+            no_diagnostics=no_diagnostics,
         )
 
     def update_registries(
@@ -365,6 +367,25 @@ Phase descriptions:
         action="store_true",
         dest="verify_baseline",
         help="Verify validation baseline freshness (<10s, no test execution)"
+    )
+    validate_parser.add_argument(
+        "--no-diagnostics",
+        action="store_true",
+        dest="no_diagnostics",
+        help=(
+            "Suppress the validation diagnostics artifact and stdout summary "
+            "(issue #449). Default: enabled — `.atdd/diagnostics/validation/<phase>.yaml` "
+            "is written on every run."
+        ),
+    )
+    validate_parser.add_argument(
+        "--diagnostics-only",
+        action="store_true",
+        dest="diagnostics_only",
+        help=(
+            "Read and print the most recent diagnostics artifact in <100 ms "
+            "without running pytest. Issue #449."
+        ),
     )
     validate_parser.add_argument(
         "--no-cache",
@@ -1562,6 +1583,17 @@ Phase descriptions:
     elif args.command == "validate":
         repo_path = Path(args.repo) if hasattr(args, 'repo') and args.repo else None
 
+        # --diagnostics-only: read+print the most recent artifact without
+        # invoking pytest. Must complete in <100 ms (issue #449).
+        if getattr(args, 'diagnostics_only', False):
+            from atdd.coach.commands.diagnostics import (
+                print_latest_diagnostics,
+            )
+            return print_latest_diagnostics(
+                phase=args.phase,
+                repo_root=repo_path,
+            )
+
         # --smoke-required: record smoke evidence for an issue (#358).
         # Resolves COACH-RATCHET-PRES-001 by writing the gate-unblocking file.
         smoke_required = getattr(args, 'smoke_required', None)
@@ -1606,8 +1638,12 @@ Phase descriptions:
             if fix_rc != 0:
                 return fix_rc
 
-        # --verify-baseline: fast path, no test execution
+        # --verify-baseline: fast path, no test execution. Diagnostics
+        # plugin must be a no-op here (issue #449 GT-140) — verify-baseline
+        # doesn't run pytest at all, but the env var also flips off the
+        # plugin if anything inside the verifier ever does.
         if getattr(args, 'verify_baseline', False):
+            os.environ["ATDD_DIAGNOSTICS_DISABLED"] = "1"
             from atdd.coach.commands.validation_baseline import (
                 verify_validation_baseline,
             )
@@ -1646,6 +1682,7 @@ Phase descriptions:
 
         coach = ATDDCoach(repo_root=repo_path)
         skip_api = getattr(args, 'skip_api', False)
+        no_diagnostics = getattr(args, 'no_diagnostics', False)
         rc = coach.run_validators(
             phase=args.phase,
             verbose=args.verbose,
@@ -1655,6 +1692,7 @@ Phase descriptions:
             split=not args.no_split and not skip_api,
             local=args.local,
             skip_api=skip_api,
+            no_diagnostics=no_diagnostics,
         )
 
         # Write baseline on success

--- a/src/atdd/coach/commands/diagnostics.py
+++ b/src/atdd/coach/commands/diagnostics.py
@@ -1,0 +1,129 @@
+"""``atdd validate --diagnostics-only`` reader (issue #449).
+
+Reads the most recent ``.atdd/diagnostics/validation/<phase>.yaml``
+artifact and prints a stdout summary mirroring the format produced by the
+diagnostics plugin's session-finish hook. Designed to complete in
+<100 ms (no pytest invocation, no validator collection).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from atdd.coach.utils.repo import find_repo_root
+
+
+def diagnostics_path(repo_root: Path, phase: str) -> Path:
+    return repo_root / ".atdd" / "diagnostics" / "validation" / f"{phase}.yaml"
+
+
+def print_latest_diagnostics(
+    phase: str = "all",
+    repo_root: Optional[Path] = None,
+) -> int:
+    """Read + print the diagnostics artifact for *phase*. Exit 0 on success.
+
+    Returns 1 if the artifact does not exist (no prior run, or
+    --no-diagnostics was used). Returns 2 on YAML parse error.
+    """
+    root = repo_root or find_repo_root()
+    artifact = diagnostics_path(root, phase)
+
+    if not artifact.exists():
+        print(
+            f"No diagnostics artifact at {artifact.relative_to(root)}.\n"
+            f"Run: atdd validate {phase} --local"
+        )
+        return 1
+
+    try:
+        document = yaml.safe_load(artifact.read_text()) or {}
+    except yaml.YAMLError as exc:
+        print(f"Failed to parse diagnostics artifact at {artifact}: {exc}")
+        return 2
+
+    _print_summary(document, artifact, root)
+    return 0
+
+
+def _print_summary(document: Dict[str, Any], artifact_path: Path, repo_root: Path) -> None:
+    schema_version = document.get("schema_version")
+    if schema_version != 1:
+        print(
+            f"Warning: diagnostics artifact has schema_version={schema_version} "
+            f"(this CLI understands v1). Output may be incomplete."
+        )
+
+    run = document.get("run") or {}
+    findings: List[Dict[str, Any]] = list(document.get("findings") or [])
+    toolkit_issues: List[Dict[str, Any]] = list(document.get("toolkit_packaging_issues") or [])
+    outcome = run.get("outcome") or {}
+
+    print(f"=== DIAGNOSTICS — {run.get('phase', '?')} (ran_at={run.get('ran_at', '?')}) ===")
+    print(
+        f"  outcome: passed={outcome.get('passed', 0)}, "
+        f"failed={outcome.get('failed', 0)}, "
+        f"skipped={outcome.get('skipped', 0)}, "
+        f"deselected={outcome.get('deselected', 0)}"
+    )
+    print(f"  duration: {run.get('duration_seconds', 0)}s, atdd_version: {run.get('atdd_version', '?')}")
+
+    if not findings:
+        print("\nNo findings recorded.")
+        try:
+            rel = artifact_path.relative_to(repo_root)
+        except ValueError:
+            rel = artifact_path
+        print(f"\nFull diagnostics: {rel}")
+        return
+
+    by_category: Dict[str, List[Dict[str, Any]]] = {}
+    for f in findings:
+        by_category.setdefault(f.get("category", "unmigrated"), []).append(f)
+
+    print(f"\n{len(findings)} finding(s), {len(by_category)} categories:")
+    for category in sorted(by_category):
+        bucket = by_category[category]
+        item_total = sum(max(len(f.get("items") or []), 1) for f in bucket)
+        suffix_findings = "s" if len(bucket) != 1 else " "
+        suffix_items = "s" if item_total != 1 else ""
+        print(
+            f"  [{category:<14}] {len(bucket):>2} finding{suffix_findings},"
+            f" {item_total:>3} item{suffix_items}"
+        )
+
+    print("\nTop fixes (sorted by category, capped at 10):")
+    printed = 0
+    for category in sorted(by_category):
+        for finding in by_category[category]:
+            if printed >= 10:
+                break
+            items = finding.get("items") or []
+            if items:
+                item = items[0]
+                location = item.get("file") or "(no file)"
+                if item.get("line"):
+                    location = f"{location}:{item['line']}"
+                fix_text = item.get("fix") or finding.get("summary", "")
+                print(f"  {location}\n    {fix_text}")
+                printed += 1
+            else:
+                vp = finding.get("validator_path") or "unknown"
+                print(f"  ({vp})\n    {finding.get('summary', '')}")
+                printed += 1
+        if printed >= 10:
+            break
+
+    try:
+        rel = artifact_path.relative_to(repo_root)
+    except ValueError:
+        rel = artifact_path
+    print(f"\nFull diagnostics: {rel} ({len(findings)} finding(s))")
+    if toolkit_issues:
+        print(f"Toolkit packaging issues: {len(toolkit_issues)} (see file)")
+
+
+__all__ = ["diagnostics_path", "print_latest_diagnostics"]

--- a/src/atdd/coach/commands/diagnostics.py
+++ b/src/atdd/coach/commands/diagnostics.py
@@ -41,7 +41,10 @@ def print_latest_diagnostics(
 
     try:
         document = yaml.safe_load(artifact.read_text()) or {}
-    except yaml.YAMLError as exc:
+    except yaml.YAMLError as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-06
+        # Reported via print + non-zero exit code — observable by both
+        # the user and CI. Re-raising would obscure the actual problem
+        # (corrupt artifact) behind a stack trace.
         print(f"Failed to parse diagnostics artifact at {artifact}: {exc}")
         return 2
 

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -476,6 +476,10 @@ class ProjectInitializer:
 
             # Ensure .atdd/cache/ is gitignored
             self._ensure_gitignore_entry(".atdd/cache/")
+            # Issue #449: validation diagnostics artifact directory.
+            # Written by `atdd validate` on every run — local artifact,
+            # not git history.
+            self._ensure_gitignore_entry(".atdd/diagnostics/")
 
             # Create manifest.yaml
             self._create_manifest(force)

--- a/src/atdd/coach/commands/test_runner.py
+++ b/src/atdd/coach/commands/test_runner.py
@@ -65,6 +65,7 @@ class TestRunner:
         html_report: bool = False,
         markers: Optional[List[str]] = None,
         parallel: bool = True,
+        no_diagnostics: bool = False,
     ) -> list:
         """Build a pytest command list."""
         # Module-form invocation so atdd's own interpreter resolves pytest.
@@ -102,6 +103,15 @@ class TestRunner:
             print("  pytest-xdist not installed, running sequentially")
 
         cmd.append("--tb=short")
+
+        # Validation diagnostics plugin (issue #449). Argv injection only —
+        # never via conftest.py / pytest_plugins, which would auto-load it
+        # in consumer suites outside ``atdd validate``. Suppressible via
+        # ``--no-diagnostics`` for the rare runner that needs the legacy
+        # stdout-only output (CI smoke jobs, --verify-baseline, etc.).
+        if not no_diagnostics:
+            cmd.extend(["-p", "atdd.coach.plugins.diagnostics"])
+
         return cmd
 
     def _run_pytest(self, cmd: list) -> int:
@@ -127,6 +137,7 @@ class TestRunner:
         parallel: bool = True,
         split: bool = True,
         local: bool = False,
+        no_diagnostics: bool = False,
     ) -> int:
         """
         Run ATDD validators with specified options.
@@ -164,11 +175,13 @@ class TestRunner:
             return self._run_split(
                 validator_dirs, verbose=verbose, coverage=coverage,
                 html_report=html_report, markers=markers, parallel=parallel,
+                no_diagnostics=no_diagnostics,
             )
 
         cmd = self._build_pytest_cmd(
             validator_dirs, verbose=verbose, coverage=coverage,
             html_report=html_report, markers=markers, parallel=parallel,
+            no_diagnostics=no_diagnostics,
         )
         return self._run_pytest(cmd)
 
@@ -180,6 +193,7 @@ class TestRunner:
         html_report: bool = False,
         markers: Optional[List[str]] = None,
         parallel: bool = True,
+        no_diagnostics: bool = False,
     ) -> int:
         """Run validators in two stages: fast then slow.
 
@@ -203,16 +217,21 @@ class TestRunner:
         fast_cmd = self._build_pytest_cmd(
             validator_dirs, verbose=verbose, coverage=coverage,
             html_report=False, markers=fast_markers, parallel=parallel,
+            no_diagnostics=no_diagnostics,
         )
 
         print("\n[1/2] Fast validators (file parsing + local platform, no API):")
         fast_rc = self._run_pytest(fast_cmd)
 
-        # Stage 2: github_api tests, sequential to share session fixtures
+        # Stage 2: github_api tests, sequential to share session fixtures.
+        # Diagnostics plugin disabled for the slow stage so the artifact
+        # written by the fast stage isn't overwritten with a tiny tail of
+        # github_api results (often 0 collected → empty findings list).
         slow_markers = list(markers or []) + ["github_api"]
         slow_cmd = self._build_pytest_cmd(
             validator_dirs, verbose=verbose, coverage=False,
             html_report=html_report, markers=slow_markers, parallel=False,
+            no_diagnostics=True,
         )
 
         print("\n[2/2] GitHub API validators (live API):")

--- a/src/atdd/coach/plugins/__init__.py
+++ b/src/atdd/coach/plugins/__init__.py
@@ -1,0 +1,8 @@
+"""Pytest plugins for atdd toolkit-internal use.
+
+Plugins in this package are loaded via argv injection (``-p
+atdd.coach.plugins.<name>``) by the atdd validate runner only. They are
+NOT registered via ``pytest_plugins`` or any ``conftest.py``, which would
+cause them to auto-load in consumer test suites and leak behavior outside
+the validate phase.
+"""

--- a/src/atdd/coach/plugins/diagnostics.py
+++ b/src/atdd/coach/plugins/diagnostics.py
@@ -114,18 +114,13 @@ def _is_toolkit_packaging_issue(filename: Optional[str]) -> bool:
         return False
     try:
         target = Path(filename).resolve()
-    except (OSError, ValueError):
+    except (OSError, ValueError):  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-06
+        # Bogus path (NUL byte, symlink loop, etc.) — not a toolkit
+        # resource by definition. Returning False is the only sensible
+        # answer; raising would mask the actual test failure.
         return False
     pkg = _atdd_pkg_dir()
-    try:
-        return target.is_relative_to(pkg)
-    except AttributeError:
-        # Defensive: pre-3.9 fallback. Toolkit pins 3.10+ so this is dead.
-        try:
-            target.relative_to(pkg)
-            return True
-        except ValueError:
-            return False
+    return target.is_relative_to(pkg)
 
 
 _FNFE_FILENAME_RE = re.compile(r"FileNotFoundError.*?'([^']+)'", re.DOTALL)

--- a/src/atdd/coach/plugins/diagnostics.py
+++ b/src/atdd/coach/plugins/diagnostics.py
@@ -1,0 +1,430 @@
+"""Pytest plugin: structured diagnostics artifact (issue #449).
+
+Loaded by ``atdd validate`` via argv injection
+(``-p atdd.coach.plugins.diagnostics``). NEVER auto-loaded via
+``conftest.py`` or ``pytest_plugins`` — that would leak diagnostics
+emission into consumer test suites running outside ``atdd validate``.
+
+Behavior:
+  * Tracks active nodeid for each test (so ``fail_with_diagnostic`` can
+    record findings against the right test).
+  * Captures every failed test's structured ``Finding`` (when migrated)
+    or synthesizes an ``unmigrated``-category Finding from
+    ``report.longrepr`` text (when not migrated).
+  * Detects ``FileNotFoundError`` whose missing path lives inside the
+    installed ``atdd`` package directory and surfaces it as a
+    toolkit-packaging issue (separate from per-validator findings).
+  * Writes ``.atdd/diagnostics/validation/<phase>.yaml`` at session
+    finish — but ONLY on the master under xdist (worker processes
+    short-circuit) and ONLY when not disabled via env.
+  * Prints a stdout summary (only when ``failed > 0``) after pytest's
+    own summary.
+
+Disabled when:
+  * ``ATDD_DIAGNOSTICS_DISABLED`` env var is set (e.g. by the runner
+    when ``--verify-baseline`` is in effect).
+  * Running on an xdist worker (``session.config.workerinput`` truthy).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+import yaml
+
+import atdd
+from atdd.coach.utils.diagnostics import (
+    Finding,
+    Item,
+    LEGAL_CATEGORIES,
+    clear_pending_findings,
+    get_pending_findings,
+    set_active_nodeid,
+)
+from atdd.coach.utils.repo import find_repo_root
+
+
+SCHEMA_VERSION = 1
+
+# Categories that auto-classify based on validator-path keywords. Used as a
+# best-effort hint for unmigrated validators so the [<category>] stdout
+# bucket isn't 100% [unmigrated]. Validators that have migrated to
+# ``fail_with_diagnostic`` set their own category and bypass this map.
+_PATH_CATEGORY_HINTS = (
+    ("naming", "naming"),
+    ("boundary", "boundary"),
+    ("boundaries", "boundary"),
+    ("syspath", "hygiene"),
+    ("contract", "contract"),
+    ("hygiene", "hygiene"),
+    ("quality", "quality"),
+    ("metric", "quality"),
+    ("train", "train"),
+    ("workflow", "workflow"),
+    ("convention", "convention"),
+)
+
+
+# ---------------------------------------------------------------------------
+# Plugin state — single instance per pytest session.
+# ---------------------------------------------------------------------------
+
+
+class _DiagnosticsState:
+    def __init__(self) -> None:
+        self.start_time: float = 0.0
+        self.findings: List[Finding] = []
+        self.toolkit_packaging_issues: List[Dict[str, Any]] = []
+        # Counts mirror pytest's terminal summary so the artifact is
+        # self-describing without re-parsing stdout.
+        self.passed: int = 0
+        self.failed: int = 0
+        self.skipped: int = 0
+        self.deselected: int = 0
+        self.errors: int = 0
+
+
+_STATE = _DiagnosticsState()
+
+
+# ---------------------------------------------------------------------------
+# Toolkit-packaging detection.
+# ---------------------------------------------------------------------------
+
+
+def _atdd_pkg_dir() -> Path:
+    return Path(atdd.__file__).resolve().parent
+
+
+def _is_toolkit_packaging_issue(filename: Optional[str]) -> bool:
+    """True iff *filename* resolves to a path under the installed atdd pkg.
+
+    Decision #5 (refined): substring matching on path strings is forbidden
+    because consumer tmp paths can contain ``atdd``. We resolve the path
+    (handling symlinks) and use ``Path.is_relative_to`` (Python 3.10+).
+    """
+    if not filename:
+        return False
+    try:
+        target = Path(filename).resolve()
+    except (OSError, ValueError):
+        return False
+    pkg = _atdd_pkg_dir()
+    try:
+        return target.is_relative_to(pkg)
+    except AttributeError:
+        # Defensive: pre-3.9 fallback. Toolkit pins 3.10+ so this is dead.
+        try:
+            target.relative_to(pkg)
+            return True
+        except ValueError:
+            return False
+
+
+_FNFE_FILENAME_RE = re.compile(r"FileNotFoundError.*?'([^']+)'", re.DOTALL)
+
+
+def _extract_fnfe_filename(longrepr: Any) -> Optional[str]:
+    """Best-effort recover of the missing path from a FileNotFoundError repr.
+
+    Pytest's ``longrepr`` is either a ``ReprExceptionInfo`` or a string;
+    we coerce to ``str(longrepr)`` and pattern-match. ``Errno 2`` reprs
+    embed the filename inside single-quotes after ``FileNotFoundError``.
+    """
+    text = str(longrepr) if longrepr is not None else ""
+    match = _FNFE_FILENAME_RE.search(text)
+    if match:
+        return match.group(1)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Pytest hooks.
+# ---------------------------------------------------------------------------
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    if _is_disabled():
+        return
+    _STATE.start_time = time.time()
+    _STATE.findings = []
+    _STATE.toolkit_packaging_issues = []
+    _STATE.passed = 0
+    _STATE.failed = 0
+    _STATE.skipped = 0
+    _STATE.deselected = 0
+    _STATE.errors = 0
+    clear_pending_findings()
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    if _is_disabled():
+        return
+    set_active_nodeid(item.nodeid)
+
+
+def pytest_runtest_teardown(item: pytest.Item) -> None:
+    if _is_disabled():
+        return
+    set_active_nodeid(None)
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Capture per-call results into the session counters + finding list."""
+    if _is_disabled():
+        return
+    # Tally outcomes from the call phase only (setup/teardown errors are
+    # counted via the ``failed`` bucket of their respective phase too).
+    if report.when == "call":
+        if report.passed:
+            _STATE.passed += 1
+        elif report.failed:
+            _STATE.failed += 1
+            _record_failure(report)
+        elif report.skipped:
+            _STATE.skipped += 1
+    elif report.when in ("setup", "teardown") and report.failed:
+        _STATE.errors += 1
+        _record_failure(report)
+
+
+def pytest_deselected(items: List[pytest.Item]) -> None:
+    if _is_disabled():
+        return
+    _STATE.deselected += len(items)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Write the diagnostics artifact + print stdout summary on the master."""
+    if _is_disabled():
+        return
+    # xdist workers forward reports to the master; only the master writes
+    # the artifact. ``workerinput`` is set by xdist on each worker config.
+    if getattr(session.config, "workerinput", None) is not None:
+        return
+
+    repo_root = find_repo_root()
+    phase = _detect_phase(session)
+
+    artifact_path = _diagnostics_path(repo_root, phase)
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+
+    duration = time.time() - _STATE.start_time
+    document = _build_document(phase=phase, duration=duration)
+    artifact_path.write_text(yaml.safe_dump(document, default_flow_style=False, sort_keys=False))
+
+    if _STATE.failed > 0 or _STATE.errors > 0:
+        try:
+            _print_summary(artifact_path)
+        except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow)
+            # Never let summary failure mask the test outcome.
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Internals.
+# ---------------------------------------------------------------------------
+
+
+def _is_disabled() -> bool:
+    """Whether the plugin should short-circuit (env-controlled by the runner)."""
+    return os.environ.get("ATDD_DIAGNOSTICS_DISABLED") == "1"
+
+
+def _record_failure(report: pytest.TestReport) -> None:
+    """Look for migrated-validator findings; synthesize an unmigrated one if not."""
+    nodeid = report.nodeid
+
+    # Toolkit-packaging detection — runs even when the validator migrated.
+    fnfe_path = _extract_fnfe_filename(report.longrepr)
+    if fnfe_path and _is_toolkit_packaging_issue(fnfe_path):
+        # De-dup by (resource, validator).
+        entry = {"resource": fnfe_path, "referenced_by": [nodeid]}
+        existing = next(
+            (e for e in _STATE.toolkit_packaging_issues if e["resource"] == fnfe_path),
+            None,
+        )
+        if existing is None:
+            _STATE.toolkit_packaging_issues.append(entry)
+        elif nodeid not in existing["referenced_by"]:
+            existing["referenced_by"].append(nodeid)
+
+    pending = get_pending_findings(nodeid)
+    if pending:
+        _STATE.findings.extend(pending)
+        return
+
+    # Synthesize an unmigrated finding from the longrepr text.
+    raw = str(report.longrepr) if report.longrepr is not None else ""
+    summary = _first_meaningful_line(raw)
+    validator_id = nodeid.rsplit("::", 1)[-1] if "::" in nodeid else nodeid
+    validator_path = nodeid.split("::", 1)[0] if "::" in nodeid else None
+    category = _hint_category_from_path(validator_path) or "unmigrated"
+
+    _STATE.findings.append(
+        Finding(
+            validator_id=validator_id,
+            validator_path=validator_path,
+            category=category,
+            severity="error",
+            summary=summary,
+            raw_message=raw,
+            items=[],
+            convention_ref=None,
+        )
+    )
+
+
+def _first_meaningful_line(text: str) -> str:
+    """First non-empty line of a longrepr, trimmed to ~140 chars."""
+    for line in text.splitlines():
+        s = line.strip().lstrip("E ").strip()
+        if s and not s.startswith(">") and not s.startswith("_") and not s.startswith("-"):
+            return s[:140]
+    return (text.strip() or "<no message>")[:140]
+
+
+def _hint_category_from_path(path: Optional[str]) -> Optional[str]:
+    if not path:
+        return None
+    lowered = path.lower()
+    for needle, category in _PATH_CATEGORY_HINTS:
+        if needle in lowered:
+            return category
+    return None
+
+
+def _detect_phase(session: pytest.Session) -> str:
+    """Resolve the validator phase from the session's collected items.
+
+    Looks at the first segment after ``src/atdd/`` in any test path. If
+    the run spans multiple phases, returns ``"all"``.
+    """
+    phases: set[str] = set()
+    for arg in session.config.args:
+        for name in ("planner", "tester", "coder", "coach"):
+            if f"/{name}/validators" in str(arg) or str(arg).endswith(f"/{name}/validators"):
+                phases.add(name)
+                break
+    if len(phases) == 1:
+        return next(iter(phases))
+    if len(phases) > 1:
+        return "all"
+
+    # Fallback: inspect collected items.
+    for item in session.items:
+        path = str(getattr(item, "fspath", "") or item.nodeid)
+        for name in ("planner", "tester", "coder", "coach"):
+            if f"/{name}/validators" in path:
+                phases.add(name)
+                break
+    if len(phases) == 1:
+        return next(iter(phases))
+    if len(phases) > 1:
+        return "all"
+    return "all"
+
+
+def _diagnostics_path(repo_root: Path, phase: str) -> Path:
+    return repo_root / ".atdd" / "diagnostics" / "validation" / f"{phase}.yaml"
+
+
+def _invocation_string() -> str:
+    return " ".join([os.path.basename(sys.argv[0])] + sys.argv[1:])
+
+
+def _build_document(phase: str, duration: float) -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run": {
+            "phase": phase,
+            "ran_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "duration_seconds": round(duration, 2),
+            "atdd_version": atdd.__version__,
+            "invocation": _invocation_string(),
+            "outcome": {
+                "passed": _STATE.passed,
+                "failed": _STATE.failed + _STATE.errors,
+                "skipped": _STATE.skipped,
+                "deselected": _STATE.deselected,
+            },
+        },
+        "findings": [f.to_dict() for f in _STATE.findings],
+        "toolkit_packaging_issues": list(_STATE.toolkit_packaging_issues),
+    }
+
+
+def _print_summary(artifact_path: Path) -> None:
+    findings = _STATE.findings
+    if not findings:
+        return
+
+    by_category: Dict[str, List[Finding]] = {}
+    for f in findings:
+        by_category.setdefault(f.category, []).append(f)
+
+    total_findings = len(findings)
+    total_categories = len(by_category)
+
+    out = sys.stdout
+    out.write(f"\n=== DIAGNOSTICS ({total_findings} findings, {total_categories} categories) ===\n")
+
+    # Stable ordering: alphabetical by category name. Items column is the
+    # sum of items across the bucket (not just findings).
+    for category in sorted(by_category):
+        bucket = by_category[category]
+        item_total = sum(max(len(f.items), 1) for f in bucket)
+        out.write(
+            f"[{category:<14}] {len(bucket):>2} finding{'s' if len(bucket) != 1 else ' '},"
+            f" {item_total:>3} item{'s' if item_total != 1 else ''}\n"
+        )
+
+    # Top fixes — capped at 10 lines, ordered by category name then file.
+    out.write("\nTop fixes (sorted by category, capped at 10):\n")
+    printed = 0
+    for category in sorted(by_category):
+        for finding in by_category[category]:
+            if printed >= 10:
+                break
+            for item in finding.items[:1]:
+                if printed >= 10:
+                    break
+                location = item.file or "(no file)"
+                if item.line:
+                    location = f"{location}:{item.line}"
+                fix_text = item.fix or finding.summary
+                out.write(f"  {location}\n    {fix_text}\n")
+                printed += 1
+            else:
+                if not finding.items and printed < 10:
+                    out.write(f"  ({finding.validator_path or 'unknown'})\n    {finding.summary}\n")
+                    printed += 1
+        if printed >= 10:
+            break
+
+    try:
+        rel = artifact_path.relative_to(find_repo_root())
+        location_str = str(rel)
+    except ValueError:
+        location_str = str(artifact_path)
+    out.write(
+        f"\nFull diagnostics: {location_str} ({total_findings} finding"
+        f"{'s' if total_findings != 1 else ''})\n"
+    )
+    if _STATE.toolkit_packaging_issues:
+        out.write(
+            f"Toolkit packaging issues: {len(_STATE.toolkit_packaging_issues)} (see file)\n"
+        )
+    out.flush()
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+]

--- a/src/atdd/coach/plugins/diagnostics.py
+++ b/src/atdd/coach/plugins/diagnostics.py
@@ -79,7 +79,11 @@ _PATH_CATEGORY_HINTS = (
 
 class _DiagnosticsState:
     def __init__(self) -> None:
-        self.start_time: float = 0.0
+        # Default to time.time() so that if anyone resets the state mid-
+        # session (toolkit-self dogfood, tests), duration_seconds doesn't
+        # blow up to ``time.time() - 0.0``. pytest_sessionstart still
+        # overwrites this with the real session start.
+        self.start_time: float = time.time()
         self.findings: List[Finding] = []
         self.toolkit_packaging_issues: List[Dict[str, Any]] = []
         # Counts mirror pytest's terminal summary so the artifact is

--- a/src/atdd/coach/plugins/tests/test_diagnostics.py
+++ b/src/atdd/coach/plugins/tests/test_diagnostics.py
@@ -1,0 +1,371 @@
+"""Plugin tests for ``atdd.coach.plugins.diagnostics`` (issue #449).
+
+The plugin owns:
+  * Session-finish artifact write (only on master, never on xdist worker).
+  * --verify-baseline / ATDD_DIAGNOSTICS_DISABLED env short-circuit.
+  * Toolkit-packaging detection via ``Path.is_relative_to``.
+  * Stdout summary structure (NOT a hard-coded snapshot — too brittle).
+
+We exercise the hooks directly with synthetic objects rather than spinning
+up a fixture repo. Decision per issue body: keep Phase 4 LOC bounded.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List, Optional
+
+import pytest
+import yaml
+
+from atdd.coach.plugins import diagnostics as plugin
+from atdd.coach.utils import diagnostics as diag
+from atdd.coach.utils import repo as repo_utils
+from atdd.coach.utils.diagnostics import (
+    ConventionRef,
+    Finding,
+    Item,
+    set_active_nodeid,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — synthesize the parts of pytest the plugin actually touches.
+# ---------------------------------------------------------------------------
+
+
+def _make_session(repo_root: Path, args: Optional[List[str]] = None, *, worker: bool = False) -> Any:
+    """Build a duck-typed pytest.Session enough for the plugin's hooks."""
+    config_extras = {}
+    if worker:
+        config_extras["workerinput"] = {"workerid": "gw0"}
+    config = SimpleNamespace(args=args or [], **config_extras)
+    return SimpleNamespace(config=config, items=[])
+
+
+def _make_report(
+    nodeid: str,
+    *,
+    when: str = "call",
+    outcome: str = "failed",
+    longrepr: Any = "fail",
+) -> Any:
+    return SimpleNamespace(
+        nodeid=nodeid,
+        when=when,
+        passed=(outcome == "passed"),
+        failed=(outcome == "failed"),
+        skipped=(outcome == "skipped"),
+        longrepr=longrepr,
+    )
+
+
+def _reset_state() -> None:
+    plugin._STATE = plugin._DiagnosticsState()
+    diag.clear_pending_findings()
+    set_active_nodeid(None)
+    # ``find_repo_root`` is lru_cached — purge between tests so each test
+    # sees its own ATDD_REPO_ROOT monkeypatch.
+    repo_utils.find_repo_root.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Schema + artifact write
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_writes_artifact_with_schema_v1(tmp_path, monkeypatch):
+    """End-to-end: setup → failed report → sessionfinish → artifact exists."""
+    _reset_state()
+    monkeypatch.delenv("ATDD_DIAGNOSTICS_DISABLED", raising=False)
+    monkeypatch.setenv("ATDD_REPO_ROOT", str(tmp_path))
+
+    session = _make_session(tmp_path, args=[str(tmp_path / "src/atdd/coder/validators")])
+    plugin.pytest_sessionstart(session)
+
+    # Migrated validator path: caller pre-records a finding.
+    nodeid = "src/atdd/coder/validators/test_x.py::test_named"
+    set_active_nodeid(nodeid)
+    diag._PENDING_FINDINGS[nodeid] = [Finding(
+        validator_id="test_named",
+        validator_path="src/atdd/coder/validators/test_x.py",
+        category="naming",
+        severity="error",
+        summary="2 violations",
+        raw_message="2 class naming violations",
+        items=[Item(file="x.py", symbol="testFoo", expected="TestFoo", found="testFoo", fix="rename")],
+        convention_ref=ConventionRef(file="conv.yaml", anchor="anchor"),
+    )]
+    set_active_nodeid(None)
+    plugin.pytest_runtest_logreport(_make_report(nodeid))
+    plugin.pytest_sessionfinish(session, exitstatus=1)
+
+    artifact = tmp_path / ".atdd" / "diagnostics" / "validation" / "coder.yaml"
+    assert artifact.exists()
+    document = yaml.safe_load(artifact.read_text())
+    assert document["schema_version"] == 1
+    assert document["run"]["phase"] == "coder"
+    assert document["run"]["outcome"]["failed"] == 1
+    assert document["findings"][0]["category"] == "naming"
+    assert document["findings"][0]["items"][0]["expected"] == "TestFoo"
+
+
+def test_plugin_synthesizes_unmigrated_finding_when_helper_not_used(tmp_path, monkeypatch):
+    """Non-migrated validators still get a Finding (raw_message-only)."""
+    _reset_state()
+    monkeypatch.delenv("ATDD_DIAGNOSTICS_DISABLED", raising=False)
+    monkeypatch.setenv("ATDD_REPO_ROOT", str(tmp_path))
+
+    session = _make_session(tmp_path, args=[str(tmp_path / "src/atdd/tester/validators")])
+    plugin.pytest_sessionstart(session)
+
+    nodeid = "src/atdd/tester/validators/test_unmigrated.py::test_a"
+    plugin.pytest_runtest_logreport(_make_report(
+        nodeid,
+        longrepr="E       AssertionError: thing went wrong\nstacktrace...\n",
+    ))
+    plugin.pytest_sessionfinish(session, exitstatus=1)
+
+    document = yaml.safe_load((tmp_path / ".atdd/diagnostics/validation/tester.yaml").read_text())
+    assert len(document["findings"]) == 1
+    f = document["findings"][0]
+    # Path-based hint puts unmigrated tester findings into a category bucket
+    # the plugin can detect — falls back to ``unmigrated`` if no hint hits.
+    assert f["category"] in plugin.LEGAL_CATEGORIES if hasattr(plugin, "LEGAL_CATEGORIES") else True
+    assert "AssertionError" in f["raw_message"] or "thing went wrong" in f["raw_message"]
+    assert f["items"] == []
+
+
+# ---------------------------------------------------------------------------
+# xdist worker short-circuit
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_no_artifact_write_on_xdist_worker(tmp_path, monkeypatch):
+    _reset_state()
+    monkeypatch.delenv("ATDD_DIAGNOSTICS_DISABLED", raising=False)
+    monkeypatch.setenv("ATDD_REPO_ROOT", str(tmp_path))
+
+    worker_session = _make_session(
+        tmp_path,
+        args=[str(tmp_path / "src/atdd/coder/validators")],
+        worker=True,
+    )
+    plugin.pytest_sessionstart(worker_session)
+    plugin.pytest_runtest_logreport(_make_report("nodeid::test"))
+    plugin.pytest_sessionfinish(worker_session, exitstatus=1)
+
+    # Workers must NOT write the artifact — only the master does.
+    assert not (tmp_path / ".atdd/diagnostics/validation/coder.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# --verify-baseline short-circuit (GT-140)
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_no_op_when_diagnostics_disabled_env_set(tmp_path, monkeypatch):
+    """GT-140: ATDD_DIAGNOSTICS_DISABLED=1 → plugin writes nothing."""
+    _reset_state()
+    monkeypatch.setenv("ATDD_DIAGNOSTICS_DISABLED", "1")
+    monkeypatch.setenv("ATDD_REPO_ROOT", str(tmp_path))
+
+    session = _make_session(tmp_path, args=[str(tmp_path / "src/atdd/coder/validators")])
+    plugin.pytest_sessionstart(session)
+    plugin.pytest_runtest_logreport(_make_report("nodeid::test"))
+    plugin.pytest_sessionfinish(session, exitstatus=1)
+
+    assert not (tmp_path / ".atdd/diagnostics/validation/coder.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# Toolkit-packaging detection (Decision #5: Path.is_relative_to, no substring)
+# ---------------------------------------------------------------------------
+
+
+def test_toolkit_packaging_detection_uses_resolve_and_is_relative_to():
+    """Decision #5: a path under the installed atdd package counts."""
+    import atdd
+    pkg = Path(atdd.__file__).resolve().parent
+    inside = pkg / "tester" / "fixtures" / "missing.json"
+    assert plugin._is_toolkit_packaging_issue(str(inside)) is True
+
+
+def test_toolkit_packaging_detection_does_not_false_positive_on_substring(tmp_path):
+    """Consumer tmp paths containing 'atdd' must NOT count."""
+    sneaky = tmp_path / "atdd-consumer" / "x.json"
+    sneaky.parent.mkdir(parents=True)
+    sneaky.write_text("{}")
+    assert plugin._is_toolkit_packaging_issue(str(sneaky)) is False
+
+
+def test_toolkit_packaging_issue_recorded_on_fnfe_inside_pkg(tmp_path, monkeypatch):
+    _reset_state()
+    monkeypatch.delenv("ATDD_DIAGNOSTICS_DISABLED", raising=False)
+    monkeypatch.setenv("ATDD_REPO_ROOT", str(tmp_path))
+
+    import atdd
+    pkg = Path(atdd.__file__).resolve().parent
+    fnfe_path = pkg / "tester" / "validators" / "fixtures" / "ghost.json"
+    longrepr = (
+        f"FileNotFoundError: [Errno 2] No such file or directory: "
+        f"'{fnfe_path}'"
+    )
+
+    session = _make_session(tmp_path, args=[str(tmp_path / "src/atdd/tester/validators")])
+    plugin.pytest_sessionstart(session)
+    plugin.pytest_runtest_logreport(_make_report(
+        "src/atdd/tester/validators/test_pack.py::test_one",
+        longrepr=longrepr,
+    ))
+    plugin.pytest_sessionfinish(session, exitstatus=1)
+
+    document = yaml.safe_load((tmp_path / ".atdd/diagnostics/validation/tester.yaml").read_text())
+    assert len(document["toolkit_packaging_issues"]) == 1
+    entry = document["toolkit_packaging_issues"][0]
+    assert str(fnfe_path) in entry["resource"]
+
+
+# ---------------------------------------------------------------------------
+# Stdout summary structure (no hard-coded snapshot — fragile)
+# ---------------------------------------------------------------------------
+
+
+def test_stdout_summary_structure(tmp_path, monkeypatch, capsys):
+    """Issue #449 spec: structural assertions only — never a snapshot.
+
+    Required:
+      * starts with `=== DIAGNOSTICS`
+      * one `[<category>]` line per category present in findings
+      * `Top fixes` header followed by ≤10 `file:line` lines
+      * ends with `Full diagnostics: <path>`
+    """
+    _reset_state()
+    monkeypatch.delenv("ATDD_DIAGNOSTICS_DISABLED", raising=False)
+    monkeypatch.setenv("ATDD_REPO_ROOT", str(tmp_path))
+
+    session = _make_session(tmp_path, args=[str(tmp_path / "src/atdd/coder/validators")])
+    plugin.pytest_sessionstart(session)
+
+    # Two categories: naming + hygiene.
+    nodeid_a = "src/atdd/coder/validators/test_x.py::test_a"
+    diag._PENDING_FINDINGS[nodeid_a] = [Finding(
+        validator_id="test_a", validator_path="src/atdd/coder/validators/test_x.py",
+        category="naming", severity="error", summary="naming violation",
+        raw_message="naming",
+        items=[Item(file="a.py", line=10, fix="rename to A")],
+    )]
+    plugin.pytest_runtest_logreport(_make_report(nodeid_a))
+
+    nodeid_b = "src/atdd/coder/validators/test_y.py::test_b"
+    diag._PENDING_FINDINGS[nodeid_b] = [Finding(
+        validator_id="test_b", validator_path="src/atdd/coder/validators/test_y.py",
+        category="hygiene", severity="error", summary="syspath",
+        raw_message="syspath",
+        items=[Item(file="b.py", line=5, fix="remove sys.path.insert")],
+    )]
+    plugin.pytest_runtest_logreport(_make_report(nodeid_b))
+
+    plugin.pytest_sessionfinish(session, exitstatus=1)
+
+    captured = capsys.readouterr().out
+    assert "=== DIAGNOSTICS" in captured
+    assert "[naming" in captured
+    assert "[hygiene" in captured
+    assert "Top fixes" in captured
+
+    # Top-fixes block: the 2 file:line entries we set up.
+    assert "a.py:10" in captured
+    assert "b.py:5" in captured
+
+    # Footer with artifact path.
+    assert "Full diagnostics:" in captured
+    assert "coder.yaml" in captured
+
+
+def test_stdout_summary_skipped_when_no_failures(tmp_path, monkeypatch, capsys):
+    _reset_state()
+    monkeypatch.delenv("ATDD_DIAGNOSTICS_DISABLED", raising=False)
+    monkeypatch.setenv("ATDD_REPO_ROOT", str(tmp_path))
+
+    session = _make_session(tmp_path, args=[str(tmp_path / "src/atdd/coder/validators")])
+    plugin.pytest_sessionstart(session)
+    plugin.pytest_runtest_logreport(_make_report("any::test", outcome="passed"))
+    plugin.pytest_sessionfinish(session, exitstatus=0)
+
+    out = capsys.readouterr().out
+    assert "=== DIAGNOSTICS" not in out
+    # Artifact still written on success — schema demands it.
+    assert (tmp_path / ".atdd/diagnostics/validation/coder.yaml").exists()
+
+
+# ---------------------------------------------------------------------------
+# --diagnostics-only reader
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_only_reader_prints_summary(tmp_path, monkeypatch, capsys):
+    """`atdd validate --diagnostics-only` reads + prints without pytest."""
+    _reset_state()
+    monkeypatch.delenv("ATDD_DIAGNOSTICS_DISABLED", raising=False)
+    monkeypatch.setenv("ATDD_REPO_ROOT", str(tmp_path))
+
+    artifact = tmp_path / ".atdd/diagnostics/validation/coder.yaml"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text(yaml.safe_dump({
+        "schema_version": 1,
+        "run": {
+            "phase": "coder", "ran_at": "2026-05-06T12:00:00Z",
+            "duration_seconds": 1.2, "atdd_version": "3.7.0",
+            "invocation": "atdd validate --local",
+            "outcome": {"passed": 10, "failed": 1, "skipped": 0, "deselected": 0},
+        },
+        "findings": [{
+            "validator_id": "test_a",
+            "validator_path": "src/x.py",
+            "category": "naming",
+            "severity": "error",
+            "summary": "naming violation",
+            "items": [{"file": "a.py", "line": 7, "fix": "rename"}],
+            "raw_message": "raw",
+        }],
+        "toolkit_packaging_issues": [],
+    }))
+
+    from atdd.coach.commands.diagnostics import print_latest_diagnostics
+    rc = print_latest_diagnostics(phase="coder", repo_root=tmp_path)
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "=== DIAGNOSTICS" in out
+    assert "[naming" in out
+    assert "a.py:7" in out
+    assert "Full diagnostics" in out
+
+
+def test_diagnostics_only_reader_returns_1_when_artifact_absent(tmp_path, capsys):
+    from atdd.coach.commands.diagnostics import print_latest_diagnostics
+    rc = print_latest_diagnostics(phase="coder", repo_root=tmp_path)
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "No diagnostics artifact" in out
+
+
+# ---------------------------------------------------------------------------
+# Phase detection
+# ---------------------------------------------------------------------------
+
+
+def test_detect_phase_single_phase(tmp_path):
+    session = _make_session(tmp_path, args=["src/atdd/coder/validators"])
+    assert plugin._detect_phase(session) == "coder"
+
+
+def test_detect_phase_multiple_phases_returns_all(tmp_path):
+    session = _make_session(tmp_path, args=[
+        "src/atdd/coder/validators",
+        "src/atdd/tester/validators",
+    ])
+    assert plugin._detect_phase(session) == "all"

--- a/src/atdd/coach/utils/diagnostics.py
+++ b/src/atdd/coach/utils/diagnostics.py
@@ -1,0 +1,231 @@
+"""Structured diagnostics helpers (issue #449).
+
+Provides ``fail_with_diagnostic()`` — a drop-in replacement for
+``pytest.fail()`` that records a structured ``Finding`` (with optional
+per-violation ``Item`` rows) into a module-level pending-findings map
+keyed by the active pytest nodeid, then raises ``pytest.fail(message)``.
+
+The diagnostics plugin (``atdd.coach.plugins.diagnostics``):
+  * Tracks the active nodeid in ``pytest_runtest_setup`` /
+    ``pytest_runtest_teardown`` (writing into ``set_active_nodeid``).
+  * Reads pending findings off ``get_pending_findings()`` in
+    ``pytest_runtest_logreport`` and attaches them to the report.
+  * Writes everything to ``.atdd/diagnostics/validation/<phase>.yaml``
+    at session finish.
+
+Schema is frozen as ``schema_version: 1`` — see
+``docs/specs/atdd-diagnostics-spec-v1.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+import pytest
+
+# Closed enum — keep in sync with the spec doc.
+LEGAL_CATEGORIES = frozenset({
+    "naming",
+    "missing-file",
+    "contract",
+    "boundary",
+    "hygiene",
+    "quality",
+    "train",
+    "workflow",
+    "convention",
+    "unmigrated",
+})
+
+LEGAL_SEVERITIES = frozenset({"error", "warning"})
+
+
+@dataclass
+class Item:
+    """One concrete violation within a finding."""
+
+    file: Optional[str] = None
+    line: Optional[int] = None
+    column: Optional[int] = None
+    symbol: Optional[str] = None
+    expected: Optional[str] = None
+    found: Optional[str] = None
+    fix: Optional[str] = None
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ConventionRef:
+    """Pointer to a convention rule (file + anchor) backing a finding."""
+
+    file: Optional[str] = None
+    anchor: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class Finding:
+    """One failed validator's structured failure record."""
+
+    validator_id: str
+    validator_path: Optional[str]
+    category: str
+    severity: str
+    summary: str
+    raw_message: str
+    items: List[Item] = field(default_factory=list)
+    convention_ref: Optional[ConventionRef] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "validator_id": self.validator_id,
+            "validator_path": self.validator_path,
+            "category": self.category,
+            "severity": self.severity,
+        }
+        if self.convention_ref is not None:
+            d["convention_ref"] = self.convention_ref.to_dict()
+        d["summary"] = self.summary
+        d["items"] = [i.to_dict() for i in self.items]
+        d["raw_message"] = self.raw_message
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Active-item bookkeeping (used by the diagnostics plugin).
+# ---------------------------------------------------------------------------
+# A module-level "currently running test" pointer. Pytest is single-threaded
+# per worker process (xdist runs one item at a time per worker), so the
+# pointer is safe without locking. The plugin sets it in
+# ``pytest_runtest_setup`` and clears it in ``pytest_runtest_teardown``.
+
+_ACTIVE_NODEID: Optional[str] = None
+_PENDING_FINDINGS: Dict[str, List[Finding]] = {}
+
+
+def set_active_nodeid(nodeid: Optional[str]) -> None:
+    """Plugin hook — record the nodeid of the currently-running pytest item.
+
+    Called from the diagnostics plugin's ``pytest_runtest_setup`` /
+    ``pytest_runtest_teardown`` hooks. Outside a pytest run the value
+    stays ``None`` and ``fail_with_diagnostic`` becomes a thin wrapper
+    around ``pytest.fail`` (no recording side-effect).
+    """
+    global _ACTIVE_NODEID
+    _ACTIVE_NODEID = nodeid
+
+
+def get_pending_findings(nodeid: str) -> List[Finding]:
+    """Plugin hook — pop the pending findings recorded against *nodeid*."""
+    return _PENDING_FINDINGS.pop(nodeid, [])
+
+
+def clear_pending_findings() -> None:
+    """Test/plugin hook — drop all pending findings (e.g. on session start)."""
+    _PENDING_FINDINGS.clear()
+
+
+def _coerce_items(items: Sequence[Any]) -> List[Item]:
+    """Accept ``Item`` instances OR plain dicts and return ``Item`` rows."""
+    out: List[Item] = []
+    for raw in items:
+        if isinstance(raw, Item):
+            out.append(raw)
+            continue
+        if isinstance(raw, dict):
+            out.append(Item(**{k: v for k, v in raw.items() if k in Item.__dataclass_fields__}))
+            continue
+        out.append(Item(extra={"value": repr(raw)}))
+    return out
+
+
+def fail_with_diagnostic(
+    message: str,
+    *,
+    category: str,
+    items: Sequence[Any] = (),
+    convention_ref: Optional[ConventionRef] = None,
+    severity: str = "error",
+    summary: Optional[str] = None,
+) -> None:
+    """Record a structured diagnostic finding then call ``pytest.fail()``.
+
+    Behavior:
+      * Always calls ``pytest.fail(message)`` after recording the finding —
+        callers that have not migrated still see the same ``longrepr`` text
+        they always have.
+      * Empty ``items`` is valid — the validator is reporting a structural
+        failure ("file missing") rather than per-item violations.
+      * Outside a pytest run (helper called from a script), the recording
+        step is a silent no-op and ``pytest.fail`` still raises.
+
+    Args:
+        message: Verbose message — passed verbatim to ``pytest.fail`` and
+            stored as ``raw_message`` on the finding.
+        category: Closed-enum classification (see ``LEGAL_CATEGORIES``).
+        items: Optional per-violation ``Item`` rows (or dicts).
+        convention_ref: Optional ``ConventionRef`` backing the failure.
+        severity: ``"error"`` (default) or ``"warning"``.
+        summary: Short one-line summary; defaults to first non-empty
+            line of ``message``.
+    """
+    nodeid = _ACTIVE_NODEID
+    finding = Finding(
+        validator_id=_validator_id_from_nodeid(nodeid),
+        validator_path=_validator_path_from_nodeid(nodeid),
+        category=category,
+        severity=severity if severity in LEGAL_SEVERITIES else "error",
+        summary=summary or _first_line(message),
+        raw_message=message,
+        items=_coerce_items(items),
+        convention_ref=convention_ref,
+    )
+
+    if nodeid is not None:
+        _PENDING_FINDINGS.setdefault(nodeid, []).append(finding)
+
+    pytest.fail(message)
+
+
+def _first_line(text: str) -> str:
+    """Return the first non-empty line of *text*, stripped."""
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    return text.strip()
+
+
+def _validator_id_from_nodeid(nodeid: Optional[str]) -> str:
+    if not nodeid:
+        return "<unknown>"
+    if "::" in nodeid:
+        return nodeid.rsplit("::", 1)[-1]
+    return nodeid
+
+
+def _validator_path_from_nodeid(nodeid: Optional[str]) -> Optional[str]:
+    if not nodeid:
+        return None
+    if "::" in nodeid:
+        return nodeid.split("::", 1)[0]
+    return nodeid
+
+
+__all__ = [
+    "ConventionRef",
+    "Finding",
+    "Item",
+    "LEGAL_CATEGORIES",
+    "LEGAL_SEVERITIES",
+    "clear_pending_findings",
+    "fail_with_diagnostic",
+    "get_pending_findings",
+    "set_active_nodeid",
+]

--- a/src/atdd/coach/utils/tests/test_diagnostics.py
+++ b/src/atdd/coach/utils/tests/test_diagnostics.py
@@ -1,0 +1,172 @@
+"""Unit tests for ``atdd.coach.utils.diagnostics`` (issue #449).
+
+Covers:
+  * ``Item`` / ``Finding`` / ``ConventionRef`` to_dict() shape.
+  * ``fail_with_diagnostic`` empty-items semantics.
+  * ``fail_with_diagnostic`` records on the active nodeid.
+  * Outside a pytest run (no active nodeid) the helper still calls
+    ``pytest.fail`` and the recording is a silent no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from atdd.coach.utils import diagnostics as diag
+from atdd.coach.utils.diagnostics import (
+    ConventionRef,
+    Finding,
+    Item,
+    LEGAL_CATEGORIES,
+    LEGAL_SEVERITIES,
+    fail_with_diagnostic,
+    get_pending_findings,
+    set_active_nodeid,
+)
+
+
+def test_legal_categories_includes_unmigrated_bucket():
+    """category=unmigrated must be valid — auto-assigned for non-migrated validators."""
+    assert "unmigrated" in LEGAL_CATEGORIES
+
+
+def test_severity_enum_is_error_warning_only():
+    """Severity vocabulary frozen at v1: error | warning."""
+    assert LEGAL_SEVERITIES == frozenset({"error", "warning"})
+
+
+def test_item_to_dict_round_trip():
+    item = Item(file="x.py", line=10, symbol="Foo", expected="Bar", found="Foo", fix="Rename Foo to Bar")
+    d = item.to_dict()
+    assert d["file"] == "x.py"
+    assert d["line"] == 10
+    assert d["expected"] == "Bar"
+    assert d["fix"] == "Rename Foo to Bar"
+    assert d["extra"] == {}
+
+
+def test_convention_ref_to_dict_round_trip():
+    ref = ConventionRef(file="conv.yaml", anchor="anchor-1")
+    assert ref.to_dict() == {"file": "conv.yaml", "anchor": "anchor-1"}
+
+
+def test_finding_to_dict_includes_convention_ref_when_present():
+    finding = Finding(
+        validator_id="t",
+        validator_path="path/x.py",
+        category="naming",
+        severity="error",
+        summary="s",
+        raw_message="r",
+        items=[Item(file="x.py")],
+        convention_ref=ConventionRef(file="c.yaml", anchor="a"),
+    )
+    d = finding.to_dict()
+    assert d["convention_ref"] == {"file": "c.yaml", "anchor": "a"}
+    assert d["category"] == "naming"
+    assert d["raw_message"] == "r"
+    assert len(d["items"]) == 1
+
+
+def test_finding_to_dict_omits_convention_ref_when_none():
+    finding = Finding(
+        validator_id="t", validator_path=None, category="unmigrated",
+        severity="error", summary="s", raw_message="r",
+    )
+    d = finding.to_dict()
+    assert "convention_ref" not in d
+
+
+def test_fail_with_diagnostic_records_finding_for_active_nodeid():
+    diag.clear_pending_findings()
+    set_active_nodeid("src/atdd/x/test_y.py::test_z")
+    try:
+        with pytest.raises(pytest.fail.Exception):
+            fail_with_diagnostic(
+                "boom",
+                category="naming",
+                items=[Item(file="x.py", symbol="A", expected="B", found="A", fix="rename")],
+                convention_ref=ConventionRef(file="c.yaml", anchor="a"),
+            )
+
+        recorded = get_pending_findings("src/atdd/x/test_y.py::test_z")
+        assert len(recorded) == 1
+        f = recorded[0]
+        assert f.category == "naming"
+        assert f.validator_id == "test_z"
+        assert f.validator_path == "src/atdd/x/test_y.py"
+        assert f.summary == "boom"
+        assert f.raw_message == "boom"
+        assert len(f.items) == 1
+        assert f.items[0].symbol == "A"
+    finally:
+        set_active_nodeid(None)
+
+
+def test_fail_with_diagnostic_empty_items_is_valid():
+    """Issue #449 Phase 1: empty items means structural failure."""
+    diag.clear_pending_findings()
+    set_active_nodeid("nodeid-empty")
+    try:
+        with pytest.raises(pytest.fail.Exception):
+            fail_with_diagnostic("file missing", category="missing-file")
+        recorded = get_pending_findings("nodeid-empty")
+        assert len(recorded) == 1
+        assert recorded[0].items == []
+        assert recorded[0].raw_message == "file missing"
+    finally:
+        set_active_nodeid(None)
+
+
+def test_fail_with_diagnostic_outside_pytest_run_is_silent_no_op_recording():
+    """Without an active nodeid, fail still raises and no finding is stored."""
+    diag.clear_pending_findings()
+    set_active_nodeid(None)
+    with pytest.raises(pytest.fail.Exception):
+        fail_with_diagnostic("orphan", category="hygiene")
+    # No nodeid → nothing was stored.
+    assert get_pending_findings("anything") == []
+
+
+def test_fail_with_diagnostic_accepts_dict_items_and_coerces():
+    diag.clear_pending_findings()
+    set_active_nodeid("dict-items-nodeid")
+    try:
+        with pytest.raises(pytest.fail.Exception):
+            fail_with_diagnostic(
+                "dict items",
+                category="hygiene",
+                items=[{"file": "x.py", "line": 7, "fix": "do thing"}],
+            )
+        recorded = get_pending_findings("dict-items-nodeid")
+        assert recorded[0].items[0].file == "x.py"
+        assert recorded[0].items[0].line == 7
+    finally:
+        set_active_nodeid(None)
+
+
+def test_fail_with_diagnostic_summary_defaults_to_first_meaningful_line():
+    diag.clear_pending_findings()
+    set_active_nodeid("summary-nodeid")
+    try:
+        with pytest.raises(pytest.fail.Exception):
+            fail_with_diagnostic(
+                "\n\n  one-liner summary\nmore body text\n",
+                category="naming",
+            )
+        recorded = get_pending_findings("summary-nodeid")
+        assert recorded[0].summary == "one-liner summary"
+    finally:
+        set_active_nodeid(None)
+
+
+def test_fail_with_diagnostic_invalid_severity_falls_back_to_error():
+    diag.clear_pending_findings()
+    set_active_nodeid("sev-nodeid")
+    try:
+        with pytest.raises(pytest.fail.Exception):
+            fail_with_diagnostic("x", category="naming", severity="catastrophic")
+        recorded = get_pending_findings("sev-nodeid")
+        assert recorded[0].severity == "error"
+    finally:
+        set_active_nodeid(None)

--- a/src/atdd/coder/validators/test_train_infrastructure.py
+++ b/src/atdd/coder/validators/test_train_infrastructure.py
@@ -31,6 +31,11 @@ from pathlib import Path
 from typing import List, Dict, Optional, Set, Tuple, Any
 
 import atdd
+from atdd.coach.utils.diagnostics import (
+    ConventionRef,
+    Item,
+    fail_with_diagnostic,
+)
 from atdd.coach.utils.repo import find_repo_root
 from atdd.coach.utils.train_spec_phase import (
     TrainSpecPhase,
@@ -199,28 +204,99 @@ def test_train_runner_class_exists():
     """TrainRunner class must exist in python/trains/runner.py or python/trains/runner/runner.py."""
     runner_file = _find_train_file("runner", "runner.py")
 
-    assert runner_file is not None, (
-        "runner.py not found.\n"
-        "Searched: python/trains/runner/runner.py, python/trains/runner.py"
-    )
+    if runner_file is None:
+        candidates = [
+            "python/trains/runner/runner.py",
+            "python/trains/runner.py",
+        ]
+        message = (
+            "runner.py not found.\n"
+            f"Searched: {', '.join(candidates)}"
+        )
+        fail_with_diagnostic(
+            message,
+            category="missing-file",
+            items=[
+                Item(
+                    file=path,
+                    expected="present",
+                    found="absent",
+                    fix=(
+                        "Create python/trains/runner.py (or "
+                        "python/trains/runner/runner.py) defining "
+                        "class TrainRunner with __init__, execute, "
+                        "_execute_step methods"
+                    ),
+                )
+                for path in candidates
+            ],
+            convention_ref=ConventionRef(
+                file="coder/conventions/train.convention.yaml",
+                anchor="train_structure",
+            ),
+            summary="train runner module missing — searched two well-known paths",
+        )
+        return
 
     with open(runner_file, 'r', encoding='utf-8') as f:
         content = f.read()
 
     # Check for TrainRunner class
-    assert "class TrainRunner" in content, (
-        f"TrainRunner class not found in {runner_file.relative_to(REPO_ROOT)}\n"
-        "Expected: class TrainRunner with execute() method"
-    )
+    rel_runner = runner_file.relative_to(REPO_ROOT)
+    if "class TrainRunner" not in content:
+        message = (
+            f"TrainRunner class not found in {rel_runner}\n"
+            "Expected: class TrainRunner with execute() method"
+        )
+        fail_with_diagnostic(
+            message,
+            category="missing-file",
+            items=[
+                Item(
+                    file=str(rel_runner),
+                    symbol="TrainRunner",
+                    expected="class TrainRunner: ...",
+                    found="<not defined>",
+                    fix="Define class TrainRunner with __init__, execute, _execute_step methods",
+                ),
+            ],
+            convention_ref=ConventionRef(
+                file="coder/conventions/train.convention.yaml",
+                anchor="train_structure",
+            ),
+            summary=f"TrainRunner class missing in {rel_runner}",
+        )
+        return
 
     # Check for key methods
     required_methods = ["__init__", "execute", "_execute_step"]
     missing_methods = [m for m in required_methods if f"def {m}" not in content]
 
     if missing_methods:
-        pytest.fail(
+        message = (
             f"\nTrainRunner missing required methods: {', '.join(missing_methods)}\n"
             "Expected methods: __init__, execute, _execute_step"
+        )
+        fail_with_diagnostic(
+            message,
+            category="missing-file",
+            items=[
+                Item(
+                    file=str(rel_runner),
+                    symbol=f"TrainRunner.{method}",
+                    expected=f"def {method}(self, ...)",
+                    found="<not defined>",
+                    fix=f"Add {method}() method to TrainRunner",
+                )
+                for method in missing_methods
+            ],
+            convention_ref=ConventionRef(
+                file="coder/conventions/train.convention.yaml",
+                anchor="train_structure",
+            ),
+            summary=(
+                f"TrainRunner missing {len(missing_methods)} required method(s)"
+            ),
         )
 
 

--- a/src/atdd/coder/validators/test_wagon_boundaries.py
+++ b/src/atdd/coder/validators/test_wagon_boundaries.py
@@ -28,6 +28,11 @@ from typing import List, Tuple, Set
 import ast
 
 import atdd
+from atdd.coach.utils.diagnostics import (
+    ConventionRef,
+    Item,
+    fail_with_diagnostic,
+)
 from atdd.coach.utils.repo import find_repo_root
 
 # Path constants
@@ -401,6 +406,7 @@ def test_no_syspath_manipulation_in_tests():
         pytest.skip("No test files found to validate")
 
     violations = []
+    items: list[Item] = []
 
     for test_file in test_files:
         syspath_lines = check_for_syspath_manipulation(test_file)
@@ -414,13 +420,29 @@ def test_no_syspath_manipulation_in_tests():
                     f"  Issue: Test file manipulates sys.path\n"
                     f"  Fix: Remove sys.path manipulation; pytest pythonpath handles this"
                 )
+                items.append(Item(
+                    file=str(rel_path),
+                    line=line_no,
+                    found=line_content,
+                    fix="Remove sys.path manipulation — pytest pythonpath handles this",
+                ))
 
     if violations:
-        pytest.fail(
+        message = (
             f"\n\nFound {len(violations)} sys.path manipulations in test files:\n\n" +
             "\n\n".join(violations[:10]) +
             (f"\n\n... and {len(violations) - 10} more" if len(violations) > 10 else "") +
             "\n\nSee: atdd/coder/conventions/boundaries.convention.yaml::namespacing.syspath_prohibition"
+        )
+        fail_with_diagnostic(
+            message,
+            category="hygiene",
+            items=items,
+            convention_ref=ConventionRef(
+                file="coder/conventions/boundaries.convention.yaml",
+                anchor="namespacing.syspath_prohibition",
+            ),
+            summary=f"{len(violations)} sys.path manipulation(s) in test files",
         )
 
 

--- a/src/atdd/tester/validators/test_python_test_naming.py
+++ b/src/atdd/tester/validators/test_python_test_naming.py
@@ -16,6 +16,11 @@ import pytest
 import re
 from pathlib import Path
 
+from atdd.coach.utils.diagnostics import (
+    ConventionRef,
+    Item,
+    fail_with_diagnostic,
+)
 from atdd.coach.utils.repo import find_repo_root
 
 
@@ -205,6 +210,18 @@ def test_python_test_functions_named_correctly():
         )
 
 
+def _suggest_pascal_case(class_name: str) -> str:
+    """Best-effort: collapse underscores after 'Test' to PascalCase.
+
+    ``TestL001_LoadYaml`` → ``TestL001LoadYaml``. Not perfect (won't fix
+    leading-lowercase or all-snake_case names) but covers the vast
+    majority of naming.convention.yaml::TN-03 violations.
+    """
+    if not class_name.startswith("Test"):
+        return class_name
+    return class_name.replace("_", "")
+
+
 @pytest.mark.tester
 def test_python_test_classes_named_correctly():
     """
@@ -225,6 +242,7 @@ def test_python_test_classes_named_correctly():
         pytest.skip("No Python test files found")
 
     violations = []
+    items: list[Item] = []
 
     for test_file in test_files:
         classes = extract_test_classes(test_file)
@@ -234,27 +252,54 @@ def test_python_test_classes_named_correctly():
             if not class_name.startswith('Test'):
                 continue
 
+            rel = test_file.relative_to(REPO_ROOT)
+
             # Check PascalCase
             if not re.match(r'^Test[A-Z][a-zA-Z0-9]*$', class_name):
+                expected = _suggest_pascal_case(class_name)
                 violations.append(
-                    f"{test_file.relative_to(REPO_ROOT)}\\n"
-                    f"  Class: {class_name}\\n"
+                    f"{rel}\n"
+                    f"  Class: {class_name}\n"
                     f"  Issue: Test class should use PascalCase after 'Test'"
                 )
+                items.append(Item(
+                    file=str(rel),
+                    symbol=class_name,
+                    expected=expected,
+                    found=class_name,
+                    fix=f"Rename {class_name} to {expected}",
+                ))
 
             # Check if too short
             if len(class_name) < 8:  # Test + at least 3 chars
                 violations.append(
-                    f"{test_file.relative_to(REPO_ROOT)}\\n"
-                    f"  Class: {class_name}\\n"
+                    f"{rel}\n"
+                    f"  Class: {class_name}\n"
                     f"  Issue: Test class name too short (should be descriptive)"
                 )
+                items.append(Item(
+                    file=str(rel),
+                    symbol=class_name,
+                    found=class_name,
+                    fix=f"Expand {class_name} to a more descriptive name (>=8 chars)",
+                    extra={"reason": "too-short"},
+                ))
 
     if violations:
-        pytest.fail(
-            f"\\n\\nFound {len(violations)} class naming violations:\\n\\n" +
-            "\\n\\n".join(violations[:10]) +
-            (f"\\n\\n... and {len(violations) - 10} more" if len(violations) > 10 else "")
+        message = (
+            f"\n\nFound {len(violations)} class naming violations:\n\n" +
+            "\n\n".join(violations[:10]) +
+            (f"\n\n... and {len(violations) - 10} more" if len(violations) > 10 else "")
+        )
+        fail_with_diagnostic(
+            message,
+            category="naming",
+            items=items,
+            convention_ref=ConventionRef(
+                file="tester/conventions/filename.convention.yaml",
+                anchor="test_class_pascalcase",
+            ),
+            summary=f"{len(violations)} test class naming violation(s)",
         )
 
 


### PR DESCRIPTION
Closes #449

## Summary

Ships a structured, machine-readable diagnostics artifact for `atdd validate`. Every run now writes `.atdd/diagnostics/validation/<phase>.yaml` (frozen as `schema_version: 1`) so downstream consumers (AI agents, CI dashboards, codemods, PR bots) can stop re-grepping pytest stdout for fix instructions.

Lived motivation: a downstream consumer agent triaging 27 `atdd validate` failures with `| tail -60 | grep ^FAILED` lost the entire actionable diagnostic body and produced a confidently-wrong fix plan from validator names alone. The data the agent needed was emitted by validators — but the only access path was unprincipled stdout grepping.

## Phases (all landed)

### Phase 1 — Plugin scaffold + schema (`d38a1a1`)
- `src/atdd/coach/plugins/diagnostics.py` — pytest plugin with the full hook surface (`pytest_sessionstart`, `pytest_runtest_setup/teardown/logreport`, `pytest_deselected`, `pytest_sessionfinish`).
- `src/atdd/coach/utils/diagnostics.py` — `Finding` / `Item` / `ConventionRef` dataclasses + `fail_with_diagnostic()` drop-in for `pytest.fail()`.
- `TestRunner._build_pytest_cmd` injects `-p atdd.coach.plugins.diagnostics` after `--tb=short`. **Argv-injection only**, never via `conftest.py` / `pytest_plugins` (would leak the plugin into consumer test suites outside `atdd validate`).
- xdist worker handling: `pytest_sessionfinish` short-circuits when `session.config.workerinput` is truthy. Master alone owns the artifact write.
- `--verify-baseline` short-circuit via `ATDD_DIAGNOSTICS_DISABLED=1` env (GT-140).
- Empty-items in `fail_with_diagnostic` is valid (structural failure).
- Toolkit-packaging detection via `Path(filename).resolve().is_relative_to(Path(atdd.__file__).resolve().parent)` — no substring matching (Decision #5).

### Phase 2 — 3 worked-example validator migrations (`a117b21`)
- `test_python_test_classes_named_correctly` → `category=naming` with per-class `Item` rows (file/symbol/expected/found/fix).
- `test_no_syspath_manipulation_in_tests` → `category=hygiene` with per-line `Item` rows.
- `test_train_runner_class_exists` → `category=missing-file` with `Item` rows per missing path/method.

All other validators continue to emit `raw_message`-only findings via the plugin's synthesized-from-`longrepr` path (zero-effort migration validated).

### Phase 3 — gitignore (`be29aa6`)
- `atdd init --force` adds `.atdd/diagnostics/` to consumer `.gitignore` (sibling to `.atdd/cache/`).
- Toolkit-self `.gitignore` also gets the line.

### Phase 4 — Tests + spec doc (`4799704`)
- 25 new tests across `coach/utils/tests/test_diagnostics.py` + `coach/plugins/tests/test_diagnostics.py`. Coverage: dataclass round-trips, empty-items, active-nodeid recording, no-pytest fallback, dict-coercion, schema-v1 artifact, xdist no-op, `ATDD_DIAGNOSTICS_DISABLED` (GT-140), toolkit-packaging detection (positive + substring-false-positive), stdout summary structural assertions (no hard-coded snapshot), `--diagnostics-only` reader.
- `docs/specs/atdd-diagnostics-spec-v1.md` freezes schema + plugin behavior + Schema versioning policy (breaking/additive policies, emission, consumer guidance).

### Release (`c6b429b`, `c9e2136`)
- Version bump 3.6.1 → 3.7.0 (MINOR — additive feature surface).
- Suppress markers + dead-code removal for the silent-swallow validator.
- `_DiagnosticsState.start_time` defaults to `time.time()` so duration_seconds doesn't blow up in dogfood reset cycles.

## Test plan

- [x] `pytest src/atdd/coach/plugins/ src/atdd/coach/utils/tests/test_diagnostics.py` — 25 passed.
- [x] Full suite vs main: same 21 pre-existing failures (substrate plugin double-registration + babysit tests + E001 char test); 1 new `test_release_versioning` failure resolved by the version bump (post-merge tag).
- [x] `--diagnostics-only` benchmarked at ~30 ms (target: <100 ms).
- [x] End-to-end dogfood: artifact emitted with valid `schema_version: 1` + sane `duration_seconds`.
- [x] `-p atdd.coach.plugins.diagnostics` argv injection verified via `TestRunner._build_pytest_cmd`; suppressible via `--no-diagnostics`.

## Out of scope (per issue)

- Auto-fix tooling (separate downstream consumer).
- Replacing `validation_baseline.py` (parallel, distinct purpose).
- Mass migration of remaining validators (3 worked examples sufficient for v1).
- Cross-run history / diff (each run overwrites `<phase>.yaml`).
- Standalone `pip install pytest-atdd-diagnostics` (auto-loaded via `atdd validate` only in v1).