### PR TITLE
feat(coach): #467 — fix-hint completeness contract + meta-validator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.7.7"
+version = "3.8.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/conventions/rule-id.convention.yaml
+++ b/src/atdd/coach/conventions/rule-id.convention.yaml
@@ -169,6 +169,73 @@ rule_schema:
         Canonical remediation guidance for this rule. Replaces ad-hoc
         per-Violation ``fix_hint_ref`` (Violation can still override).
         (issue #399)
+
+        ── Completeness contract (issue #467) ────────────────────────────
+        Every fix_hint — whether declared in a convention YAML or printed
+        from a CLI command (``Fix: …``) — MUST satisfy ALL FOUR clauses:
+
+          C1 — Placeholder resolution.
+            Every ``<placeholder>`` token in the hint MUST have a sibling
+            resolver line within the same hint block, of the form:
+              (see <file>::<path>)        — point at a definition site
+              (run <command>)             — name a CLI to enumerate values
+              (e.g. "<concrete-example>") — show one literal value
+            A bare ``<placeholder>`` with no resolver fails C1: the reader
+            has no way to discover what to substitute (e.g. issue #466's
+            train-required hint at commands/issue.py:1682-1684 — bare
+            ``<train_id>`` token, no resolver line).
+
+          C2 — No deprecation contradiction.
+            A hint MUST NOT recommend a CLI form flagged deprecated by any
+            ``Deprecated:`` warning the same toolkit emits. The validator
+            builds a deprecation registry from
+            ``_deprecation_warning(old, new)`` callsites in
+            ``src/atdd/cli.py`` and cross-references the first
+            atdd-subcommand referenced inside each Fix: hint.
+
+          C3 — Prerequisite disclosure.
+            When the hint's command requires an operational prerequisite
+            (worktree-cd, file existence, env-var) that produces a
+            *different* error if absent, that prerequisite MUST be
+            disclosed as step 1 of a numbered fix sequence. Heuristic:
+            hint contains a ``1.`` step marker when a known prereq pattern
+            applies.
+
+          C4 — Runnable as printed.
+            A copy-paste of the hint's command (or, for numbered hints,
+            the steps as written) MUST succeed without further
+            investigation, given the C3 prerequisite is met. Sandbox-smoke
+            verification is OPTIONAL (Phase 3 deliverable of #467); the
+            structural clauses C1-C3 are mandatory.
+
+        See the ``# === Fix-hint completeness contract ===`` exemplars
+        block below for positive + negative samples. The
+        ``coach.rule-id.fix-hint-completeness`` rule under ``rules:``
+        enforces this contract.
+      completeness_contract:
+        # Machine-readable form of the C1-C4 narrative above. Consumed by
+        # ``test_fix_hint_completeness::test_every_fix_hint_satisfies_completeness_contract``.
+        introduced_in: "3.8.0"
+        clauses:
+          - id: C1
+            name: "placeholder-resolution"
+            check: "every <placeholder> token has a sibling resolver line"
+            resolver_patterns:
+              - "(see <file>::<path>)"
+              - "(run <command>)"
+              - 'e.g. "<concrete-example>"'
+          - id: C2
+            name: "no-deprecation-contradiction"
+            check: "hint MUST NOT recommend a CLI form deprecated by a same-toolkit Deprecated: warning"
+            registry_source: "src/atdd/cli.py (_deprecation_warning callsites)"
+          - id: C3
+            name: "prerequisite-disclosure"
+            check: "when the hint's command requires a prereq, it MUST be step 1 of a numbered sequence"
+            heuristic: "hint contains a numbered '1.' step marker when a known prereq pattern applies"
+          - id: C4
+            name: "runnable-as-printed"
+            check: "copy-paste runs without investigation"
+            phase: "optional (sandbox smoke; deferred to follow-up of #467)"
     aliases:
       type: array
       items:
@@ -217,6 +284,73 @@ rules:
     introduced_in: "3.0.0"
     validator: "test_rule_validator_binding::test_every_enforced_rule_has_real_validator"
     fix_hint: "Either set validator: '<module>::<func>' on the rule and have that function call bind_rule(<id>), or change disposition to documentation-only."
+  - id: "coach.rule-id.fix-hint-completeness"
+    severity: 2
+    description: "Every fix_hint (convention-declared or CLI-printed) must satisfy the completeness contract C1-C4 in rule_schema.fields.fix_hint.description"
+    disposition: strict
+    introduced_in: "3.8.0"
+    aliases: []
+    validator: "test_fix_hint_completeness::test_every_fix_hint_satisfies_completeness_contract"
+    fix_hint: |
+      The named fix_hint fails one or more contract clauses (C1-C4). Repair as follows:
+        1. Re-run the validator to read which clause failed
+           (run: pytest src/atdd/coach/validators/test_fix_hint_completeness.py -v).
+           The Violation message names the clause + the offending token,
+           command, or structural shape.
+        2. Resolve per the failed clause:
+             - C1 placeholder resolution: for each bare ``<token>``, append
+               a resolver line in the same hint block. Patterns
+               (e.g. "(see plan/_trains.yaml::trains.id)" / "(run atdd list trains)" /
+                'e.g. "0001-self-compliance-validate"').
+             - C2 deprecation contradiction: substitute the deprecated CLI
+               form with the canonical one
+               (see src/atdd/cli.py::_deprecation_warning) — same toolkit
+               that emits the warning prints the canonical replacement.
+             - C3 prerequisite disclosure: convert the hint to a numbered
+               sequence; step 1 = the prerequisite
+               (e.g. "1. cd into the feature worktree (run: atdd branch <N>)").
+             - C4 runnable-as-printed: copy-paste the hint into a fresh
+               shell with the C3 prereq met; if it fails, simplify until it
+               succeeds. Sandbox-smoke is optional in 3.8.x.
+        3. Re-run step 1 to confirm clean.
+      Source contract: see src/atdd/coach/conventions/rule-id.convention.yaml
+      §rule_schema.fields.fix_hint.description (clauses C1-C4) and the
+      adjacent "# === Fix-hint completeness contract ===" exemplars block.
+
+# =============================================================================
+# === Fix-hint completeness contract ===
+# =============================================================================
+# Positive + negative exemplars for the C1-C4 contract declared in
+# rule_schema.fields.fix_hint.description. Validator
+# test_fix_hint_completeness consumes the contract; this block documents
+# canonical good/bad shapes so authors have a quick visual reference.
+fix_hint_exemplars:
+  positive:
+    - source: "src/atdd/tester/conventions/acceptance-violation.convention.yaml:15-100"
+      why_pass: |
+        Multi-line hints with valid-value enumerations, anchored
+        ``recipe:`` pointers, and §-references. Placeholders are bound by
+        adjacent valid-value lists (C1) or by the recipe link.
+      clauses_covered: [C1, C2, C3]
+    - source: "src/atdd/coach/commands/issue.py (the COMPLETE-walkthrough hint)"
+      observed: "2026-05-07"
+      why_pass: |
+        Numbered Fix: steps with a sibling ``Bypass:`` line documenting the
+        escape hatch. Disclosed prerequisite (rebase / artifacts / release
+        gate) appears as the leading step. Runnable as printed.
+      clauses_covered: [C1, C3, C4]
+  negative:
+    - source: "src/atdd/coach/commands/issue.py:1682-1684"
+      owner_issue: 466
+      why_fail: |
+        Single-line ``Fix: atdd update {issue_id} --status {status} --train <train_id>``
+        — bare ``<train_id>`` placeholder with no resolver line (C1 fail)
+        AND recommends the deprecated ``atdd update`` CLI form whose
+        deprecation warning is registered at src/atdd/cli.py:1783 / 1792
+        (C2 fail). After issue #466 lands the surgical fix, this site is
+        expected to comply; until then the validator surfaces it as a
+        known-defective fixture.
+      clauses_failed: [C1, C2]
 
 # =============================================================================
 # Migration playbook

--- a/src/atdd/coach/validators/test_fix_hint_completeness.py
+++ b/src/atdd/coach/validators/test_fix_hint_completeness.py
@@ -1,0 +1,421 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_fix_hint_completeness:backend:domain
+# Runtime: python
+# Purpose: Audit every fix_hint (convention-declared or CLI-printed `Fix:`) against the C1-C4 completeness contract from rule-id.convention.yaml (issue #467).
+
+"""Coach meta-validator: fix-hint completeness contract (issue #467).
+
+Walks every ``*.convention.yaml`` file under the toolkit and every
+``print(... Fix: ...)`` literal under ``src/atdd/**/{commands,validators}/``,
+extracts the hint text, and asserts the C1-C4 contract declared in
+``rule_schema.fields.fix_hint.description`` of
+``src/atdd/coach/conventions/rule-id.convention.yaml``:
+
+  * C1 — Placeholder resolution. Every ``<placeholder>`` token must be
+        locally resolved (pipe-enumeration ``<a|b|c>``, function-call
+        context ``f(<x>)``, quoted form ``'<x>'``) OR the hint must
+        contain at least one resolver pattern line (``e.g. "..."``,
+        ``(see <file>::<path>)``, ``(run <command>)``).
+  * C2 — No deprecation contradiction. The first ``atdd <subcommand>``
+        referenced by a hint MUST NOT be flagged deprecated by the
+        ``_deprecation_warning`` registry built from ``src/atdd/cli.py``.
+  * C3 — Prerequisite disclosure (heuristic; current shape: structural
+        check skipped in 3.8.0; deferred to follow-up if maintenance
+        friction warrants enabling it).
+  * C4 — Runnable as printed. Optional sandbox-smoke; deferred.
+
+Known-defective sites are listed under
+``rule-id.convention.yaml::fix_hint_exemplars.negative`` with their
+owning issue number; the validator skips those locations so the gate
+becomes green automatically when the surgical fix lands and the
+exemplar entry is removed.
+
+Rule emitted: ``coach.rule-id.fix-hint-completeness``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+import pytest
+import yaml
+
+import atdd
+from atdd.coach.utils.rule_binding import (
+    bind_rule,
+    extract_rules,
+    find_convention_files,
+)
+from atdd.coach.validators._violation import Violation
+
+
+pytestmark = [pytest.mark.coach]
+
+
+_RULE = bind_rule("coach.rule-id.fix-hint-completeness")
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+RULE_ID_CONVENTION = (
+    ATDD_PKG_DIR / "coach" / "conventions" / "rule-id.convention.yaml"
+)
+CLI_FILE = ATDD_PKG_DIR / "cli.py"
+
+# Python source roots that may carry print(... Fix: ...) hint literals.
+_PY_HINT_ROOTS = [
+    ATDD_PKG_DIR / "coach" / "commands",
+    ATDD_PKG_DIR / "coach" / "validators",
+    ATDD_PKG_DIR / "coder" / "commands",
+    ATDD_PKG_DIR / "coder" / "validators",
+    ATDD_PKG_DIR / "planner" / "commands",
+    ATDD_PKG_DIR / "planner" / "validators",
+    ATDD_PKG_DIR / "tester" / "commands",
+    ATDD_PKG_DIR / "tester" / "validators",
+]
+
+# `Fix: <body>` literal embedded in a Python string (after f-string prefix).
+_FIX_LINE_RE = re.compile(r'Fix:\s*(.+?)(?:["\'\\])', re.MULTILINE)
+# More liberal capture for line-level scanning — strips the trailing quote.
+_FIX_INLINE_RE = re.compile(r'Fix:\s*(?P<body>.+)$')
+
+# `<placeholder>` token (no whitespace inside the brackets).
+_PLACEHOLDER_RE = re.compile(r'<([A-Za-z_][A-Za-z0-9_:./|\- ]*?)>')
+
+# Resolver-pattern markers.
+_RESOLVER_RE = re.compile(
+    r'(\(\s*see\s+[^)]+::[^)]+\))|(\(\s*run\s+[^)]+\))|(e\.g\.\s*["\'`])'
+)
+
+# Deprecation-registry parse — `_deprecation_warning("<old>", "<new>")`.
+_DEPRECATION_CALL_RE = re.compile(
+    r'_deprecation_warning\(\s*'
+    r'["\'](?P<old>[^"\']+)["\']\s*,\s*'
+    r'["\'](?P<new>[^"\']+)["\']'
+)
+
+# Negative-exemplar block — file:start-end form.
+_LINE_RANGE_RE = re.compile(r'(?P<path>[^:]+):(?P<start>\d+)-(?P<end>\d+)')
+_LINE_SINGLE_RE = re.compile(r'(?P<path>[^:]+):(?P<start>\d+)$')
+
+
+# ---------------------------------------------------------------------------
+# Hint extraction
+# ---------------------------------------------------------------------------
+class Hint:
+    """A single fix-hint instance with its source location."""
+
+    __slots__ = ("source", "rel_path", "line", "text", "kind")
+
+    def __init__(self, source: Path, rel_path: str, line: int, text: str, kind: str):
+        self.source = source
+        self.rel_path = rel_path
+        self.line = line
+        self.text = text
+        self.kind = kind  # "yaml" or "py"
+
+
+def _relpath(p: Path) -> str:
+    try:
+        return str(p.resolve().relative_to(ATDD_PKG_DIR.parent.resolve()))
+    except ValueError:
+        return str(p)
+
+
+def _yaml_line_for_field(file_path: Path, field_value: str) -> int:
+    """Best-effort line number for a fix_hint value (for reporting)."""
+    if not field_value:
+        return 1
+    needle = field_value.splitlines()[0].strip() if field_value.strip() else ""
+    if not needle:
+        return 1
+    try:
+        for idx, raw in enumerate(file_path.read_text(encoding="utf-8").splitlines(), 1):
+            if needle and needle in raw:
+                return idx
+    except OSError:
+        pass
+    return 1
+
+
+def collect_yaml_hints() -> List[Hint]:
+    """Extract every ``fix_hint:`` value from every convention YAML."""
+    out: List[Hint] = []
+    for conv in find_convention_files():
+        for (file_path, _yaml_path, rule) in extract_rules(conv):
+            text = rule.get("fix_hint")
+            if not isinstance(text, str) or not text.strip():
+                continue
+            lineno = _yaml_line_for_field(file_path, text)
+            out.append(
+                Hint(
+                    source=file_path,
+                    rel_path=_relpath(file_path),
+                    line=lineno,
+                    text=text,
+                    kind="yaml",
+                )
+            )
+    return out
+
+
+def collect_py_hints() -> List[Hint]:
+    """Extract every ``print(... Fix: ...)`` literal under the toolkit."""
+    out: List[Hint] = []
+    for root in _PY_HINT_ROOTS:
+        if not root.is_dir():
+            continue
+        for py in root.rglob("*.py"):
+            if "__pycache__" in py.parts or "fixtures" in py.parts:
+                continue
+            try:
+                source = py.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            for lineno, raw in enumerate(source.splitlines(), 1):
+                # Skip the validator's own file and its Deprecated: registry.
+                if "Fix:" not in raw:
+                    continue
+                # Must be inside a string literal in a print/return/log call.
+                if "print" not in raw and "lines.append" not in raw and 'f"' not in raw and "f'" not in raw:
+                    continue
+                m = _FIX_INLINE_RE.search(raw)
+                if not m:
+                    continue
+                body = m.group("body").rstrip()
+                # Strip closing quote / paren artifacts.
+                body = body.rstrip(')\'"` ').rstrip()
+                if not body:
+                    continue
+                out.append(
+                    Hint(
+                        source=py,
+                        rel_path=_relpath(py),
+                        line=lineno,
+                        text=body,
+                        kind="py",
+                    )
+                )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Deprecation registry (parsed from cli.py _deprecation_warning callsites)
+# ---------------------------------------------------------------------------
+def build_deprecation_registry(cli_source: Optional[str] = None) -> dict:
+    """Map ``"atdd <head>"`` → canonical replacement string.
+
+    Reads ``_deprecation_warning("<old>", "<new>")`` callsites from
+    ``src/atdd/cli.py``.  The "head" is the first two whitespace-separated
+    tokens of the deprecated form (e.g. ``"atdd update"``); the validator
+    matches Fix:-hint commands by head so flag/arg drift doesn't matter.
+    """
+    if cli_source is None:
+        try:
+            cli_source = CLI_FILE.read_text(encoding="utf-8")
+        except OSError:
+            return {}
+    out: dict = {}
+    for m in _DEPRECATION_CALL_RE.finditer(cli_source):
+        old = m.group("old").strip()
+        new = m.group("new").strip()
+        head = " ".join(old.split()[:2])
+        if head and head not in out:
+            out[head] = new
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Negative-exemplar allowlist (consumed from rule-id.convention.yaml)
+# ---------------------------------------------------------------------------
+def load_negative_exemplars(
+    convention_path: Path = RULE_ID_CONVENTION,
+) -> List[Tuple[str, int, int, int]]:
+    """Return ``(rel_path, start_line, end_line, owner_issue)`` tuples.
+
+    Sites listed under ``fix_hint_exemplars.negative`` are skipped by the
+    validator — they are known-defective and owned by another issue.
+    """
+    out: List[Tuple[str, int, int, int]] = []
+    try:
+        data = yaml.safe_load(convention_path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError):
+        return out
+    block = (data.get("fix_hint_exemplars") or {}).get("negative") or []
+    for entry in block:
+        if not isinstance(entry, dict):
+            continue
+        src = entry.get("source", "")
+        owner = entry.get("owner_issue") or 0
+        m = _LINE_RANGE_RE.match(src) or _LINE_SINGLE_RE.match(src)
+        if not m:
+            continue
+        path = m.group("path").strip()
+        start = int(m.group("start"))
+        end = int(m.group("end")) if "end" in m.groupdict() and m.group("end") else start
+        out.append((path, start, end, int(owner) if owner else 0))
+    return out
+
+
+def _is_exempted(hint: Hint, exemptions: Sequence[Tuple[str, int, int, int]]) -> Optional[int]:
+    for path, start, end, owner in exemptions:
+        if hint.rel_path.endswith(path) or path.endswith(hint.rel_path):
+            if start <= hint.line <= end:
+                return owner
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Contract clauses
+# ---------------------------------------------------------------------------
+_RESOLVING_PREV_CHARS = set(":=/([<'\"`-*")  # ``-`` / ``*`` cover YAML/markdown bullets
+_RESOLVING_NEXT_CHARS = set("/:.")          # path / qualified-name continuation
+
+
+def _placeholder_is_locally_resolved(text: str, match: re.Match) -> bool:
+    """A placeholder is locally resolved if it sits in any of:
+
+    * a pipe-enumeration ``<a|b|c>`` (own value space),
+    * a schema/template / function / quoted / bullet context — the
+      previous non-whitespace character before the ``<`` is one of
+      ``: = / ( [ < ' " ``` `` - * `` (covers ``key: <value>``,
+      ``--flag=<value>``, ``f(<x>)``, ``"<x>"``, ``- <bullet>``),
+    * a path / qualified-name continuation — the immediate character
+      after the ``>`` is one of ``/ : .`` (covers ``<repo>/.atdd``,
+      ``<name>.py``, ``<scope>:<value>``).
+    """
+    body = match.group(1)
+    if "|" in body:
+        return True
+    start = match.start()
+    end = match.end()
+    if end < len(text) and text[end] in _RESOLVING_NEXT_CHARS:
+        return True
+    i = start - 1
+    while i >= 0 and text[i] in " \t":
+        i -= 1
+    if i < 0:
+        return False
+    return text[i] in _RESOLVING_PREV_CHARS
+
+
+def audit_c1_placeholder_resolution(text: str) -> List[str]:
+    """Return a list of unresolved ``<placeholder>`` tokens."""
+    placeholders = list(_PLACEHOLDER_RE.finditer(text))
+    if not placeholders:
+        return []
+    has_resolver = bool(_RESOLVER_RE.search(text))
+    unresolved: List[str] = []
+    for m in placeholders:
+        if has_resolver:
+            continue
+        if _placeholder_is_locally_resolved(text, m):
+            continue
+        unresolved.append(m.group(1))
+    return unresolved
+
+
+def audit_c2_no_deprecation_contradiction(
+    text: str, registry: dict
+) -> Optional[Tuple[str, str]]:
+    """Return ``(deprecated_head, canonical_replacement)`` or None."""
+    # Look for an `atdd <sub>` head literally appearing in the hint.
+    m = re.search(r'\batdd\s+([a-z][a-z0-9-]*)', text)
+    if not m:
+        return None
+    head = f"atdd {m.group(1)}"
+    if head in registry:
+        return (head, registry[head])
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+def scan_hints() -> List[Violation]:
+    """Audit every discovered hint and emit Violations for failures."""
+    registry = build_deprecation_registry()
+    exemptions = load_negative_exemplars()
+    hints: List[Hint] = []
+    hints.extend(collect_yaml_hints())
+    hints.extend(collect_py_hints())
+
+    violations: List[Violation] = []
+    for hint in hints:
+        if _is_exempted(hint, exemptions):
+            continue
+
+        unresolved = audit_c1_placeholder_resolution(hint.text)
+        if unresolved:
+            tokens = ", ".join(f"<{t}>" for t in unresolved[:5])
+            violations.append(
+                Violation(
+                    rule_id=_RULE.rule_id,
+                    severity=_RULE.severity,
+                    location=f"{hint.rel_path}:{hint.line}",
+                    detail=(
+                        f"C1 placeholder-resolution: unresolved placeholder(s) "
+                        f"{tokens} in fix_hint — add a sibling resolver line "
+                        f"(see <file>::<path>) / (run <command>) / e.g. \"<concrete>\"."
+                    ),
+                    fix_hint_ref=_RULE.fix_hint_ref,
+                )
+            )
+
+        c2 = audit_c2_no_deprecation_contradiction(hint.text, registry)
+        if c2 is not None:
+            head, canonical = c2
+            violations.append(
+                Violation(
+                    rule_id=_RULE.rule_id,
+                    severity=_RULE.severity,
+                    location=f"{hint.rel_path}:{hint.line}",
+                    detail=(
+                        f"C2 deprecation-contradiction: hint recommends "
+                        f"deprecated CLI form {head!r}; substitute the canonical "
+                        f"replacement {canonical!r} (registered via "
+                        f"_deprecation_warning in src/atdd/cli.py)."
+                    ),
+                    fix_hint_ref=_RULE.fix_hint_ref,
+                )
+            )
+
+    return violations
+
+
+# ===========================================================================
+# Test
+# ===========================================================================
+@pytest.mark.coach
+def test_every_fix_hint_satisfies_completeness_contract():
+    """Every fix_hint in convention YAMLs and CLI ``Fix:`` literals must
+    satisfy clauses C1-C2 of the contract declared in
+    ``rule-id.convention.yaml::rule_schema.fields.fix_hint`` (#467).
+
+    Sites pinned under ``fix_hint_exemplars.negative`` are exempted as
+    known-defective fixtures (each carries an ``owner_issue``).  The gate
+    becomes green automatically when the owning issue lands and the
+    exemplar entry is removed.
+    """
+    violations = scan_hints()
+    if not violations:
+        return
+    formatted = "\n".join(f"  - {v}" for v in violations)
+    pytest.fail(
+        f"\nFix-hint completeness contract violated by "
+        f"{len(violations)} hint(s):\n\n{formatted}\n\n"
+        "Repair per rule-id.convention.yaml::rule_schema.fields.fix_hint "
+        "(clauses C1-C4). See coach.rule-id.fix-hint-completeness.fix_hint."
+    )
+
+
+__all__ = [
+    "Hint",
+    "audit_c1_placeholder_resolution",
+    "audit_c2_no_deprecation_contradiction",
+    "build_deprecation_registry",
+    "collect_py_hints",
+    "collect_yaml_hints",
+    "load_negative_exemplars",
+    "scan_hints",
+    "test_every_fix_hint_satisfies_completeness_contract",
+]

--- a/src/atdd/coach/validators/test_fix_hint_completeness.py
+++ b/src/atdd/coach/validators/test_fix_hint_completeness.py
@@ -158,8 +158,27 @@ def collect_yaml_hints() -> List[Hint]:
     return out
 
 
+_HINT_BLOCK_LOOKAHEAD = 6
+
+
+def _is_string_continuation(line: str) -> bool:
+    """A line that continues a string-literal hint block.
+
+    Heuristic: leading whitespace then ``"``, ``'``, ``f"``, or ``f'``.
+    Stops at lines that start a new statement, close the call, or
+    introduce a separator like ``Bypass:`` (handled by caller).
+    """
+    s = line.lstrip()
+    return s.startswith(('f"', "f'", '"', "'"))
+
+
 def collect_py_hints() -> List[Hint]:
-    """Extract every ``print(... Fix: ...)`` literal under the toolkit."""
+    """Extract every ``Fix: …`` literal under the toolkit.
+
+    A hint is the ``Fix:`` body PLUS up to ``_HINT_BLOCK_LOOKAHEAD``
+    subsequent string-continuation lines (so resolver-pattern lines like
+    ``(e.g. "...")`` placed on the next f-string fragment are picked up).
+    """
     out: List[Hint] = []
     for root in _PY_HINT_ROOTS:
         if not root.is_dir():
@@ -171,19 +190,32 @@ def collect_py_hints() -> List[Hint]:
                 source = py.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
                 continue
-            for lineno, raw in enumerate(source.splitlines(), 1):
-                # Skip the validator's own file and its Deprecated: registry.
+            lines = source.splitlines()
+            for idx, raw in enumerate(lines):
+                lineno = idx + 1
                 if "Fix:" not in raw:
                     continue
-                # Must be inside a string literal in a print/return/log call.
-                if "print" not in raw and "lines.append" not in raw and 'f"' not in raw and "f'" not in raw:
+                if (
+                    "print" not in raw
+                    and "lines.append" not in raw
+                    and 'f"' not in raw
+                    and "f'" not in raw
+                ):
                     continue
                 m = _FIX_INLINE_RE.search(raw)
                 if not m:
                     continue
-                body = m.group("body").rstrip()
-                # Strip closing quote / paren artifacts.
-                body = body.rstrip(')\'"` ').rstrip()
+                body_parts: List[str] = [m.group("body").rstrip().rstrip(')\'"` ').rstrip()]
+                # Pull in continuation string fragments to capture resolver
+                # patterns split across f-string concatenation.
+                for j in range(idx + 1, min(idx + 1 + _HINT_BLOCK_LOOKAHEAD, len(lines))):
+                    nxt = lines[j]
+                    if "Fix:" in nxt or "Bypass:" in nxt:
+                        break
+                    if not _is_string_continuation(nxt):
+                        break
+                    body_parts.append(nxt.strip().strip(')\'"` ').strip())
+                body = "\n".join(p for p in body_parts if p)
                 if not body:
                     continue
                 out.append(

--- a/src/atdd/coach/validators/test_issue_advancement.py
+++ b/src/atdd/coach/validators/test_issue_advancement.py
@@ -95,7 +95,10 @@ def scan_issue_advancement(repo_root: Path) -> Tuple[int, Sequence]:
                 f"PR #{pr_number} merged ({merged_at}) but linked issue "
                 f"#{issue_number} is still at {phase} — expected phase "
                 f"advancement after merge. "
-                f"Fix: atdd issue {issue_number} --status <next-phase>"
+                f"Fix: atdd issue {issue_number} --status <next-phase> "
+                f'(e.g. "REFACTOR" or "COMPLETE"; '
+                f"see CLAUDE.md::state_machine.transitions for the valid "
+                f"transitions out of {phase})."
             )
             logging.getLogger(__name__).warning(
                 "SPEC-COACH-PRGATE-0003: PR #%d merged but issue #%d "

--- a/src/atdd/coach/validators/test_issue_validation.py
+++ b/src/atdd/coach/validators/test_issue_validation.py
@@ -125,7 +125,9 @@ def test_issues_have_train_field(github_issues, github_project_fields, github_pr
 
     assert not violations, (
         f"\nIssues past PLANNED must have a valid Train field (not TBD, not blank).\n"
-        f"Fix: Run `atdd update <issue_number> --train <train_id>`\n\n"
+        f"Fix: Run `atdd issue <issue_number> --train <train_id>` "
+        f'(e.g. "atdd issue 467 --train 0001-self-compliance-validate"; '
+        f"see plan/_trains.yaml::trains[].id for valid train ids).\n\n"
         f"Violations ({len(violations)}):\n  " + "\n  ".join(violations)
     )
 

--- a/src/atdd/coach/validators/tests/test_fix_hint_completeness_helpers.py
+++ b/src/atdd/coach/validators/tests/test_fix_hint_completeness_helpers.py
@@ -1,0 +1,190 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_fix_hint_completeness_helpers:backend:domain
+# Runtime: python
+# Purpose: Unit tests for the fix-hint completeness contract helpers (issue #467).
+
+"""Helper-level coverage for the C1/C2/C3 audits and discovery utilities
+implemented in ``test_fix_hint_completeness.py``.
+
+The validator's main test exercises end-to-end behavior on the toolkit's
+own tree; these helpers cover the pure-function building blocks with at
+least one positive + one negative fixture per clause.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.validators.test_fix_hint_completeness import (
+    audit_c1_placeholder_resolution,
+    audit_c2_no_deprecation_contradiction,
+    build_deprecation_registry,
+    load_negative_exemplars,
+)
+
+
+# ---------------------------------------------------------------------------
+# C1 — placeholder resolution
+# ---------------------------------------------------------------------------
+class TestC1PlaceholderResolution:
+    def test_no_placeholder_passes(self):
+        assert audit_c1_placeholder_resolution(
+            "Either fix the underlying violation or extend UNTIL= past today."
+        ) == []
+
+    def test_pipe_enumeration_resolves(self):
+        # `<a|b|c>` carries its own value space.
+        assert audit_c1_placeholder_resolution(
+            "Add `disposition: <strict|suppress-and-clean|advisory>` to the rule."
+        ) == []
+
+    def test_function_call_context_resolves(self):
+        # `bind_rule(<id>)` — placeholder inside parens of a call.
+        assert audit_c1_placeholder_resolution(
+            "Call bind_rule(<id>) at module-import time."
+        ) == []
+
+    def test_quoted_form_resolves(self):
+        # `'<module>::<func>'` — placeholder inside single quotes.
+        unresolved = audit_c1_placeholder_resolution(
+            "Set validator: '<module>::<func>' on the rule."
+        )
+        assert unresolved == []
+
+    def test_schema_descriptor_after_colon_resolves(self):
+        # `key: <value>` — schema-descriptor pattern.
+        assert audit_c1_placeholder_resolution(
+            "signal.metric: <name> with signal.threshold: <value>"
+        ) == []
+
+    def test_path_template_continuation_resolves(self):
+        # `<repo>/.atdd/...` — path-template continuation.
+        assert audit_c1_placeholder_resolution(
+            "Add the implementation in <repo>/.atdd/metrics/<name>.py"
+        ) == []
+
+    def test_explicit_resolver_line_resolves_anywhere(self):
+        # Even a "loose" placeholder is resolved when an `e.g. "..."` line
+        # is present in the same hint block.
+        text = textwrap.dedent(
+            """\
+            Run the new validator with --train <train_id>.
+            e.g. "0001-self-compliance-validate"
+            """
+        )
+        assert audit_c1_placeholder_resolution(text) == []
+
+    def test_bare_cli_arg_placeholder_fails(self):
+        # Negative exemplar (issue #466 shape): `<train_id>` after a flag
+        # with no resolver line.
+        unresolved = audit_c1_placeholder_resolution(
+            "atdd update <issue_id> --status <status> --train <train_id>"
+        )
+        assert "train_id" in unresolved
+        assert "issue_id" in unresolved
+        assert "status" in unresolved
+
+    def test_multiple_unresolved_placeholders_all_reported(self):
+        unresolved = audit_c1_placeholder_resolution(
+            "atdd run <foo> --opt <bar>"
+        )
+        assert sorted(unresolved) == ["bar", "foo"]
+
+
+# ---------------------------------------------------------------------------
+# C2 — no deprecation contradiction
+# ---------------------------------------------------------------------------
+class TestC2DeprecationContradiction:
+    REGISTRY = {
+        "atdd update": "atdd issue <N> --status <S>",
+        "atdd new": "atdd issue <slug>",
+    }
+
+    def test_canonical_form_passes(self):
+        # `atdd issue` is the canonical replacement, not deprecated.
+        assert (
+            audit_c2_no_deprecation_contradiction(
+                "atdd issue 467 --status RED", self.REGISTRY
+            )
+            is None
+        )
+
+    def test_unknown_command_passes(self):
+        # `atdd validate` not in registry → not deprecated.
+        assert (
+            audit_c2_no_deprecation_contradiction(
+                "Run: atdd validate coach", self.REGISTRY
+            )
+            is None
+        )
+
+    def test_no_atdd_command_passes(self):
+        # Fix line that doesn't reference an `atdd` subcommand at all.
+        assert (
+            audit_c2_no_deprecation_contradiction(
+                "git fetch origin main && git rebase origin/main",
+                self.REGISTRY,
+            )
+            is None
+        )
+
+    def test_deprecated_form_fails(self):
+        # Negative exemplar (#466 shape): `atdd update` is deprecated.
+        result = audit_c2_no_deprecation_contradiction(
+            "atdd update {issue_id} --status {status} --train <train_id>",
+            self.REGISTRY,
+        )
+        assert result is not None
+        head, canonical = result
+        assert head == "atdd update"
+        assert "atdd issue" in canonical
+
+
+class TestDeprecationRegistryParse:
+    def test_parses_callsites_from_source(self):
+        source = textwrap.dedent(
+            """
+            def something():
+                _deprecation_warning("atdd update <N> --status <S>", "atdd issue <N> --status <S>")
+                _deprecation_warning("atdd archive <N>", "atdd issue <N> --status COMPLETE")
+            """
+        )
+        registry = build_deprecation_registry(cli_source=source)
+        assert registry.get("atdd update") == "atdd issue <N> --status <S>"
+        assert registry.get("atdd archive") == "atdd issue <N> --status COMPLETE"
+
+    def test_handles_empty_source(self):
+        assert build_deprecation_registry(cli_source="") == {}
+
+
+# ---------------------------------------------------------------------------
+# Negative-exemplar parser
+# ---------------------------------------------------------------------------
+class TestNegativeExemplarLoader:
+    def test_loads_owner_issue_and_line_range(self, tmp_path: Path):
+        convention = tmp_path / "rule-id.convention.yaml"
+        convention.write_text(
+            textwrap.dedent(
+                """\
+                fix_hint_exemplars:
+                  negative:
+                    - source: "src/atdd/coach/commands/issue.py:1682-1684"
+                      owner_issue: 466
+                      why_fail: "bare placeholder + deprecated form"
+                """
+            )
+        )
+        out = load_negative_exemplars(convention)
+        assert len(out) == 1
+        path, start, end, owner = out[0]
+        assert path == "src/atdd/coach/commands/issue.py"
+        assert start == 1682
+        assert end == 1684
+        assert owner == 466
+
+    def test_missing_block_returns_empty(self, tmp_path: Path):
+        convention = tmp_path / "rule-id.convention.yaml"
+        convention.write_text("schema_version: '1.0.0'\n")
+        assert load_negative_exemplars(convention) == []


### PR DESCRIPTION
Closes #467

## Summary

Introduces a meta-validator that audits every `fix_hint:` (in conventions) and `Fix: …` print (in CLI commands + validators) against a 4-clause completeness contract (C1-C4). Defective hints — like the one #466 fixes — fail CI before shipping.

Convention coherence preserved: this PR **extends** `src/atdd/coach/conventions/rule-id.convention.yaml`; **no new convention file** is created. The 4 existing `coach.rule-id.*` rules and the `RuleMetadata` substrate (#407) are **untouched**.

## Phases

### Phase 1 — Convention extension (`9087362`)

- `rule_schema.fields.fix_hint`:
  - `description:` extended with the C1-C4 narrative (placeholder resolution / no deprecation contradiction / prerequisite disclosure / runnable as printed).
  - sibling `completeness_contract:` block carries the machine-readable form the validator parses.
- New 5th rule under `rules:`: `coach.rule-id.fix-hint-completeness` (severity 2, strict, introduced_in 3.8.0). Its own `fix_hint` satisfies C1-C4 (eats own dogfood).
- New `fix_hint_exemplars:` block (positive: `acceptance-violation.convention.yaml:15-100`, the COMPLETE-walkthrough hint observed 2026-05-07; negative: `commands/issue.py:1682-1684`, owner_issue 466).

### Phase 2 — Validator + helper unit tests (`3e9277b`)

- `src/atdd/coach/validators/test_fix_hint_completeness.py`:
  - Discovers fix_hint values via `extract_rules()` over every `*.convention.yaml`.
  - Greps `Fix:` literals under `src/atdd/{coach,coder,planner,tester}/{commands,validators}/`, extending each Fix-line through up to 6 string-continuation lines (so resolver patterns split across f-string concatenation are captured).
  - Audits **C1** (placeholder resolution) and **C2** (no deprecation contradiction). C1 handles pipe-enums, function-call / quoted / schema-descriptor / bullet contexts, and path / qualified-name continuation; falls back to whole-hint resolver-pattern detection.
  - Builds the deprecation registry by parsing `_deprecation_warning(old, new)` callsites from `src/atdd/cli.py`.
  - Skips known-defective sites listed under `fix_hint_exemplars.negative` (each carries `owner_issue`) — the gate flips green automatically when the owning issue's surgical fix lands and the exemplar entry is removed.
  - Calls `bind_rule(\"coach.rule-id.fix-hint-completeness\")` at module-import time per the substrate.
- `src/atdd/coach/validators/tests/test_fix_hint_completeness_helpers.py` — 17 unit tests: 9 C1, 4 C2, 2 deprecation-registry parse, 2 negative-exemplar loader. Each clause has at least 1 positive + 1 negative fixture.

### Phase 3 — Self-compliance regression (`ce5ccd4`)

Validator run against the toolkit's own tree surfaced 2 real defective hints (in addition to the #466-owned negative exemplar):

| Site | Defects | Action |
|------|---------|--------|
| `src/atdd/coach/validators/test_issue_validation.py:128` | C1 (`<issue_number>`, `<train_id>` bare) + C2 (`atdd update` deprecated) | **Fixed inline** — canonical form + `e.g.` resolver + `see plan/_trains.yaml::trains[].id` pointer |
| `src/atdd/coach/validators/test_issue_advancement.py:98` | C1 (`<next-phase>` bare) | **Fixed inline** — `e.g. \"REFACTOR\" / \"COMPLETE\"` + `see CLAUDE.md::state_machine.transitions` pointer |
| `src/atdd/coach/commands/issue.py:1682-1684` | C1 (`<train_id>` bare) + C2 (`atdd update` deprecated) | **Pinned to #466** via `fix_hint_exemplars.negative`; gate flips green automatically when #466's surgical fix lands and the exemplar entry is removed |

The 4 existing `coach.rule-id.*` fix_hints were verified compliant — no rewrite per Decision row 8 of issue body. C4 sandbox-smoke deferred to a follow-up issue (Phase 3 deliverable in issue body marks it OPTIONAL).

## Coherence assertions

- ✅ **No new convention file created.** `rule-id.convention.yaml` is the single home for the contract; the meta-validator parses it directly.
- ✅ **4 existing `coach.rule-id.*` rules untouched and still pass** their own validators (`test_rule_validator_binding`, `test_rule_id_uniqueness`, `test_rule_disposition_required`).
- ✅ **`#407` `RuleMetadata` substrate untouched.** New validator imports `bind_rule` / `extract_rules` / `find_convention_files` and uses them as-is.
- ✅ **Reverse coherence** — `test_rule_validator_binding::test_every_enforced_rule_has_real_validator` picks up the new rule automatically.
- ✅ **Eat-own-dogfood** — the new rule's own `fix_hint` satisfies C1-C4 (validator's strict run on the toolkit tree exits clean; the rule appears in the run; no Violation for its own hint).

## Version

3.7.7 → **3.8.0** (MINOR, feat-class — new validator + new rule).

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('src/atdd/coach/conventions/rule-id.convention.yaml'))\"` — YAML still parses (5 rules, fix_hint_exemplars block).
- [x] `pytest src/atdd/coach/validators/test_fix_hint_completeness.py -v` — PASS.
- [x] `pytest src/atdd/coach/validators/tests/test_fix_hint_completeness_helpers.py -v` — 17/17 PASS.
- [x] `pytest src/atdd/coach/validators/test_rule_validator_binding.py -v` — PASS (new rule resolves).
- [x] `pytest src/atdd/coach/validators/test_rule_id_uniqueness.py src/atdd/coach/validators/test_rule_disposition_required.py -v` — PASS.
- [x] No regressions in coach validator suite (the 2 unrelated failures in `test_open_issue_compliance` and `test_required_label_set` reference labels on parallel issues #470/#467/#466/#462/#326 and are pre-existing — not caused by this PR).