### PR TITLE
chore(atdd): Branch Pr Empty Commit Failure (#478)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -351,3 +351,14 @@ sessions:
   wagon: null
   feature: null
   train: 0001-self-compliance-validate
+- id: '478'
+  slug: 478-branch-pr-empty
+  file: null
+  issue_number: 478
+  type: cleanup
+  status: RED
+  created: '2026-05-07'
+  archived: null
+  wagon: null
+  feature: null
+  train: 0001-self-compliance-validate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.11.0"
+version = "3.11.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/branch.py
+++ b/src/atdd/coach/commands/branch.py
@@ -20,8 +20,24 @@ import yaml
 
 from atdd.coach.commands.issue import ALLOWED_BRANCH_PREFIXES, TYPE_TO_PREFIX
 from atdd.coach.github import GitHubClient, GitHubClientError, ProjectConfig
+from atdd.coach.utils.default_branch import resolve_default_branch
 
 logger = logging.getLogger(__name__)
+
+
+def _rev_count_past_default(worktree_path: Path, default_branch: str) -> Optional[int]:
+    """Return commits in HEAD past origin/<default_branch>; None on failure."""
+    result = subprocess.run(
+        ["git", "rev-list", "--count", f"origin/{default_branch}..HEAD"],
+        capture_output=True, text=True, timeout=10,
+        cwd=worktree_path,
+    )
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    if not out.isdigit():
+        return None
+    return int(out)
 
 
 class BranchManager:
@@ -54,6 +70,24 @@ class BranchManager:
             print(f"  PR: #{pr_num} already exists")
             return
 
+        default_branch = resolve_default_branch(self.target_dir)
+
+        # Defer PR creation when the branch has no commits past default.
+        # GitHub's createPullRequest mutation hard-fails when head==base, and
+        # the standard `atdd branch` flow always lands on an empty branch.
+        rev_count = _rev_count_past_default(worktree_path, default_branch)
+        if rev_count == 0:
+            print(
+                f"  Note: Draft PR deferred — branch has 0 commits past "
+                f"`{default_branch}`."
+            )
+            print(
+                f"        Commit your work, then run `atdd pr {issue_number}` "
+                f"to open the draft PR."
+            )
+            print( "        See `CLAUDE.md::issues.commands.new` for lifecycle.")
+            return
+
         # Fetch issue title for the PR title
         prefix = TYPE_TO_PREFIX.get(issue_type, "feat")
         pr_title = f"{prefix}: {slug.replace('-', ' ')} (#{issue_number})"
@@ -74,7 +108,7 @@ class BranchManager:
              "--title", pr_title,
              "--body", pr_body,
              "--head", branch_name,
-             "--base", "main"],
+             "--base", default_branch],
             capture_output=True, text=True, timeout=15,
             cwd=worktree_path,
         )
@@ -82,7 +116,14 @@ class BranchManager:
             pr_url = result.stdout.strip()
             print(f"  Draft PR: {pr_url}")
         else:
-            print(f"  Warning: Could not create draft PR: {result.stderr.strip()}")
+            # Real PR-create failure (non-empty branch, actual API error).
+            # Print structured Fix hint per #467 contract.
+            print(f"  Error: Could not create draft PR: {result.stderr.strip()}")
+            print( "  Fix:")
+            print(f"    1. cd {worktree_path}")
+            print(f"    2. atdd pr {issue_number}")
+            print( "  Why: `atdd branch` defers PR creation to `atdd pr` when the")
+            print( "       inline createPullRequest call fails (e.g. transient gh/API).")
 
     def _load_manifest(self):
         if not self.manifest_file.exists():

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -1567,6 +1567,45 @@ class IssueManager:
         )
         return False, messages
 
+    def _validate_pr_exists_for_branch(
+        self, branch_name: str,
+    ) -> Tuple[bool, List[str]]:
+        """Issue #478: PR-existence check for INIT → PLANNED gate.
+
+        Returns ``(exists, messages)``. ``exists`` is True when ``gh pr list
+        --head <branch>`` returns a non-empty result. Subprocess failures
+        (gh missing, timeout) fail-open with True so the gate never wedges
+        a transition on local tooling problems.
+        """
+        messages: List[str] = []
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "list", "--head", branch_name,
+                 "--state", "open", "--json", "number",
+                 "--jq", ".[0].number"],
+                capture_output=True, text=True, timeout=10,
+                cwd=str(self.target_dir),
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            logger.debug(
+                "PR-existence gate fail-open: %s",
+                exc,
+                extra={"branch": branch_name, "action": "fail_open"},
+            )
+            return True, []
+        if result.returncode != 0:
+            logger.debug(
+                "gh pr list failed; PR-existence gate fail-open: %s",
+                result.stderr.strip(),
+                extra={"branch": branch_name, "action": "fail_open"},
+            )
+            return True, []
+        pr_number = result.stdout.strip()
+        if pr_number:
+            messages.append(f"  PR: #{pr_number} found for branch '{branch_name}'")
+            return True, messages
+        return False, messages
+
     # -------------------------------------------------------------------------
     # E004: update
     # -------------------------------------------------------------------------
@@ -1693,6 +1732,50 @@ class IssueManager:
                 except GitHubClientError:
                     # If we can't read fields, allow the transition (fail open)
                     logger.debug("Could not read Train field, allowing transition", extra={"action": "fail_open"})
+
+            # Issue #478 — PR-existence gate at INIT → PLANNED.
+            # `atdd branch` defers PR creation; `atdd pr` opens it post-commit.
+            # Block PLANNED transition when no PR exists for the issue's branch.
+            # --force bypasses the gate with a ::warning::.
+            if status == "PLANNED":
+                gate_branch = branch
+                if not gate_branch:
+                    try:
+                        field_values = client.get_project_item_field_values(item_id)
+                        gate_branch = (field_values.get("ATDD Branch") or "").strip()
+                    except GitHubClientError:
+                        gate_branch = ""
+
+                if gate_branch:
+                    pr_exists, pr_messages = self._validate_pr_exists_for_branch(
+                        gate_branch
+                    )
+                    for msg in pr_messages:
+                        print(msg)
+                    if not pr_exists:
+                        if force:
+                            print(
+                                "::warning::PR-existence gate bypassed (--force); "
+                                f"branch '{gate_branch}' has no open PR."
+                            )
+                        else:
+                            print(
+                                f"\nError: No open PR found for branch "
+                                f"'{gate_branch}' — cannot transition to PLANNED."
+                            )
+                            print( "  Fix:")
+                            print( "    1. cd into the issue's worktree")
+                            print( "       (find via: git worktree list | grep <branch>):")
+                            print(f"       cd /path/to/<feat-or-fix>-<slug>")
+                            print( "    2. Make at least one commit on the branch:")
+                            print( "       git add <files> && git commit -m \"<message>\"")
+                            print( "       git push")
+                            print(f"    3. atdd pr {issue_id}")
+                            print(f"    4. atdd issue {issue_id} --status PLANNED")
+                            print( "  Why PR: PLANNED transition assumes the branch is reviewable;")
+                            print( "          a draft PR is the canonical review surface. (See #478.)")
+                            print(f"  Bypass: atdd issue {issue_id} --status PLANNED --force")
+                            return 1
 
             # Train cross-reference: validate --train value against _trains.yaml
             # This check applies regardless of --force (identity enforcement)

--- a/src/atdd/coach/commands/pr.py
+++ b/src/atdd/coach/commands/pr.py
@@ -144,7 +144,11 @@ class PRManager:
                 capture_output=True, text=True, timeout=10,
                 cwd=self.target_dir,
             )
-        except (subprocess.TimeoutExpired, FileNotFoundError):
+        except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            logger.debug(
+                "rev-count past default branch failed",
+                extra={"branch": default_branch, "error": str(exc)},
+            )
             return None
         if result.returncode != 0:
             return None

--- a/src/atdd/coach/commands/pr.py
+++ b/src/atdd/coach/commands/pr.py
@@ -26,6 +26,7 @@ from typing import Dict, List, Optional
 import yaml
 
 from atdd.coach.commands.issue import TYPE_TO_PREFIX
+from atdd.coach.utils.default_branch import resolve_default_branch
 from atdd.coach.utils.risk_score import (
     compute_risk_breakdown,
     format_risk_breakdown_section,
@@ -134,6 +135,23 @@ class PRManager:
         except (subprocess.TimeoutExpired, FileNotFoundError):  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
             pass
         return None
+
+    def _rev_count_past_default(self, default_branch: str) -> Optional[int]:
+        """Return commits in HEAD past origin/<default_branch>; None on failure."""
+        try:
+            result = subprocess.run(
+                ["git", "rev-list", "--count", f"origin/{default_branch}..HEAD"],
+                capture_output=True, text=True, timeout=10,
+                cwd=self.target_dir,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return None
+        if result.returncode != 0:
+            return None
+        out = result.stdout.strip()
+        if not out.isdigit():
+            return None
+        return int(out)
 
     # ------------------------------------------------------------------
     # PR → Issue resolution (4-strategy cascade)
@@ -513,6 +531,25 @@ class PRManager:
             print(f"PR already exists for branch '{branch}':")
             print(f"  {existing}")
             return 0
+
+        # 2b. Empty-branch gate — GitHub rejects createPullRequest when
+        # head==base. Print structured Fix hint per #467 contract C1-C4
+        # instead of forwarding the GraphQL error.
+        default_branch = resolve_default_branch(self.target_dir)
+        rev_count = self._rev_count_past_default(default_branch)
+        if rev_count == 0:
+            print(
+                f"Error: Branch '{branch}' has 0 commits past "
+                f"`{default_branch}` — cannot open PR."
+            )
+            print( "  Fix:")
+            print( "    1. Make at least one commit on this branch:")
+            print( "       git add <files> && git commit -m \"<message>\"")
+            print( "       git push")
+            print(f"    2. atdd pr {issue_number}")
+            print( "  Why: GitHub's createPullRequest mutation requires at least")
+            print(f"       one commit diverging from `{default_branch}`. (See #478.)")
+            return 1
 
         # 3. Fetch issue metadata from GitHub
         issue_data = self._fetch_issue(issue_number)

--- a/src/atdd/coach/commands/tests/test_branch_empty_pr_defer.py
+++ b/src/atdd/coach/commands/tests/test_branch_empty_pr_defer.py
@@ -1,0 +1,165 @@
+"""Fixture lock for the empty-branch PR-deferral contract (issue #478).
+
+`atdd branch <N>` MUST NOT call `gh pr create` when the branch has 0 commits
+past the resolved default branch — GitHub's createPullRequest mutation hard-
+fails when head==base, and that failure looks like a real error to users.
+
+Three fixtures cover:
+  (a) empty branch produces a structured hint and never invokes `gh pr create`
+  (b) non-empty branch still attempts PR creation (deferral does not regress
+      the happy path)
+  (c) `atdd pr <N>` on an empty branch exits non-zero with a #467-shaped Fix
+      hint, never invoking `gh pr create`
+
+Run: PYTHONPATH=src python3 -m pytest -q \\
+     src/atdd/coach/commands/tests/test_branch_empty_pr_defer.py -v
+"""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from atdd.coach.commands.branch import BranchManager
+from atdd.coach.commands.pr import PRManager
+
+
+pytestmark = [pytest.mark.platform]
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = ""):
+    proc = MagicMock()
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+def _fake_subprocess_run_factory(rev_count: str, gh_pr_calls: list):
+    """Return a side_effect that mocks the subprocess sequence we drive.
+
+    Recorded calls to `gh pr create` (full argv) land in ``gh_pr_calls``.
+    """
+
+    def side_effect(cmd, **kwargs):
+        # gh pr list (existing-PR check) — return empty
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return _completed(0, "", "")
+        # git rev-list --count origin/<default>..HEAD
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return _completed(0, rev_count, "")
+        # gh pr create — record and refuse (GraphQL would fail anyway)
+        if cmd[:3] == ["gh", "pr", "create"]:
+            gh_pr_calls.append(list(cmd))
+            return _completed(0, "https://example/pr/1", "")
+        # git push, git fetch, git worktree, etc.
+        return _completed(0, "", "")
+
+    return side_effect
+
+
+# ---------------------------------------------------------------------------
+# Fixture (a): empty branch — hint printed, no `gh pr create`
+# ---------------------------------------------------------------------------
+
+def test_empty_branch_defers_pr_with_structured_hint(tmp_path, capsys):
+    mgr = BranchManager(target_dir=tmp_path)
+    gh_pr_calls: list = []
+
+    with patch(
+        "atdd.coach.commands.branch.subprocess.run",
+        side_effect=_fake_subprocess_run_factory("0", gh_pr_calls),
+    ), patch(
+        "atdd.coach.commands.branch.resolve_default_branch",
+        return_value="main",
+    ):
+        mgr._create_draft_pr(
+            branch_name="feat/empty-test",
+            issue_number=478,
+            slug="empty-test",
+            issue_type="cleanup",
+            worktree_path=tmp_path,
+        )
+
+    out = capsys.readouterr().out
+
+    assert gh_pr_calls == [], "must NOT invoke `gh pr create` on empty branch"
+    assert "Draft PR deferred" in out
+    assert "0 commits past" in out
+    assert "atdd pr 478" in out
+    assert "GraphQL" not in out  # no scary error wording
+    assert "Warning: Could not create draft PR" not in out
+
+
+# ---------------------------------------------------------------------------
+# Fixture (b): non-empty branch — PR creation still attempted
+# ---------------------------------------------------------------------------
+
+def test_non_empty_branch_still_attempts_pr_creation(tmp_path):
+    mgr = BranchManager(target_dir=tmp_path)
+    gh_pr_calls: list = []
+
+    with patch(
+        "atdd.coach.commands.branch.subprocess.run",
+        side_effect=_fake_subprocess_run_factory("3", gh_pr_calls),
+    ), patch(
+        "atdd.coach.commands.branch.resolve_default_branch",
+        return_value="main",
+    ), patch(
+        "atdd.coach.commands.branch.ProjectConfig.from_config",
+        side_effect=Exception("no config — fall back to slug"),
+    ):
+        mgr._create_draft_pr(
+            branch_name="feat/non-empty-test",
+            issue_number=478,
+            slug="non-empty-test",
+            issue_type="cleanup",
+            worktree_path=tmp_path,
+        )
+
+    assert len(gh_pr_calls) == 1, "non-empty branch must invoke `gh pr create`"
+    argv = gh_pr_calls[0]
+    assert "--base" in argv and argv[argv.index("--base") + 1] == "main"
+    assert "--head" in argv and argv[argv.index("--head") + 1] == "feat/non-empty-test"
+
+
+# ---------------------------------------------------------------------------
+# Fixture (c): `atdd pr <N>` on empty branch — clean exit + #467 hint
+# ---------------------------------------------------------------------------
+
+def test_atdd_pr_on_empty_branch_fails_clean_with_hint(tmp_path, capsys):
+    mgr = PRManager(target_dir=tmp_path)
+    gh_pr_calls: list = []
+
+    def side_effect(cmd, **kwargs):
+        # _detect_branch
+        if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return _completed(0, "feat/empty\n", "")
+        # _existing_pr_for_branch
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return _completed(0, "", "")
+        # _rev_count_past_default
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return _completed(0, "0\n", "")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            gh_pr_calls.append(list(cmd))
+            return _completed(0, "", "")
+        return _completed(0, "", "")
+
+    with patch(
+        "atdd.coach.commands.pr.subprocess.run",
+        side_effect=side_effect,
+    ), patch(
+        "atdd.coach.commands.pr.resolve_default_branch",
+        return_value="main",
+    ):
+        rc = mgr.pr(issue_number=478)
+
+    out = capsys.readouterr().out
+    assert rc == 1, "empty-branch path must exit non-zero"
+    assert gh_pr_calls == [], "must NOT invoke `gh pr create` on empty branch"
+    assert "0 commits past" in out
+    assert "Fix:" in out
+    # #467 contract: numbered prereqs, runnable as printed, no deprecated CLI
+    assert "1." in out and "2." in out
+    assert "atdd pr 478" in out
+    assert "atdd update" not in out  # deprecated form must not appear

--- a/src/atdd/coach/commands/tests/test_issue_planned_pr_gate.py
+++ b/src/atdd/coach/commands/tests/test_issue_planned_pr_gate.py
@@ -1,0 +1,158 @@
+"""Fixture lock for the PR-existence gate at INIT → PLANNED (issue #478).
+
+The PLANNED transition assumes the branch is reviewable. Since `atdd branch`
+defers PR creation (Phase 1), the gate has to live at the next step in the
+lifecycle — `atdd issue <N> --status PLANNED` — and it must satisfy the
+#467 hint contract (numbered prereqs, runnable as printed, no deprecated
+CLI form).
+
+Three fixtures cover:
+  (a) PR exists for the issue's branch → transition succeeds.
+  (b) No PR for the branch → transition blocked with structured Fix hint.
+  (c) ``--force`` overrides with a ``::warning::`` line and proceeds.
+
+Run: PYTHONPATH=src python3 -m pytest -q \\
+     src/atdd/coach/commands/tests/test_issue_planned_pr_gate.py -v
+"""
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from atdd.coach.commands.issue import IssueManager
+
+
+pytestmark = [pytest.mark.platform]
+
+
+def _setup_atdd_config(tmp_path: Path) -> Path:
+    cfg_dir = tmp_path / ".atdd"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.yaml").write_text(yaml.safe_dump({
+        "github": {"repo": "owner/repo", "project_id": "PVT_test"},
+    }))
+    (cfg_dir / "manifest.yaml").write_text(yaml.safe_dump({
+        "version": "2.0",
+        "sessions": [
+            {"id": "478", "slug": "478-branch-pr-empty",
+             "issue_number": 478, "type": "cleanup", "status": "INIT"},
+        ],
+    }))
+    return tmp_path
+
+
+def _init_issue() -> dict:
+    return {
+        "number": 478,
+        "title": "branch-pr-empty",
+        "state": "OPEN",
+        "labels": [{"name": "atdd:INIT"}, {"name": "atdd-issue"}],
+        "body": "| Type | `cleanup` |\n",
+    }
+
+
+def _fresh_mgr_with_client(tmp_path: Path) -> tuple:
+    target = _setup_atdd_config(tmp_path)
+    mgr = IssueManager(target_dir=target)
+
+    client = MagicMock()
+    client.get_issue.return_value = _init_issue()
+    client.get_project_fields.return_value = {
+        "ATDD Status": {"id": "f_s", "options": {"PLANNED": "opt_planned"}},
+    }
+    client.get_project_item_id.return_value = "item_478"
+    client.get_project_item_field_values.return_value = {
+        "ATDD Branch": "chore/478-branch-pr-empty",
+    }
+    return mgr, client
+
+
+# ---------------------------------------------------------------------------
+# Fixture (a): PR exists → transition succeeds
+# ---------------------------------------------------------------------------
+
+def test_planned_transition_succeeds_when_pr_exists(tmp_path, capsys):
+    mgr, client = _fresh_mgr_with_client(tmp_path)
+
+    def gh_run(cmd, **kwargs):
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stderr = ""
+        if cmd[:3] == ["gh", "pr", "list"]:
+            proc.stdout = "478\n"
+        else:
+            proc.stdout = ""
+        return proc
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"), \
+         patch("atdd.coach.commands.issue.subprocess.run",
+               side_effect=gh_run):
+        rc = mgr.update("478", status="PLANNED")
+
+    assert rc == 0, "PLANNED transition must succeed when a PR exists"
+    out = capsys.readouterr().out
+    assert "PR: #478 found for branch" in out
+    assert "::warning::" not in out
+    assert "Error: No open PR found" not in out
+
+
+# ---------------------------------------------------------------------------
+# Fixture (b): no PR → transition blocked with structured hint
+# ---------------------------------------------------------------------------
+
+def test_planned_transition_blocked_when_no_pr(tmp_path, capsys):
+    mgr, client = _fresh_mgr_with_client(tmp_path)
+
+    def gh_run(cmd, **kwargs):
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = ""
+        proc.stderr = ""
+        return proc
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"), \
+         patch("atdd.coach.commands.issue.subprocess.run",
+               side_effect=gh_run):
+        rc = mgr.update("478", status="PLANNED")
+
+    assert rc == 1, "PLANNED transition must abort when no PR exists"
+    out = capsys.readouterr().out
+    assert "Error: No open PR found" in out
+    assert "Fix:" in out
+    # #467 contract — numbered prereqs, runnable as printed
+    assert "1." in out and "2." in out and "3." in out and "4." in out
+    assert "atdd pr 478" in out
+    assert "atdd issue 478 --status PLANNED" in out
+    # No deprecated CLI form
+    assert "atdd update" not in out
+    # Bypass surfaced
+    assert "--force" in out
+
+
+# ---------------------------------------------------------------------------
+# Fixture (c): --force override accepted with ::warning::
+# ---------------------------------------------------------------------------
+
+def test_planned_transition_force_override_emits_warning(tmp_path, capsys):
+    mgr, client = _fresh_mgr_with_client(tmp_path)
+
+    def gh_run(cmd, **kwargs):
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.stdout = ""
+        proc.stderr = ""
+        return proc
+
+    with patch.object(mgr, "_get_github_client", return_value=client), \
+         patch.object(mgr, "_update_manifest_status"), \
+         patch("atdd.coach.commands.issue.subprocess.run",
+               side_effect=gh_run):
+        rc = mgr.update("478", status="PLANNED", force=True)
+
+    assert rc == 0, "PLANNED transition with --force must proceed"
+    out = capsys.readouterr().out
+    assert "::warning::PR-existence gate bypassed" in out
+    assert "Error: No open PR found" not in out

--- a/src/atdd/coach/utils/default_branch.py
+++ b/src/atdd/coach/utils/default_branch.py
@@ -1,0 +1,78 @@
+"""
+Default-branch resolver shared by ``atdd branch`` and ``atdd pr``.
+
+Resolution order:
+    1. ``.atdd/config.yaml::github.default_branch`` if present.
+    2. ``gh repo view --json defaultBranchRef --jq .defaultBranchRef.name``.
+    3. Literal ``"main"`` with a ``::warning::`` log.
+
+Cross-coordination: introduced for issues #477 and #478. First-mover wins;
+both PRs converge on this single canonical home so the literal ``"main"``
+hardcode disappears from ``branch.py:73`` and ``pr.py:478``.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_default_branch(repo_root: Optional[Path] = None) -> str:
+    """Resolve the repository's default branch name.
+
+    Args:
+        repo_root: Repo root containing ``.atdd/config.yaml``. Defaults to cwd.
+
+    Returns:
+        Branch name string (e.g. ``"main"``).
+    """
+    root = repo_root or Path.cwd()
+
+    cfg_default = _read_config_default_branch(root / ".atdd" / "config.yaml")
+    if cfg_default:
+        return cfg_default
+
+    gh_default = _query_gh_default_branch(root)
+    if gh_default:
+        return gh_default
+
+    print("::warning::default-branch resolver fell back to literal 'main'")
+    logger.warning(
+        "default-branch resolver fell back to literal 'main'",
+        extra={"action": "default_branch_fallback"},
+    )
+    return "main"
+
+
+def _read_config_default_branch(config_file: Path) -> Optional[str]:
+    if not config_file.exists():
+        return None
+    try:
+        data = yaml.safe_load(config_file.read_text()) or {}
+    except yaml.YAMLError:
+        return None
+    value = (data.get("github") or {}).get("default_branch")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _query_gh_default_branch(cwd: Path) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "defaultBranchRef",
+             "--jq", ".defaultBranchRef.name"],
+            capture_output=True, text=True, timeout=10,
+            cwd=cwd,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    name = result.stdout.strip()
+    return name or None

--- a/src/atdd/coach/utils/default_branch.py
+++ b/src/atdd/coach/utils/default_branch.py
@@ -54,7 +54,11 @@ def _read_config_default_branch(config_file: Path) -> Optional[str]:
         return None
     try:
         data = yaml.safe_load(config_file.read_text()) or {}
-    except yaml.YAMLError:
+    except yaml.YAMLError as exc:
+        logger.debug(
+            "default_branch config read failed",
+            extra={"path": str(config_file), "error": str(exc)},
+        )
         return None
     value = (data.get("github") or {}).get("default_branch")
     if isinstance(value, str) and value.strip():
@@ -70,7 +74,11 @@ def _query_gh_default_branch(cwd: Path) -> Optional[str]:
             capture_output=True, text=True, timeout=10,
             cwd=cwd,
         )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        logger.debug(
+            "gh repo view default-branch query failed",
+            extra={"cwd": str(cwd), "error": str(exc)},
+        )
         return None
     if result.returncode != 0:
         return None


### PR DESCRIPTION
Closes #478

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #478 |
| Type | cleanup |
| Slug | 478-branch-pr-empty |
| Train | 0001-self-compliance-validate |

## Phase 1 — defer empty-branch PR creation

`atdd branch <N>` no longer attempts `gh pr create --draft` when the
new branch has 0 commits past the resolved default branch. The
GraphQL `createPullRequest` mutation hard-fails when head==base, and
that failure looked like a real error to first-time users.

- `branch.py:73` — replace literal `"main"` with `resolve_default_branch()`.
- `branch.py:212-219` — wrap `_create_draft_pr()` body in an empty-branch
  check (`git rev-list --count origin/<default>..HEAD == 0`). On 0 commits,
  print a structured `Note: Draft PR deferred — branch has 0 commits past
  <default>.` pointing users at `atdd pr <N>` after first commit.
- `branch.py:85` — replaced the `Warning: Could not create draft PR` line
  with a #467-shaped Fix hint, only fires for genuine API failures (the
  empty-branch case is caught earlier).
- `pr.py:~510` — added the same empty-branch gate immediately after the
  existing-PR check at `:511-516`. On 0 commits, exit `1` with a Fix hint
  satisfying #467 contract C1-C4 (numbered prereqs, runnable as printed,
  no deprecated CLI form).

Test fixture: `src/atdd/coach/commands/tests/test_branch_empty_pr_defer.py`
locks all 3 cases (empty → defer + hint, non-empty → PR still attempted,
`atdd pr` on empty → rc=1 + hint).

## Phase 2 — PR-existence gate at `atdd issue --status PLANNED`

Phase 1 deferred PR creation, so the lifecycle gate moves one step later.
INIT → PLANNED now blocks when `gh pr list --head <branch> --state open`
returns empty, and emits a #467-shaped hint with `--force` bypass.

- `issue.py:_validate_pr_exists_for_branch(branch_name)` — new helper.
  Fail-open on subprocess errors so the gate never wedges a transition on
  local tooling glitches.
- `issue.py:~1670` — gate is wired alongside the existing train-required
  gate, before the transition apply. Branch resolved from `--branch` arg
  or (fallback) the project's `ATDD Branch` field.
- `--force` accepted with a `::warning::PR-existence gate bypassed` line.
- Hint shape modeled after the train-required hint that #466 fixed
  (numbered cd → commit → push → `atdd pr` → re-run, plus bypass line).

Test fixture: `src/atdd/coach/commands/tests/test_issue_planned_pr_gate.py`
locks (a) PR exists → success, (b) no PR → rc=1 + hint, (c) --force →
::warning:: + proceed.

## Cross-coord with #477

#477 has the same hardcoded-`"main"` bug surface at `pr.py:478`. Per the
shared coordination protocol, this PR **introduced** the canonical helper
at `src/atdd/coach/utils/default_branch.py::resolve_default_branch()`.
Resolution order:

1. `.atdd/config.yaml::github.default_branch`
2. `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`
3. Literal `"main"` with a `::warning::` log

Cross-coord check at impl-start time:
```
[ -f src/atdd/coach/utils/default_branch.py ] && echo "EXISTS" || echo "INTRODUCE"
# → INTRODUCE (this PR is first-mover; #477 will reuse)
```

When #477 lands it will import this helper from `pr.py:478` and drop its
own copy. No duplication.

## Eat-own-dogfood

This PR was opened via `atdd pr 478` **after** Phase 1's first commit
landed — exercising the deferred flow this PR introduces:

```
$ atdd pr 478 --draft
PR created: https://github.com/afokapu/atdd/pull/479
  Title: chore(atdd): Branch Pr Empty Commit Failure (#478)
  Closes: #478
```

`atdd branch` running on this branch printed the deferred-PR hint
(no GraphQL leak); the first commit unblocked PR creation; `atdd pr`
opened the draft cleanly. End-to-end smoke for the new lifecycle.

## Version

3.11.0 → 3.11.1 (PATCH, `chore/`-prefix per #462's bump map; the
contract change is hint-shape only, no breaking CLI surface).

## Verification

```
PYTHONPATH=src python3 -m pytest -q \
  src/atdd/coach/commands/tests/test_branch_empty_pr_defer.py \
  src/atdd/coach/commands/tests/test_issue_planned_pr_gate.py \
  src/atdd/coach/commands/tests/test_issue_train_required_hint.py \
  src/atdd/coach/commands/tests/test_issue_lifecycle.py
# 38 passed
```