### PR TITLE
feat(devops): #462 phase 2 — bump-on-merge automation

### DIFF
--- a/.github/workflows/atdd-validate.yml
+++ b/.github/workflows/atdd-validate.yml
@@ -169,53 +169,12 @@ jobs:
         if: env.SMOKE_BASE_URL != ''
         run: npx playwright test "e2e/**/*smoke*.spec.ts"
 
-  version-bump:
-    name: Version bump check
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Check version was bumped
-        run: |
-          pip3 install pyyaml -q
-          python3 - <<'PYEOF'
-          import yaml, re, json, subprocess, sys
-
-          cfg = yaml.safe_load(open(".atdd/config.yaml"))
-          vf = cfg["release"]["version_file"]
-
-          def read_version(content, filename):
-              if filename.endswith(".toml"):
-                  m = re.search(r'^version\s*=\s*["\x27]([^"\x27]+)["\x27]', content, re.M)
-                  return m.group(1) if m else ""
-              elif filename.endswith(".json"):
-                  return json.loads(content).get("version", "")
-              else:
-                  return content.strip().split()[0]
-
-          # PR branch version (current checkout)
-          pr_version = read_version(open(vf).read(), vf)
-
-          # Main branch version
-          main_content = subprocess.check_output(
-              ["git", "show", f"origin/main:{vf}"], text=True
-          )
-          main_version = read_version(main_content, vf)
-
-          if pr_version == main_version:
-              print(f"::error::Version not bumped. PR: {pr_version}, main: {main_version}")
-              print(f"Bump the version in {vf} before merging.")
-              sys.exit(1)
-          else:
-              print(f"Version bumped: {main_version} → {pr_version}")
-          PYEOF
+  # Note: the pre-merge `version-bump` PR check was removed in #462 phase 2.
+  # Version is now bumped automatically on main by the bump-on-merge step in
+  # `.github/workflows/post-merge-lifecycle.yml` (branch-prefix → semver
+  # class). Branch protection's `Version bump check` required-check must be
+  # removed by an admin BEFORE this PR merges, otherwise PRs will hang on a
+  # check that no longer reports.
 
   validate-gate:
     needs: [validate-planner, validate-tester, validate-coder, validate-coach, validate-smoke]

--- a/.github/workflows/post-merge-lifecycle.yml
+++ b/.github/workflows/post-merge-lifecycle.yml
@@ -172,6 +172,127 @@ jobs:
 
           echo "Updated ATDD Status to COMPLETE for issue #${ISSUE}."
 
+      # ─── Bump-on-merge (issue #462 phase 2) ──────────────────────────────
+      # Replaces the pre-merge `version-bump` PR check. Branch prefix → semver
+      # class:
+      #   feat/                                  → MINOR
+      #   fix/, chore/, docs/, refactor/, devops/ → PATCH
+      #   PR title contains "BREAKING CHANGE" or matches "<type>!:" → MAJOR
+      # Skip path: if the merged PR already touched pyproject.toml::version
+      # (legacy/manual bump), do nothing.
+      # Push uses PROJECT_TOKEN (PAT) — GITHUB_TOKEN-pushed commits don't fire
+      # the workflow_run cascade that the Publish workflow depends on.
+      - name: Detect legacy version-bump in PR diff
+        if: github.event.pull_request.merged == true
+        id: legacy_bump
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          PATCH=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate \
+            --jq '.[] | select(.filename == "pyproject.toml") | .patch' 2>/dev/null || true)
+          if echo "$PATCH" | grep -qE '^[+-]version[[:space:]]*=[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"'; then
+            echo "::warning title=bump-on-merge skipped::PR #${PR_NUMBER} already modified pyproject.toml::version (legacy/manual bump). Auto-bump skipped."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify PROJECT_TOKEN is configured
+        if: github.event.pull_request.merged == true && steps.legacy_bump.outputs.skip == 'false'
+        env:
+          PT: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          if [ -z "${PT:-}" ]; then
+            cat >&2 <<'MSG'
+          ::error title=PROJECT_TOKEN required for bump-on-merge::PROJECT_TOKEN secret is unset. Bump-on-merge needs a PAT (or App token) with contents:write to push the bump commit so it triggers the Publish workflow on main; commits pushed with GITHUB_TOKEN do NOT fire workflow_run cascades. Configure PROJECT_TOKEN in repo Settings → Secrets and variables → Actions.
+          MSG
+            exit 1
+          fi
+
+      - name: Checkout main for bump-on-merge
+        if: github.event.pull_request.merged == true && steps.legacy_bump.outputs.skip == 'false'
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.PROJECT_TOKEN }}
+
+      - name: Bump version on main (atomic with retries)
+        if: github.event.pull_request.merged == true && steps.legacy_bump.outputs.skip == 'false'
+        env:
+          BRANCH_REF: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          # Compute next version inline; re-runs each attempt against the
+          # latest origin/main so we never push a stale version.
+          cat > /tmp/compute_next_version.py <<'PYEOF'
+          import os, re, sys
+          branch = os.environ["BRANCH_REF"]
+          title = os.environ["PR_TITLE"]
+          text = open("pyproject.toml").read()
+          m = re.search(r'^version\s*=\s*"([0-9]+)\.([0-9]+)\.([0-9]+)"', text, re.M)
+          if not m:
+              print("Could not parse version from pyproject.toml", file=sys.stderr)
+              sys.exit(1)
+          maj, mnr, pat = (int(g) for g in m.groups())
+          breaking = (
+              "BREAKING CHANGE" in title
+              or bool(re.match(r'^[a-z]+(\([^)]+\))?!:', title))
+          )
+          if breaking:
+              cls, nv = "major", f"{maj+1}.0.0"
+          elif branch.startswith("feat/"):
+              cls, nv = "minor", f"{maj}.{mnr+1}.0"
+          else:
+              # fix/, chore/, docs/, refactor/, devops/, and any other prefix
+              cls, nv = "patch", f"{maj}.{mnr}.{pat+1}"
+          old = f"{maj}.{mnr}.{pat}"
+          new_text = re.sub(
+              r'^(version\s*=\s*")' + re.escape(old) + r'(")',
+              rf'\g<1>{nv}\g<2>', text, count=1, flags=re.M)
+          open("pyproject.toml", "w").write(new_text)
+          print(f"old={old} new={nv} class={cls} branch={branch}", file=sys.stderr)
+          print(nv)
+          PYEOF
+
+          for attempt in 1 2 3; do
+            echo "::group::bump-on-merge attempt ${attempt}"
+            git fetch origin main
+            git reset --hard origin/main
+
+            if ! NEW=$(python3 /tmp/compute_next_version.py); then
+              echo "::error::Failed to compute next version on attempt ${attempt}"
+              echo "::endgroup::"
+              exit 1
+            fi
+
+            git add pyproject.toml
+            git commit -m "chore(release): bump version to ${NEW} [auto]"
+
+            if git push origin HEAD:main; then
+              echo "::notice title=bump-on-merge succeeded::Bumped to ${NEW} on attempt ${attempt} (pr=${PR_NUMBER}, branch=${BRANCH_REF})"
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            echo "::warning::Push rejected on attempt ${attempt} (likely fast-forward race) — re-fetching"
+            sleep 2
+            echo "::endgroup::"
+          done
+
+          echo "::error title=bump-on-merge failed::pr=${PR_NUMBER} branch=${BRANCH_REF} attempts=3 — manual bump required on next PR. Publish tag-push is idempotent, so a missed bump is recoverable on the next merge."
+          exit 1
+
       - name: Read version from pyproject.toml
         if: steps.extract.outputs.found == 'true'
         id: version

--- a/.github/workflows/post-merge-lifecycle.yml
+++ b/.github/workflows/post-merge-lifecycle.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      contents: read
+      contents: write   # bump-on-merge step pushes a follow-up commit to main
     steps:
       - name: Extract linked issue number
         id: extract

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.7.7"
+version = "3.8.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Closes #462 (this PR completes Phases 1 + 2 of the publish-workflow-resilience issue; Phase 1 shipped via #463, this is Phase 2). Phase 3 — diagnostic artifact + new validator — is a separate follow-up issue if pursued.

Phase 2 eliminates the pre-merge `Version bump check` race that surfaces when two PRs are open in parallel (both bump from the same base; the second hits `Version not bumped. PR: X.Y.Z, main: X.Y.Z` after the first merges and requires a manual rebase + re-bump). Replaces it with **bump-on-merge**: a step in `post-merge-lifecycle.yml` that pushes the version bump as a follow-up commit on `main` after each PR merges, derived deterministically from the merged PR's branch prefix.

Branch prefix → semver class:
- `feat/` → MINOR
- `fix/`, `chore/`, `docs/`, `refactor/`, `devops/` → PATCH
- PR title contains `BREAKING CHANGE` or matches `<type>!:` → MAJOR

## Changes

| Commit | Change |
|---|---|
| `af6ab2f` | Grant `contents: write` to the post-merge-lifecycle job (was `contents: read`). |
| `08a72d5` | Add the bump-on-merge step block: legacy-bump detection → `PROJECT_TOKEN` guard → checkout main with PAT → atomic bump + push with up to 3 retries on fast-forward race. |
| `7a1a1cb` | Delete the `version-bump` job from `atdd-validate.yml` (Decision row 7 — non-load-bearing under bump-on-merge). |
| `bbda6ba` | Bump version 3.7.7 → 3.8.0 (MINOR — new automation; LAST manual bump on this repo). |

## ⚠️ Before merge: admin step

This PR removes the `version-bump` job from `atdd-validate.yml`. If `Version bump check` remains a required check on `main`'s branch protection after this PR merges, **every future PR will hang forever waiting on a check that no longer reports** (Decision row 8).

**Required action:** an admin must remove `Version bump check` from `Settings → Branches → main → Require status checks to pass before merging` **before** merging this PR.

Order:
1. Admin removes `Version bump check` from main branch-protection required-checks.
2. Merge this PR.

## Token-source clarification

The bump push uses **`secrets.PROJECT_TOKEN`** (the same PAT already wired into `atdd-auto-phase.yml`). Reason: commits pushed via `${{ secrets.GITHUB_TOKEN }}` do **not** trigger downstream `workflow_run` cascades, and the Publish workflow is gated on `workflow_run` of `ATDD Validate` on `main`. Using a PAT (or App token) is what makes the bump-commit fire Publish so a tag + PyPI release happens automatically.

A guard step (`Verify PROJECT_TOKEN is configured`) fails the job with a descriptive `::error::` if the secret is unset, so a missing PAT surfaces immediately rather than silently degrading to a `GITHUB_TOKEN` push that wouldn't trigger Publish.

If `PROJECT_TOKEN` lacks `contents: write` scope (e.g. it was provisioned only for Projects-write), the push will 403 and the retry loop exits with `::error title=bump-on-merge failed::`. **Maintainer prerequisite:** verify `PROJECT_TOKEN`'s scope includes write access to repo contents on `afokapu/atdd`. If it doesn't, either upgrade the existing PAT's scopes or add a new repo-scoped PAT (e.g. `BUMP_BOT_TOKEN`) and rename the `secrets.PROJECT_TOKEN` reference in `post-merge-lifecycle.yml::Checkout main` accordingly.

## Backwards-compat: legacy/already-bumped PRs

Per Decision row 4, the bump-on-merge step inspects the merged PR's `pyproject.toml` patch via the GitHub Files API. If the PR already touched the `version = "X.Y.Z"` line (legacy/manual bump in flight when this lands), auto-bump is skipped with a `::warning::`. This means open PRs that were already bumped manually won't double-bump; new PRs (post-merge of this) shouldn't bump manually.

Note: this PR itself bumps version manually (3.7.7 → 3.8.0) because bump-on-merge isn't live yet at the time of this PR's merge. The skip path will correctly detect that and not double-bump 3.8.0 → 3.8.1 on the way in.

## Atomic update + retry behaviour

Per Patch 4: each bump attempt does (1) `git fetch origin main`, (2) `git reset --hard origin/main`, (3) re-compute next version from current `pyproject.toml`, (4) commit, (5) push. Up to 3 attempts. On final failure: `::error title=bump-on-merge failed::` with structured fields (`pr`, `branch`, `attempts`). The Publish workflow's existing tag-push idempotency means a missed bump is recoverable on the next merge — no data loss, no manual surgery.

## Reproducer plan (verify after merge)

1. **Verify the bump-on-merge actually fires:** Open a trivial follow-up PR (e.g. one-line doc fix on a `docs/` branch) after this merges. Expected: after that PR merges, `main` receives a SECOND commit `chore(release): bump version to 3.8.1 [auto]` from `github-actions[bot]`. The `Publish` workflow then fires (because the bot's commit was pushed via PAT) and tags + publishes `v3.8.1`.
2. **Verify legacy-skip:** If anyone has a PR open from before this PR merged that already bumped `pyproject.toml::version`, the bump-on-merge step should log `::warning title=bump-on-merge skipped::` and exit clean. No double-bump.
3. **Verify the deleted job is no longer required:** After the admin step, open a PR — the `Version bump check` check should NOT appear in the PR's check list. Other `validate-*` checks should still appear.

## Test plan

- [ ] Admin removes `Version bump check` from main branch-protection required-checks.
- [ ] Verify `PROJECT_TOKEN` repo secret exists and has `contents: write` scope on `afokapu/atdd`.
- [ ] Merge this PR.
- [ ] Confirm `main` receives a manual bump (3.7.7 → 3.8.0) — only because this PR was bumped by hand; no `[auto]` commit expected for THIS PR's merge.
- [ ] Open a trivial follow-up PR (e.g. `docs/` fix) — after merge, observe `chore(release): bump version to 3.8.1 [auto]` on main + a Publish run firing.
- [ ] Confirm `Version bump check` no longer appears as a required check on new PRs.

## Out of scope (deferred)

- Phase 3: per-run `.atdd/diagnostics/publish/<run-id>.yaml` artifact + `test_publish_diagnostics.py` validator. Lands as a separate PR (or stays as a follow-up issue if dropped).

🤖 Implemented for ATDD Phase 2 of #462.