### PR TITLE
feat(atdd): #455 — auto_upgrade PyPI cache-bust + post-install verify

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -277,3 +277,14 @@ sessions:
   wagon: null
   feature: null
   train: 0001-self-compliance-validate
+- id: '455'
+  slug: auto-upgrade-pypi-cache-bust
+  file: null
+  issue_number: 455
+  type: implementation
+  status: PLANNED
+  created: '2026-05-07'
+  archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:atdd-upgrade-pypi-propagation-window
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.7.2"
+version = "3.7.3"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/tests/test_version_check.py
+++ b/src/atdd/tests/test_version_check.py
@@ -1,9 +1,27 @@
-"""Tests for src/atdd/version_check.py — auto_upgrade PEP 668 fallback."""
+"""Tests for src/atdd/version_check.py — auto_upgrade PEP 668 fallback +
+PyPI propagation-window cache-bust.
+
+Six-cell matrix for ``auto_upgrade``:
+  1. Clean happy path (pip succeeds + verify passes).
+  2. PEP 668 first-attempt refusal + retry-with-flag success + verify pass.
+  3. Stale-cache: returncode=0 + verify fails on attempt 1 → pinned retry → verify passes.
+  4. PEP 668 + stale-cache combined (both retry dimensions on each attempt).
+  5. Pinned retry also fails → False.
+  6. ``expected=None`` (PyPI unreachable) → returncode alone decides.
+
+Plus a dedicated ``_verify_installed_version`` timeout test.
+"""
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from atdd.version_check import _is_pep668_error, auto_upgrade
+from atdd.version_check import (
+    _is_pep668_error,
+    _run_with_pep668_retry,
+    _verify_installed_version,
+    auto_upgrade,
+)
 
 
 class TestIsPep668Error:
@@ -23,44 +41,214 @@ class TestIsPep668Error:
         assert _is_pep668_error("") is False
 
 
-class TestAutoUpgrade:
-    def test_returns_true_on_first_pip_success(self):
+class TestVerifyInstalledVersion:
+    def test_returns_true_when_expected_is_none(self):
+        # No target → no check.
+        assert _verify_installed_version(None) is True
+
+    def test_returns_true_when_expected_is_empty(self):
+        assert _verify_installed_version("") is True
+
+    def test_returns_true_on_subprocess_match(self):
         with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="3.7.2\n")
+            assert _verify_installed_version("3.7.2") is True
+
+    def test_returns_false_on_subprocess_mismatch(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="3.7.1\n")
+            assert _verify_installed_version("3.7.2") is False
+
+    def test_returns_false_on_subprocess_failure(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert _verify_installed_version("3.7.2") is False
+
+    def test_returns_false_on_subprocess_timeout(self):
+        # TimeoutExpired must not crash auto_upgrade — it must surface as False.
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="x", timeout=10)):
+            assert _verify_installed_version("3.7.2") is False
+
+    def test_passes_timeout_kwarg(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="3.7.2\n")
+            _verify_installed_version("3.7.2")
+            assert mock_run.call_args.kwargs.get("timeout") == 10
+
+
+class TestRunWithPep668Retry:
+    def test_success_first_try(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            ok, _stderr = _run_with_pep668_retry(["pip", "install", "x"])
+            assert ok is True
+            assert mock_run.call_count == 1
+
+    def test_retries_on_pep668(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=1, stderr="error: externally-managed-environment"),
+                MagicMock(returncode=0, stderr=""),
+            ]
+            ok, _stderr = _run_with_pep668_retry(["pip", "install", "x"])
+            assert ok is True
+            assert mock_run.call_count == 2
+            assert "--break-system-packages" in mock_run.call_args_list[1].args[0]
+
+    def test_no_retry_on_unrelated_error(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stderr="other error")
+            ok, _stderr = _run_with_pep668_retry(["pip", "install", "x"])
+            assert ok is False
+            assert mock_run.call_count == 1
+
+
+class TestAutoUpgrade:
+    """Six-cell matrix for the cache-bust + verify behavior."""
+
+    def test_cell1_clean_happy_path(self):
+        """returncode=0 on attempt 1 + verify passes → True, single pip call."""
+        with patch("atdd.version_check._fetch_latest_version", return_value="3.7.2"), \
+             patch("atdd.version_check._verify_installed_version", return_value=True), \
+             patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stderr="")
             assert auto_upgrade() is True
             assert mock_run.call_count == 1
+            # --no-cache-dir always present.
+            assert "--no-cache-dir" in mock_run.call_args_list[0].args[0]
 
-    def test_returns_false_on_pip_failure_without_pep668(self):
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=1,
-                stderr="ERROR: Could not find a version that satisfies the requirement atdd",
-            )
-            assert auto_upgrade() is False
-            assert mock_run.call_count == 1, "Should not retry for non-PEP-668 errors"
-
-    def test_retries_with_break_system_packages_on_pep668(self):
-        with patch("subprocess.run") as mock_run:
+    def test_cell2_pep668_retry_first_attempt(self):
+        """PEP 668 refusal → --break-system-packages retry → verify passes."""
+        with patch("atdd.version_check._fetch_latest_version", return_value="3.7.2"), \
+             patch("atdd.version_check._verify_installed_version", return_value=True), \
+             patch("subprocess.run") as mock_run:
             mock_run.side_effect = [
                 MagicMock(returncode=1, stderr="error: externally-managed-environment"),
                 MagicMock(returncode=0, stderr=""),
             ]
             assert auto_upgrade() is True
             assert mock_run.call_count == 2
+            assert "--break-system-packages" in mock_run.call_args_list[1].args[0]
+            # No pinned attempt fired.
+            for call in mock_run.call_args_list:
+                assert "atdd==3.7.2" not in call.args[0]
 
-            # Second call must include --break-system-packages
-            second_call_args = mock_run.call_args_list[1].args[0]
-            assert "--break-system-packages" in second_call_args
+    def test_cell3_stale_cache_triggers_pinned_retry(self):
+        """returncode=0 but verify fails → pinned attempt → verify passes."""
+        verify_results = [False, True]  # attempt 1 verify fails; attempt 2 verify passes
+        with patch("atdd.version_check._fetch_latest_version", return_value="3.7.2"), \
+             patch("atdd.version_check._verify_installed_version",
+                   side_effect=verify_results), \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            assert auto_upgrade() is True
+            # Two pip calls: name-only, then pinned.
+            assert mock_run.call_count == 2
+            assert "atdd" in mock_run.call_args_list[0].args[0]
+            assert "atdd==3.7.2" in mock_run.call_args_list[1].args[0]
 
-    def test_returns_false_if_pep668_retry_also_fails(self):
-        with patch("subprocess.run") as mock_run:
+    def test_cell4_pep668_plus_stale_cache_combined(self):
+        """Both retry dimensions on attempt 1, then pinned attempt also clean."""
+        verify_results = [False, True]
+        with patch("atdd.version_check._fetch_latest_version", return_value="3.7.2"), \
+             patch("atdd.version_check._verify_installed_version",
+                   side_effect=verify_results), \
+             patch("subprocess.run") as mock_run:
             mock_run.side_effect = [
+                # Attempt 1: PEP 668 refusal then BSP success (verify still fails).
                 MagicMock(returncode=1, stderr="error: externally-managed-environment"),
-                MagicMock(returncode=1, stderr="some other error"),
+                MagicMock(returncode=0, stderr=""),
+                # Attempt 2 (pinned): clean.
+                MagicMock(returncode=0, stderr=""),
+            ]
+            assert auto_upgrade() is True
+            assert mock_run.call_count == 3
+            assert "--break-system-packages" in mock_run.call_args_list[1].args[0]
+            assert "atdd==3.7.2" in mock_run.call_args_list[2].args[0]
+
+    def test_cell5_pinned_retry_also_fails(self):
+        """First attempt verify-fails, pinned attempt also verify-fails → False."""
+        with patch("atdd.version_check._fetch_latest_version", return_value="3.7.2"), \
+             patch("atdd.version_check._verify_installed_version",
+                   side_effect=[False, False]), \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            assert auto_upgrade() is False
+            assert mock_run.call_count == 2
+
+    def test_cell5b_pinned_attempt_pip_failure(self):
+        """First attempt verify-fails, pinned attempt pip-fails (e.g., 404) → False."""
+        with patch("atdd.version_check._fetch_latest_version", return_value="3.7.2"), \
+             patch("atdd.version_check._verify_installed_version",
+                   side_effect=[False]), \
+             patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0, stderr=""),
+                MagicMock(returncode=1, stderr="ERROR: No matching distribution"),
             ]
             assert auto_upgrade() is False
             assert mock_run.call_count == 2
 
-    def test_returns_false_on_subprocess_exception(self):
-        with patch("subprocess.run", side_effect=OSError("boom")):
+    def test_cell6_expected_none_returncode_decides(self):
+        """PyPI unreachable (target=None) → returncode alone decides; no verify-fail path."""
+        with patch("atdd.version_check._fetch_latest_version", return_value=None), \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            assert auto_upgrade() is True
+            assert mock_run.call_count == 1
+            # No pinned attempt — we have nothing to pin to.
+            for call in mock_run.call_args_list:
+                assert not any("atdd==" in str(arg) for arg in call.args[0])
+
+    def test_cell6b_expected_none_pip_fails(self):
+        """target=None and pip fails (no PEP 668) → False, no pinned retry."""
+        with patch("atdd.version_check._fetch_latest_version", return_value=None), \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stderr="ERROR: Could not find a version that satisfies the requirement atdd",
+            )
             assert auto_upgrade() is False
+            assert mock_run.call_count == 1
+
+    def test_returns_false_on_subprocess_exception(self):
+        with patch("atdd.version_check._fetch_latest_version", return_value="3.7.2"), \
+             patch("subprocess.run", side_effect=OSError("boom")):
+            assert auto_upgrade() is False
+
+    def test_no_cache_dir_always_present(self):
+        """Regression: --no-cache-dir on every pip invocation."""
+        verify_results = [False, True]
+        with patch("atdd.version_check._fetch_latest_version", return_value="3.7.2"), \
+             patch("atdd.version_check._verify_installed_version",
+                   side_effect=verify_results), \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stderr="")
+            auto_upgrade()
+            for call in mock_run.call_args_list:
+                assert "--no-cache-dir" in call.args[0], \
+                    f"--no-cache-dir missing from {call.args[0]}"
+
+    def test_lived_3_7_1_to_3_7_2_regression(self):
+        """Regression test reproducing the lived case (issue #455).
+
+        PyPI's JSON API reports 3.7.2 but pip's resolver serves stale 3.7.1
+        on the name-only attempt (returncode=0, "Requirement already satisfied").
+        Verify catches the mismatch; pinned retry installs 3.7.2.
+        """
+        verify_results = [False, True]  # name-only got 3.7.1; pinned got 3.7.2
+        with patch("atdd.version_check._fetch_latest_version", return_value="3.7.2"), \
+             patch("atdd.version_check._verify_installed_version",
+                   side_effect=verify_results) as mock_verify, \
+             patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stderr="",
+                stdout="Requirement already satisfied: atdd 3.7.1",
+            )
+            assert auto_upgrade() is True
+            # Verify was called with "3.7.2" both times.
+            for call in mock_verify.call_args_list:
+                assert call.args[0] == "3.7.2"
+            # Pinned attempt fired with the correct version.
+            assert "atdd==3.7.2" in mock_run.call_args_list[1].args[0]

--- a/src/atdd/version_check.py
+++ b/src/atdd/version_check.py
@@ -347,7 +347,10 @@ def _verify_installed_version(expected: Optional[str]) -> bool:
             capture_output=True, text=True, timeout=10,
         )
     except _sp.TimeoutExpired:
-        logger.debug("auto_upgrade verify: subprocess timed out after 10s")
+        logger.debug(
+            "auto_upgrade verify: subprocess timed out after 10s",
+            extra={"phase": "verify", "outcome": "timeout", "timeout_s": 10},
+        )
         return False
     except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
         return False
@@ -369,7 +372,10 @@ def _run_with_pep668_retry(cmd: list, *, timeout: int = 120) -> Tuple[bool, str]
     if result.returncode == 0:
         return True, result.stderr
     if _is_pep668_error(result.stderr):
-        logger.debug("PEP 668 refusal detected; retrying with --break-system-packages")
+        logger.debug(
+            "PEP 668 refusal detected; retrying with --break-system-packages",
+            extra={"phase": "pip-install", "mechanism": "pep668-fallback"},
+        )
         retry = _sp.run(
             cmd + ["--break-system-packages"],
             capture_output=True, text=True, timeout=timeout,
@@ -401,15 +407,22 @@ def auto_upgrade() -> bool:
     base_cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "--no-cache-dir", "atdd"]
 
     try:
-        logger.debug("auto_upgrade attempt 1: cmd=%s", base_cmd)
+        logger.debug(
+            "auto_upgrade attempt %d: cmd=%s", 1, base_cmd,
+            extra={"phase": "pip-install", "attempt": 1, "cmd": base_cmd, "target": target},
+        )
         ok, _stderr = _run_with_pep668_retry(base_cmd)
         if ok and _verify_installed_version(target):
-            logger.debug("upgrade verified: atdd %s installed", target)
+            logger.debug(
+                "upgrade verified: atdd %s installed", target,
+                extra={"phase": "verify", "attempt": 1, "version": target, "outcome": "match"},
+            )
             return True
         if ok and target:
             logger.debug(
                 "pip install returncode=0 but installed != expected=%s; retrying with explicit pin",
                 target,
+                extra={"phase": "verify", "attempt": 1, "expected": target, "outcome": "mismatch"},
             )
         if not ok and not target:
             return False
@@ -419,10 +432,16 @@ def auto_upgrade() -> bool:
                 sys.executable, "-m", "pip", "install",
                 "--upgrade", "--no-cache-dir", f"atdd=={target}",
             ]
-            logger.debug("auto_upgrade attempt 2 (pinned): cmd=%s", pinned_cmd)
+            logger.debug(
+                "auto_upgrade attempt %d (pinned): cmd=%s", 2, pinned_cmd,
+                extra={"phase": "pip-install", "attempt": 2, "cmd": pinned_cmd, "target": target},
+            )
             ok2, _stderr2 = _run_with_pep668_retry(pinned_cmd)
             if ok2 and _verify_installed_version(target):
-                logger.debug("upgrade verified after pin: atdd %s installed", target)
+                logger.debug(
+                    "upgrade verified after pin: atdd %s installed", target,
+                    extra={"phase": "verify", "attempt": 2, "version": target, "outcome": "match"},
+                )
                 return True
             return False
 

--- a/src/atdd/version_check.py
+++ b/src/atdd/version_check.py
@@ -10,17 +10,20 @@ Disable PyPI check: CI=true ATDD_NO_UPDATE_CHECK=1 (CI only)
 Disable sync reminder: CI=true ATDD_NO_UPGRADE_NOTICE=1 (CI only)
 """
 import json
+import logging
 import os
 import sys
 import time
 from pathlib import Path
 from typing import Optional, Tuple
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 from urllib.error import URLError
 
 import yaml
 
 from atdd import __version__
+
+logger = logging.getLogger(__name__)
 
 # Version-specific upgrade notes shown to consumers after upgrade.
 # Key = version, value = short human-readable note.
@@ -76,9 +79,15 @@ def _save_cache(data: dict) -> None:
 
 
 def _fetch_latest_version() -> Optional[str]:
-    """Fetch latest version from PyPI."""
+    """Fetch latest version from PyPI.
+
+    Sends ``Cache-Control: no-cache`` to defeat any future PyPI/CDN caching
+    of the JSON metadata endpoint — belt-and-braces against the propagation
+    window observed during fresh-tag publishes.
+    """
     try:
-        with urlopen(PYPI_URL, timeout=2) as response:
+        request = Request(PYPI_URL, headers={"Cache-Control": "no-cache"})
+        with urlopen(request, timeout=2) as response:
             data = json.loads(response.read().decode())
             return data.get("info", {}).get("version")
     except (URLError, json.JSONDecodeError, OSError, TimeoutError):  # atdd:suppress(coder.logging.coach-silent-swallow)
@@ -310,29 +319,113 @@ def _is_pep668_error(stderr: str) -> bool:
     return "externally-managed-environment" in stderr or "error: externally-managed" in stderr
 
 
-def auto_upgrade() -> bool:
-    """Run pip install --upgrade atdd. Returns True on success.
+def _verify_installed_version(expected: Optional[str]) -> bool:
+    """Verify the on-disk installed atdd version matches ``expected``.
 
-    Falls back to --break-system-packages on PEP 668 refusal, which is the
-    documented override for "I'm a CLI tool, not a system library" upgrades
-    on Homebrew/Debian-managed Pythons.
+    Spawns a fresh subprocess to read ``importlib.metadata.version("atdd")``.
+    A subprocess is required because ``importlib.metadata`` caches its
+    distribution-finder state at module-import time; after ``pip install``
+    mutates ``site-packages``, ``importlib.reload(atdd)`` re-runs
+    ``__init__.py`` but the in-process metadata cache still serves the
+    pre-install version. A fresh interpreter starts with no cache and reads
+    the actual on-disk ``*.dist-info/`` directory.
+
+    Returns:
+        True iff ``expected`` is None (no target → no check) or the spawned
+        subprocess reports the same version. False on subprocess failure,
+        timeout, or version mismatch.
+    """
+    if not expected:
+        return True
+
+    import subprocess as _sp
+
+    try:
+        result = _sp.run(
+            [sys.executable, "-c",
+             "import importlib.metadata; print(importlib.metadata.version('atdd'))"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except _sp.TimeoutExpired:
+        logger.debug("auto_upgrade verify: subprocess timed out after 10s")
+        return False
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
+        return False
+
+    if result.returncode != 0:
+        return False
+    installed = result.stdout.strip()
+    return installed == expected
+
+
+def _run_with_pep668_retry(cmd: list, *, timeout: int = 120) -> Tuple[bool, str]:
+    """Run a pip command, retrying once with ``--break-system-packages`` on PEP 668 refusal.
+
+    Returns (success, stderr_of_last_attempt).
     """
     import subprocess as _sp
 
-    base_cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "atdd"]
+    result = _sp.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if result.returncode == 0:
+        return True, result.stderr
+    if _is_pep668_error(result.stderr):
+        logger.debug("PEP 668 refusal detected; retrying with --break-system-packages")
+        retry = _sp.run(
+            cmd + ["--break-system-packages"],
+            capture_output=True, text=True, timeout=timeout,
+        )
+        return retry.returncode == 0, retry.stderr
+    return False, result.stderr
+
+
+def auto_upgrade() -> bool:
+    """Run pip install --upgrade atdd. Returns True on success.
+
+    Two-attempt strategy to handle PyPI's CDN propagation window after a
+    fresh tag publish:
+
+    1. **Attempt 1** — name-only resolution: ``pip install --upgrade
+       --no-cache-dir atdd``. ``--no-cache-dir`` busts pip's local wheel
+       cache (belt-and-braces). On returncode 0, verify the installed
+       version matches what ``_fetch_latest_version`` reported.
+    2. **Attempt 2** — explicit version pin: if Attempt 1 succeeded but
+       verify failed (pip's resolver served a stale "latest" from its
+       in-process metadata cache), retry with
+       ``pip install --upgrade --no-cache-dir atdd==<expected>``. The
+       version pin forces fresh resolution and is the load-bearing fix.
+
+    Each attempt retries with ``--break-system-packages`` on PEP 668
+    refusal (Homebrew/Debian-managed Pythons).
+    """
+    target = _fetch_latest_version()
+    base_cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "--no-cache-dir", "atdd"]
 
     try:
-        result = _sp.run(base_cmd, capture_output=True, text=True, timeout=120)
-        if result.returncode == 0:
+        logger.debug("auto_upgrade attempt 1: cmd=%s", base_cmd)
+        ok, _stderr = _run_with_pep668_retry(base_cmd)
+        if ok and _verify_installed_version(target):
+            logger.debug("upgrade verified: atdd %s installed", target)
             return True
-        if _is_pep668_error(result.stderr):
-            # PEP 668 refusal — retry with --break-system-packages.
-            # Safe for atdd because it's a stand-alone CLI, not a shared library.
-            retry = _sp.run(
-                base_cmd + ["--break-system-packages"],
-                capture_output=True, text=True, timeout=120,
+        if ok and target:
+            logger.debug(
+                "pip install returncode=0 but installed != expected=%s; retrying with explicit pin",
+                target,
             )
-            return retry.returncode == 0
+        if not ok and not target:
+            return False
+
+        if target:
+            pinned_cmd = [
+                sys.executable, "-m", "pip", "install",
+                "--upgrade", "--no-cache-dir", f"atdd=={target}",
+            ]
+            logger.debug("auto_upgrade attempt 2 (pinned): cmd=%s", pinned_cmd)
+            ok2, _stderr2 = _run_with_pep668_retry(pinned_cmd)
+            if ok2 and _verify_installed_version(target):
+                logger.debug("upgrade verified after pin: atdd %s installed", target)
+                return True
+            return False
+
         return False
     except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
         return False


### PR DESCRIPTION
## Summary

Closes #455.

Fixes a silent-fail in `atdd upgrade` / pre-push hook auto-upgrade during PyPI's CDN propagation window (lived 3.7.1→3.7.2 case, 2026-05-07): `is_outdated()` reported the new version, but `pip install --upgrade atdd` resolved to the prior version from pip's in-process resolver cache and returned `returncode=0`. `auto_upgrade()` reported success, the user looped on "atdd 3.7.1 is up to date" while PyPI showed 3.7.2.

## Phases

- **Phase 1** — cache-bust + verify helper:
  - `--no-cache-dir` on every pip invocation in `auto_upgrade`.
  - `Cache-Control: no-cache` header on `_fetch_latest_version`.
  - New `_verify_installed_version(expected)` that spawns a fresh `python -c "import importlib.metadata; print(...)"` subprocess (`timeout=10`) — required because `importlib.metadata` caches its distribution-finder state at module-import time, so `importlib.reload(atdd)` returns the pre-install version even after pip mutates `site-packages`.
- **Phase 2** — explicit-pin retry:
  - If attempt 1 returns `returncode=0` but verify fails (stale resolver cache), retry with `pip install --upgrade --no-cache-dir atdd==<expected>`. The version pin is the load-bearing fix.
  - Extracted `_run_with_pep668_retry(cmd)` so `auto_upgrade` doesn't grow a state-machine — both attempts share the PEP 668 (#430) retry path.
- **Phase 2.5** — diagnostic `logger.debug` at each attempt + retry decision point. Silent on default log level; surfaces in bug reports.
- **Phase 3** — 6-cell test matrix in `src/atdd/tests/test_version_check.py`:
  1. Clean happy path.
  2. PEP 668 retry on attempt 1.
  3. Stale-cache: verify-fail → pinned retry.
  4. PEP 668 + stale-cache combined.
  5. Pinned retry also fails (verify-fail or pip-fail) → False.
  6. `expected=None` (PyPI unreachable) → returncode alone decides.
  Plus `_verify_installed_version` timeout test, `_run_with_pep668_retry` unit tests, lived 3.7.1→3.7.2 regression test, and `--no-cache-dir`-always-present regression test. **25 tests, all green.**

## Release

Version bumped 3.7.2 → 3.7.3 (PATCH — internal helper improvement, no consumer-visible behavior change beyond "atdd upgrade now correctly handles the PyPI propagation window"). CI tags + publishes on merge.

## Test plan

- [x] `pytest src/atdd/tests/test_version_check.py -v` → 25 passed.
- [x] `atdd validate --quick` → no new regressions (3 pre-existing unrelated failures: #386 branch field, #393/#326/#260 missing from manifest).
- [ ] Post-merge smoke test: trigger another release tag from a follow-up PR; run `atdd upgrade` from a fresh venv during the PyPI propagation window; verify it lands on the newer version (not the prior).