### PR TITLE
fix(coach): #466 — train-required CLI hint rewrite

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -318,3 +318,14 @@ sessions:
   wagon: null
   feature: null
   train: 0001-self-compliance-validate
+- id: '466'
+  slug: train-required-fix-hint-incomplete
+  file: null
+  issue_number: 466
+  type: fix
+  status: RED
+  created: '2026-05-07'
+  archived: null
+  wagon: null
+  feature: null
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.7.7"
+version = "3.7.8"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-<<<<<<< HEAD
 version = "3.8.1"
-=======
-version = "3.8.1"
->>>>>>> origin/main
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -1681,7 +1681,14 @@ class IssueManager:
                     if not current_train or current_train.upper() == "TBD":
                         print(f"Error: Train field required for {issue_type or 'unknown'} type before transitioning to {status}")
                         print(f"  Current Train: {current_train or '(empty)'}")
-                        print(f"  Fix: atdd update {issue_id} --status {status} --train <train_id>")
+                        print( "  Fix:")
+                        print( "    1. cd into the issue's worktree (find via: git worktree list | grep <branch>):")
+                        print( "       cd /path/to/<feat-or-fix>-<slug>")
+                        print( "    2. Pick a train_id from plan/_trains.yaml::trains[].train_id (e.g. \"0001-self-compliance-validate\")")
+                        print( "    3. Run:")
+                        print(f"       atdd issue {issue_id} --status {status} --train <train_id>")
+                        print( "  Why train: implementation-type issues require lineage to a Train past PLANNED")
+                        print( "  so cross-cutting work threads to a shared journey. (See `plan/_trains.yaml`.)")
                         return 1
                 except GitHubClientError:
                     # If we can't read fields, allow the transition (fail open)

--- a/src/atdd/coach/commands/tests/test_issue_train_required_hint.py
+++ b/src/atdd/coach/commands/tests/test_issue_train_required_hint.py
@@ -1,0 +1,85 @@
+"""Fixture lock for the train-required CLI hint contract (issue #466).
+
+The train-required error path at IssueManager.update prints a Fix block when
+an implementation-type issue tries to transition past PLANNED without a Train
+assigned. Issue #466 rewrote that hint to:
+
+  C1: NOT recommend the deprecated `atdd update` invocation.
+  C2: Cite `plan/_trains.yaml` as the resolver for <train_id>.
+  C3: Disclose the worktree prereq (`cd` step) as step 1 of a numbered fix.
+
+Run: PYTHONPATH=src python3 -m pytest -q \\
+     src/atdd/coach/commands/tests/test_issue_train_required_hint.py -v
+"""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from atdd.coach.commands.issue import IssueManager
+
+
+pytestmark = [pytest.mark.platform]
+
+
+def _setup_atdd_config(tmp_path: Path) -> Path:
+    cfg_dir = tmp_path / ".atdd"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text(yaml.safe_dump({
+        "github": {"repo": "owner/repo", "project_id": "PVT_test"},
+    }))
+    return tmp_path
+
+
+def _impl_issue(status: str = "PLANNED") -> dict:
+    return {
+        "number": 466,
+        "title": "regression: train-required hint",
+        "state": "OPEN",
+        "labels": [{"name": f"atdd:{status}"}, {"name": "atdd-issue"}],
+        "body": "| Type | `implementation` |\n",
+    }
+
+
+def _capture_train_required_hint(tmp_path: Path, capsys) -> str:
+    """Drive update() into the train-required branch and return stdout."""
+    target = _setup_atdd_config(tmp_path)
+    mgr = IssueManager(target_dir=target)
+
+    client = MagicMock()
+    client.get_issue.return_value = _impl_issue("PLANNED")
+    client.get_project_fields.return_value = {
+        "ATDD Status": {"id": "f_s", "options": {"RED": "opt_red"}},
+    }
+    client.get_project_item_id.return_value = "item_466"
+    client.get_project_item_field_values.return_value = {"ATDD Train": ""}
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"):
+        rc = mgr.update("466", status="RED")
+
+    assert rc == 1, "missing-train must abort (rc=1)"
+    return capsys.readouterr().out
+
+
+def test_hint_does_not_recommend_deprecated_atdd_update(tmp_path, capsys):
+    """C1: hint must NOT cite the deprecated `atdd update` invocation."""
+    out = _capture_train_required_hint(tmp_path, capsys)
+    assert "atdd update" not in out, (
+        "hint regressed: still recommends deprecated `atdd update`"
+    )
+
+
+def test_hint_cites_plan_trains_yaml_as_resolver(tmp_path, capsys):
+    """C2: hint must point users at plan/_trains.yaml for <train_id>."""
+    out = _capture_train_required_hint(tmp_path, capsys)
+    assert "plan/_trains.yaml" in out, (
+        "hint missing resolver pointer to plan/_trains.yaml"
+    )
+
+
+def test_hint_discloses_worktree_cd_prereq(tmp_path, capsys):
+    """C3: hint must disclose the `cd` worktree prereq."""
+    out = _capture_train_required_hint(tmp_path, capsys)
+    assert "cd" in out, "hint missing worktree `cd` prereq"


### PR DESCRIPTION
Closes #466

## Summary
The train-required error path at `src/atdd/coach/commands/issue.py:1682-1684` printed a 3-line hint with three defects:
1. Recommended the deprecated `atdd update` form (same run also prints an "atdd update" deprecation warning — self-contradictory).
2. Left `<train_id>` unbound — no resolver pointer.
3. Hid the worktree prereq (must `cd` into the issue's worktree first).

This PR rewrites the hint into a numbered Fix block that uses canonical `atdd issue`, cites `plan/_trains.yaml::trains[].train_id` as the resolver, and discloses the `cd` prereq as step 1.

## Hint diff

**Before (3 lines):**
```
Error: Train field required for implementation type before transitioning to RED
  Current Train: (empty)
  Fix: atdd update 466 --status RED --train <train_id>
```

**After (9 lines):**
```
Error: Train field required for implementation type before transitioning to RED
  Current Train: (empty)
  Fix:
    1. cd into the issue's worktree (find via: git worktree list | grep <branch>):
       cd /path/to/<feat-or-fix>-<slug>
    2. Pick a train_id from plan/_trains.yaml::trains[].train_id (e.g. "0001-self-compliance-validate")
    3. Run:
       atdd issue 466 --status RED --train <train_id>
  Why train: implementation-type issues require lineage to a Train past PLANNED
  so cross-cutting work threads to a shared journey. (See `plan/_trains.yaml`.)
```

## Fixture test (`test_issue_train_required_hint.py`)
Locks the contract via 3 assertions on captured stdout from the train-required code path:
- **C1** — `"atdd update"` NOT in hint (no deprecated form).
- **C2** — `"plan/_trains.yaml"` IS in hint (resolver cited).
- **C3** — `"cd"` IS in hint (worktree prereq disclosed).

## Test plan
- [x] `pytest src/atdd/coach/commands/tests/test_issue_train_required_hint.py -v` — 3/3 PASS
- [x] No regression in `src/atdd/coach/commands/tests/` (10 pre-existing babysit/E001 failures unrelated to this change)
- [x] Version bumped: 3.7.7 → 3.7.8 (PATCH, fix-class)

> Note: title prefix `fix(coach):` despite `feat/`-defaulted branch slug — the branch-name auto-prefix is ahead of the issue type rename.