### PR TITLE
fix(devops): #462 phase 1 — softprops/action-gh-release migration

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -299,3 +299,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:multi-agent-sync-coverage-extended
   train: 0001-self-compliance-validate
+- id: '462'
+  slug: publish-workflow-resilience
+  file: null
+  issue_number: 462
+  type: fix
+  status: PLANNED
+  created: '2026-05-07'
+  archived: null
+  wagon: null
+  feature: null
+  train: 0001-self-compliance-validate

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,24 +93,45 @@ jobs:
           echo "pypi_status=pending" >> "$GITHUB_OUTPUT"
           echo "pypi_version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Create GitHub Release
+      - name: Compose release metadata
+        id: release_meta
         if: env.CREATED == 'true'
         run: |
           COMMIT_SUBJECT=$(git log -1 --format='%s')
-          TITLE="$TAG — $COMMIT_SUBJECT"
-          PYPI_LINE=""
           if [ "$PYPI_STATUS" = "published" ]; then
             PYPI_LINE="Published to PyPI: atdd==$PYPI_VERSION"
           else
             PYPI_LINE="PyPI publication pending (may still be propagating)"
           fi
-          gh release create "$TAG" --generate-notes --title "$TITLE" \
-            --notes-start-tag "$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo '')" \
-            || gh release create "$TAG" --title "$TITLE" --notes "$PYPI_LINE"
-          # Append PyPI status to existing release body
-          EXISTING_BODY=$(gh release view "$TAG" --json body --jq '.body' 2>/dev/null || echo "")
-          gh release edit "$TAG" --notes "$(printf '%s\n\n---\n%s' "$EXISTING_BODY" "$PYPI_LINE")"
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            NOTES=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$TAG" \
+              -f previous_tag_name="$PREV_TAG" \
+              --jq '.body' 2>/dev/null || echo "")
+          else
+            NOTES=$(gh api -X POST "repos/${GITHUB_REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$TAG" \
+              --jq '.body' 2>/dev/null || echo "")
+          fi
+          {
+            echo "title=$TAG — $COMMIT_SUBJECT"
+            echo "pypi_line=$PYPI_LINE"
+            echo "body<<RELEASE_BODY_EOF"
+            printf '%s\n\n---\n%s\n' "$NOTES" "$PYPI_LINE"
+            echo "RELEASE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYPI_STATUS: ${{ steps.pypi_verify.outputs.pypi_status }}
           PYPI_VERSION: ${{ steps.pypi_verify.outputs.pypi_version }}
+
+      - name: Create GitHub Release
+        if: env.CREATED == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.TAG }}
+          name: ${{ steps.release_meta.outputs.title }}
+          body: ${{ steps.release_meta.outputs.body }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.7.5"
+version = "3.7.6"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Addresses #462 Phase 1 (rate-limit retries via action swap). Phases 2 (bump-on-merge) and 3 (diagnostic artifact) follow as separate PRs.

## Why

On 2026-05-06 between 11:14–12:30 the `Publish` workflow failed 11 successive runs with `GraphQL: API rate limit already exceeded for site ID installation` on the `Create GitHub Release` step. PyPI publication had succeeded in every case — only the GitHub-release call false-failed the workflow. The current `gh release create … || gh release create …` two-shot has no backoff between attempts, so a rate-limit incident takes both shots out together.

## What

Replaces lines 96–114 of `.github/workflows/publish.yml` with `softprops/action-gh-release@v2`, which uses Octokit's `@octokit/plugin-throttling` to auto-retry on secondary rate-limit (HTTP 403 with Retry-After). The action is idempotent on workflow re-runs of the same tag.

A small `Compose release metadata` step before the action computes the title and body so the `Create GitHub Release` step has no scripting in it.

## Body-shape contract verification

The migrated release body MUST contain (Patch 2):

1. **Auto-generated changelog** — produced via `gh api .../releases/generate-notes` in the compose step, falls back to empty on API failure.
2. **Horizontal-rule separator** — `---` between changelog and PyPI line.
3. **PyPI line** — either `Published to PyPI: atdd==<version>` or `PyPI publication pending (may still be propagating)`, sourced from the existing `Verify PyPI publication` step's `pypi_status` output.

These three are composed in the bash step via `printf '%s\n\n---\n%s\n' "$NOTES" "$PYPI_LINE"` and passed to softprops via the `body` input. We do **not** rely on the action's default body generation alone (Patch 2 lock-in).

### Why we omit `generate_release_notes: true`

The impl plan called for `generate_release_notes: true` + templated `body`. Inspection of softprops/action-gh-release@v2 source (`src/github.ts`) shows the composition rule when both are set is `body = \`${input_body}\n\n${generated_notes}\``, i.e. **body is placed BEFORE generated notes**. That inverts the contract (PyPI line would precede the changelog), so we generate notes up-front and pass a fully composed `body` instead.

## Reference: v3.7.5 release body snapshot

```
## What's Changed
* chore(atdd): #460 — anonymize consumer-repo references by @afokapu in https://github.com/afokapu/atdd/pull/461


**Full Changelog**: https://github.com/afokapu/atdd/compare/v3.7.4...v3.7.5

---
Published to PyPI: atdd==3.7.5
```

After v3.7.6 publishes, compare bodies with:

```
diff <(gh release view v3.7.5 --json body --jq '.body') \
     <(gh release view v3.7.6 --json body --jq '.body')
```

Expected delta: only the changelog content differs; the structural shape (changelog → `---` → PyPI line) is identical.

## Caveats

- Generic 5xx / primary rate-limit / non-rate-limit 403s are **NOT** auto-retried by softprops (the `@octokit/plugin-throttling` plugin only retries on secondary rate-limit). If those start appearing in run logs after this lands, follow-up with option α (explicit retry loop with exponential backoff).
- The `gh api` generate-notes call inside the compose step is not retried; on failure it falls back to empty notes so the create step still succeeds with the PyPI line + separator alone.

## Out of scope

- Phase 2 — bump-on-merge automation
- Phase 3 — diagnostic artifact upload + new validator
- Permissions block change to `post-merge-lifecycle.yml`

All tracked under #462; will ship as separate PRs.

## Version bump

`3.7.5 → 3.7.6` (PATCH, fix-class). Note: parallel #459 is also bumping; whichever merges first lands at 3.7.6 — if #459 wins, this PR re-bumps to 3.7.7.

## Verification

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` → `YAML OK`
- [ ] `gh pr checks` green
- [ ] After merge + v3.7.6 publishes: `diff` of release bodies confirms structural equivalence with v3.7.5