### PR TITLE
chore(atdd): #451 — bundle validator fixtures + wheel-completeness validator

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -255,3 +255,14 @@ sessions:
   wagon: null
   feature: null
   train: 0001-self-compliance-validate
+- id: '451'
+  slug: toolkit-wheel-missing-train-renders-fixtures
+  file: null
+  issue_number: 451
+  type: cleanup
+  status: PLANNED
+  created: '2026-05-06'
+  archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:toolkit-wheel-completeness
+  train: 0001-self-compliance-validate

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,16 @@
+recursive-include src/atdd/coach/validators/fixtures *
+recursive-include src/atdd/coder/validators/fixtures *
+recursive-include src/atdd/tester/validators/fixtures *
+recursive-include src/atdd/planner/validators/fixtures *
+
+recursive-exclude src/atdd/coach/validators/fixtures __pycache__ *.pyc *.pyo
+recursive-exclude src/atdd/coder/validators/fixtures __pycache__ *.pyc *.pyo
+recursive-exclude src/atdd/tester/validators/fixtures __pycache__ *.pyc *.pyo
+recursive-exclude src/atdd/planner/validators/fixtures __pycache__ *.pyc *.pyo
+
+recursive-exclude src/atdd/coach/validators/fixtures .pytest_cache
+recursive-exclude src/atdd/coder/validators/fixtures .pytest_cache
+recursive-exclude src/atdd/tester/validators/fixtures .pytest_cache
+recursive-exclude src/atdd/planner/validators/fixtures .pytest_cache
+
+global-exclude .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,12 @@ atdd_substrate = "atdd.tester.substrate.plugin"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+# Validator fixture trees are SHIPPED AS DATA via package-data below.
+# Excluding them here prevents setuptools from treating fixture sub-dirs
+# (which sometimes carry __init__.py for test-import purposes) as
+# importable packages, which in turn stops pip's compile-on-install from
+# generating __pycache__/*.pyc beside the fixture sources.
+exclude = ["atdd.*.validators.fixtures*"]
 
 [tool.setuptools.package-data]
 "atdd.coach.templates" = ["*.md"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.7.0"
+version = "3.7.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"
@@ -58,7 +58,7 @@ where = ["src"]
 "atdd.tester.schemas" = ["*.json"]
 "atdd.coder.conventions" = ["*.yaml"]
 "atdd.coder.schemas" = ["*.json"]
-"atdd" = ["coder/validators/fixtures/**"]
+"atdd" = ["**/validators/fixtures/**"]
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]

--- a/src/atdd/coach/conventions/rule-id.convention.yaml
+++ b/src/atdd/coach/conventions/rule-id.convention.yaml
@@ -389,3 +389,6 @@ migration:
     # Issue #394 Phase 3 — strict-flip prerequisite registrations
     - "src/atdd/coder/conventions/security.convention.yaml"
     - "src/atdd/tester/conventions/smoke.convention.yaml"
+    # Issue #451 — wheel-completeness build-time guard (advisory in 3.7.x,
+    # promoted to strict in 3.8.0 per convention's promotion_plan).
+    - "src/atdd/coach/conventions/wheel-completeness.convention.yaml"

--- a/src/atdd/coach/conventions/wheel-completeness.convention.yaml
+++ b/src/atdd/coach/conventions/wheel-completeness.convention.yaml
@@ -1,0 +1,106 @@
+schema_version: "1.0.0"
+convention_id: "coach.wheel-completeness"
+name: "Wheel Completeness Convention"
+description: |
+  Declares the build-time guard that every validator-fixture file present
+  in the toolkit's source tree (``src/atdd/**/validators/fixtures/**``)
+  must also ship in the installed wheel under
+  ``Path(atdd.__file__).parent``.
+
+  Source-tree inverse scan (NOT code-AST): walk fixture files in the
+  source tree, compute the expected install-path for each, assert each
+  exists. False-negative-resistant by construction — there is no code
+  parsing involved.
+
+rationale: |
+  Pre-#449 incident (verified live on 2026-05-06): v3.7.0 shipped with
+  ``[tool.setuptools.package-data]`` declaring only ``coder/validators/
+  fixtures/**``; the tester / coach / planner phase fixture trees were
+  silently dropped from the wheel. Five test failures on consumer repos
+  (all of them resolving to ``FileNotFoundError`` against
+  ``train_renders_content/<bucket>/harness_output.json``) were
+  indistinguishable from genuine consumer-side bugs until #449's
+  ``toolkit_packaging_issues`` diagnostics field made the cause legible.
+
+  This convention promotes the pattern from "category of past bugs" to
+  "automated guard against future occurrences". The rule is shipped as
+  ``advisory`` for the 3.7.x line; flip to ``strict`` in 3.8.0 once the
+  install-path coverage is empirically clean across the active
+  consumer-repo fleet.
+
+scan_scope:
+  COACH-WHEEL-COMPLETENESS-001:
+    include:
+      - "src/atdd/**/validators/fixtures/**"
+    note: |
+      Walk every file under any phase's validator fixture tree. Skip
+      cache-cruft (``__pycache__/``, ``*.pyc``, ``*.pyo``,
+      ``.pytest_cache/``, ``.DS_Store``) — those are build-artifacts
+      not source-of-truth and are explicitly recursive-excluded by
+      ``MANIFEST.in``.
+    exempt:
+      - "Editable install — when ``Path(atdd.__file__).resolve()`` is the
+        repo's own ``src/atdd/__init__.py`` the source tree IS the wheel
+        root, so the check is trivially satisfied. ``pytest.skip`` keeps
+        local-dev runs noise-free; CI exercises the wheel-built path."
+
+rules:
+  - id: "coach.wheel-completeness.fixture-missing-from-wheel"
+    aliases: ["COACH-WHEEL-COMPLETENESS-001"]
+    name: "fixture-missing-from-wheel"
+    description: |
+      Every file under ``src/atdd/**/validators/fixtures/**`` (excluding
+      cache-cruft) must exist at the corresponding path under
+      ``Path(atdd.__file__).resolve().parent``.
+    severity: 3
+    disposition: advisory
+    introduced_in: "3.7.1"
+    validator: "test_wheel_completeness::test_validator_fixtures_present_in_wheel"
+    detection: |
+      Source-tree inverse scan. For each source-tree fixture file
+      ``<repo_root>/src/atdd/<rel>``, compute expected install path
+      ``Path(atdd.__file__).resolve().parent/<rel>`` and assert
+      ``.exists()``. Skip the entire check when the resolved
+      ``atdd.__file__`` IS ``<repo_root>/src/atdd/__init__.py``
+      (editable install — source == wheel root).
+    rationale: |
+      Pre-fix v3.7.0 packaging dropped 13 fixture files from the wheel
+      (5 tester + 8 coach + 0 planner). Diagnostics #449 surfaced 4 of
+      them via ``toolkit_packaging_issues`` (the failing-test
+      references); the inverse scan would have surfaced all 13 at
+      build-time, before publish.
+    canonical_recipe:
+      bad: |
+        # pyproject.toml — narrow glob misses non-coder phase fixtures
+        [tool.setuptools.package-data]
+        "atdd" = ["coder/validators/fixtures/**"]
+      good: |
+        # pyproject.toml — recursive glob covers every phase's fixtures
+        [tool.setuptools.package-data]
+        "atdd" = ["**/validators/fixtures/**"]
+    exemptions:
+      - "Editable install (``pip install -e``) — source is the wheel root."
+      - "Cache-cruft files (``__pycache__/``, ``*.pyc``, ``*.pyo``,
+        ``.pytest_cache``, ``.DS_Store``) — those must NOT ship; the
+        scan walks past them."
+    incident_refs:
+      - "#449"
+      - "#451"
+    promotion_plan:
+      target_disposition: "strict"
+      target_version: "3.8.0"
+      gate: "Empirically clean inverse-scan across the active consumer
+        fleet for one minor cycle (3.7.x). Track via the ratchet baseline."
+
+enforcement:
+  validator: "src/atdd/coach/validators/test_wheel_completeness.py"
+  specs:
+    - id: "SPEC-COACH-WHEEL-COMPLETENESS-0001"
+      description: "Source-tree inverse scan asserts every fixture ships in the wheel"
+      validates: "COACH-WHEEL-COMPLETENESS-001"
+    - id: "SPEC-COACH-WHEEL-COMPLETENESS-0002"
+      description: "Editable install short-circuits the scan via pytest.skip"
+      validates: "COACH-WHEEL-COMPLETENESS-001"
+    - id: "SPEC-COACH-WHEEL-COMPLETENESS-0003"
+      description: "Cache-cruft (__pycache__, *.pyc, .DS_Store) is excluded from the scan"
+      validates: "COACH-WHEEL-COMPLETENESS-001"

--- a/src/atdd/coach/validators/test_wheel_completeness.py
+++ b/src/atdd/coach/validators/test_wheel_completeness.py
@@ -1,0 +1,238 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_wheel_completeness:backend:domain
+# Runtime: python
+# Purpose: Build-time guard — every src-tree validator fixture must ship in the installed wheel.
+
+"""
+Coach validator for wheel-completeness (issue #451).
+
+Source-tree inverse scan, NOT code AST: walk every file under
+``<repo_root>/src/atdd/**/validators/fixtures/**`` and assert each one
+exists at the corresponding path under
+``Path(atdd.__file__).resolve().parent``.
+
+Why inverse scan instead of parsing validator code for fixture references:
+the AST approach is prone to false negatives on f-string / dynamic-path
+patterns (``for bucket in (...): path = base / bucket / "harness_output.json"``).
+The inverse scan walks the source tree directly and is impossible to
+confuse — there is no parsing involved.
+
+The validator ships at ``disposition: advisory`` for the 3.7.x line; flip
+to ``strict`` in 3.8.0 once the install-path coverage is empirically
+clean across the active consumer-repo fleet.
+
+Editable install:
+    When ``Path(atdd.__file__).resolve()`` is the repo's own
+    ``src/atdd/__init__.py``, the source tree IS the wheel root, so the
+    check is trivially satisfied. The validator ``pytest.skip``s in that
+    case — value emerges in CI on a wheel-built environment, not local
+    dev.
+
+Convention: ``src/atdd/coach/conventions/wheel-completeness.convention.yaml``
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import pytest
+
+import atdd
+from atdd.coach.utils.rule_binding import bind_rule
+from atdd.coach.validators._violation import Violation
+
+
+pytestmark = [pytest.mark.coach, pytest.mark.platform]
+
+
+_RULE = bind_rule("coach.wheel-completeness.fixture-missing-from-wheel")
+
+# ---------------------------------------------------------------------------
+# Cache-cruft exclusion (mirrors MANIFEST.in recursive-exclude directives)
+# ---------------------------------------------------------------------------
+_CACHE_CRUFT_DIR_NAMES = frozenset({"__pycache__", ".pytest_cache"})
+_CACHE_CRUFT_FILE_SUFFIXES = (".pyc", ".pyo")
+_CACHE_CRUFT_FILE_NAMES = frozenset({".DS_Store"})
+
+
+def _is_cache_cruft(path: Path) -> bool:
+    """True iff *path* is a build-artifact / OS-cruft file we must not assert on.
+
+    The MANIFEST.in directives strip these from the wheel; the inverse
+    scan must equally skip them on the source side or we'd assert on
+    files that legitimately don't ship.
+    """
+    if path.name in _CACHE_CRUFT_FILE_NAMES:
+        return True
+    if path.suffix in _CACHE_CRUFT_FILE_SUFFIXES:
+        return True
+    for part in path.parts:
+        if part in _CACHE_CRUFT_DIR_NAMES:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Repo-root + source-tree discovery
+# ---------------------------------------------------------------------------
+def find_repo_src_atdd() -> Path | None:
+    """Return the source-tree ``src/atdd`` path for the repo this validator
+    runs in, or ``None`` when no source tree is reachable.
+
+    Walk parents of this file looking for the conventional layout marker
+    (a sibling ``pyproject.toml`` next to ``src/atdd``). When the
+    validator runs from an installed wheel inside a consumer repo, the
+    source tree is not reachable and the function returns ``None`` —
+    the test then ``pytest.skip``s rather than mis-asserting.
+    """
+    here = Path(__file__).resolve()
+    for ancestor in here.parents:
+        candidate_src_atdd = ancestor / "src" / "atdd"
+        candidate_pyproject = ancestor / "pyproject.toml"
+        if candidate_src_atdd.is_dir() and candidate_pyproject.is_file():
+            return candidate_src_atdd
+    return None
+
+
+def is_editable_install(repo_src_atdd: Path | None) -> bool:
+    """True iff the imported ``atdd`` package IS the source tree.
+
+    When ``Path(atdd.__file__).resolve().parent`` is the repo's own
+    ``src/atdd/`` directory, source == wheel-root and the wheel-
+    completeness check is a tautology — skip rather than run.
+    """
+    if repo_src_atdd is None:
+        return False
+    installed_atdd_dir = Path(atdd.__file__).resolve().parent
+    return installed_atdd_dir == repo_src_atdd.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Source-tree inverse scan
+# ---------------------------------------------------------------------------
+def collect_source_fixture_files(repo_src_atdd: Path) -> List[Path]:
+    """All files under any ``<phase>/validators/fixtures/`` tree.
+
+    Cache-cruft is filtered out so the scan only considers files that
+    are genuinely supposed to ship.
+    """
+    fixture_files: List[Path] = []
+    for phase_dir in sorted(repo_src_atdd.iterdir()):
+        if not phase_dir.is_dir():
+            continue
+        fixtures_root = phase_dir / "validators" / "fixtures"
+        if not fixtures_root.is_dir():
+            continue
+        for path in fixtures_root.rglob("*"):
+            if not path.is_file():
+                continue
+            if _is_cache_cruft(path):
+                continue
+            fixture_files.append(path)
+    return fixture_files
+
+
+def expected_install_path(
+    src_path: Path, repo_src_atdd: Path, installed_atdd_dir: Path
+) -> Path:
+    """Map a source-tree fixture path to its expected install location."""
+    relative = src_path.relative_to(repo_src_atdd)
+    return installed_atdd_dir / relative
+
+
+def find_missing_fixtures(
+    source_files: Iterable[Path],
+    repo_src_atdd: Path,
+    installed_atdd_dir: Path,
+) -> List[Tuple[Path, Path]]:
+    """Return ``[(src_path, expected_install_path), ...]`` for every fixture
+    file present in the source tree but missing from the installed wheel.
+    """
+    missing: List[Tuple[Path, Path]] = []
+    for src in source_files:
+        expected = expected_install_path(src, repo_src_atdd, installed_atdd_dir)
+        if not expected.exists():
+            missing.append((src, expected))
+    return missing
+
+
+# ---------------------------------------------------------------------------
+# Violation construction
+# ---------------------------------------------------------------------------
+def build_violations(
+    missing: Iterable[Tuple[Path, Path]],
+    repo_src_atdd: Path,
+) -> List[Violation]:
+    """Translate ``(src, expected)`` pairs into ``Violation`` records."""
+    violations: List[Violation] = []
+    repo_root = repo_src_atdd.parent.parent  # <repo>/src/atdd → <repo>
+    for src, expected in missing:
+        try:
+            location = str(src.relative_to(repo_root))
+        except ValueError:
+            location = str(src)
+        detail = (
+            f"fixture present in source tree but missing from installed "
+            f"wheel: expected at {expected}. Check pyproject.toml "
+            f"[tool.setuptools.package-data] glob and MANIFEST.in "
+            f"recursive-exclude rules."
+        )
+        violations.append(
+            Violation(
+                rule_id=_RULE.rule_id,
+                severity=_RULE.severity,
+                location=f"{location}:1",
+                detail=detail,
+                fix_hint_ref="recipe:wheel-completeness#package-data",
+            )
+        )
+    return violations
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+@pytest.mark.coach
+def test_validator_fixtures_present_in_wheel():
+    """SPEC-COACH-WHEEL-COMPLETENESS-0001: every source-tree fixture ships in the wheel.
+
+    Walks ``src/atdd/**/validators/fixtures/**`` (excluding cache-cruft)
+    and asserts each file exists at the corresponding path under the
+    installed atdd package directory. Skips cleanly on editable install
+    (source == wheel root) or when no source tree is reachable
+    (consumer-repo install).
+    """
+    repo_src_atdd = find_repo_src_atdd()
+    if repo_src_atdd is None:
+        pytest.skip(
+            "no toolkit source tree reachable — wheel-completeness only "
+            "meaningful when run from the toolkit repo"
+        )
+
+    if is_editable_install(repo_src_atdd):
+        pytest.skip(
+            "editable install — source tree IS the wheel root, "
+            "wheel-completeness check is trivially satisfied"
+        )
+
+    source_files = collect_source_fixture_files(repo_src_atdd)
+    if not source_files:
+        pytest.skip("no validator fixtures found in source tree")
+
+    installed_atdd_dir = Path(atdd.__file__).resolve().parent
+    missing = find_missing_fixtures(
+        source_files, repo_src_atdd, installed_atdd_dir
+    )
+
+    if missing:
+        violations = build_violations(missing, repo_src_atdd)
+        formatted = "\n".join(f"  {v}" for v in violations)
+        pytest.fail(
+            f"{len(missing)} validator fixture file(s) present in source "
+            f"tree but missing from installed wheel "
+            f"({installed_atdd_dir}):\n{formatted}\n"
+            f"Convention: src/atdd/coach/conventions/"
+            f"wheel-completeness.convention.yaml\n"
+            f"Disposition: {_RULE.disposition} (3.7.x); promoted to "
+            f"strict in 3.8.0."
+        )

--- a/src/atdd/coach/validators/tests/test_wheel_completeness_helpers.py
+++ b/src/atdd/coach/validators/tests/test_wheel_completeness_helpers.py
@@ -1,0 +1,267 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_wheel_completeness_helpers:backend:domain
+# Runtime: python
+# Purpose: Unit tests for wheel-completeness helper functions (issue #451).
+
+"""
+Unit tests for ``test_wheel_completeness`` helper functions.
+
+The integration test ``test_validator_fixtures_present_in_wheel`` is meant
+to fire in CI on a wheel-built environment (source tree + installed wheel
+both reachable, but distinct). Locally, pytest's
+``pyproject.toml::pythonpath = ["src"]`` makes ``atdd`` import from the
+source tree, so the integration test legitimately ``pytest.skip``s.
+
+These unit tests use ``tmp_path`` to construct synthetic source-tree and
+install-tree layouts, then exercise the helpers directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.validators.test_wheel_completeness import (
+    _is_cache_cruft,
+    build_violations,
+    collect_source_fixture_files,
+    expected_install_path,
+    find_missing_fixtures,
+    is_editable_install,
+)
+
+
+pytestmark = [pytest.mark.coach, pytest.mark.platform]
+
+
+# ---------------------------------------------------------------------------
+# _is_cache_cruft — recognizes build-artifacts the wheel must not ship
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "path",
+    [
+        Path("foo/__pycache__/bar.cpython-314.pyc"),
+        Path("foo/.pytest_cache/v/lastfailed"),
+        Path("foo/bar.pyc"),
+        Path("foo/bar.pyo"),
+        Path("foo/.DS_Store"),
+        Path("foo/__pycache__/whatever"),
+    ],
+)
+def test_cache_cruft_recognized(path: Path):
+    assert _is_cache_cruft(path) is True
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        Path("foo/harness_output.json"),
+        Path("foo/bar/test_minimal_pass.py"),
+        Path("foo/bar/__init__.py"),
+        Path("foo/baz/data.yaml"),
+    ],
+)
+def test_legitimate_files_not_cache_cruft(path: Path):
+    assert _is_cache_cruft(path) is False
+
+
+# ---------------------------------------------------------------------------
+# Synthetic source-tree fixture builder
+# ---------------------------------------------------------------------------
+def _build_synthetic_src_atdd(root: Path) -> Path:
+    """Construct a minimal ``<root>/src/atdd/...`` tree mirroring the real
+    multi-phase fixture layout. Returns the ``src/atdd`` path.
+    """
+    src_atdd = root / "src" / "atdd"
+    # Toolkit's pyproject marker for find_repo_src_atdd discovery.
+    (root / "pyproject.toml").write_text("[project]\nname='synthetic-atdd'\n")
+    # Three phases with one fixture each + cache-cruft alongside.
+    for phase, fixture_rel in (
+        ("tester", "train_renders/pass/harness_output.json"),
+        ("coach", "minimal_repo/test_minimal_pass.py"),
+        ("coder", "silent_swallow/python_clean/observed_handlers.py"),
+    ):
+        fpath = src_atdd / phase / "validators" / "fixtures" / fixture_rel
+        fpath.parent.mkdir(parents=True, exist_ok=True)
+        fpath.write_text("# fixture content\n")
+        # Sprinkle cache-cruft to confirm the scanner ignores it.
+        cache = fpath.parent / "__pycache__" / "stale.cpython-314.pyc"
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        cache.write_bytes(b"\x00\x00")
+        ds = fpath.parent / ".DS_Store"
+        ds.write_bytes(b"\x00")
+    return src_atdd
+
+
+# ---------------------------------------------------------------------------
+# collect_source_fixture_files — walks every phase's fixture tree, skips cruft
+# ---------------------------------------------------------------------------
+def test_collect_source_fixture_files_walks_all_phases(tmp_path: Path):
+    src_atdd = _build_synthetic_src_atdd(tmp_path)
+    files = collect_source_fixture_files(src_atdd)
+    rels = sorted(f.relative_to(src_atdd).as_posix() for f in files)
+    assert rels == [
+        "coach/validators/fixtures/minimal_repo/test_minimal_pass.py",
+        "coder/validators/fixtures/silent_swallow/python_clean/"
+        "observed_handlers.py",
+        "tester/validators/fixtures/train_renders/pass/harness_output.json",
+    ]
+
+
+def test_collect_source_fixture_files_excludes_cache_cruft(tmp_path: Path):
+    src_atdd = _build_synthetic_src_atdd(tmp_path)
+    files = collect_source_fixture_files(src_atdd)
+    for f in files:
+        assert "__pycache__" not in f.parts
+        assert f.suffix not in (".pyc", ".pyo")
+        assert f.name != ".DS_Store"
+
+
+def test_collect_source_fixture_files_handles_missing_phases(tmp_path: Path):
+    """When a phase has no ``validators/fixtures/`` tree, it's skipped silently."""
+    src_atdd = tmp_path / "src" / "atdd"
+    (src_atdd / "tester" / "validators" / "fixtures").mkdir(parents=True)
+    only_file = src_atdd / "tester" / "validators" / "fixtures" / "single.json"
+    only_file.write_text("{}")
+    # planner exists but has no fixtures dir
+    (src_atdd / "planner").mkdir(parents=True)
+    files = collect_source_fixture_files(src_atdd)
+    assert [f.name for f in files] == ["single.json"]
+
+
+# ---------------------------------------------------------------------------
+# expected_install_path — maps src to install location
+# ---------------------------------------------------------------------------
+def test_expected_install_path_strips_src_atdd_prefix(tmp_path: Path):
+    src_atdd = tmp_path / "src" / "atdd"
+    install_dir = tmp_path / "site-packages" / "atdd"
+    src_file = (
+        src_atdd
+        / "tester"
+        / "validators"
+        / "fixtures"
+        / "train_renders"
+        / "pass"
+        / "harness_output.json"
+    )
+    expected = expected_install_path(src_file, src_atdd, install_dir)
+    assert expected == install_dir / "tester" / "validators" / "fixtures" / (
+        "train_renders/pass/harness_output.json"
+    ).replace("/", "/")
+    assert expected.relative_to(install_dir) == src_file.relative_to(src_atdd)
+
+
+# ---------------------------------------------------------------------------
+# find_missing_fixtures — diffs source tree against install location
+# ---------------------------------------------------------------------------
+def test_find_missing_fixtures_complete_install(tmp_path: Path):
+    """When every source-tree fixture is mirrored under the install dir,
+    the scan returns no missing entries.
+    """
+    src_atdd = _build_synthetic_src_atdd(tmp_path)
+    install_dir = tmp_path / "site-packages" / "atdd"
+    for src in collect_source_fixture_files(src_atdd):
+        target = expected_install_path(src, src_atdd, install_dir)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(src.read_bytes())
+    missing = find_missing_fixtures(
+        collect_source_fixture_files(src_atdd), src_atdd, install_dir
+    )
+    assert missing == []
+
+
+def test_find_missing_fixtures_detects_dropped_files(tmp_path: Path):
+    """When the install dir is missing one fixture, that file is flagged
+    with the correct expected path.
+    """
+    src_atdd = _build_synthetic_src_atdd(tmp_path)
+    install_dir = tmp_path / "site-packages" / "atdd"
+    sources = collect_source_fixture_files(src_atdd)
+    # Mirror only the first two; deliberately drop the third.
+    dropped = sources[-1]
+    for src in sources[:-1]:
+        target = expected_install_path(src, src_atdd, install_dir)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(src.read_bytes())
+
+    missing = find_missing_fixtures(sources, src_atdd, install_dir)
+    assert len(missing) == 1
+    src_missing, expected_missing = missing[0]
+    assert src_missing == dropped
+    assert expected_missing == expected_install_path(
+        dropped, src_atdd, install_dir
+    )
+
+
+def test_find_missing_fixtures_empty_install_dir_flags_everything(tmp_path: Path):
+    """When the install dir doesn't exist at all, every source fixture is missing."""
+    src_atdd = _build_synthetic_src_atdd(tmp_path)
+    install_dir = tmp_path / "site-packages" / "atdd"  # never created
+    sources = collect_source_fixture_files(src_atdd)
+    missing = find_missing_fixtures(sources, src_atdd, install_dir)
+    assert len(missing) == len(sources)
+
+
+# ---------------------------------------------------------------------------
+# is_editable_install — source IS the wheel root
+# ---------------------------------------------------------------------------
+def test_is_editable_install_matches_when_paths_equal(monkeypatch, tmp_path: Path):
+    src_atdd = _build_synthetic_src_atdd(tmp_path)
+    init = src_atdd / "__init__.py"
+    init.write_text("")
+
+    fake_atdd_module_file = init
+
+    class _FakeAtdd:
+        __file__ = str(fake_atdd_module_file)
+
+    monkeypatch.setattr(
+        "atdd.coach.validators.test_wheel_completeness.atdd",
+        _FakeAtdd,
+    )
+    assert is_editable_install(src_atdd) is True
+
+
+def test_is_editable_install_false_when_paths_differ(monkeypatch, tmp_path: Path):
+    src_atdd = _build_synthetic_src_atdd(tmp_path)
+    (src_atdd / "__init__.py").write_text("")
+
+    other_install = tmp_path / "site-packages" / "atdd"
+    other_install.mkdir(parents=True)
+    fake_init = other_install / "__init__.py"
+    fake_init.write_text("")
+
+    class _FakeAtdd:
+        __file__ = str(fake_init)
+
+    monkeypatch.setattr(
+        "atdd.coach.validators.test_wheel_completeness.atdd",
+        _FakeAtdd,
+    )
+    assert is_editable_install(src_atdd) is False
+
+
+def test_is_editable_install_handles_no_source_tree():
+    """When ``find_repo_src_atdd`` returned ``None`` (consumer-repo install),
+    the helper must return ``False`` so the integration test can route to
+    a different skip reason.
+    """
+    assert is_editable_install(None) is False
+
+
+# ---------------------------------------------------------------------------
+# build_violations — well-formed Violation records
+# ---------------------------------------------------------------------------
+def test_build_violations_records_wellformed(tmp_path: Path):
+    src_atdd = _build_synthetic_src_atdd(tmp_path)
+    install_dir = tmp_path / "site-packages" / "atdd"  # never created
+    sources = collect_source_fixture_files(src_atdd)
+    missing = find_missing_fixtures(sources, src_atdd, install_dir)
+    violations = build_violations(missing, src_atdd)
+    assert len(violations) == len(missing)
+    for v in violations:
+        assert v.rule_id == "coach.wheel-completeness.fixture-missing-from-wheel"
+        assert v.severity == 3
+        assert v.location.endswith(":1")
+        assert "missing from installed wheel" in v.detail
+        assert v.fix_hint_ref == "recipe:wheel-completeness#package-data"


### PR DESCRIPTION
Closes #451

## Summary

**Phase 1** — extends `pyproject.toml` `[tool.setuptools.package-data]` to ship every phase's validator fixture tree (was: only `coder/validators/fixtures/**`). Recursive glob `**/validators/fixtures/**` covers tester / coach / planner / coder. Adds `MANIFEST.in` with `recursive-exclude` directives for `__pycache__/`, `*.pyc`, `*.pyo`, `.pytest_cache/`, and `global-exclude .DS_Store` so the broader glob does not ship cache-cruft. Excludes fixture sub-trees from `[tool.setuptools.packages.find]` so pip's compile-on-install doesn't generate `__pycache__` beside fixtures (fixtures are data, not importable packages). Bumps version 3.7.0 → 3.7.1 (PATCH).

**Phase 2** — new `src/atdd/coach/validators/test_wheel_completeness.py` validator. Source-tree inverse scan (NOT code AST) walks `src/atdd/**/validators/fixtures/**` and asserts each file ships at the corresponding path under `Path(atdd.__file__).resolve().parent`. Skips on editable install (source IS the wheel root) and on consumer-repo installs where no source tree is reachable. Disposition: `advisory` for the 3.7.x line; promotion to `strict` in 3.8.0 tracked as a separate follow-up issue per the convention's `promotion_plan`. Helper unit tests live under `src/atdd/coach/validators/tests/test_wheel_completeness_helpers.py` (21 tests covering cache-cruft detection, source-tree walk, missing-file diff, editable-install detection, and Violation construction).

## Verification

- `pytest src/atdd/coach/validators/tests/test_wheel_completeness_helpers.py` — 21/21 pass
- `pip wheel --no-deps -w dist .` then introspecting the wheel zip: tester=5, coach=6, coder=50, planner=0 fixture files; `__pycache__` / `*.pyc` / `.DS_Store` count in wheel = 0
- `pytest <installed>/atdd/tester/validators/test_train_renders_content.py` — 5/5 train_renders tests pass against installed v3.7.1 (were failing on v3.7.0 with `FileNotFoundError`)
- Registry coherence (`test_rule_id_uniqueness`, `test_rule_disposition_required`, `test_no_hardcoded_rule_severity`, `test_rule_validator_binding`, `test_rule_id_registry_coherence`) — 7/7 pass

## Operator note

Consumers upgrading from v3.7.0 → v3.7.1 should remove their `.atdd/baselines/validation/` directory and re-run `atdd validate` to regenerate baselines against the fixed wheel. Pre-fix baselines reflect the broken-wheel state and will misalign with v3.7.1's pass-set.