### PR TITLE
feat(coach): #457 — extend agent sync registry with GLM + Mistral

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -288,3 +288,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:atdd-upgrade-pypi-propagation-window
   train: 0001-self-compliance-validate
+- id: '457'
+  slug: add-glm-and-mistral-agent-sync
+  file: null
+  issue_number: 457
+  type: implementation
+  status: PLANNED
+  created: '2026-05-07'
+  archived: null
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:multi-agent-sync-coverage-extended
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.7.3"
+version = "3.7.4"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -803,7 +803,7 @@ Phase descriptions:
     sync_parser.add_argument(
         "--agent",
         type=str,
-        choices=["claude", "codex", "gemini", "qwen"],
+        choices=["claude", "codex", "gemini", "qwen", "glm", "mistral"],
         help="Sync specific agent only"
     )
     sync_parser.add_argument(

--- a/src/atdd/coach/commands/sync.py
+++ b/src/atdd/coach/commands/sync.py
@@ -34,6 +34,8 @@ class AgentConfigSync:
         "codex": "AGENTS.md",
         "gemini": "GEMINI.md",
         "qwen": "QWEN.md",
+        "glm": "GLM.md",
+        "mistral": "MISTRAL.md",
     }
 
     BLOCK_BEGIN = "# --- ATDD:BEGIN (managed by atdd, do not edit) ---"

--- a/src/atdd/coach/commands/tests/test_sync.py
+++ b/src/atdd/coach/commands/tests/test_sync.py
@@ -1,0 +1,113 @@
+"""
+Tests for AgentConfigSync (atdd sync).
+
+Covers issue #457: extending the agent registry with GLM (z.ai) and
+Mistral Vibe. The parametrized round-trip test (`test_every_agent_round_trips`)
+iterates `AgentConfigSync.AGENT_FILES` so the test surface grows
+automatically as new agents are added — catching future regressions
+where a code path silently skips an agent.
+
+Run:
+    PYTHONPATH=src python3 -m pytest -q \
+        src/atdd/coach/commands/tests/test_sync.py -v
+"""
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.commands.sync import AgentConfigSync
+
+
+def _make_sync(tmp_path: Path) -> AgentConfigSync:
+    """Return a sync instance whose target dir is an empty tmp dir."""
+    return AgentConfigSync(target_dir=tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("agent", "filename"),
+    sorted(AgentConfigSync.AGENT_FILES.items()),
+)
+def test_every_agent_round_trips(tmp_path: Path, agent: str, filename: str) -> None:
+    """Every entry in AGENT_FILES must produce its config file with a managed block.
+
+    Self-scaling: parametrized over the dict, so adding a new agent to
+    AGENT_FILES automatically extends the test surface.
+    """
+    sync = _make_sync(tmp_path)
+    rc = sync.sync(agents=[agent])
+    assert rc == 0
+
+    target = tmp_path / filename
+    assert target.exists(), f"{filename} should be written for agent={agent}"
+
+    content = target.read_text()
+    assert AgentConfigSync.BLOCK_BEGIN in content
+    assert AgentConfigSync.BLOCK_END in content
+
+
+def test_glm_registered() -> None:
+    """GLM (z.ai) must be in AGENT_FILES with the GLM.md filename."""
+    assert AgentConfigSync.AGENT_FILES.get("glm") == "GLM.md"
+
+
+def test_mistral_registered() -> None:
+    """Mistral Vibe must be in AGENT_FILES with the MISTRAL.md filename."""
+    assert AgentConfigSync.AGENT_FILES.get("mistral") == "MISTRAL.md"
+
+
+def test_sync_glm_writes_managed_block(tmp_path: Path) -> None:
+    sync = _make_sync(tmp_path)
+    rc = sync.sync(agents=["glm"])
+    assert rc == 0
+
+    glm_md = tmp_path / "GLM.md"
+    assert glm_md.exists()
+    content = glm_md.read_text()
+    assert AgentConfigSync.BLOCK_BEGIN in content
+    assert AgentConfigSync.BLOCK_END in content
+
+
+def test_sync_mistral_writes_managed_block(tmp_path: Path) -> None:
+    sync = _make_sync(tmp_path)
+    rc = sync.sync(agents=["mistral"])
+    assert rc == 0
+
+    mistral_md = tmp_path / "MISTRAL.md"
+    assert mistral_md.exists()
+    content = mistral_md.read_text()
+    assert AgentConfigSync.BLOCK_BEGIN in content
+    assert AgentConfigSync.BLOCK_END in content
+
+
+def test_glm_overlay_applied(tmp_path: Path) -> None:
+    """Overlay file src/atdd/coach/overlays/glm.md must be appended to GLM.md."""
+    sync = _make_sync(tmp_path)
+    sync.sync(agents=["glm"])
+    content = (tmp_path / "GLM.md").read_text()
+    assert "Agent-specific: glm" in content
+
+
+def test_mistral_overlay_applied(tmp_path: Path) -> None:
+    """Overlay file src/atdd/coach/overlays/mistral.md must be appended to MISTRAL.md."""
+    sync = _make_sync(tmp_path)
+    sync.sync(agents=["mistral"])
+    content = (tmp_path / "MISTRAL.md").read_text()
+    assert "Agent-specific: mistral" in content
+
+
+def test_status_lists_all_six_agents(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`atdd sync --status` must surface all 6 registered agents."""
+    sync = _make_sync(tmp_path)
+    rc = sync.status()
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    for agent in ("claude", "codex", "gemini", "qwen", "glm", "mistral"):
+        assert agent in out, f"status output missing agent={agent}"
+
+
+def test_unknown_agent_rejected(tmp_path: Path) -> None:
+    """Unknown agent name must fail the sync call."""
+    sync = _make_sync(tmp_path)
+    rc = sync.sync(agents=["bogus"])
+    assert rc == 1

--- a/src/atdd/coach/overlays/glm.md
+++ b/src/atdd/coach/overlays/glm.md
@@ -1,0 +1,2 @@
+# GLM-specific additions
+# This content is appended to the base ATDD.md when syncing to GLM.md

--- a/src/atdd/coach/overlays/mistral.md
+++ b/src/atdd/coach/overlays/mistral.md
@@ -1,0 +1,2 @@
+# Mistral-specific additions
+# This content is appended to the base ATDD.md when syncing to MISTRAL.md


### PR DESCRIPTION
Closes #457

## Summary

Pure additive: extend the multi-agent sync registry from 4 → 6 agents.

- `claude` / `codex` / `gemini` / `qwen` (existing)
- **`glm`** → `GLM.md` (z.ai's GLM coding agent)
- **`mistral`** → `MISTRAL.md` (Mistral Vibe, agent-coding mode)

Existing 4-agent sync behavior is unchanged — same managed-block format, same overlay-loading code path, same `--verify` / `--status` / `--agent` semantics.

## Phases

### Phase 1 — Registry + CLI choices
- `src/atdd/coach/commands/sync.py:33-38` — added `\"glm\": \"GLM.md\"` and `\"mistral\": \"MISTRAL.md\"` to `AgentConfigSync.AGENT_FILES`.
- `src/atdd/cli.py:806` — added `\"glm\"`, `\"mistral\"` to `--agent` choices.
- `.atdd/manifest.yaml` — registered issue #457.

### Phase 2 — Overlay scaffolds
- `src/atdd/coach/overlays/glm.md` — minimal header + placeholder, mirrors `claude.md`.
- `src/atdd/coach/overlays/mistral.md` — same.
- No `pyproject.toml` package-data change required: `\"atdd.coach.overlays\" = [\"*.md\"]` already declared at line 60.

### Phase 3 — Tests
- **NEW** `src/atdd/coach/commands/tests/test_sync.py` (no `AgentConfigSync` test file existed; the existing `test_sync_labels.py` and `test_sync_wmbts*.py` cover different commands).
- 14 tests covering: registration assertions for both new agents, managed-block writes, overlay application, `--status` lists all 6 agents, unknown-agent rejection, and a **parametrized `test_every_agent_round_trips`** that iterates `AGENT_FILES` so the test surface grows automatically as new agents are added.

## Verification

```
$ pytest src/atdd/coach/commands/tests/test_sync.py -v
14 passed in 0.05s

$ pytest src/atdd/coach/commands/tests/test_sync*.py -v
28 passed in 0.14s

$ atdd sync --agent glm     # in /tmp fixture repo
Synced: GLM.md

$ atdd sync --agent mistral
Synced: MISTRAL.md

$ atdd sync --status
* glm      GLM.md          synced               auto
* mistral  MISTRAL.md      synced               auto
(... + 4 existing agents listed disabled by default)
Overlays:
  - claude.md (found)
  - glm.md (found)
  - mistral.md (found)

$ atdd sync --agent invalid
error: argument --agent: invalid choice: 'invalid'
       (choose from claude, codex, gemini, qwen, glm, mistral)
```

## Filename verification

The chosen filenames follow the existing toolkit convention of vendor/model-named UPPERCASE markdown at the repo root (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `QWEN.md`).

- **`GLM.md`** — chosen by analogy with `QWEN.md` (model-family-named; z.ai is the vendor, GLM is the agent family). I do **not** have an authoritative source confirming z.ai's GLM CLI auto-loads `GLM.md` at the repo root the way Claude Code reads `CLAUDE.md`. Maintainer to confirm against z.ai's published CLI docs / observed behavior in a test repo before merge. If the convention is `Z.md` or `~/.glm/system_instructions.md`, the registry entry needs updating accordingly.
- **`MISTRAL.md`** — chosen by analogy with vendor-named files (`CLAUDE.md` = Anthropic, `GEMINI.md` = Google). I do **not** have an authoritative source confirming Mistral Vibe's auto-load filename. Maintainer to confirm; if the convention is `VIBE.md` or `~/.mistralrc`, update the registry entry.

If either filename is wrong, the only changes needed are the dict value in `sync.py`, the rename of the overlay file, and updating the `--status` smoke-test snapshot.

## Consumer enablement

Adding `glm` / `mistral` to the registry makes them available as `atdd sync --agent <name>` choices but does **NOT** auto-include them in default sync. Consumers add them to `.atdd/config.yaml::sync.agents` to opt in:

```yaml
# .atdd/config.yaml
sync:
  agents:
    - claude
    - glm        # opt in
    - mistral    # opt in
```

Auto-detect also kicks in: if `GLM.md` already exists at the target repo root, default `atdd sync` will refresh it without explicit config (this is the existing 4-agent auto-detection behavior, unchanged).

## Test plan

- [x] All 14 new tests in `test_sync.py` pass
- [x] All 28 sync-area tests (`test_sync*.py`) pass
- [x] `atdd sync --agent glm` writes `GLM.md` with managed block in a fresh fixture dir
- [x] `atdd sync --agent mistral` writes `MISTRAL.md` with managed block
- [x] `atdd sync --status` lists all 6 agents and 3 overlays
- [x] `atdd sync --agent invalid` is rejected with the full 6-agent choice list
- [ ] Maintainer confirms `GLM.md` / `MISTRAL.md` are the correct filenames for the respective tools