### PR TITLE
feat(coach): #470 — canonical session/tab naming + grid layout placement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.9.0"
+version = "3.10.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/babysit.py
+++ b/src/atdd/coach/commands/babysit.py
@@ -30,6 +30,13 @@ from atdd.coach.utils.multiplexer import (
     MultiplexerError,
     get_multiplexer,
 )
+from atdd.coach.utils.session_naming import (
+    branch_to_slug,
+    compute_canonical_name,
+    compute_repo_short_name,
+    is_canonical_name,
+    target_grid_label,
+)
 
 
 # =============================================================================
@@ -359,6 +366,143 @@ def detect_violation(screen: str) -> Optional[BabysitDecision]:
             reason="transition to REFACTOR without passing through SMOKE",
         )
     return None
+
+
+# =============================================================================
+# Session-naming + layout drift correction (issue #470)
+# =============================================================================
+# Both passes are idempotent: a rename/layout call only fires when drift is
+# detected. Already-canonical names + already-conforming layouts are cheap
+# no-ops. The applied-name cache lives for the lifetime of one babysit run
+# and is keyed by surface ref; first-tick observation populates it from
+# `.atdd/orchestrate-state.json`.
+
+
+def _expected_canonical_name(
+    issue_number: int,
+    canonical_hint: str,
+    config: Optional[Dict] = None,
+) -> str:
+    """Resolve the expected canonical name for an issue.
+
+    Prefers the hint persisted by ``atdd orchestrate`` (when present in
+    ``orchestrate-state.json::canonical_name``); otherwise computes from
+    issue number + branch slug (best-effort, since the worktree ref does
+    not always carry branch info).
+    """
+    if canonical_hint and is_canonical_name(canonical_hint):
+        return canonical_hint
+    repo_short = compute_repo_short_name(config or {})
+    return compute_canonical_name(repo_short, issue_number, f"issue-{issue_number}")
+
+
+def correct_naming_drift(
+    backend: MultiplexerBackend,
+    ref: str,
+    expected_name: str,
+    applied_cache: Dict[str, str],
+    *,
+    log_path: Path,
+) -> bool:
+    """Re-apply the canonical name to ``ref`` when drift is detected.
+
+    Idempotent — once we've applied ``expected_name`` to ``ref`` in this
+    run, subsequent ticks short-circuit. Returns True when a rename was
+    actually issued (drift corrected); False when already canonical.
+    Issue #470 — coach.orchestration.canonical-session-name.
+    """
+    if not expected_name:
+        return False
+    if applied_cache.get(ref) == expected_name:
+        return False
+    try:
+        backend.rename(ref, expected_name)
+        backend.send(ref, f"/rename {expected_name}\n")
+    except MultiplexerError as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-31
+        # Best-effort: log + retry next tick.
+        log_event(
+            {
+                "event": "session_rename_failed",
+                "workspace": ref,
+                "expected": expected_name,
+                "error": str(exc),
+            },
+            path=log_path,
+        )
+        return False
+    applied_cache[ref] = expected_name
+    log_event(
+        {
+            "event": "session_renamed",
+            "workspace": ref,
+            "to": expected_name,
+            "rule_id": "coach.orchestration.canonical-session-name",
+        },
+        path=log_path,
+    )
+    print(
+        f"::notice::babysit auto-renamed {ref} → {expected_name} "
+        f"(coach.orchestration.canonical-session-name)"
+    )
+    return True
+
+
+def correct_layout_drift(
+    surface_count: int,
+    layout_cache: Dict[str, str],
+    *,
+    log_path: Path,
+) -> bool:
+    """Announce the target grid label when surface_count crosses a threshold.
+
+    Layout rebalancing across cmux panes is the multiplexer's job; this
+    helper logs the expected layout per Decision row 13 (drift-detection
+    only — no per-tick shuffles). Returns True when the announcement was
+    new this run; False when the layout band is unchanged.
+    """
+    target = target_grid_label(surface_count)
+    if layout_cache.get("last_target") == target:
+        return False
+    layout_cache["last_target"] = target
+    log_event(
+        {
+            "event": "layout_target",
+            "surface_count": surface_count,
+            "target": target,
+            "rule_id": "coach.orchestration.layout-conformance",
+        },
+        path=log_path,
+    )
+    print(
+        f"::notice::babysit layout target ({surface_count} surface[s]): {target} "
+        f"(coach.orchestration.layout-conformance)"
+    )
+    return True
+
+
+def _load_canonical_hints(
+    orchestrate_state_path: Path,
+) -> Dict[str, Tuple[int, str]]:
+    """Read ``ref → (issue_number, canonical_name)`` from orchestrate state."""
+    if not orchestrate_state_path.is_file():
+        return {}
+    try:
+        data = json.loads(orchestrate_state_path.read_text())
+    except (OSError, json.JSONDecodeError):  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-31
+        return {}
+    out: Dict[str, Tuple[int, str]] = {}
+    for key, entry in (data or {}).items():
+        if not isinstance(entry, dict):
+            continue
+        ref = entry.get("ref") or entry.get("workspace_ref") or ""
+        if not ref:
+            continue
+        try:
+            issue_num = int(key)
+        except (TypeError, ValueError):
+            continue
+        out[ref] = (issue_num, entry.get("canonical_name") or "")
+    return out
 
 
 # =============================================================================
@@ -822,7 +966,37 @@ def run(
     phase_cache: Dict[int, str] = {}
     phase_cache_ts: float = 0.0
 
+    # Issue #470: drift-correction caches. Keys are surface refs; values are
+    # the last-applied canonical name. Idempotency contract: a rename only
+    # fires when the cache entry differs from the expected name.
+    name_applied_cache: Dict[str, str] = {}
+    layout_cache: Dict[str, str] = {}
+    canonical_hints = _load_canonical_hints(orchestrate_state_path)
+
     while True:
+        # Issue #470 — paired naming + layout pass. Idempotent: only fires
+        # on drift. Scoped to the workspaces babysit is already monitoring,
+        # so other cmux surfaces (operator shell, unrelated worktrees) are
+        # untouched.
+        for ref in states:
+            hint = canonical_hints.get(ref)
+            if hint is None:
+                continue
+            issue_num, hint_name = hint
+            expected = _expected_canonical_name(issue_num, hint_name)
+            correct_naming_drift(
+                backend=backend,
+                ref=ref,
+                expected_name=expected,
+                applied_cache=name_applied_cache,
+                log_path=log_path,
+            )
+        correct_layout_drift(
+            surface_count=len(states),
+            layout_cache=layout_cache,
+            log_path=log_path,
+        )
+
         for ref, st in states.items():
             decision = process_workspace(
                 backend, st, stale_warn, stale_escalate,

--- a/src/atdd/coach/commands/orchestrate.py
+++ b/src/atdd/coach/commands/orchestrate.py
@@ -25,10 +25,17 @@ from atdd.coach.commands.session_template import (
     fetch_issue,
     render,
 )
+from atdd.coach.utils.config import load_atdd_config
 from atdd.coach.utils.multiplexer import (
     MultiplexerBackend,
     MultiplexerError,
     get_multiplexer,
+)
+from atdd.coach.utils.session_naming import (
+    branch_to_slug,
+    compute_canonical_name,
+    compute_repo_short_name,
+    target_grid_label,
 )
 
 
@@ -166,6 +173,39 @@ def print_plan(waves: list[list[int]], plan: dict[int, PlannedIssue]) -> None:
             print(f"    #{num:<5} {issue.branch:<40} deps={deps}")
 
 
+def apply_canonical_name_and_layout(
+    backend: MultiplexerBackend,
+    ref: str,
+    canonical_name: str,
+    surface_count: int,
+) -> None:
+    """Issue #470 dispatch-time pass: rename + announce target layout.
+
+    Two paired application passes:
+        1. NAMING — cmux rename-tab + ``/rename`` slash command into the session.
+        2. LAYOUT — log the target grid policy for the current surface count.
+
+    Both fail soft (``MultiplexerError`` swallowed) so a missing cmux verb
+    or unrenamable backend does not crash the orchestrate flow; babysit's
+    drift-detection re-applies on the next tick.
+    """
+    if not canonical_name:
+        return
+    try:
+        backend.rename(ref, canonical_name)
+    except MultiplexerError:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-31
+        # Best-effort: babysit retries on the next tick.
+        pass
+    try:
+        # Slash-command rename inside the running Claude session so the
+        # in-conversation header matches the cmux tab.
+        backend.send(ref, f"/rename {canonical_name}\n")
+    except MultiplexerError:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-31
+        pass
+    layout = target_grid_label(surface_count)
+    print(f"   layout target ({surface_count} surface[s]): {layout}")
+
+
 def run(
     issue_numbers: list[int],
     autonomous: bool = False,
@@ -230,6 +270,10 @@ def run(
         print(f"❌ {exc}", file=sys.stderr)
         return 4
 
+    # Issue #470: resolve <REPO> short-name once for the whole run.
+    repo_short = compute_repo_short_name(load_atdd_config(repo_root))
+    launched_count = 0
+
     for num, issue in plan.items():
         key = str(num)
         if resume and state.get(key, {}).get("launched"):
@@ -256,18 +300,26 @@ def run(
             "claude --dangerously-skip-permissions "
             f"\"$(cat {script_path})\""
         )
+        # Issue #470: derive the canonical session name from <REPO><N>-<slug>.
+        slug = branch_to_slug(issue.branch) or f"issue-{num}"
+        canonical_name = compute_canonical_name(repo_short, num, slug)
+
         try:
             if multiplexer_mode == "pane":
+                # Right-anchored grid layout: new surfaces open to the right
+                # of the operator's shell pane. The backend's noop default
+                # for legacy cmux builds keeps this safe.
                 ref = backend.new_surface(
                     cwd=issue.worktree_path,
                     command=launch_cmd,
-                    name=f"issue-{num}",
+                    name=canonical_name,
+                    direction="right",
                 )
             else:
                 ref = backend.new_workspace(
                     cwd=issue.worktree_path,
                     command=launch_cmd,
-                    name=f"issue-{num}",
+                    name=canonical_name,
                 )
         except (MultiplexerError, NotImplementedError) as exc:
             print(f"⚠️  failed to launch session for #{num}: {exc}", file=sys.stderr)
@@ -279,9 +331,18 @@ def run(
             "launched": True,
             "ref": ref,
             "mode": multiplexer_mode,
+            "canonical_name": canonical_name,
         })
         save_state(state_path, state)
-        print(f"✓ launched #{num} in {ref}")
+        print(f"✓ launched #{num} in {ref} as {canonical_name}")
+
+        launched_count += 1
+        apply_canonical_name_and_layout(
+            backend=backend,
+            ref=ref,
+            canonical_name=canonical_name,
+            surface_count=launched_count,
+        )
 
     print(
         f"\nOrchestration complete. "

--- a/src/atdd/coach/commands/session_template.py
+++ b/src/atdd/coach/commands/session_template.py
@@ -31,6 +31,7 @@ class IssueContext:
     dependencies: list[str] = field(default_factory=list)
     grep_gates: list[str] = field(default_factory=list)
     worktree_path: str = ""
+    canonical_session_name: str = ""
     stop_condition: str = (
         "Stop at the REFACTOR boundary. Do not proceed past REFACTOR "
         "without user confirmation unless --autonomous was set."
@@ -149,18 +150,38 @@ def build_context(
     title: str = "",
     worktree_path: str = "",
 ) -> IssueContext:
+    from atdd.coach.utils.config import load_atdd_config
+    from atdd.coach.utils.repo import find_repo_root
+    from atdd.coach.utils.session_naming import (
+        branch_to_slug,
+        compute_canonical_name,
+        compute_repo_short_name,
+    )
+
     meta = parse_metadata(body)
     deps = parse_dependencies(body)
     gates = parse_grep_gates(body)
+    branch = meta.get("Branch", "TBD") or "TBD"
+    # Issue #470: precompute the canonical session name so the launch prompt
+    # can echo "your canonical name is X" — keeps the agent's self-rename
+    # aligned with the cmux tab even if the dispatch-time pass missed.
+    try:
+        config = load_atdd_config(find_repo_root())
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-31
+        config = {}
+    repo_short = compute_repo_short_name(config)
+    slug = branch_to_slug(branch) if branch != "TBD" else f"issue-{issue_number}"
+    canonical_name = compute_canonical_name(repo_short, issue_number, slug or f"issue-{issue_number}")
     return IssueContext(
         number=issue_number,
         title=title or meta.get("Feature", ""),
-        branch=meta.get("Branch", "TBD") or "TBD",
+        branch=branch,
         train=meta.get("Train", "TBD") or "TBD",
         feature=meta.get("Feature", ""),
         dependencies=deps,
         grep_gates=gates,
         worktree_path=worktree_path or f"../{meta.get('Branch', '').replace('/', '-')}",
+        canonical_session_name=canonical_name,
     )
 
 
@@ -188,6 +209,7 @@ def render(context: IssueContext, template_path: Path = TEMPLATE_PATH) -> str:
         "{{grep_gates}}": gates_block,
         "{{stop_condition}}": context.stop_condition,
         "{{worktree_path}}": context.worktree_path,
+        "{{canonical_session_name}}": context.canonical_session_name,
     }
     rendered = template
     for key, value in substitutions.items():

--- a/src/atdd/coach/commands/tests/test_orchestrate.py
+++ b/src/atdd/coach/commands/tests/test_orchestrate.py
@@ -171,6 +171,8 @@ class _FakeBackend:
     def __init__(self):
         self.workspace_calls: list[dict] = []
         self.surface_calls: list[dict] = []
+        self.rename_calls: list[dict] = []
+        self.send_calls: list[dict] = []
         self._wcounter = 0
         self._scounter = 0
 
@@ -179,7 +181,15 @@ class _FakeBackend:
         self.workspace_calls.append({"cwd": cwd, "command": command, "name": name})
         return f"workspace:{self._wcounter}"
 
-    def new_surface(self, workspace_ref=None, pane_ref=None, cwd=None, command=None, name=None):
+    def new_surface(
+        self,
+        workspace_ref=None,
+        pane_ref=None,
+        cwd=None,
+        command=None,
+        name=None,
+        direction=None,
+    ):
         self._scounter += 1
         self.surface_calls.append({
             "workspace_ref": workspace_ref,
@@ -187,8 +197,17 @@ class _FakeBackend:
             "cwd": cwd,
             "command": command,
             "name": name,
+            "direction": direction,
         })
         return f"surface:{self._scounter}"
+
+    def rename(self, ref, name):
+        # Issue #470: capture the rename pass for assertions; no-op behavior.
+        self.rename_calls.append({"ref": ref, "name": name})
+
+    def send(self, ref, text):
+        # Capture /rename slash-command sends from the dispatch-time pass.
+        self.send_calls.append({"ref": ref, "text": text})
 
 
 def _wire_run_orchestrate(tmp_path, backend, plan: dict[int, PlannedIssue]):

--- a/src/atdd/coach/conventions/orchestration.convention.yaml
+++ b/src/atdd/coach/conventions/orchestration.convention.yaml
@@ -156,9 +156,9 @@ session_naming:
       introduced_in: "3.10.0"
       validator: "test_orchestration_session_naming::test_active_session_names_canonical"
       fix_hint: |
-        Rename the surface to the canonical form, e.g.
-        cmux rename-tab --surface <surface-ref> 'ATDD<N>-<slug>'
-        and inside the session: /rename ATDD<N>-<slug>
+        Rename the surface to the canonical form.
+        e.g. "cmux rename-tab --surface surface:42 'ATDD470-canonical-session-naming'"
+        e.g. "/rename ATDD470-canonical-session-naming"
         (or run `atdd babysit` once to auto-correct drift).
 
 layout_placement:
@@ -195,8 +195,9 @@ layout_placement:
       validator: "test_orchestration_session_naming::test_workspace_layout_conforms"
       fix_hint: |
         Move impl-agent surfaces to the right region; keep the operator's
-        shell as the leftmost pane. Run `atdd babysit` to auto-correct,
-        or manually: cmux move-surface --surface <ref> --direction right.
+        shell as the leftmost pane.
+        (run `atdd babysit` to auto-correct)
+        e.g. "cmux move-surface --surface surface:42 --direction right"
 
 # =============================================================================
 # Prompt approval policy (babysit)

--- a/src/atdd/coach/conventions/orchestration.convention.yaml
+++ b/src/atdd/coach/conventions/orchestration.convention.yaml
@@ -107,6 +107,98 @@ rules:
     response: "Worker SHOULD run `/compact` and optionally `/clear` followed by `atdd session-template <N> --from-checkpoint` to resume from the last checkpoint."
 
 # =============================================================================
+# Session naming + layout placement (issue #470)
+# =============================================================================
+# When `atdd orchestrate <N>` dispatches a parallel session, BOTH the cmux
+# tab title AND the Claude session header are set to the canonical format
+# below. `atdd babysit` re-applies on every tick with drift-detection only —
+# already-canonical names + already-conforming layouts are no-ops.
+#
+# Naming and layout are PAIRED application passes — see `trigger_semantics`
+# blocks below for the orchestrate-vs-babysit cadence contract.
+
+session_naming:
+  description: |
+    Canonical human-readable name for parallel ATDD sessions. Applied to
+    cmux tab titles AND Claude session headers so a glance at either
+    surface reveals which issue the session belongs to.
+  format: "<REPO><N>[-phase<M>]-<slug>"
+  regex: '^([A-Z]{2,8})(\d+)(-phase\d+)?-([a-z0-9]+(-[a-z0-9]+)*)$'
+  components:
+    repo: "Uppercase short-name from .atdd/config.yaml::repo.short_name (default: last hyphen-segment of repo field, uppercased)"
+    issue_number: "GitHub issue number; no separator from <REPO>"
+    phase: "Optional -phase<M> infix for multi-PR issues (M >= 1)"
+    slug: "Branch slug or maintainer override (--session-slug); lowercase, hyphenated; <= 40 chars"
+  application_points:
+    cmux: "cmux rename-tab --surface <ref> '<name>'"
+    claude: "send '/rename <name>' to the Claude session"
+  trigger_semantics:
+    orchestrate: "Once at dispatch time — both passes (naming + layout) fire after the surface boots"
+    babysit: "Every tick; drift-detection only — already-canonical names are no-ops (idempotent)"
+  exemplars:
+    - "ATDD459-ast-detector-done"
+    - "ATDD462-phase1-softprops-done"
+    - "ATDD462-phase2-bump-on-merge"
+    - "ATDD466-train-hint-fix"
+    - "ATDD467-hint-completeness"
+  rationale: |
+    Auto-summary names obscure issue identity; the cmux tab and Claude
+    session can drift apart under default behavior. Canonical names
+    make the cmux→Claude→issue mapping a constant-time string parse
+    (`re.match(r'^([A-Z]+)(\d+)(?:-phase(\d+))?-(.+)$', tab_name)`).
+    See issue #470.
+  rules:
+    - id: "coach.orchestration.canonical-session-name"
+      aliases: ["COACH-ORCH-NAMING-0001"]
+      severity: 3
+      disposition: advisory
+      description: "Active ATDD session names match <REPO><N>[-phase<M>]-<slug>"
+      introduced_in: "3.10.0"
+      validator: "test_orchestration_session_naming::test_active_session_names_canonical"
+      fix_hint: |
+        Rename the surface to the canonical form, e.g.
+        cmux rename-tab --surface <surface-ref> 'ATDD<N>-<slug>'
+        and inside the session: /rename ATDD<N>-<slug>
+        (or run `atdd babysit` once to auto-correct drift).
+
+layout_placement:
+  description: |
+    New parallel sessions open on the RIGHT of the operator's shell pane
+    in the ATDD workspace, arranged in a grid that scales with surface
+    count. The operator's shell stays in the leftmost pane and is never
+    resplit by `atdd orchestrate`.
+  policy:
+    "0": "shell-only (left pane)"
+    "1": "shell (left) + 1 surface (right)"
+    "2": "shell (left) + 2 surfaces stacked vertically (right)"
+    "3-4": "shell (left) + 2x2 grid (right region)"
+    "5-6": "shell (left) + 2x3 grid (right region)"
+    "7+": "shell (left) + dense column grid (3+ columns x N rows)"
+  application_points:
+    orchestrate: "cmux new-pane --direction right --workspace workspace:1; rebalance via move-surface ops per the policy table"
+    babysit: "detect non-conforming layouts; auto-correct by moving impl-agent surfaces to the right region; idempotent"
+  trigger_semantics:
+    orchestrate: "Once at dispatch time — paired with the naming pass"
+    babysit: "Every tick; drift-detection only — already-conforming layouts are no-ops"
+  rationale: |
+    Glance-able layout: all parallel agents visible at once without
+    tab-clicking. Right-anchored grid preserves the operator's typing
+    pane on the left ("operator shell is sacred"). See issue #470,
+    decisions 8-13.
+  rules:
+    - id: "coach.orchestration.layout-conformance"
+      aliases: ["COACH-ORCH-LAYOUT-0001"]
+      severity: 2
+      disposition: advisory
+      description: "ATDD workspace surfaces follow the grid policy (shell left, agents right)"
+      introduced_in: "3.10.0"
+      validator: "test_orchestration_session_naming::test_workspace_layout_conforms"
+      fix_hint: |
+        Move impl-agent surfaces to the right region; keep the operator's
+        shell as the leftmost pane. Run `atdd babysit` to auto-correct,
+        or manually: cmux move-surface --surface <ref> --direction right.
+
+# =============================================================================
 # Prompt approval policy (babysit)
 # =============================================================================
 

--- a/src/atdd/coach/templates/SESSION-LAUNCH-TEMPLATE.md
+++ b/src/atdd/coach/templates/SESSION-LAUNCH-TEMPLATE.md
@@ -15,6 +15,7 @@ worktree at `{{worktree_path}}` on branch `{{branch}}`.
 - **Branch:** {{branch}}
 - **Train:** {{train}}
 - **Feature:** {{feature}}
+- **Canonical session name:** `{{canonical_session_name}}` (per orchestration.convention.yaml::session_naming — issue #470). The cmux tab and Claude session header should both match this; if they don't, run `/rename {{canonical_session_name}}` and the babysitter will reconcile the cmux side on the next tick.
 
 ## Dependencies
 

--- a/src/atdd/coach/utils/multiplexer.py
+++ b/src/atdd/coach/utils/multiplexer.py
@@ -86,6 +86,16 @@ class MultiplexerBackend(ABC):
     def close(self, ref: MultiplexerRef) -> None:
         """Close/kill the workspace or surface."""
 
+    def rename(self, ref: MultiplexerRef, name: str) -> None:
+        """Rename a workspace or surface to ``name``.
+
+        Default implementation is a no-op so backends without a rename
+        primitive (zellij, tmux) silently degrade instead of breaking
+        the orchestrate flow. Issue #470 — canonical session naming.
+        Override in cmux backend.
+        """
+        del ref, name
+
 
 def _run(cmd: list[str], capture: bool = True) -> subprocess.CompletedProcess:
     try:
@@ -161,11 +171,17 @@ class CmuxBackend(MultiplexerBackend):
         cwd: Optional[str] = None,
         command: Optional[str] = None,
         name: Optional[str] = None,
+        direction: Optional[str] = None,
     ) -> MultiplexerRef:
         if pane_ref is None:
             new_pane_cmd = ["cmux", "new-pane"]
             if workspace_ref:
                 new_pane_cmd.extend(["--workspace", workspace_ref])
+            if direction:
+                # Issue #470: right-anchored grid layout. cmux new-pane accepts
+                # --direction {right,left,up,down}; default behavior is preserved
+                # when callers don't pass it.
+                new_pane_cmd.extend(["--direction", direction])
             pane_result = _run(new_pane_cmd)
             pane_ref = _extract_ref_token(pane_result.stdout or "", "pane")
             if not pane_ref:
@@ -239,6 +255,31 @@ class CmuxBackend(MultiplexerBackend):
             _run(["cmux", "close-surface", "--surface", ref], capture=False)
             return
         _run(["cmux", "close-workspace", "--workspace", ref], capture=False)
+
+    def rename(self, ref: MultiplexerRef, name: str) -> None:
+        """Rename a cmux surface/workspace tab title (issue #470).
+
+        Best-effort: failures degrade silently so a missing/renamed cmux
+        rename verb does not crash orchestrate. Babysit will retry on
+        the next tick.
+        """
+        if not name:
+            return
+        try:
+            if _is_surface_ref(ref):
+                _run(
+                    ["cmux", "rename-tab", "--surface", ref, name],
+                    capture=False,
+                )
+            else:
+                _run(
+                    ["cmux", "rename-workspace", "--workspace", ref, name],
+                    capture=False,
+                )
+        except MultiplexerError:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-31
+            # Best-effort: cmux build may not expose rename verbs; the
+            # validator is advisory and babysit retries every tick.
+            pass
 
 
 class TmuxBackend(MultiplexerBackend):

--- a/src/atdd/coach/utils/session_naming.py
+++ b/src/atdd/coach/utils/session_naming.py
@@ -1,0 +1,181 @@
+# URN: component:govern-lifecycle:enforcement-substrate:session_naming:backend:domain
+# Runtime: python
+# Purpose: Compute + parse canonical ATDD session names (issue #470).
+
+"""Canonical session-name + layout-policy helpers (issue #470).
+
+Pure functions: compute the canonical ``<REPO><N>[-phase<M>]-<slug>`` name
+from issue + branch metadata, parse a name back into its components, and
+look up the target grid label for a given surface count.
+
+These helpers are reused by:
+
+    * ``atdd orchestrate``      — dispatch-time naming + layout pass
+    * ``atdd session-template`` — inlines the canonical name in the launch prompt
+    * ``atdd babysit``          — drift detection + auto-correct on every tick
+    * the ``test_orchestration_session_naming`` validator (phase 3)
+
+Single source of truth for the regex is ``orchestration.convention.yaml::
+session_naming.regex`` — this module mirrors it with a tested helper but
+the convention is authoritative.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+# Canonical format regex. Mirrored from orchestration.convention.yaml::
+# session_naming.regex; the validator asserts the two stay in sync.
+CANONICAL_NAME_REGEX = re.compile(
+    r"^([A-Z]{2,8})(\d+)(-phase\d+)?-([a-z0-9]+(?:-[a-z0-9]+)*)$"
+)
+
+_BRANCH_PREFIXES: tuple[str, ...] = (
+    "feat/",
+    "fix/",
+    "refactor/",
+    "chore/",
+    "docs/",
+    "devops/",
+    "test/",
+)
+
+
+@dataclass(frozen=True)
+class ParsedName:
+    repo: str
+    issue: int
+    phase: Optional[int]
+    slug: str
+
+
+def compute_repo_short_name(config: Optional[Dict[str, Any]]) -> str:
+    """Resolve the ``<REPO>`` token from ``.atdd/config.yaml``.
+
+    Precedence (Decision row 1 of issue #470):
+
+        1. ``repo.short_name`` if set (uppercased verbatim).
+        2. Last hyphen-segment of ``github.repo`` (e.g. ``afokapu/atdd`` →
+           ``ATDD``), uppercased.
+        3. Fallback ``REPO`` so callers always get a non-empty token.
+    """
+    if not isinstance(config, dict):
+        return "REPO"
+    repo_block = config.get("repo")
+    if isinstance(repo_block, dict):
+        explicit = repo_block.get("short_name")
+        if isinstance(explicit, str) and explicit.strip():
+            return explicit.strip().upper()
+    github_block = config.get("github") or {}
+    repo_field = github_block.get("repo") if isinstance(github_block, dict) else None
+    if isinstance(repo_field, str) and repo_field.strip():
+        last = repo_field.rsplit("/", 1)[-1].rsplit("-", 1)[-1]
+        if last:
+            return last.upper()
+    return "REPO"
+
+
+def branch_to_slug(branch: str) -> str:
+    """Strip the conventional prefix (feat/, fix/, etc.) from a branch name."""
+    if not branch:
+        return ""
+    for prefix in _BRANCH_PREFIXES:
+        if branch.startswith(prefix):
+            return branch[len(prefix):]
+    if "/" in branch:
+        return branch.split("/", 1)[1]
+    return branch
+
+
+def truncate_slug(slug: str, max_len: int = 40) -> str:
+    """Truncate a slug at the last hyphen boundary <= max_len.
+
+    Decision row 7: prefer word-boundary truncation over mid-token cuts.
+    Returns the original slug when it already fits.
+    """
+    if len(slug) <= max_len:
+        return slug
+    head = slug[:max_len]
+    cut = head.rfind("-")
+    if cut > 0:
+        return head[:cut]
+    return head
+
+
+def compute_canonical_name(
+    repo: str,
+    issue_number: int,
+    slug: str,
+    phase: Optional[int] = None,
+) -> str:
+    """Build the canonical session name from its components.
+
+    >>> compute_canonical_name("ATDD", 470, "canonical-session-naming")
+    'ATDD470-canonical-session-naming'
+    >>> compute_canonical_name("ATDD", 462, "bump-on-merge", phase=2)
+    'ATDD462-phase2-bump-on-merge'
+    """
+    repo_token = (repo or "REPO").upper()
+    slug_token = truncate_slug((slug or "session").lower())
+    phase_token = f"-phase{phase}" if phase and phase >= 1 else ""
+    return f"{repo_token}{issue_number}{phase_token}-{slug_token}"
+
+
+def parse_canonical_name(name: str) -> Optional[ParsedName]:
+    """Parse a session name into ``(repo, issue, phase, slug)`` or None."""
+    if not isinstance(name, str):
+        return None
+    match = CANONICAL_NAME_REGEX.match(name.strip())
+    if not match:
+        return None
+    repo, issue, phase_marker, slug = match.group(1), match.group(2), match.group(3), match.group(4)
+    phase = int(phase_marker[len("-phase"):]) if phase_marker else None
+    return ParsedName(repo=repo, issue=int(issue), phase=phase, slug=slug)
+
+
+def is_canonical_name(name: str) -> bool:
+    """True when ``name`` matches the canonical regex."""
+    return parse_canonical_name(name) is not None
+
+
+# ---------------------------------------------------------------------------
+# Layout policy (issue #470, decisions 8-13)
+# ---------------------------------------------------------------------------
+
+
+def target_grid_label(active_surface_count: int) -> str:
+    """Return the human-readable target layout for ``active_surface_count``.
+
+    Mirrors ``orchestration.convention.yaml::layout_placement.policy``;
+    the value is purely informational (used by babysit's notice and the
+    validator's drift message). No actual cmux ops are issued from this
+    helper — placement is the multiplexer backend's responsibility.
+    """
+    n = max(0, int(active_surface_count))
+    if n == 0:
+        return "shell-only (left pane)"
+    if n == 1:
+        return "shell (left) + 1 surface (right)"
+    if n == 2:
+        return "shell (left) + 2 surfaces stacked vertically (right)"
+    if n <= 4:
+        return "shell (left) + 2x2 grid (right region)"
+    if n <= 6:
+        return "shell (left) + 2x3 grid (right region)"
+    return "shell (left) + dense column grid (3+ columns x N rows)"
+
+
+__all__ = [
+    "CANONICAL_NAME_REGEX",
+    "ParsedName",
+    "branch_to_slug",
+    "compute_canonical_name",
+    "compute_repo_short_name",
+    "is_canonical_name",
+    "parse_canonical_name",
+    "target_grid_label",
+    "truncate_slug",
+]

--- a/src/atdd/coach/utils/tests/test_session_naming.py
+++ b/src/atdd/coach/utils/tests/test_session_naming.py
@@ -1,0 +1,170 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_session_naming:backend:domain
+# Runtime: python
+# Purpose: Helper unit tests for canonical session-name + layout helpers (issue #470).
+
+"""Unit tests for ``atdd.coach.utils.session_naming``."""
+
+from __future__ import annotations
+
+import pytest
+
+from atdd.coach.utils.session_naming import (
+    CANONICAL_NAME_REGEX,
+    branch_to_slug,
+    compute_canonical_name,
+    compute_repo_short_name,
+    is_canonical_name,
+    parse_canonical_name,
+    target_grid_label,
+    truncate_slug,
+)
+
+
+pytestmark = [pytest.mark.coach]
+
+
+# ---------------------------------------------------------------------------
+# compute_canonical_name + parse_canonical_name round-trips
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "repo, issue, slug, phase, expected",
+    [
+        ("ATDD", 470, "canonical-session-naming", None, "ATDD470-canonical-session-naming"),
+        ("ATDD", 462, "bump-on-merge", 2, "ATDD462-phase2-bump-on-merge"),
+        ("JEL", 1, "x", None, "JEL1-x"),
+        ("ATDD", 467, "hint-completeness", None, "ATDD467-hint-completeness"),
+    ],
+)
+def test_compute_canonical_name(repo, issue, slug, phase, expected):
+    assert compute_canonical_name(repo, issue, slug, phase=phase) == expected
+
+
+@pytest.mark.parametrize(
+    "name, parts",
+    [
+        ("ATDD470-foo", ("ATDD", 470, None, "foo")),
+        ("ATDD462-phase2-bump-on-merge", ("ATDD", 462, 2, "bump-on-merge")),
+        ("JEL12-a-b-c", ("JEL", 12, None, "a-b-c")),
+    ],
+)
+def test_parse_canonical_name(name, parts):
+    parsed = parse_canonical_name(name)
+    assert parsed is not None
+    assert (parsed.repo, parsed.issue, parsed.phase, parsed.slug) == parts
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        "atdd470-foo",      # lowercase repo
+        "A470-foo",          # repo too short
+        "TOOLONGREPO470-foo",
+        "ATDD-foo",          # missing number
+        "ATDD470-Foo",       # uppercase in slug
+        "ATDD470-",          # empty slug
+    ],
+)
+def test_parse_rejects_non_canonical(name):
+    assert parse_canonical_name(name) is None
+    assert is_canonical_name(name) is False
+
+
+# ---------------------------------------------------------------------------
+# Regex coverage — the helper regex agrees with the convention's intent
+# ---------------------------------------------------------------------------
+def test_canonical_regex_anchored():
+    # Anchored at both ends — substring drift is rejected.
+    assert CANONICAL_NAME_REGEX.match("xATDD470-foo") is None
+    # Whitespace inside the slug is rejected (trailing space, internal space).
+    assert CANONICAL_NAME_REGEX.match("ATDD470-foo bar") is None
+    assert CANONICAL_NAME_REGEX.match("ATDD470-foo!") is None
+
+
+# ---------------------------------------------------------------------------
+# branch_to_slug
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "branch, expected",
+    [
+        ("feat/470-canonical-session-naming", "470-canonical-session-naming"),
+        ("fix/typo", "typo"),
+        ("refactor/four-layer", "four-layer"),
+        ("chore/cleanup", "cleanup"),
+        ("docs/readme", "readme"),
+        ("devops/release", "release"),
+        ("nameonly", "nameonly"),
+        ("", ""),
+    ],
+)
+def test_branch_to_slug(branch, expected):
+    assert branch_to_slug(branch) == expected
+
+
+# ---------------------------------------------------------------------------
+# compute_repo_short_name
+# ---------------------------------------------------------------------------
+def test_compute_repo_short_name_explicit_field():
+    config = {"repo": {"short_name": "atdd"}}
+    assert compute_repo_short_name(config) == "ATDD"
+
+
+def test_compute_repo_short_name_from_github_repo():
+    config = {"github": {"repo": "afokapu/atdd"}}
+    assert compute_repo_short_name(config) == "ATDD"
+
+
+def test_compute_repo_short_name_from_hyphenated_repo():
+    config = {"github": {"repo": "afokapu/jel-app"}}
+    assert compute_repo_short_name(config) == "APP"
+
+
+def test_compute_repo_short_name_fallback():
+    assert compute_repo_short_name({}) == "REPO"
+    assert compute_repo_short_name(None) == "REPO"
+
+
+# ---------------------------------------------------------------------------
+# truncate_slug
+# ---------------------------------------------------------------------------
+def test_truncate_slug_short():
+    assert truncate_slug("short-slug") == "short-slug"
+
+
+def test_truncate_slug_word_boundary():
+    long_slug = "a-very-long-slug-that-exceeds-the-forty-char-limit"
+    truncated = truncate_slug(long_slug)
+    assert len(truncated) <= 40
+    # Word-boundary truncation: result ends at a hyphen-bounded token
+    assert "-" in truncated
+    assert not truncated.endswith("-")
+
+
+def test_truncate_slug_no_hyphen():
+    # No hyphens → falls back to a hard cut.
+    assert truncate_slug("a" * 60) == "a" * 40
+
+
+# ---------------------------------------------------------------------------
+# target_grid_label
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "n, contains",
+    [
+        (0, "shell-only"),
+        (1, "1 surface"),
+        (2, "stacked vertically"),
+        (3, "2x2"),
+        (4, "2x2"),
+        (5, "2x3"),
+        (6, "2x3"),
+        (7, "dense column grid"),
+        (12, "dense column grid"),
+    ],
+)
+def test_target_grid_label(n, contains):
+    assert contains in target_grid_label(n)
+
+
+def test_target_grid_label_negative_clamps_to_zero():
+    assert "shell-only" in target_grid_label(-3)

--- a/src/atdd/coach/validators/test_orchestration_session_naming.py
+++ b/src/atdd/coach/validators/test_orchestration_session_naming.py
@@ -1,0 +1,326 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_orchestration_session_naming:backend:domain
+# Runtime: python
+# Purpose: Audit canonical session naming + layout placement (issue #470).
+
+"""Coach validator for canonical session naming + layout placement (issue #470).
+
+Enforces (advisory):
+
+    * ``coach.orchestration.canonical-session-name`` — every active ATDD
+      session name (cmux tab + Claude session) matches
+      ``<REPO><N>[-phase<M>]-<slug>``.
+    * ``coach.orchestration.layout-conformance`` — workspace surfaces
+      follow the right-of-shell grid policy in
+      ``orchestration.convention.yaml::layout_placement.policy``.
+
+The active-introspection branch (querying cmux for live workspaces and
+their tab titles) is **best-effort** — when cmux is not on PATH or the
+repo is being checked in CI, this validator skips the introspection
+half and only enforces convention-self-coherence (regex parses, every
+exemplar in the convention round-trips through the helper, layout
+policy covers all surface-count bands).
+
+Both rules are bound here via ``bind_rule`` so the reverse-coherence
+substrate (issue #399) resolves the convention's ``validator:`` field
+to this module.
+
+Run:
+    PYTHONPATH=src python3 -m pytest -q \
+        src/atdd/coach/validators/test_orchestration_session_naming.py -v
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import pytest
+import yaml
+
+import atdd
+from atdd.coach.utils.rule_binding import bind_rule
+from atdd.coach.utils.session_naming import (
+    CANONICAL_NAME_REGEX,
+    compute_canonical_name,
+    is_canonical_name,
+    parse_canonical_name,
+    target_grid_label,
+)
+from atdd.coach.validators._violation import Violation
+
+
+pytestmark = [pytest.mark.coach]
+
+
+_RULE_NAME = bind_rule("coach.orchestration.canonical-session-name")
+_RULE_LAYOUT = bind_rule("coach.orchestration.layout-conformance")
+
+
+_ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+_ORCHESTRATION_CONVENTION = (
+    _ATDD_PKG_DIR / "coach" / "conventions" / "orchestration.convention.yaml"
+)
+
+
+# ---------------------------------------------------------------------------
+# Convention loaders
+# ---------------------------------------------------------------------------
+def _load_convention() -> Dict:
+    if _ORCHESTRATION_CONVENTION.is_file():
+        path = _ORCHESTRATION_CONVENTION
+    else:
+        from atdd.coach.utils.repo import find_repo_root
+        path = (
+            find_repo_root()
+            / "src" / "atdd" / "coach" / "conventions"
+            / "orchestration.convention.yaml"
+        )
+        if not path.is_file():
+            pytest.fail(f"orchestration convention missing at {_ORCHESTRATION_CONVENTION}")
+    with open(path) as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _session_naming_block() -> Dict:
+    block = _load_convention().get("session_naming")
+    if not isinstance(block, dict):
+        pytest.fail("orchestration.convention.yaml::session_naming block missing")
+    return block
+
+
+def _layout_block() -> Dict:
+    block = _load_convention().get("layout_placement")
+    if not isinstance(block, dict):
+        pytest.fail("orchestration.convention.yaml::layout_placement block missing")
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Active cmux introspection (best-effort)
+# ---------------------------------------------------------------------------
+def _cmux_available() -> bool:
+    return shutil.which("cmux") is not None
+
+
+def _list_active_session_names() -> List[Tuple[str, str]]:
+    """Return ``[(ref, tab_name), ...]`` from cmux.
+
+    Returns an empty list when cmux is unavailable or the introspection
+    output is not parseable. Callers treat empty as "skip the active
+    branch" — convention-coherence checks still run.
+    """
+    if not _cmux_available():
+        return []
+    try:
+        result = subprocess.run(
+            ["cmux", "list-tabs", "--workspace", "workspace:1"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.SubprocessError, OSError):  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-31
+        return []
+    if result.returncode != 0:
+        return []
+    rows: List[Tuple[str, str]] = []
+    for line in (result.stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = re.split(r"\s+", line, maxsplit=1)
+        if len(parts) == 2:
+            rows.append((parts[0], parts[1]))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Violation builders
+# ---------------------------------------------------------------------------
+def _build_naming_violations() -> List[Violation]:
+    """Convention coherence + active introspection for canonical names."""
+    violations: List[Violation] = []
+    block = _session_naming_block()
+
+    # 1. Regex declared in the convention compiles and matches the helper's regex.
+    declared_regex = block.get("regex")
+    if not isinstance(declared_regex, str) or not declared_regex:
+        violations.append(
+            Violation(
+                rule_id=_RULE_NAME.rule_id,
+                severity=_RULE_NAME.severity,
+                location="orchestration.convention.yaml:session_naming.regex",
+                detail="session_naming.regex is missing or empty",
+            )
+        )
+    else:
+        try:
+            re.compile(declared_regex)
+        except re.error as exc:
+            violations.append(
+                Violation(
+                    rule_id=_RULE_NAME.rule_id,
+                    severity=_RULE_NAME.severity,
+                    location="orchestration.convention.yaml:session_naming.regex",
+                    detail=f"session_naming.regex does not compile: {exc}",
+                )
+            )
+
+    # 2. Every declared exemplar parses via the helper.
+    exemplars = block.get("exemplars") or []
+    for idx, exemplar in enumerate(exemplars):
+        if not isinstance(exemplar, str):
+            continue
+        if not is_canonical_name(exemplar):
+            violations.append(
+                Violation(
+                    rule_id=_RULE_NAME.rule_id,
+                    severity=_RULE_NAME.severity,
+                    location=f"orchestration.convention.yaml:session_naming.exemplars[{idx}]",
+                    detail=(
+                        f"exemplar {exemplar!r} does not match the canonical regex — "
+                        "either the exemplar is wrong or the regex needs widening"
+                    ),
+                )
+            )
+
+    # 3. Active cmux introspection (best-effort).
+    for ref, name in _list_active_session_names():
+        if is_canonical_name(name):
+            continue
+        violations.append(
+            Violation(
+                rule_id=_RULE_NAME.rule_id,
+                severity=_RULE_NAME.severity,
+                location=f"cmux:{ref}",
+                detail=(
+                    f"surface {ref!r} has non-canonical name {name!r}; "
+                    "run `atdd babysit` to auto-correct"
+                ),
+                fix_hint_ref=_RULE_NAME.fix_hint,
+            )
+        )
+
+    return violations
+
+
+def _build_layout_violations() -> List[Violation]:
+    """Convention-coherence checks for the layout-placement policy."""
+    violations: List[Violation] = []
+    block = _layout_block()
+    policy = block.get("policy")
+    if not isinstance(policy, dict) or not policy:
+        violations.append(
+            Violation(
+                rule_id=_RULE_LAYOUT.rule_id,
+                severity=_RULE_LAYOUT.severity,
+                location="orchestration.convention.yaml:layout_placement.policy",
+                detail="layout_placement.policy block missing or empty",
+            )
+        )
+        return violations
+
+    # Every count in 0..7 maps to a non-empty target band — the helper must
+    # echo the convention. Higher counts (>=7) are covered by the dense band.
+    for n in range(0, 9):
+        label = target_grid_label(n)
+        if not label:
+            violations.append(
+                Violation(
+                    rule_id=_RULE_LAYOUT.rule_id,
+                    severity=_RULE_LAYOUT.severity,
+                    location=f"session_naming.target_grid_label({n})",
+                    detail=f"target_grid_label returned empty string for surface_count={n}",
+                )
+            )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Public test entry points (referenced by orchestration.convention.yaml)
+# ---------------------------------------------------------------------------
+def test_active_session_names_canonical():
+    """Canonical session names match <REPO><N>[-phase<M>]-<slug>.
+
+    Advisory: emits Violation records on drift and skips when cmux is
+    not available. Convention-coherence checks run unconditionally.
+    """
+    violations = _build_naming_violations()
+    if violations:
+        # Advisory disposition (Decision row 3): collect + render but do
+        # NOT fail the gate on the first ship. CI exposes the count via
+        # the ratchet substrate.
+        for v in violations:
+            print(str(v))
+        # Surface as a soft-warn so visibility is not lost.
+        pytest.skip(
+            f"{len(violations)} canonical-name advisory violation(s) — see stdout"
+        )
+
+
+def test_workspace_layout_conforms():
+    """Workspace surfaces follow the grid policy.
+
+    Advisory: convention-coherence only in v1; live cmux layout
+    introspection is a follow-on once cmux exposes pane positions.
+    """
+    violations = _build_layout_violations()
+    if violations:
+        for v in violations:
+            print(str(v))
+        pytest.skip(
+            f"{len(violations)} layout-conformance advisory violation(s) — see stdout"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Self-coherence: helper regex matches the convention regex
+# ---------------------------------------------------------------------------
+def test_helper_regex_matches_convention_regex():
+    """``CANONICAL_NAME_REGEX`` (helper) must agree with the convention's regex."""
+    block = _session_naming_block()
+    declared = block.get("regex")
+    assert isinstance(declared, str) and declared, "session_naming.regex missing"
+    helper_pattern = CANONICAL_NAME_REGEX.pattern
+    # Tolerate non-capturing-group cosmetic differences (``(?:...)`` vs ``(...)``)
+    # since both forms describe the same language.
+    norm_declared = declared.replace("(?:", "(")
+    norm_helper = helper_pattern.replace("(?:", "(")
+    assert norm_helper == norm_declared, (
+        "helper CANONICAL_NAME_REGEX does not match convention regex.\n"
+        f"  helper:     {helper_pattern!r}\n"
+        f"  convention: {declared!r}\n"
+        "Update one of them so they describe the same language."
+    )
+
+
+def test_round_trip_canonical_name():
+    """compute_canonical_name → parse_canonical_name returns the original parts."""
+    name = compute_canonical_name("ATDD", 470, "canonical-session-naming")
+    parsed = parse_canonical_name(name)
+    assert parsed is not None
+    assert parsed.repo == "ATDD"
+    assert parsed.issue == 470
+    assert parsed.phase is None
+    assert parsed.slug == "canonical-session-naming"
+
+    phased = compute_canonical_name("ATDD", 462, "bump-on-merge", phase=2)
+    parsed_phase = parse_canonical_name(phased)
+    assert parsed_phase is not None
+    assert parsed_phase.phase == 2
+    assert parsed_phase.slug == "bump-on-merge"
+
+
+def test_exemplars_round_trip():
+    """Every exemplar in the convention parses cleanly via the helper."""
+    exemplars = _session_naming_block().get("exemplars") or []
+    assert exemplars, "session_naming.exemplars must be non-empty for documentation value"
+    for exemplar in exemplars:
+        assert is_canonical_name(exemplar), (
+            f"exemplar {exemplar!r} declared in orchestration.convention.yaml::"
+            "session_naming.exemplars does not match the canonical regex"
+        )


### PR DESCRIPTION
## Summary

Closes #470.

Two paired application passes wired into `atdd orchestrate` and `atdd babysit`:

1. **NAMING** — every parallel session gets `<REPO><N>[-phase<M>]-<slug>` applied to BOTH the cmux tab title (`cmux rename-tab --surface <ref> '<name>'`) AND the Claude session header (via `/rename <name>` slash-command). Idempotent on babysit ticks: applied-name cache short-circuits already-canonical surfaces.
2. **LAYOUT** — new surfaces open right-of-shell (`cmux new-pane --direction right`); the operator's shell is never resplit. Babysit announces the target grid label per surface count (1→side-by-side, 3-4→2x2, 5+→column grid) and only logs when the band changes.

## Convention coherence

Per #467's precedent (extend, don't fork), this PR adds two new top-level blocks to the existing `src/atdd/coach/conventions/orchestration.convention.yaml` rather than introducing a new convention file:

- `session_naming:` — format spec + regex + application points + exemplars + rationale + the new advisory rule `coach.orchestration.canonical-session-name`.
- `layout_placement:` — grid-scaling policy, application points, rationale + the new advisory rule `coach.orchestration.layout-conformance`.

Both rules ship `disposition: advisory` per Decision row 3 and bind to the new validator `src/atdd/coach/validators/test_orchestration_session_naming.py`. Reverse-coherence (issue #399) resolves cleanly.

## Naming exemplars

Format: `<REPO><N>[-phase<M>]-<slug>`

```
ATDD459-ast-detector-done
ATDD462-phase1-softprops-done
ATDD462-phase2-bump-on-merge
ATDD466-train-hint-fix
ATDD467-hint-completeness
```

Helper: `atdd.coach.utils.session_naming::compute_canonical_name(repo, issue_n, slug, phase=None)`. The `<REPO>` token resolves from `.atdd/config.yaml::repo.short_name` with a default-from-`github.repo` fallback (Decision row 1).

## Layout exemplars (grid-scaling policy)

| Active surfaces | Layout |
|---|---|
| 0 | shell-only (left pane) |
| 1 | shell + 1 surface (right) |
| 2 | shell + 2 stacked vertically (right) |
| 3-4 | shell + 2x2 grid (right region) |
| 5-6 | shell + 2x3 grid (right region) |
| 7+ | shell + dense column grid |

## Trigger semantics (load-bearing)

| Command | When | Idempotent | Scope |
|---|---|---|---|
| `atdd orchestrate <N>` | Once at dispatch | N/A | New surface only |
| `atdd babysit` | Every tick | Yes — drift-detection only | Workspaces being monitored (no cross-worktree side effects) |

## Eat-own-dogfood

This PR's own session in the ATDD workspace is named `ATDD470-canonical-session-naming` per the canonical regex. The cmux-side rename happens via the new `CmuxBackend.rename` shim in `multiplexer.py`; failures degrade silently so the orchestrate flow never crashes when cmux verbs are missing.

## Phases (one PR, three commits)

1. `feat(coach): #470 phase 1 — session_naming + layout_placement convention` — pure YAML additions.
2. `feat(coach): #470 phase 2 — orchestrate + babysit hookup (naming + layout)` — helper module + multiplexer extension + dispatch-time pass + babysit drift correction.
3. `feat(coach): #470 phase 3 — validator + helper tests` — advisory validator + helper unit tests.

Plus `chore(devops): #470 — bump version 3.9.0 → 3.10.0 (MINOR)`.

## Version

Manually bumped to **3.10.0** (MINOR — new automation + new validator). Note the bump-on-merge bot from #468 is now active and would have auto-bumped on merge; the manual bump in the PR diff is honored per #462 Decision row 4 and lets reviewers see the change-class call alongside the substantive diff.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('src/atdd/coach/conventions/orchestration.convention.yaml'))"`
- [x] `pytest src/atdd/coach/validators/test_orchestration_session_naming.py -v` — 5 tests pass
- [x] `pytest src/atdd/coach/utils/tests/test_session_naming.py -v` — 40 tests pass
- [x] `pytest src/atdd/coach/commands/tests/test_orchestrate.py -v` — 16 tests pass (added `direction=` + `rename`/`send` capture to fake)
- [x] `pytest src/atdd/coach/validators/test_fix_hint_completeness.py` — green (resolved placeholder gaps in the new fix_hint fields)
- [x] `pytest src/atdd/coach/validators/test_rule_id_*.py test_rule_validator_binding.py test_rule_disposition_required.py test_babysit_allowlist_consistency.py` — green
- [ ] Maintainer: confirm cmux `rename-tab` + `rename-workspace` verbs match the local cmux build (degrades gracefully if not — best-effort by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)