### PR TITLE
fix(coach): #473 phase 1 — init template uses --skip-api (PATCH 3.10.1)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -329,3 +329,14 @@ sessions:
   wagon: null
   feature: null
   train: 0001-self-compliance-validate
+- id: '473'
+  slug: 473-init-template-fix
+  file: null
+  issue_number: 473
+  type: fix
+  status: RED
+  created: '2026-05-07'
+  archived: null
+  wagon: null
+  feature: null
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.10.0"
+version = "3.10.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -1467,7 +1467,7 @@ class ProjectInitializer:
         run: pip3 install atdd
 
       - name: Run {phase} validators
-        run: atdd validate {phase}{' -m "not github_api"' if phase == 'coach' else ''}
+        run: atdd validate {phase}{' --skip-api' if phase == 'coach' else ''}
         env:
           GH_TOKEN: ${{{{ secrets.GITHUB_TOKEN }}}}
 """

--- a/src/atdd/coach/commands/tests/test_initializer_workflow_emission.py
+++ b/src/atdd/coach/commands/tests/test_initializer_workflow_emission.py
@@ -1,0 +1,129 @@
+"""Workflow-template/CLI parseability lock for `atdd init` (issue #473).
+
+Issue #473 reproducer: `atdd init --force` on 3.10.0 wrote workflow
+templates that emitted `-m "not github_api"` to a `atdd validate` parser
+that no longer accepts `-m`. Every consumer who re-inits after upgrade
+hit `unrecognized arguments: -m` on first push to a feature branch.
+
+This test locks the contract for the **main validate workflow**
+(`.github/workflows/atdd-validate.yml`, written by `_write_workflow`):
+every `atdd validate ...` `run:` line it emits must parse cleanly under
+the live `atdd` argparse. We treat the template as a black box —
+generate it via the real ProjectInitializer, grep the run-lines back
+out, and feed each (with `--diagnostics-only` appended to short-circuit
+after parse) through a real `python -m atdd` subprocess. A parse miss
+manifests as exit code 2 + `unrecognized arguments` on stderr.
+
+Phase scope (issue #473):
+  - Phase 1 (this PR, 3.10.1 PATCH): the main validate workflow is fixed
+    (`-m "not github_api"` → `--skip-api`); this test locks that fix.
+  - Phase 2 (3.11.0 MINOR): the infra workflow (`atdd-validate-infra.yml`)
+    will be fixed by introducing `--api-only`; this test will be extended
+    to cover its `run:` lines and the `--skip-api`/`--api-only` exclusivity.
+
+Run: PYTHONPATH=src python3 -m pytest -q \\
+     src/atdd/coach/commands/tests/test_initializer_workflow_emission.py -v
+"""
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+import pytest
+import yaml
+
+from atdd.coach.commands.initializer import ProjectInitializer
+
+
+pytestmark = [pytest.mark.platform]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+RUN_LINE_RE = re.compile(r"^\s*run:\s*(atdd\s+validate\b.*?)$", re.MULTILINE)
+
+
+def _make_initializer(tmp_path: Path) -> ProjectInitializer:
+    """Set up a minimal target dir so _write_workflow can run."""
+    cfg_dir = tmp_path / ".atdd"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text(yaml.safe_dump({
+        "github": {"repo": "owner/repo"},
+    }))
+    return ProjectInitializer(target_dir=tmp_path)
+
+
+def _emit_main_validate_workflow(tmp_path: Path) -> Path:
+    """Drive _write_workflow and return the generated atdd-validate.yml path."""
+    init = _make_initializer(tmp_path)
+    init._write_workflow(repo="owner/repo")
+    path = tmp_path / ".github" / "workflows" / "atdd-validate.yml"
+    assert path.exists(), "_write_workflow did not emit atdd-validate.yml"
+    return path
+
+
+def _extract_validate_run_lines(workflow_path: Path) -> List[str]:
+    """Pull every `run: atdd validate ...` literal out of the generated YAML."""
+    text = workflow_path.read_text()
+    return [m.group(1).strip() for m in RUN_LINE_RE.finditer(text)]
+
+
+def _parse_under_live_cli(cmd: str) -> subprocess.CompletedProcess:
+    """Feed `cmd` (a raw bash run-line) through the live atdd argparse.
+
+    `--diagnostics-only` is appended so a successful parse short-circuits
+    in <100 ms instead of running every validator. Argparse failures still
+    fire first and surface as rc=2 + `unrecognized arguments`.
+    """
+    tokens = shlex.split(cmd)
+    assert tokens[:2] == ["atdd", "validate"], f"unexpected emit shape: {cmd!r}"
+    full = [sys.executable, "-m", "atdd"] + tokens[1:] + ["--diagnostics-only"]
+    return subprocess.run(
+        full,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=REPO_ROOT,
+    )
+
+
+# ----------------------------------------------------------------------
+# Tests — main validate workflow (Phase 1 scope)
+# ----------------------------------------------------------------------
+
+def test_main_workflow_emits_validate_run_lines(tmp_path):
+    """Sanity: regression guard if someone deletes the validate jobs entirely."""
+    cmds = _extract_validate_run_lines(_emit_main_validate_workflow(tmp_path))
+    assert cmds, "expected at least one `run: atdd validate ...` line"
+
+
+def test_main_workflow_run_lines_parse_under_live_cli(tmp_path):
+    """Every `run: atdd validate ...` line in the main workflow must parse.
+
+    Locks the issue #473 fix for the high-traffic gate workflow (every push
+    + every PR). Phase 2 will extend this contract to the infra workflow.
+    """
+    cmds = _extract_validate_run_lines(_emit_main_validate_workflow(tmp_path))
+    failures: List[str] = []
+    for cmd in cmds:
+        result = _parse_under_live_cli(cmd)
+        if result.returncode == 2 and "unrecognized arguments" in result.stderr:
+            tail = result.stderr.strip().splitlines()[-1]
+            failures.append(f"  {cmd!r}\n    → {tail}")
+    assert not failures, (
+        "emitted run-lines fail the live argparse "
+        "(issue #473 reproducer):\n" + "\n".join(failures)
+    )
+
+
+def test_main_workflow_does_not_emit_removed_dash_m_flag(tmp_path):
+    """Belt-and-suspenders: explicit guard against the exact #473 regression."""
+    cmds = _extract_validate_run_lines(_emit_main_validate_workflow(tmp_path))
+    offenders = [c for c in cmds if re.search(r"(^|\s)-m(\s|$)", c)]
+    assert not offenders, (
+        "main validate workflow emits `-m FLAG` removed in 3.10.0 (#473): "
+        f"{offenders!r}"
+    )


### PR DESCRIPTION
## Summary

Closes #473 partial — **Phase 1 ONLY**. Phases 2+3 follow as separate PR.

`atdd init --force` writes `.github/workflows/atdd-validate.yml` containing `run: atdd validate coach -m "not github_api"`. The 3.10.0 release dropped `-m FLAG` from `atdd validate`, so every consumer who upgraded to ≥3.10.0 and re-inited (the toolkit's own recommended upgrade flow) saw their first push fail with `unrecognized arguments: -m` on a required gate.

This PR replaces the dead flag with `--skip-api` (the supported equivalent) and adds a regression lock so this drift is caught at toolkit-self-validate time rather than by downstream CI.

- `src/atdd/coach/commands/initializer.py:1470` — f-string conditional now emits `--skip-api` instead of `-m "not github_api"`.
- `src/atdd/coach/commands/tests/test_initializer_workflow_emission.py` — new unit test generates the workflow YAML in `tmp_path`, greps every `run: atdd validate ...` line, and feeds each through the live argparse via subprocess (with `--diagnostics-only` to short-circuit after parse). Locks the contract.
- `pyproject.toml` — manual bump 3.10.0 → 3.10.1 (PATCH; per #462 Decision row 4, the bump-on-merge bot honors manual bumps).

## Empirical reproducer (from issue body)

A downstream consumer (`janetbusiness/jel-ledger`) ran `atdd init --force` after upgrading to 3.10.0. CI auto-installs `atdd` from PyPI without a pin, so first push to a feature branch produced:

```
+ atdd validate coach -m "not github_api"
usage: atdd [-h] [--version] [--repo PATH]
            {version,validate,inventory,...} ...
atdd: error: unrecognized arguments: -m not github_api
##[error]Process completed with exit code 2.
```

The PR's `validate-gate` (a required check the toolkit's own `atdd init` installs as branch protection) failed before any actual validators ran. **Every consumer who upgrades to ≥3.10.0 and re-inits hits this**: the upgrade flow recommends `atdd init --force`, the init writes broken templates, the next CI fails. Phase 1 unblocks all such consumers.

## Phase split

This PR ships only the high-impact main-validate-gate fix and its regression lock. The infra workflow (`atdd-validate-infra.yml`, line 1698) still emits `-m github_api` and will be fixed in Phase 2+3:

- **Phase 2** (MINOR 3.11.0): introduce `atdd validate --api-only` as the symmetric counterpart to `--skip-api` (mutually-exclusive group); replace `-m github_api` with `--api-only` in the infra template; extend the unit test to lock both run-lines.
- **Phase 3** (same PR as Phase 2): drift-detection coach validator + new rule `coach.initializer.template-cli-drift` declared in `rule-id.convention.yaml` (sibling to existing rules; **no new convention file**).

Phase 1 alone is shipped as PATCH because it is a defect fix with no surface change. Phase 2+3 ships as MINOR because of the new `--api-only` flag.

## Test plan

- [x] `PYTHONPATH=src python3 -m pytest -q src/atdd/coach/commands/tests/test_initializer_workflow_emission.py -v` passes (3/3).
- [x] Generated `atdd-validate.yml` no longer contains `-m`.
- [x] Live argparse accepts `atdd validate coach --skip-api`.
- [ ] Downstream `jel-ledger` re-runs `atdd init --force` after 3.10.1 publish — first push gate is green.