### PR TITLE
feat(coach): #473 phases 2+3 — --api-only flag + drift-detection validator (recovery from misrouted #475)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -329,3 +329,14 @@ sessions:
   wagon: null
   feature: null
   train: 0001-self-compliance-validate
+- id: '473'
+  slug: 473-init-template-fix
+  file: null
+  issue_number: 473
+  type: fix
+  status: RED
+  created: '2026-05-07'
+  archived: null
+  wagon: null
+  feature: null
+  train: 0001-self-compliance-validate

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -340,3 +340,14 @@ sessions:
   wagon: null
   feature: null
   train: 0001-self-compliance-validate
+- id: '473-phase-2'
+  slug: 473-api-only-and-drift
+  file: null
+  issue_number: 473
+  type: feat
+  status: RED
+  created: '2026-05-07'
+  archived: null
+  wagon: null
+  feature: null
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.10.0"
+version = "3.10.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.10.1"
+version = "3.11.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -126,13 +126,22 @@ class ATDDCoach:
         split: bool = True,
         local: bool = False,
         skip_api: bool = False,
+        api_only: bool = False,
         no_diagnostics: bool = False,
     ) -> int:
         """Run ATDD validators."""
         if quick:
             return self.validator_runner.quick_check()
 
-        markers = ["not github_api"] if skip_api else None
+        # Issue #473: --skip-api and --api-only are symmetric counterparts.
+        # The argparse layer enforces mutual exclusivity; here we map either
+        # flag to the appropriate pytest marker filter.
+        if skip_api:
+            markers = ["not github_api"]
+        elif api_only:
+            markers = ["github_api"]
+        else:
+            markers = None
 
         return self.validator_runner.run_tests(
             phase=phase,
@@ -356,11 +365,20 @@ Phase descriptions:
         action="store_true",
         help="Run validators locally (default: GH Actions only)"
     )
-    validate_parser.add_argument(
+    # Issue #473: --skip-api / --api-only are mutually exclusive (running both
+    # at once would resolve to an empty marker set and silently skip all tests).
+    api_group = validate_parser.add_mutually_exclusive_group()
+    api_group.add_argument(
         "--skip-api",
         action="store_true",
         dest="skip_api",
         help="Skip github_api tests (for offline development)"
+    )
+    api_group.add_argument(
+        "--api-only",
+        action="store_true",
+        dest="api_only",
+        help="Run ONLY github_api tests (counterpart to --skip-api)"
     )
     validate_parser.add_argument(
         "--verify-baseline",
@@ -1682,6 +1700,7 @@ Phase descriptions:
 
         coach = ATDDCoach(repo_root=repo_path)
         skip_api = getattr(args, 'skip_api', False)
+        api_only = getattr(args, 'api_only', False)
         no_diagnostics = getattr(args, 'no_diagnostics', False)
         rc = coach.run_validators(
             phase=args.phase,
@@ -1689,9 +1708,10 @@ Phase descriptions:
             coverage=args.coverage,
             html=args.html,
             quick=args.quick,
-            split=not args.no_split and not skip_api,
+            split=not args.no_split and not skip_api and not api_only,
             local=args.local,
             skip_api=skip_api,
+            api_only=api_only,
             no_diagnostics=no_diagnostics,
         )
 

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -1695,7 +1695,7 @@ class ProjectInitializer:
             "        run: pip3 install atdd\n"
             "\n"
             '      - name: Run github_api validators\n'
-            '        run: atdd validate coach -m github_api\n'
+            '        run: atdd validate coach --api-only\n'
             "        env:\n"
             "          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}\n"
         )

--- a/src/atdd/coach/commands/initializer.py
+++ b/src/atdd/coach/commands/initializer.py
@@ -1467,7 +1467,7 @@ class ProjectInitializer:
         run: pip3 install atdd
 
       - name: Run {phase} validators
-        run: atdd validate {phase}{' -m "not github_api"' if phase == 'coach' else ''}
+        run: atdd validate {phase}{' --skip-api' if phase == 'coach' else ''}
         env:
           GH_TOKEN: ${{{{ secrets.GITHUB_TOKEN }}}}
 """

--- a/src/atdd/coach/commands/tests/test_initializer_workflow_emission.py
+++ b/src/atdd/coach/commands/tests/test_initializer_workflow_emission.py
@@ -15,11 +15,14 @@ after parse) through a real `python -m atdd` subprocess. A parse miss
 manifests as exit code 2 + `unrecognized arguments` on stderr.
 
 Phase scope (issue #473):
-  - Phase 1 (this PR, 3.10.1 PATCH): the main validate workflow is fixed
-    (`-m "not github_api"` → `--skip-api`); this test locks that fix.
-  - Phase 2 (3.11.0 MINOR): the infra workflow (`atdd-validate-infra.yml`)
-    will be fixed by introducing `--api-only`; this test will be extended
-    to cover its `run:` lines and the `--skip-api`/`--api-only` exclusivity.
+  - Phase 1 (3.10.1 PATCH): the main validate workflow is fixed
+    (`-m "not github_api"` → `--skip-api`).
+  - Phase 2 (this PR, 3.11.0 MINOR): the infra workflow
+    (`atdd-validate-infra.yml`) is fixed by introducing `--api-only` as
+    the symmetric counterpart to `--skip-api`. The two flags are mutually
+    exclusive at the argparse layer (running both at once would resolve to
+    an empty marker filter and silently skip everything). This file's
+    coverage is extended to the infra workflow + the mutex contract.
 
 Run: PYTHONPATH=src python3 -m pytest -q \\
      src/atdd/coach/commands/tests/test_initializer_workflow_emission.py -v
@@ -63,6 +66,23 @@ def _emit_main_validate_workflow(tmp_path: Path) -> Path:
     path = tmp_path / ".github" / "workflows" / "atdd-validate.yml"
     assert path.exists(), "_write_workflow did not emit atdd-validate.yml"
     return path
+
+
+def _emit_infra_validate_workflow(tmp_path: Path) -> Path:
+    """Drive _write_infra_workflow and return atdd-validate-infra.yml path."""
+    init = _make_initializer(tmp_path)
+    init._write_infra_workflow()
+    path = tmp_path / ".github" / "workflows" / "atdd-validate-infra.yml"
+    assert path.exists(), "_write_infra_workflow did not emit atdd-validate-infra.yml"
+    return path
+
+
+def _emit_all_workflows(tmp_path: Path) -> List[Path]:
+    """Drive both writers; return all generated workflow paths in sorted order."""
+    init = _make_initializer(tmp_path)
+    init._write_workflow(repo="owner/repo")
+    init._write_infra_workflow()
+    return sorted((tmp_path / ".github" / "workflows").glob("*.yml"))
 
 
 def _extract_validate_run_lines(workflow_path: Path) -> List[str]:
@@ -126,4 +146,100 @@ def test_main_workflow_does_not_emit_removed_dash_m_flag(tmp_path):
     assert not offenders, (
         "main validate workflow emits `-m FLAG` removed in 3.10.0 (#473): "
         f"{offenders!r}"
+    )
+
+
+# ----------------------------------------------------------------------
+# Tests — infra validate workflow (Phase 2 scope)
+# ----------------------------------------------------------------------
+
+def test_infra_workflow_emits_validate_run_line(tmp_path):
+    """Sanity: the infra workflow always emits at least one validate command."""
+    cmds = _extract_validate_run_lines(_emit_infra_validate_workflow(tmp_path))
+    assert cmds, "expected at least one `run: atdd validate ...` line in infra"
+
+
+def test_infra_workflow_uses_api_only_not_dash_m(tmp_path):
+    """Phase 2 contract: infra workflow targets github_api via `--api-only`.
+
+    Direct guard against the line 1698 regression that Phase 1 left intact.
+    """
+    cmds = _extract_validate_run_lines(_emit_infra_validate_workflow(tmp_path))
+    offenders = [c for c in cmds if re.search(r"(^|\s)-m(\s|$)", c)]
+    assert not offenders, (
+        f"infra workflow still emits `-m FLAG` (#473 phase 2): {offenders!r}"
+    )
+    api_only_lines = [c for c in cmds if "--api-only" in c]
+    assert api_only_lines, (
+        f"infra workflow must invoke `--api-only`; got {cmds!r}"
+    )
+
+
+# ----------------------------------------------------------------------
+# Tests — combined: every emitted run-line parses (Phase 2 contract)
+# ----------------------------------------------------------------------
+
+def test_every_emitted_run_line_parses_under_live_cli(tmp_path):
+    """All `run: atdd validate ...` lines (both workflows) parse cleanly.
+
+    Phase 2 promotes the Phase 1 contract to cover both the main validate
+    workflow and the infra workflow. Any `unrecognized arguments` diagnostic
+    fires here long before downstream CI sees it.
+    """
+    cmds: List[str] = []
+    for path in _emit_all_workflows(tmp_path):
+        cmds.extend(_extract_validate_run_lines(path))
+    assert cmds, "expected at least one validate run-line across workflows"
+
+    failures: List[str] = []
+    for cmd in cmds:
+        result = _parse_under_live_cli(cmd)
+        if result.returncode == 2 and "unrecognized arguments" in result.stderr:
+            tail = result.stderr.strip().splitlines()[-1]
+            failures.append(f"  {cmd!r}\n    → {tail}")
+    assert not failures, (
+        "emitted run-lines fail the live argparse "
+        "(issue #473 reproducer):\n" + "\n".join(failures)
+    )
+
+
+# ----------------------------------------------------------------------
+# Tests — `--skip-api` / `--api-only` mutual exclusivity (Phase 2 contract)
+# ----------------------------------------------------------------------
+
+def test_skip_api_and_api_only_are_mutually_exclusive():
+    """Argparse must reject `--skip-api --api-only` together.
+
+    Allowing both would resolve to an empty marker filter (`not github_api`
+    AND `github_api` ⇒ ∅) and silently skip every test — a footgun the
+    mutex group is meant to prevent.
+    """
+    full = [
+        sys.executable, "-m", "atdd",
+        "validate", "coach", "--skip-api", "--api-only", "--diagnostics-only",
+    ]
+    result = subprocess.run(
+        full, capture_output=True, text=True, timeout=30, cwd=REPO_ROOT,
+    )
+    assert result.returncode == 2, (
+        f"expected argparse to reject mutex pair, got rc={result.returncode}\n"
+        f"stderr: {result.stderr!r}"
+    )
+    assert "not allowed with argument" in result.stderr, (
+        f"expected mutex error message, got: {result.stderr!r}"
+    )
+
+
+def test_api_only_flag_parses_under_live_cli():
+    """Direct contract: `atdd validate <phase> --api-only` parses cleanly."""
+    full = [
+        sys.executable, "-m", "atdd",
+        "validate", "coach", "--api-only", "--diagnostics-only",
+    ]
+    result = subprocess.run(
+        full, capture_output=True, text=True, timeout=30, cwd=REPO_ROOT,
+    )
+    assert result.returncode != 2 or "unrecognized" not in result.stderr, (
+        f"--api-only failed to parse: rc={result.returncode}\n"
+        f"stderr: {result.stderr!r}"
     )

--- a/src/atdd/coach/commands/tests/test_initializer_workflow_emission.py
+++ b/src/atdd/coach/commands/tests/test_initializer_workflow_emission.py
@@ -1,0 +1,129 @@
+"""Workflow-template/CLI parseability lock for `atdd init` (issue #473).
+
+Issue #473 reproducer: `atdd init --force` on 3.10.0 wrote workflow
+templates that emitted `-m "not github_api"` to a `atdd validate` parser
+that no longer accepts `-m`. Every consumer who re-inits after upgrade
+hit `unrecognized arguments: -m` on first push to a feature branch.
+
+This test locks the contract for the **main validate workflow**
+(`.github/workflows/atdd-validate.yml`, written by `_write_workflow`):
+every `atdd validate ...` `run:` line it emits must parse cleanly under
+the live `atdd` argparse. We treat the template as a black box —
+generate it via the real ProjectInitializer, grep the run-lines back
+out, and feed each (with `--diagnostics-only` appended to short-circuit
+after parse) through a real `python -m atdd` subprocess. A parse miss
+manifests as exit code 2 + `unrecognized arguments` on stderr.
+
+Phase scope (issue #473):
+  - Phase 1 (this PR, 3.10.1 PATCH): the main validate workflow is fixed
+    (`-m "not github_api"` → `--skip-api`); this test locks that fix.
+  - Phase 2 (3.11.0 MINOR): the infra workflow (`atdd-validate-infra.yml`)
+    will be fixed by introducing `--api-only`; this test will be extended
+    to cover its `run:` lines and the `--skip-api`/`--api-only` exclusivity.
+
+Run: PYTHONPATH=src python3 -m pytest -q \\
+     src/atdd/coach/commands/tests/test_initializer_workflow_emission.py -v
+"""
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+import pytest
+import yaml
+
+from atdd.coach.commands.initializer import ProjectInitializer
+
+
+pytestmark = [pytest.mark.platform]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+RUN_LINE_RE = re.compile(r"^\s*run:\s*(atdd\s+validate\b.*?)$", re.MULTILINE)
+
+
+def _make_initializer(tmp_path: Path) -> ProjectInitializer:
+    """Set up a minimal target dir so _write_workflow can run."""
+    cfg_dir = tmp_path / ".atdd"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text(yaml.safe_dump({
+        "github": {"repo": "owner/repo"},
+    }))
+    return ProjectInitializer(target_dir=tmp_path)
+
+
+def _emit_main_validate_workflow(tmp_path: Path) -> Path:
+    """Drive _write_workflow and return the generated atdd-validate.yml path."""
+    init = _make_initializer(tmp_path)
+    init._write_workflow(repo="owner/repo")
+    path = tmp_path / ".github" / "workflows" / "atdd-validate.yml"
+    assert path.exists(), "_write_workflow did not emit atdd-validate.yml"
+    return path
+
+
+def _extract_validate_run_lines(workflow_path: Path) -> List[str]:
+    """Pull every `run: atdd validate ...` literal out of the generated YAML."""
+    text = workflow_path.read_text()
+    return [m.group(1).strip() for m in RUN_LINE_RE.finditer(text)]
+
+
+def _parse_under_live_cli(cmd: str) -> subprocess.CompletedProcess:
+    """Feed `cmd` (a raw bash run-line) through the live atdd argparse.
+
+    `--diagnostics-only` is appended so a successful parse short-circuits
+    in <100 ms instead of running every validator. Argparse failures still
+    fire first and surface as rc=2 + `unrecognized arguments`.
+    """
+    tokens = shlex.split(cmd)
+    assert tokens[:2] == ["atdd", "validate"], f"unexpected emit shape: {cmd!r}"
+    full = [sys.executable, "-m", "atdd"] + tokens[1:] + ["--diagnostics-only"]
+    return subprocess.run(
+        full,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=REPO_ROOT,
+    )
+
+
+# ----------------------------------------------------------------------
+# Tests — main validate workflow (Phase 1 scope)
+# ----------------------------------------------------------------------
+
+def test_main_workflow_emits_validate_run_lines(tmp_path):
+    """Sanity: regression guard if someone deletes the validate jobs entirely."""
+    cmds = _extract_validate_run_lines(_emit_main_validate_workflow(tmp_path))
+    assert cmds, "expected at least one `run: atdd validate ...` line"
+
+
+def test_main_workflow_run_lines_parse_under_live_cli(tmp_path):
+    """Every `run: atdd validate ...` line in the main workflow must parse.
+
+    Locks the issue #473 fix for the high-traffic gate workflow (every push
+    + every PR). Phase 2 will extend this contract to the infra workflow.
+    """
+    cmds = _extract_validate_run_lines(_emit_main_validate_workflow(tmp_path))
+    failures: List[str] = []
+    for cmd in cmds:
+        result = _parse_under_live_cli(cmd)
+        if result.returncode == 2 and "unrecognized arguments" in result.stderr:
+            tail = result.stderr.strip().splitlines()[-1]
+            failures.append(f"  {cmd!r}\n    → {tail}")
+    assert not failures, (
+        "emitted run-lines fail the live argparse "
+        "(issue #473 reproducer):\n" + "\n".join(failures)
+    )
+
+
+def test_main_workflow_does_not_emit_removed_dash_m_flag(tmp_path):
+    """Belt-and-suspenders: explicit guard against the exact #473 regression."""
+    cmds = _extract_validate_run_lines(_emit_main_validate_workflow(tmp_path))
+    offenders = [c for c in cmds if re.search(r"(^|\s)-m(\s|$)", c)]
+    assert not offenders, (
+        "main validate workflow emits `-m FLAG` removed in 3.10.0 (#473): "
+        f"{offenders!r}"
+    )

--- a/src/atdd/coach/conventions/rule-id.convention.yaml
+++ b/src/atdd/coach/conventions/rule-id.convention.yaml
@@ -284,6 +284,31 @@ rules:
     introduced_in: "3.0.0"
     validator: "test_rule_validator_binding::test_every_enforced_rule_has_real_validator"
     fix_hint: "Either set validator: '<module>::<func>' on the rule and have that function call bind_rule(<id>), or change disposition to documentation-only."
+  - id: "coach.initializer.template-cli-drift"
+    severity: 2
+    description: "Every `run: atdd ...` literal the initializer writes into consumer workflow templates must parse cleanly under the live atdd argparse"
+    disposition: strict
+    introduced_in: "3.11.0"
+    aliases: []
+    validator: "test_workflow_template_command_drift::test_every_run_line_parses_under_live_cli"
+    fix_hint: |
+      The named `run: atdd ...` line in src/atdd/coach/commands/initializer.py
+      emits a flag the live `atdd` argparse no longer accepts. Reproducer
+      case: the 3.10.0 release dropped `-m FLAG` from `atdd validate` while
+      the workflow templates still emitted `-m "not github_api"` (issue
+      #473). Repair as follows:
+
+        1. Read the validator output — the Violation cites the file:line
+           and the offending tokens (run: pytest src/atdd/coach/validators/test_workflow_template_command_drift.py -v).
+        2. Substitute the dead flag with the supported equivalent — for
+           the marker family the canonical mapping is:
+             -m "not github_api"  →  --skip-api
+             -m github_api        →  --api-only
+           (see src/atdd/cli.py::validate_parser for the live flag set;
+            run `atdd validate --help` to enumerate.)
+        3. Re-emit by re-running the unit test
+           src/atdd/coach/commands/tests/test_initializer_workflow_emission.py
+           which feeds every emitted run-line through the live argparse.
   - id: "coach.rule-id.fix-hint-completeness"
     severity: 2
     description: "Every fix_hint (convention-declared or CLI-printed) must satisfy the completeness contract C1-C4 in rule_schema.fields.fix_hint.description"

--- a/src/atdd/coach/validators/test_workflow_template_command_drift.py
+++ b/src/atdd/coach/validators/test_workflow_template_command_drift.py
@@ -1,0 +1,182 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_workflow_template_command_drift:backend:domain
+# Runtime: python
+# Purpose: Lock the contract that every `run: atdd ...` line ProjectInitializer writes into consumer workflows parses cleanly under the live argparse.
+
+"""Drift guard for `atdd init` workflow templates vs. the live CLI (issue #473).
+
+The 3.10.0 release dropped `-m FLAG` from `atdd validate`, but
+``ProjectInitializer._write_workflow`` and ``_write_infra_workflow`` kept
+emitting ``atdd validate coach -m "not github_api"`` and
+``atdd validate coach -m github_api`` into every consumer's
+``.github/workflows/atdd-validate*.yml``. Every consumer who ran
+``atdd init --force`` after the upgrade hit ``unrecognized arguments: -m``
+on first push — a required CI gate failing on a hardcoded template,
+before any actual validators ran.
+
+This validator closes that drift class. It writes the workflow templates
+into a tmp directory via the real initializer, greps every emitted
+``run: atdd ...`` literal back out, and feeds each through the live
+argparse via subprocess. ``--diagnostics-only`` is appended to short-circuit
+after parse — argparse failures still surface as rc=2 + ``unrecognized
+arguments``, so a parse miss is unambiguous.
+
+Convention: ``src/atdd/coach/conventions/rule-id.convention.yaml``
+            (rule ``coach.initializer.template-cli-drift``).
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import List
+
+import pytest
+import yaml
+
+import atdd
+from atdd.coach.commands.initializer import ProjectInitializer
+from atdd.coach.utils.disposition_gate import assert_disposition_satisfied
+from atdd.coach.utils.rule_binding import bind_rule
+from atdd.coach.validators._violation import Violation
+
+
+# ---------------------------------------------------------------------------
+# Path constants & rule binding
+# ---------------------------------------------------------------------------
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+REPO_ROOT = ATDD_PKG_DIR.parent.parent
+
+_RULE = bind_rule("coach.initializer.template-cli-drift")
+
+# Match `run: atdd ...` lines (in YAML scalar form) regardless of indentation
+# or trailing comments. Captures the bash command literal that follows `run:`.
+_RUN_LINE_RE = re.compile(r"^\s*run:\s*(atdd\s+\S.*?)$", re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# Template emission
+# ---------------------------------------------------------------------------
+def _emit_workflow_files(target_dir: Path) -> List[Path]:
+    """Drive both workflow writers and return the generated YAML paths.
+
+    Uses the real ``ProjectInitializer`` against ``target_dir`` (a tmp
+    location), so this validator measures what consumers actually receive
+    when they run ``atdd init --force``, not a static read of source.
+    """
+    cfg_dir = target_dir / ".atdd"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+    (cfg_dir / "config.yaml").write_text(
+        yaml.safe_dump({"github": {"repo": "owner/repo"}})
+    )
+    init = ProjectInitializer(target_dir=target_dir)
+    init._write_workflow(repo="owner/repo")
+    init._write_infra_workflow()
+    return sorted((target_dir / ".github" / "workflows").glob("*.yml"))
+
+
+def _extract_atdd_run_lines(workflow_path: Path) -> List[str]:
+    """Pull every `run: atdd ...` literal out of a generated workflow YAML."""
+    text = workflow_path.read_text()
+    return [m.group(1).strip() for m in _RUN_LINE_RE.finditer(text)]
+
+
+# ---------------------------------------------------------------------------
+# Live-argparse parse check
+# ---------------------------------------------------------------------------
+_PARSE_FAIL_RC = 2
+_UNRECOGNIZED_TOKEN = "unrecognized arguments"
+
+
+def _parse_under_live_cli(cmd: str) -> subprocess.CompletedProcess:
+    """Feed ``cmd`` through the live atdd argparse via subprocess.
+
+    ``--diagnostics-only`` is appended ONLY for ``atdd validate ...`` lines:
+    those carry the flag and short-circuit after argparse succeeds. Other
+    ``atdd ...`` commands (e.g. ``atdd baseline update``) are passed
+    through as-is — argparse failures still fail fast at rc=2, and we
+    treat any non-2 rc as parse-success regardless of the rest of the
+    command's behavior.
+    """
+    tokens = shlex.split(cmd)
+    assert tokens and tokens[0] == "atdd", f"expected `atdd ...` shape: {cmd!r}"
+    args = tokens[1:]
+    if args[:1] == ["validate"]:
+        args = args + ["--diagnostics-only"]
+    return subprocess.run(
+        [sys.executable, "-m", "atdd"] + args,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=REPO_ROOT,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scanner
+# ---------------------------------------------------------------------------
+def scan_workflow_templates_for_cli_drift() -> List[Violation]:
+    """Return Violations for every emitted run-line that fails live argparse."""
+    violations: List[Violation] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp)
+        for workflow_path in _emit_workflow_files(target):
+            rel_workflow = workflow_path.relative_to(target)
+            text = workflow_path.read_text()
+            # Pre-compute line offsets for line-number reporting.
+            lineno_by_match = {}
+            for match in _RUN_LINE_RE.finditer(text):
+                lineno_by_match[match.group(1).strip()] = (
+                    text[: match.start()].count("\n") + 1
+                )
+
+            for cmd in _extract_atdd_run_lines(workflow_path):
+                result = _parse_under_live_cli(cmd)
+                if (
+                    result.returncode == _PARSE_FAIL_RC
+                    and _UNRECOGNIZED_TOKEN in result.stderr
+                ):
+                    last = result.stderr.strip().splitlines()[-1]
+                    violations.append(
+                        Violation(
+                            rule_id=_RULE.rule_id,
+                            severity=_RULE.severity,
+                            location=(
+                                f"src/atdd/coach/commands/initializer.py "
+                                f"(emit → {rel_workflow}:"
+                                f"{lineno_by_match.get(cmd, '?')})"
+                            ),
+                            detail=(
+                                f"emitted run-line {cmd!r} fails the live "
+                                f"argparse: {last}"
+                            ),
+                            fix_hint_ref=getattr(_RULE, "fix_hint_ref", None),
+                        )
+                    )
+    return violations
+
+
+# ===========================================================================
+# Test
+# ===========================================================================
+@pytest.mark.coach
+def test_every_run_line_parses_under_live_cli():
+    """Every `run: atdd ...` line the initializer emits parses under live argparse.
+
+    SPEC: ``rule-id.convention.yaml::rules[coach.initializer.template-cli-drift]``.
+
+    Given:  Workflow YAMLs written by ``ProjectInitializer._write_workflow``
+            and ``_write_infra_workflow`` against a tmp target directory.
+    When:   Every emitted ``run: atdd ...`` line is fed through the live
+            ``python -m atdd`` argparse via subprocess.
+    Then:   No command produces ``rc=2`` + ``unrecognized arguments`` —
+            the templates and the CLI are in sync.
+    """
+    violations = scan_workflow_templates_for_cli_drift()
+    assert_disposition_satisfied(
+        validator_id="workflow_template_command_drift",
+        violations=violations,
+    )

--- a/src/atdd/coach/validators/tests/test_workflow_template_command_drift_helpers.py
+++ b/src/atdd/coach/validators/tests/test_workflow_template_command_drift_helpers.py
@@ -1,0 +1,108 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_workflow_template_command_drift_helpers:backend:domain
+# Runtime: python
+# Purpose: Unit tests for the parsing/emission helpers in test_workflow_template_command_drift.
+
+"""Pure-function unit tests for the workflow-template drift helpers (issue #473).
+
+The repo-walking integration test (``test_every_run_line_parses_under_live_cli``)
+lives in ``test_workflow_template_command_drift.py`` itself; this file
+isolates the parsing helpers so each invariant has a focused regression
+without re-running the live argparse.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.validators.test_workflow_template_command_drift import (
+    _RUN_LINE_RE,
+    _emit_workflow_files,
+    _extract_atdd_run_lines,
+    _parse_under_live_cli,
+)
+
+
+# ---------------------------------------------------------------------------
+# Run-line regex
+# ---------------------------------------------------------------------------
+
+class TestRunLineRegex:
+    @pytest.mark.parametrize("line, expected", [
+        ("        run: atdd validate coach --skip-api",
+         "atdd validate coach --skip-api"),
+        ("      run: atdd validate coach --api-only",
+         "atdd validate coach --api-only"),
+        ("        run: atdd baseline update",
+         "atdd baseline update"),
+        # Indented under YAML key, with trailing punctuation preserved
+        ("    run: atdd validate planner",
+         "atdd validate planner"),
+    ])
+    def test_captures_atdd_command(self, line, expected):
+        m = _RUN_LINE_RE.search(line)
+        assert m is not None, f"regex missed: {line!r}"
+        assert m.group(1).strip() == expected
+
+    @pytest.mark.parametrize("line", [
+        "        run: pip3 install atdd",          # not an `atdd ...` invocation
+        "        run: echo hi",                    # unrelated run line
+        "      - name: Run github_api validators", # not a `run:` scalar
+    ])
+    def test_skips_non_atdd_run_lines(self, line):
+        m = _RUN_LINE_RE.search(line)
+        # Either no match, or first token is `atdd` and the rest checks out;
+        # for these non-atdd cases we expect no match (the regex anchors
+        # `atdd\s+` after `run:`).
+        if m is not None:
+            assert not m.group(1).startswith("atdd"), (
+                f"regex incorrectly matched non-atdd line: {line!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Emission round-trip
+# ---------------------------------------------------------------------------
+
+class TestEmissionRoundTrip:
+    def test_emits_both_workflow_files(self, tmp_path: Path):
+        paths = _emit_workflow_files(tmp_path)
+        names = {p.name for p in paths}
+        assert "atdd-validate.yml" in names
+        assert "atdd-validate-infra.yml" in names
+
+    def test_each_emitted_file_contains_at_least_one_atdd_run_line(self, tmp_path: Path):
+        paths = _emit_workflow_files(tmp_path)
+        for p in paths:
+            cmds = _extract_atdd_run_lines(p)
+            atdd_cmds = [c for c in cmds if c.startswith("atdd ")]
+            assert atdd_cmds, f"{p.name} emitted no `atdd ...` run-lines"
+
+
+# ---------------------------------------------------------------------------
+# Live-argparse subprocess wrapper
+# ---------------------------------------------------------------------------
+
+class TestParseUnderLiveCli:
+    def test_known_good_command_parses(self):
+        result = _parse_under_live_cli("atdd validate coach --skip-api")
+        # Either rc=0 (diagnostics emitted) or rc=1 (no diagnostics yet);
+        # rc=2 would indicate parse failure.
+        assert result.returncode != 2, (
+            f"--skip-api should parse cleanly; got rc={result.returncode}\n"
+            f"stderr: {result.stderr!r}"
+        )
+
+    def test_known_bad_command_returns_unrecognized(self):
+        # `-m FLAG` was removed in 3.10.0 — the canonical #473 reproducer.
+        result = _parse_under_live_cli('atdd validate coach -m "not github_api"')
+        assert result.returncode == 2
+        assert "unrecognized arguments" in result.stderr
+
+    def test_appends_diagnostics_only_for_validate_subcommand(self):
+        # Indirectly verified: a clean validate run-line short-circuits via
+        # diagnostics-only and exits within seconds rather than running the
+        # full validator suite. We assert wall-clock is under the 30s timeout.
+        result = _parse_under_live_cli("atdd validate planner --skip-api")
+        assert result.returncode != 2


### PR DESCRIPTION
Closes #473

## Recovery context

PR #475 was opened with base \`fix/473-init-template-fix\` (a sibling PR's branch) instead of \`main\`. When that base branch was deleted as part of #474's merge, #475's merge commit (\`c202336\`) ended up orphaned on \`origin/fix/473-init-template-fix\` — visible only via \`git ls-remote\`, NOT on main. GitHub's "Closes #473" linkage fired (auto-closed the issue), but the actual Phase 2+3 work never landed on main.

This PR re-targets the same merge commit (\`c202336\`) to main as a fresh branch \`fix/473-recover-phase23\`. Diff is exactly the original #475 delta (no #474 overlap, since #474 is already on main).

## Content (identical to original #475)

8 files changed, 472 insertions:
- \`pyproject.toml\` — 3.10.1 → 3.11.0 (MINOR — new flag + new validator)
- \`src/atdd/cli.py\` — added \`--api-only\` flag in mutually-exclusive group with \`--skip-api\`
- \`src/atdd/coach/commands/initializer.py:1698\` — \`-m github_api\` → \`--api-only\`
- \`src/atdd/coach/commands/tests/test_initializer_workflow_emission.py\` — extended Phase 1 test to cover infra workflow + mutex contract
- \`src/atdd/coach/conventions/rule-id.convention.yaml\` — declared \`coach.initializer.template-cli-drift\` rule (severity 2, strict, in EXISTING rules: block — convention coherence preserved)
- \`src/atdd/coach/validators/test_workflow_template_command_drift.py\` — NEW (drift-detection validator)
- \`src/atdd/coach/validators/tests/test_workflow_template_command_drift_helpers.py\` — NEW (helper unit tests)

## Lesson learned (will file as follow-up)

The \`atdd issue\` / \`atdd branch\` / \`gh pr create\` flow doesn't enforce that the PR base is \`main\` (or the canonical default branch). A future fix could either: (a) validate base in \`atdd pr create\`, or (b) lint the orchestration to flag PRs targeting non-main branches. Not in scope here.