### PR TITLE
fix(coder): #453 — dead-code reachability tracer handles relative imports

### DIFF
--- a/.atdd/baselines/validation/coder.yaml
+++ b/.atdd/baselines/validation/coder.yaml
@@ -1,5 +1,5 @@
 phase: coder
-passed_at: '2026-05-06T02:19:26.462592+00:00'
-source_hash: 4fbc8c38858bd6329b63ec1a02f8654ec3048213369f507cd072b366e413265c
-atdd_version: 3.2.1
+passed_at: '2026-05-07T04:32:11.505711+00:00'
+source_hash: ac1002028187bc8dae82350cf21dc3f31d1eeb1dc4d115fbae85e34ccb85ffb8
+atdd_version: 3.7.1
 skipped_api: false

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -266,3 +266,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:toolkit-wheel-completeness
   train: 0001-self-compliance-validate
+- id: '453'
+  slug: dead-code-validator-misses-relative-imports
+  file: null
+  issue_number: 453
+  type: implementation
+  status: PLANNED
+  created: '2026-05-07'
+  archived: null
+  wagon: null
+  feature: null
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.7.1"
+version = "3.7.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coder/validators/test_dead_code_python.py
+++ b/src/atdd/coder/validators/test_dead_code_python.py
@@ -16,10 +16,11 @@ Structured violations (issue #394): emits ``Violation`` records keyed off
 
 import ast
 import configparser
+import logging
 import pytest
 from collections import deque
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from atdd.coach.utils.repo import find_repo_root
 from atdd.coach.utils.rule_binding import bind_rule
@@ -27,6 +28,9 @@ from atdd.coach.validators._violation import Violation
 
 import atdd
 from atdd.coach.utils.disposition_gate import assert_disposition_satisfied
+
+
+_log = logging.getLogger(__name__)
 
 
 # Rule bindings — fail at import if conventions drift (issue #394).
@@ -121,9 +125,71 @@ def is_root_file(file_path: Path) -> bool:
     return False
 
 
-def extract_imports_ast(file_path: Path) -> List[str]:
+def _resolve_module_name(
+    importer: Path,
+    module: Optional[str],
+    level: int,
+    *,
+    root: Path = None,
+) -> Optional[str]:
+    """
+    Resolve an ``ast.ImportFrom`` to an absolute dotted module path.
+
+    Args:
+        importer: Path of the file containing the import statement.
+        module: The dotted path *after* leading dots (may be ``None`` for
+            ``from . import x``).
+        level: Number of leading dots (``0`` = absolute, ``1`` = ``.``,
+            ``2`` = ``..``).
+        root: The package root (defaults to ``PYTHON_DIR``). The importer
+            must be inside this root for relative resolution to apply;
+            out-of-root importers return ``None`` (not raise).
+
+    Returns:
+        The resolved absolute dotted module name, or ``None`` when:
+          - ``importer`` is outside ``root`` (debug-logged, no raise).
+          - ``level`` exceeds the importer's depth (would escape ``root``;
+            Python rejects these at runtime).
+          - The result would be empty.
+
+    Notes:
+        For ``from . import x`` (``module=None``, ``level=1``), returns the
+        package itself (e.g., ``"pkg"``). The named binding ``x`` is reached
+        via the existing ``__init__.py`` implicit-edges pathway in
+        ``build_file_import_graph``.
+    """
+    if root is None:
+        root = PYTHON_DIR
+    if level == 0:
+        return module
+    try:
+        rel = importer.relative_to(root)
+    except ValueError:
+        _log.debug(
+            "relative import from %s outside root %s; cannot resolve",
+            importer,
+            root,
+        )
+        return None
+    pkg_parts = list(rel.parent.parts)
+    # `from . import x` (level=1) → siblings of importer (the package itself).
+    # `from ..x import y` (level=2) → parent package + "x".
+    if level - 1 > len(pkg_parts):
+        return None
+    base = pkg_parts[: len(pkg_parts) - (level - 1)]
+    suffix = module.split(".") if module else []
+    parts = base + suffix
+    return ".".join(parts) if parts else None
+
+
+def extract_imports_ast(file_path: Path, *, root: Path = None) -> List[str]:
     """
     Extract import module paths from a Python file using AST.
+
+    Relative ``from .X import Y`` imports are resolved to their absolute
+    dotted module path via ``_resolve_module_name`` (using ``file_path``
+    and the ``ast.ImportFrom.level`` attribute), so the downstream
+    ``resolve_module_to_file`` lookup finds the correct file.
 
     Returns:
         List of module path strings (e.g., ["my_wagon.feature.src.domain.calc"]).
@@ -141,8 +207,14 @@ def extract_imports_ast(file_path: Path) -> List[str]:
             for alias in node.names:
                 modules.append(alias.name)
         elif isinstance(node, ast.ImportFrom):
-            if node.module:
-                modules.append(node.module)
+            resolved = _resolve_module_name(
+                file_path,
+                node.module,
+                node.level,
+                root=root,
+            )
+            if resolved is not None:
+                modules.append(resolved)
 
     return modules
 

--- a/src/atdd/coder/validators/test_dead_code_python.py
+++ b/src/atdd/coder/validators/test_dead_code_python.py
@@ -213,8 +213,23 @@ def extract_imports_ast(file_path: Path, *, root: Path = None) -> List[str]:
                 node.level,
                 root=root,
             )
-            if resolved is not None:
-                modules.append(resolved)
+            if resolved is None:
+                continue
+            modules.append(resolved)
+            # Relative imports may name SUBMODULES, not just package
+            # attributes: ``from . import x`` and ``from .X import Y``
+            # both import the named symbol's submodule when one exists
+            # (Python's import machinery loads it as a side effect).
+            # Speculatively emit ``<resolved>.<name>`` candidates so the
+            # downstream ``resolve_module_to_file`` lookup picks up the
+            # submodule file when it exists. When the name is just an
+            # attribute (no matching file), no edge is added — strictly
+            # monotonic.
+            if node.level >= 1:
+                for alias in node.names:
+                    if alias.name == "*":
+                        continue
+                    modules.append(f"{resolved}.{alias.name}")
 
     return modules
 

--- a/src/atdd/coder/validators/tests/fixtures/flat_package/__init__.py
+++ b/src/atdd/coder/validators/tests/fixtures/flat_package/__init__.py
@@ -1,0 +1,1 @@
+from .runner import Runner

--- a/src/atdd/coder/validators/tests/fixtures/flat_package/app.py
+++ b/src/atdd/coder/validators/tests/fixtures/flat_package/app.py
@@ -1,0 +1,5 @@
+from flat_package.runner import Runner
+
+
+def main():
+    return Runner()

--- a/src/atdd/coder/validators/tests/fixtures/flat_package/models.py
+++ b/src/atdd/coder/validators/tests/fixtures/flat_package/models.py
@@ -1,0 +1,2 @@
+class Spec:
+    pass

--- a/src/atdd/coder/validators/tests/fixtures/flat_package/runner.py
+++ b/src/atdd/coder/validators/tests/fixtures/flat_package/runner.py
@@ -1,0 +1,5 @@
+from .models import Spec
+
+
+class Runner:
+    spec_cls = Spec

--- a/src/atdd/coder/validators/tests/fixtures/from_dot_import_x/python/app.py
+++ b/src/atdd/coder/validators/tests/fixtures/from_dot_import_x/python/app.py
@@ -1,0 +1,5 @@
+from pkg.runner import Runner
+
+
+def main():
+    return Runner()

--- a/src/atdd/coder/validators/tests/fixtures/from_dot_import_x/python/pkg/models.py
+++ b/src/atdd/coder/validators/tests/fixtures/from_dot_import_x/python/pkg/models.py
@@ -1,0 +1,2 @@
+class Spec:
+    pass

--- a/src/atdd/coder/validators/tests/fixtures/from_dot_import_x/python/pkg/runner.py
+++ b/src/atdd/coder/validators/tests/fixtures/from_dot_import_x/python/pkg/runner.py
@@ -1,0 +1,5 @@
+from . import models
+
+
+class Runner:
+    spec_cls = models.Spec

--- a/src/atdd/coder/validators/tests/fixtures/relative_imports_regression/python/app.py
+++ b/src/atdd/coder/validators/tests/fixtures/relative_imports_regression/python/app.py
@@ -1,0 +1,5 @@
+from trains.runner import Runner
+
+
+def main():
+    return Runner()

--- a/src/atdd/coder/validators/tests/fixtures/relative_imports_regression/python/trains/__init__.py
+++ b/src/atdd/coder/validators/tests/fixtures/relative_imports_regression/python/trains/__init__.py
@@ -1,0 +1,1 @@
+from .runner import Runner

--- a/src/atdd/coder/validators/tests/fixtures/relative_imports_regression/python/trains/models.py
+++ b/src/atdd/coder/validators/tests/fixtures/relative_imports_regression/python/trains/models.py
@@ -1,0 +1,2 @@
+class Spec:
+    pass

--- a/src/atdd/coder/validators/tests/fixtures/relative_imports_regression/python/trains/runner.py
+++ b/src/atdd/coder/validators/tests/fixtures/relative_imports_regression/python/trains/runner.py
@@ -1,0 +1,5 @@
+from .models import Spec
+
+
+class Runner:
+    spec_cls = Spec

--- a/src/atdd/coder/validators/tests/test_dead_code_python_relative_imports.py
+++ b/src/atdd/coder/validators/tests/test_dead_code_python_relative_imports.py
@@ -287,3 +287,46 @@ def test_from_dot_import_x_reaches_target_via_init_implicit_edge(
         f"models.py should be reachable via 'from . import models' two-hop; "
         f"unreachable={unreachable}"
     )
+
+
+# ============================================================================
+# Phase 3 — fixture-based regression test
+#
+# Mirrors the issue's reproducer (Notes section): app.py imports
+# trains.runner, runner.py uses ``from .models import Spec``. Pre-fix,
+# trains/models.py is reported unreachable because the relative-import
+# edge is missing. Post-fix, the edge is added and models.py is
+# reachable.
+#
+# Parametrized over expected-after-fix invariants. The xfail-baseline
+# variant from the issue Patch 2 is shipped as a comment (the fix lands
+# in this same PR; per the issue, the xfail decorator is to be removed
+# in-PR once it XPASSES) — we ship the post-fix assertion directly.
+# ============================================================================
+
+
+REGRESSION_REACHABLE_FILES = [
+    "trains/runner.py",  # imported by app.py via absolute import
+    "trains/models.py",  # imported by trains/runner.py via ``from .models``
+]
+
+
+@pytest.mark.coder
+@pytest.mark.parametrize("expected_reachable", REGRESSION_REACHABLE_FILES)
+def test_relative_imports_regression_no_unreachable(
+    expected_reachable, tmp_path, monkeypatch
+):
+    """Regression: issue #453's exact reproducer.
+
+    ``python/app.py`` → ``trains/runner.py`` → ``trains/models.py`` via
+    ``from .models import Spec``. Pre-fix, ``trains/models.py`` was
+    reported unreachable because the relative-import edge was missing.
+    Post-fix, the edge is created and the file is reachable.
+    """
+    unreachable = _stage_and_compute(
+        "relative_imports_regression", tmp_path, monkeypatch
+    )
+    assert expected_reachable not in unreachable, (
+        f"#453 regression: {expected_reachable} should be reachable in the "
+        f"reproducer fixture; unreachable={unreachable}"
+    )

--- a/src/atdd/coder/validators/tests/test_dead_code_python_relative_imports.py
+++ b/src/atdd/coder/validators/tests/test_dead_code_python_relative_imports.py
@@ -1,0 +1,289 @@
+"""
+Unit + integration tests for relative-import handling in the dead-code
+reachability tracer.
+
+Issue: #453 — `extract_imports_ast` previously ignored
+``ast.ImportFrom.level``, dropping every relative-import edge. Files only
+reached via ``from .X import Y`` were misclassified as unreachable.
+This module exercises the fix:
+
+  * unit: ``_resolve_module_name`` over level=0/1/2, module=None,
+    depth-exceeding, and out-of-root cases.
+  * integration: synthetic ``python/`` trees scanned by the validator's
+    own helpers (``build_file_import_graph`` + BFS) — verifies edges are
+    created so downstream files are reachable.
+  * regression: parametrized fixture mirroring the issue's reproducer
+    asserts that ``trains/models.py`` is NOT in the unreachable set
+    after the fix.
+
+Reference: src/atdd/coder/validators/test_dead_code_python.py
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Set
+
+import pytest
+
+from atdd.coder.validators import test_dead_code_python as dcp
+from atdd.coder.validators.test_dead_code_python import (
+    _resolve_module_name,
+    build_file_import_graph,
+    extract_imports_ast,
+    find_cli_entry_points,
+    find_reachable_files,
+    is_root_file,
+    resolve_module_to_file,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _stage_fixture(fixture_name: str, dest: Path) -> Path:
+    """Copy a fixture's ``python/`` tree into ``dest/python`` and return it."""
+    src = FIXTURES / fixture_name / "python"
+    target = dest / "python"
+    shutil.copytree(src, target)
+    return target
+
+
+def _unreachable_files(python_dir: Path) -> Set[str]:
+    """Replicate the validator's unreachable-files computation against a
+    monkeypatched ``PYTHON_DIR``. Top-level ``python/*.py`` are promoted to
+    CLI-entry-point shape (fixture trees have no ``pyproject.toml``).
+
+    Returns the relative POSIX paths of unreachable, non-``__init__`` files.
+    """
+    python_files = dcp.find_python_files()
+    graph = build_file_import_graph(python_files)
+    roots = {f for f in python_files if is_root_file(f)}
+    for py_file in python_files:
+        if py_file.parent == python_dir:
+            roots.add(py_file)
+    reachable = find_reachable_files(roots, graph)
+    reverse_graph = dcp.build_reverse_graph(graph)
+    reverse_reachable = find_reachable_files(roots, reverse_graph)
+    all_reachable = reachable | reverse_reachable
+    unreachable: Set[str] = set()
+    for py_file in python_files:
+        if py_file in all_reachable:
+            continue
+        if py_file.name == "__init__.py":
+            continue
+        unreachable.add(py_file.relative_to(python_dir).as_posix())
+    return unreachable
+
+
+def _stage_and_compute(
+    fixture_name: str, tmp_path: Path, monkeypatch
+) -> Set[str]:
+    python_dir = _stage_fixture(fixture_name, tmp_path)
+    monkeypatch.setattr(dcp, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(dcp, "PYTHON_DIR", python_dir)
+    return _unreachable_files(python_dir)
+
+
+# ============================================================================
+# Unit tests — _resolve_module_name
+# ============================================================================
+
+
+@pytest.mark.coder
+def test_resolve_level_zero_passes_through(tmp_path: Path):
+    importer = tmp_path / "trains" / "runner.py"
+    importer.parent.mkdir(parents=True)
+    importer.touch()
+    assert (
+        _resolve_module_name(importer, "trains.models", 0, root=tmp_path)
+        == "trains.models"
+    )
+
+
+@pytest.mark.coder
+def test_resolve_level_one_with_module(tmp_path: Path):
+    importer = tmp_path / "trains" / "runner.py"
+    importer.parent.mkdir(parents=True)
+    importer.touch()
+    assert (
+        _resolve_module_name(importer, "models", 1, root=tmp_path)
+        == "trains.models"
+    )
+
+
+@pytest.mark.coder
+def test_resolve_level_one_module_none_returns_package(tmp_path: Path):
+    """Decision #1: ``from . import x`` (level=1, module=None) → the package itself.
+
+    The named binding ``x`` is reached via the existing ``__init__.py``
+    implicit-edges pathway, not via this resolver.
+    """
+    importer = tmp_path / "pkg" / "runner.py"
+    importer.parent.mkdir(parents=True)
+    importer.touch()
+    assert _resolve_module_name(importer, None, 1, root=tmp_path) == "pkg"
+
+
+@pytest.mark.coder
+def test_resolve_level_two_with_module(tmp_path: Path):
+    """``from ..x.y import z`` from ``a/b/c.py`` resolves to ``a.x.y``."""
+    importer = tmp_path / "a" / "b" / "c.py"
+    importer.parent.mkdir(parents=True)
+    importer.touch()
+    assert (
+        _resolve_module_name(importer, "x.y", 2, root=tmp_path) == "a.x.y"
+    )
+
+
+@pytest.mark.coder
+def test_resolve_level_exceeding_depth_returns_none(tmp_path: Path):
+    """``from ....x import y`` from a shallow file resolves to None.
+
+    Python rejects these at runtime; the validator MUST NOT invent edges.
+    """
+    importer = tmp_path / "a" / "b.py"
+    importer.parent.mkdir(parents=True)
+    importer.touch()
+    # depth = 1 (only "a"); level=4 means three parent walks → escapes root.
+    assert _resolve_module_name(importer, "x", 4, root=tmp_path) is None
+
+
+@pytest.mark.coder
+def test_resolve_out_of_root_returns_none(tmp_path: Path):
+    """Importer outside ``root`` → None (not ValueError).
+
+    Helper boundary contract pinned by Patch 4 of the issue review.
+    """
+    foreign = Path("/tmp") / "outside.py"
+    assert _resolve_module_name(foreign, "x", 1, root=tmp_path) is None
+
+
+@pytest.mark.coder
+def test_resolve_dunder_init_relative_import(tmp_path: Path):
+    """Edge case: ``from .__init__ import X`` (rare but legal Python).
+
+    Resolves cleanly without crashing; the result is "<pkg>.__init__"
+    which ``resolve_module_to_file`` then either matches to the
+    package's ``__init__.py`` (via partial-match) or drops silently.
+    Either outcome is defensible; what matters is no crash.
+    """
+    importer = tmp_path / "pkg" / "runner.py"
+    importer.parent.mkdir(parents=True)
+    importer.touch()
+    result = _resolve_module_name(importer, "__init__", 1, root=tmp_path)
+    assert result == "pkg.__init__"
+
+
+# ============================================================================
+# Unit test — extract_imports_ast emits edge for `from .X import Y`
+# ============================================================================
+
+
+@pytest.mark.coder
+def test_extract_imports_ast_resolves_relative_to_absolute(tmp_path: Path):
+    """``from .models import X`` in pkg/foo.py emits "pkg.models"."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    foo = pkg / "foo.py"
+    foo.write_text("from .models import X\n")
+    (pkg / "models.py").write_text("class X: pass\n")
+
+    modules = extract_imports_ast(foo, root=tmp_path)
+    assert "pkg.models" in modules
+
+
+@pytest.mark.coder
+def test_extract_imports_ast_resolves_from_dot_import_x(tmp_path: Path):
+    """``from . import x`` in pkg/foo.py emits "pkg" (Decision #1)."""
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    foo = pkg / "foo.py"
+    foo.write_text("from . import models\n")
+    (pkg / "models.py").write_text("class X: pass\n")
+
+    modules = extract_imports_ast(foo, root=tmp_path)
+    assert "pkg" in modules
+
+
+@pytest.mark.coder
+def test_extract_imports_ast_absolute_unchanged(tmp_path: Path):
+    """level=0 imports (absolute) still produce the dotted name verbatim."""
+    foo = tmp_path / "foo.py"
+    foo.write_text("from trains.models import X\nimport trains.runner\n")
+    modules = extract_imports_ast(foo, root=tmp_path)
+    assert "trains.models" in modules
+    assert "trains.runner" in modules
+
+
+# ============================================================================
+# Integration tests — full validator helpers against fixture trees
+# ============================================================================
+
+
+@pytest.mark.coder
+def test_relative_import_creates_file_edge(tmp_path: Path, monkeypatch):
+    """Edge ``pkg/foo.py → pkg/bar.py`` exists when foo does ``from .bar import``."""
+    python_dir = tmp_path / "python"
+    pkg = python_dir / "pkg"
+    pkg.mkdir(parents=True)
+    foo = pkg / "foo.py"
+    bar = pkg / "bar.py"
+    foo.write_text("from .bar import X\n")
+    bar.write_text("class X: pass\n")
+    (pkg / "__init__.py").write_text("")
+
+    monkeypatch.setattr(dcp, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(dcp, "PYTHON_DIR", python_dir)
+
+    python_files = dcp.find_python_files()
+    graph = build_file_import_graph(python_files)
+    assert bar in graph[foo], (
+        f"expected edge foo→bar via relative import; graph[foo]={graph[foo]}"
+    )
+
+
+@pytest.mark.coder
+def test_flat_package_no_unreachable_after_fix(tmp_path, monkeypatch):
+    """Fixture flat-package (relative imports only) → 0 unreachable findings."""
+    python_dir = tmp_path / "python"
+    pkg_dir = python_dir / "flat_package"
+    pkg_dir.mkdir(parents=True)
+    src = FIXTURES / "flat_package"
+    for child in src.iterdir():
+        if child.is_file():
+            shutil.copy2(child, pkg_dir / child.name)
+    # Move app.py to the python/ root so it acts as the CLI entry shape.
+    (pkg_dir / "app.py").rename(python_dir / "app.py")
+
+    monkeypatch.setattr(dcp, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(dcp, "PYTHON_DIR", python_dir)
+
+    unreachable = _unreachable_files(python_dir)
+    assert unreachable == set(), (
+        f"flat package should be fully reachable after the fix; "
+        f"got unreachable={unreachable}"
+    )
+
+
+@pytest.mark.coder
+def test_from_dot_import_x_reaches_target_via_init_implicit_edge(
+    tmp_path, monkeypatch
+):
+    """Two-hop: ``from . import models`` → package → models via __init__.py edges.
+
+    REQUIRED by Patch 3 of the issue review. Without this test, the
+    level=1+module=None path could regress unnoticed if the existing
+    __init__.py implicit-edges rule changes.
+    """
+    unreachable = _stage_and_compute("from_dot_import_x", tmp_path, monkeypatch)
+    assert "pkg/models.py" not in unreachable, (
+        f"models.py should be reachable via 'from . import models' two-hop; "
+        f"unreachable={unreachable}"
+    )


### PR DESCRIPTION
Closes #453

## Summary

Fixes a false-positive in `coder.dead-code.reachability`: `extract_imports_ast` ignored `ast.ImportFrom.level`, so every relative-import edge (`from .X import Y`, `from . import x`) was silently dropped from the file-import graph. Files only reachable via relative imports were misclassified unreachable. The fix is monotonic — only previously-missed edges are now added; no new violations are introduced.

## Phase 1 — `_resolve_module_name` helper + `extract_imports_ast` update

- New helper `_resolve_module_name(importer, module, level, *, root=PYTHON_DIR)`:
  - `level=0` (absolute) → pass-through.
  - `level>=1` → walk up `level - 1` directories from importer's package and join with `module`.
  - `from . import x` (level=1, module=None) → returns the package itself (Decision #1).
  - Importer outside `root` → returns `None` (no `ValueError`); debug-logged.
  - `level` exceeds depth → returns `None` (Python rejects at runtime, validator MUST NOT invent edges).
- `extract_imports_ast(file_path, *, root=None)` now uses the importer's path + `_resolve_module_name`. For `level>=1`, also speculatively emits `<resolved>.<name>` candidates per imported name; `resolve_module_to_file` filters to real files, preserving monotonicity. This closes the two-hop gap when `__init__.py` is empty but a sibling does `from . import submodule`.

## Phase 2 — unit + integration tests (13 tests) + fixtures

- Unit: level=0/1/2, `module=None`, depth-exceeding, out-of-root (returns `None`), dunder-init edge case.
- `extract_imports_ast`: relative-to-absolute resolution, `from . import x` → package, level=0 unchanged.
- Integration: edge `pkg/foo.py → pkg/bar.py` for `from .bar import`, flat-package fixture has zero unreachable, two-hop via `from . import models` reaches target.
- Fixtures: `flat_package/`, `from_dot_import_x/`, `relative_imports_regression/`.

## Phase 3 — parametrized regression test

- Replaces the original \"self-compliance regression\" claim (trivially true since `PYTHON_DIR = REPO_ROOT/python`, never atdd's own `src/atdd/`) per Patch 2 of the issue review.
- Parametrized assertion against the issue's reproducer fixture (`relative_imports_regression`): `python/app.py → trains/runner.py → trains/models.py` via `from .models import Spec`. Pre-fix, `trains/models.py` was misclassified unreachable; post-fix, both `trains/runner.py` and `trains/models.py` are reachable.

## Verification

- `pytest src/atdd/coder/validators/tests/test_dead_code_python_relative_imports.py -v` — 15 passed.
- `pytest src/atdd/coder/validators/` — 149 passed, 112 skipped, 0 failed.
- `atdd validate coder --local` — clean (only pre-existing advisory warnings).
- Issue reproducer (`/tmp/repro453`): `trains/models.py` no longer flagged.

## Operator note

Consumers upgrading past the version that ships #453 may see fewer `coder.dead-code.reachability` violations than before — the relative-import-edge fix surfaces previously-hidden reachability via `from .X` and `from . import X` patterns. The fix is monotonic (no new violations introduced; only previously-false ones disappear). Re-run `atdd validate` and regenerate `.atdd/baselines/validation/coder.yaml` to re-baseline; the prior baseline reflects the bug's pre-fix state and will mismatch.

## Test plan

- [x] All new + existing coder validator tests pass locally.
- [x] Issue reproducer is clean post-fix.
- [x] `atdd validate coder --local` passes with no new findings.
- [ ] CI green.