### PR TITLE
fix(coach): #477 — atdd pr / gh pr create must validate base = default branch (orphan-merge prevention)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -670,9 +670,23 @@ issues:
   # generation, Project v2 field setup, and worktree metadata.
   # The coach validator (`atdd validate coach`) will flag issues that exist
   # on GitHub but are missing from .atdd/manifest.yaml.
+  #
+  # PR creation specifically: the canonical site is `atdd pr <N>`, which
+  # validates `--base` against the repo's default branch (#477). Direct
+  # `gh pr create` invocations bypass that guard. The lived incident:
+  # PR #475 (the v3.11.0 #473-Phase-2+3 work) was opened with
+  # `gh pr create` and inherited a sibling-PR's branch as its base; when
+  # the sibling merged + auto-deleted that branch, #475's squash-merge
+  # commit landed on a phantom ref invisible to `git log main`. The
+  # v3.11.0 deliverable was orphaned — Closes #473 fired without the work
+  # actually shipping. Recovery cost: PR #476, manual conflict resolution,
+  # ~15 min. The Phase-2 coach validator
+  # (`coach.pr.base-must-be-default-branch`) now flags any open PR with a
+  # non-default base on every `atdd validate coach` run. Use `atdd pr <N>`
+  # for ALL PR creation.
   prohibited_commands:
     - "gh issue create    → use: atdd issue <slug>"
-    - "gh pr create       → use: atdd branch <N> (creates worktree + PR-ready branch)"
+    - "gh pr create       → use: atdd pr <N>  (validates --base against the repo default branch; #477 / #475 orphan-merge incident)"
 
   archetypes:
     db: "Supabase PostgreSQL + JSONB"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.11.0"
+version = "3.12.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -676,6 +676,14 @@ Phase descriptions:
         default="squash",
         help="Merge strategy for auto-merge (default: squash)"
     )
+    pr_parser.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Skip the base-branch validation guard (#477). Use only for "
+            "legitimate non-default merges (release-train branches, stacked PRs)."
+        ),
+    )
 
     # ----- atdd close-wmbt <issue_number> <wmbt_id> -----
     close_wmbt_top_parser = subparsers.add_parser(
@@ -1840,6 +1848,7 @@ Phase descriptions:
             base=getattr(args, 'base', 'main'),
             auto_merge=getattr(args, 'auto', False),
             merge_strategy=getattr(args, 'merge_strategy', 'squash'),
+            force=getattr(args, 'force', False),
         )
 
     # atdd close-wmbt <issue_id> <wmbt_id> — DEPRECATED, delegates to atdd issue <N> --close-wmbt <ID>

--- a/src/atdd/coach/commands/pr.py
+++ b/src/atdd/coach/commands/pr.py
@@ -26,6 +26,7 @@ from typing import Dict, List, Optional
 import yaml
 
 from atdd.coach.commands.issue import TYPE_TO_PREFIX
+from atdd.coach.utils.default_branch import resolve_default_branch
 from atdd.coach.utils.risk_score import (
     compute_risk_breakdown,
     format_risk_breakdown_section,
@@ -478,6 +479,7 @@ class PRManager:
         base: str = "main",
         auto_merge: bool = False,
         merge_strategy: str = "squash",
+        force: bool = False,
     ) -> int:
         """Create a PR linked to the given issue number.
 
@@ -487,6 +489,7 @@ class PRManager:
             base: Base branch for the PR (default: main).
             auto_merge: If True, enable auto-merge after PR creation.
             merge_strategy: Merge strategy for auto-merge (squash, merge, rebase).
+            force: If True, skip the base-branch validation guard (#477).
 
         Returns:
             0 on success, 1 on error.
@@ -552,7 +555,48 @@ class PRManager:
             if "Everything up-to-date" not in stderr and "set up to track" not in stderr:
                 print(f"Warning: git push may have failed: {stderr}")
 
-        # 8. Create the PR via gh CLI
+        # 8. Validate base branch against repo default (issue #477)
+        # Two failure paths converge on the same orphan-merge bug:
+        #   (a) explicit --base <wrong>  → caught here in the CLI guard
+        #   (b) implicit gh pr create    → caught by the coach validator
+        # Override with --force only for legitimate non-default merges
+        # (release-train branches, stacked work). #475 was the lived
+        # incident that motivated this gate.
+        default_branch = resolve_default_branch(self.target_dir)
+        if base != default_branch:
+            if force:
+                logger.warning(
+                    "::warning::Creating PR with non-default base '%s' "
+                    "(default: '%s') — --force override active.",
+                    base, default_branch,
+                    extra={"base": base, "default_branch": default_branch, "force": True},
+                )
+                print(
+                    f"::warning::Non-default base '{base}' "
+                    f"(default: '{default_branch}') — --force override active."
+                )
+            else:
+                print(
+                    f"Error: Refusing to create PR with non-default base "
+                    f"'{base}'. Default branch: '{default_branch}'.\n"
+                    f"\n"
+                    f"Fix:\n"
+                    f"  1. Re-run with the default base (recommended):\n"
+                    f"       atdd pr {issue_number}\n"
+                    f"  2. Or pass the default explicitly:\n"
+                    f"       atdd pr {issue_number} --base {default_branch}\n"
+                    f"  3. Override only for legitimate non-default merges\n"
+                    f"     (release-train branches, stacked PRs):\n"
+                    f"       atdd pr {issue_number} --base {base} --force\n"
+                    f"\n"
+                    f"Default branch resolved from "
+                    f".atdd/config.yaml::github.default_branch (fallback: "
+                    f"gh repo view --json defaultBranchRef). "
+                    f"See issue #477 for context (orphan-merge incident #475)."
+                )
+                return 1
+
+        # 9. Create the PR via gh CLI
         cmd = [
             "gh", "pr", "create",
             "--title", pr_title,

--- a/src/atdd/coach/commands/tests/test_pr_base_validation.py
+++ b/src/atdd/coach/commands/tests/test_pr_base_validation.py
@@ -1,0 +1,170 @@
+"""
+Phase 1 unit tests for ``atdd pr`` base-branch validation (issue #477).
+
+The CLI guard at src/atdd/coach/commands/pr.py:~555 must:
+  1. Accept the default base (implicit and explicit).
+  2. Reject any non-default base unless ``--force`` is passed.
+  3. Print a runnable structured Fix hint on rejection (#467 contract C1-C4).
+  4. Honor a ``--force`` override with a ``::warning::`` log line.
+  5. Resolve the default branch via the helper at
+     ``src/atdd/coach/utils/default_branch.py`` (config → gh → "main").
+
+These tests stub out the network/subprocess seam so the CLI guard's
+control flow is exercised in isolation. Cross-coordinated with #478
+on the shared default-branch helper.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from atdd.coach.commands.pr import PRManager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> PRManager:
+    """A PRManager rooted at an isolated tmp dir (no real .atdd config)."""
+    (tmp_path / ".atdd").mkdir()
+    (tmp_path / ".atdd" / "config.yaml").write_text(
+        "github:\n"
+        "  repo: example/repo\n"
+        "  default_branch: main\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".atdd" / "manifest.yaml").write_text("sessions: []\n", encoding="utf-8")
+    return PRManager(target_dir=tmp_path)
+
+
+def _patch_common(monkeypatch, branch: str = "feat/477-pr-base-validation"):
+    """Stub the network/git seams so only the validation block runs."""
+    from atdd.coach.commands import pr as pr_module
+
+    monkeypatch.setattr(PRManager, "_detect_branch", lambda self: branch)
+    monkeypatch.setattr(PRManager, "_existing_pr_for_branch", lambda self, b: None)
+    monkeypatch.setattr(
+        PRManager, "_fetch_issue",
+        lambda self, n: {"title": "Test", "number": n, "labels": []},
+    )
+    monkeypatch.setattr(PRManager, "_find_issue_in_manifest", lambda self, n: None)
+    monkeypatch.setattr(PRManager, "_fetch_sub_issues", lambda self, n: [])
+
+    class _OK:
+        returncode = 0
+        stdout = "https://github.com/example/repo/pull/999"
+        stderr = ""
+
+    monkeypatch.setattr(pr_module.subprocess, "run", lambda *a, **kw: _OK())
+
+
+# ---------------------------------------------------------------------------
+# Fixture 1: default base implicit — accepted
+# ---------------------------------------------------------------------------
+
+
+def test_default_base_implicit_is_accepted(manager, monkeypatch, capsys):
+    """``atdd pr <N>`` with no --base resolves default and proceeds."""
+    _patch_common(monkeypatch)
+    rc = manager.pr(issue_number=477)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Refusing to create PR" not in out
+
+
+# ---------------------------------------------------------------------------
+# Fixture 2: explicit default base — accepted
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_default_base_is_accepted(manager, monkeypatch, capsys):
+    """``atdd pr <N> --base main`` (matches default) proceeds without warning."""
+    _patch_common(monkeypatch)
+    rc = manager.pr(issue_number=477, base="main")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Refusing to create PR" not in out
+    assert "::warning::" not in out
+
+
+# ---------------------------------------------------------------------------
+# Fixture 3: non-default base without --force — rejected
+# ---------------------------------------------------------------------------
+
+
+def test_non_default_base_without_force_is_rejected(manager, monkeypatch, capsys):
+    """A non-default base produces a structured rejection (#467 C1-C4 hint)."""
+    _patch_common(monkeypatch)
+    rc = manager.pr(issue_number=477, base="feat/some-other-branch")
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "Refusing to create PR" in out
+    # Numbered Fix steps (C3 + C4 contract)
+    assert "1. Re-run with the default base" in out
+    assert "2. Or pass the default explicitly" in out
+    assert "3. Override only for legitimate" in out
+    # Runnable as printed (C4): the issue number is resolved
+    assert "atdd pr 477" in out
+    # Citation back to the lived incident
+    assert "#477" in out
+
+
+# ---------------------------------------------------------------------------
+# Fixture 4: non-default base with --force — accepted with ::warning::
+# ---------------------------------------------------------------------------
+
+
+def test_force_override_accepted_with_warning(manager, monkeypatch, capsys):
+    """``--force`` lets a non-default base through but emits a ::warning::."""
+    _patch_common(monkeypatch)
+    rc = manager.pr(
+        issue_number=477,
+        base="release/v3-train",
+        force=True,
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "::warning::" in out
+    assert "release/v3-train" in out
+    assert "Refusing to create PR" not in out
+
+
+# ---------------------------------------------------------------------------
+# Fixture 5: default-branch helper falls back through resolution chain
+# ---------------------------------------------------------------------------
+
+
+def test_default_branch_lookup_falls_back_through_chain(tmp_path, monkeypatch):
+    """Helper: config absent → gh CLI → 'main' literal fallback.
+
+    Exercises all three legs of the resolver shared with #478.
+    """
+    from atdd.coach.utils import default_branch as helper
+
+    # Leg 1: config provides the answer.
+    (tmp_path / ".atdd").mkdir()
+    cfg = tmp_path / ".atdd" / "config.yaml"
+    cfg.write_text("github:\n  default_branch: trunk\n", encoding="utf-8")
+    assert helper.resolve_default_branch(tmp_path) == "trunk"
+
+    # Leg 2: config absent, gh CLI returns the default.
+    cfg.unlink()
+    class _GhOK:
+        returncode = 0
+        stdout = "master\n"
+        stderr = ""
+    with patch.object(helper.subprocess, "run", return_value=_GhOK()):
+        assert helper.resolve_default_branch(tmp_path) == "master"
+
+    # Leg 3: config absent + gh fails → "main" literal fallback.
+    class _GhFail:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: not authenticated"
+    with patch.object(helper.subprocess, "run", return_value=_GhFail()):
+        assert helper.resolve_default_branch(tmp_path) == "main"

--- a/src/atdd/coach/conventions/rule-id.convention.yaml
+++ b/src/atdd/coach/conventions/rule-id.convention.yaml
@@ -309,6 +309,39 @@ rules:
         3. Re-emit by re-running the unit test
            src/atdd/coach/commands/tests/test_initializer_workflow_emission.py
            which feeds every emitted run-line through the live argparse.
+  - id: "coach.pr.base-must-be-default-branch"
+    severity: 3
+    description: "Every PR (open or being created via `atdd pr`) must target the repo's default branch unless --force is set"
+    disposition: strict
+    introduced_in: "3.12.0"
+    aliases: []
+    validator: "test_pr_base_branch::test_every_open_pr_targets_default_branch"
+    fix_hint: |
+      The named PR targets a non-default base branch. Repair as follows
+      (run gh repo view --json defaultBranchRef --jq .defaultBranchRef.name
+       to inspect the canonical default; for atdd it is "main" and is
+       also recorded at .atdd/config.yaml::github.default_branch):
+
+        1. Read the violation — it cites "PR#<N>" where N is the PR number
+           and the message names the offending baseRefName.
+           e.g. "PR#475 ... targets base 'fix/473-init-template-fix'".
+        2. Re-target the offending PR via the GitHub UI or via
+           "gh pr edit <N> --base <default>", substituting:
+             - <N>       = the PR number from step 1, e.g. "475"
+             - <default> = the default branch name, e.g. "main"
+        3. If the non-default base is intentional (release-train
+           branches, stacked PRs), close the PR and re-open via
+           "atdd pr <issue> --base <base> --force", substituting:
+             - <issue> = the linked atdd issue number, e.g. "477"
+             - <base>  = the explicit non-default base, e.g. "release/v3"
+        4. Re-run the validator to confirm clean
+           (run pytest src/atdd/coach/validators/test_pr_base_branch.py -v).
+
+      Source contract: this rule prevents the orphan-merge incident
+      from #475 where a PR merged onto a sibling-PR's branch (which
+      was deleted post-merge), orphaning the v3.11.0 work. See
+      issue #477 and src/atdd/coach/commands/pr.py for the CLI guard
+      that catches the same class of mistake at PR-creation time.
   - id: "coach.rule-id.fix-hint-completeness"
     severity: 2
     description: "Every fix_hint (convention-declared or CLI-printed) must satisfy the completeness contract C1-C4 in rule_schema.fields.fix_hint.description"

--- a/src/atdd/coach/templates/ATDD.md
+++ b/src/atdd/coach/templates/ATDD.md
@@ -373,9 +373,23 @@ issues:
   # generation, Project v2 field setup, and worktree metadata.
   # The coach validator (`atdd validate coach`) will flag issues that exist
   # on GitHub but are missing from .atdd/manifest.yaml.
+  #
+  # PR creation specifically: the canonical site is `atdd pr <N>`, which
+  # validates `--base` against the repo's default branch (#477). Direct
+  # `gh pr create` invocations bypass that guard. The lived incident:
+  # PR #475 (the v3.11.0 #473-Phase-2+3 work) was opened with
+  # `gh pr create` and inherited a sibling-PR's branch as its base; when
+  # the sibling merged + auto-deleted that branch, #475's squash-merge
+  # commit landed on a phantom ref invisible to `git log main`. The
+  # v3.11.0 deliverable was orphaned — Closes #473 fired without the work
+  # actually shipping. Recovery cost: PR #476, manual conflict resolution,
+  # ~15 min. The Phase-2 coach validator
+  # (`coach.pr.base-must-be-default-branch`) now flags any open PR with a
+  # non-default base on every `atdd validate coach` run. Use `atdd pr <N>`
+  # for ALL PR creation.
   prohibited_commands:
     - "gh issue create    → use: atdd issue <slug>"
-    - "gh pr create       → use: atdd branch <N> (creates worktree + PR-ready branch)"
+    - "gh pr create       → use: atdd pr <N>  (validates --base against the repo default branch; #477 / #475 orphan-merge incident)"
 
   archetypes:
     db: "Supabase PostgreSQL + JSONB"

--- a/src/atdd/coach/utils/default_branch.py
+++ b/src/atdd/coach/utils/default_branch.py
@@ -1,0 +1,101 @@
+"""Resolve the canonical default branch for the current repository.
+
+Resolution order (issue #477, shared with #478):
+  1. ``.atdd/config.yaml::github.default_branch`` if present.
+  2. ``gh repo view --json defaultBranchRef --jq .defaultBranchRef.name``.
+  3. Literal ``"main"`` with a ``::warning::`` log line.
+
+The helper is the canonical default-branch source for both
+``atdd pr`` (#477) and ``atdd branch`` (#478). Hardcoded ``"main"``
+in those call sites is a known-bad pattern that breaks consumer
+repos whose default is ``master`` or another name.
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK = "main"
+
+
+def _read_from_config(repo_root: Path) -> Optional[str]:
+    cfg_path = repo_root / ".atdd" / "config.yaml"
+    if not cfg_path.is_file():
+        return None
+    try:
+        data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        logger.warning(
+            "Failed to parse %s: %s",
+            cfg_path, exc,
+            extra={"path": str(cfg_path), "error": str(exc)},
+        )
+        return None
+    value = (data.get("github") or {}).get("default_branch")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _read_from_gh(repo_root: Path) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view",
+             "--json", "defaultBranchRef",
+             "--jq", ".defaultBranchRef.name"],
+            capture_output=True, text=True, timeout=10,
+            cwd=repo_root,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        logger.warning(
+            "gh repo view failed: %s",
+            exc,
+            extra={"error": str(exc)},
+        )
+        return None
+    if result.returncode != 0:
+        logger.warning(
+            "gh repo view returned %d: %s",
+            result.returncode, result.stderr.strip(),
+            extra={"stderr": result.stderr.strip(), "returncode": result.returncode},
+        )
+        return None
+    name = result.stdout.strip()
+    return name or None
+
+
+def resolve_default_branch(repo_root: Optional[Path] = None) -> str:
+    """Return the repo's default branch name.
+
+    Resolves via ``.atdd/config.yaml::github.default_branch`` first,
+    then ``gh repo view``, then ``"main"`` as the final fallback.
+
+    Args:
+        repo_root: Repo root for config + gh CLI cwd. Defaults to ``Path.cwd()``.
+
+    Returns:
+        The default branch name (never empty).
+    """
+    root = repo_root or Path.cwd()
+
+    from_config = _read_from_config(root)
+    if from_config:
+        return from_config
+
+    from_gh = _read_from_gh(root)
+    if from_gh:
+        return from_gh
+
+    logger.warning(
+        "::warning::default-branch resolution fell back to '%s' "
+        "(no .atdd/config.yaml::github.default_branch and gh repo view failed)",
+        _FALLBACK,
+        extra={"fallback": _FALLBACK, "repo_root": str(root)},
+    )
+    return _FALLBACK

--- a/src/atdd/coach/utils/default_branch.py
+++ b/src/atdd/coach/utils/default_branch.py
@@ -15,13 +15,13 @@ from __future__ import annotations
 import logging
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Final, Optional
 
 import yaml
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK = "main"
+_FALLBACK: Final[str] = "main"
 
 
 def _read_from_config(repo_root: Path) -> Optional[str]:

--- a/src/atdd/coach/validators/test_pr_base_branch.py
+++ b/src/atdd/coach/validators/test_pr_base_branch.py
@@ -36,8 +36,6 @@ from atdd.coach.validators._violation import Violation
 
 pytestmark = [pytest.mark.coach, pytest.mark.github_api]
 
-logger = logging.getLogger(__name__)
-
 REPO_ROOT = find_repo_root()
 
 _RULE = bind_rule("coach.pr.base-must-be-default-branch")
@@ -55,14 +53,14 @@ def _fetch_open_prs(repo_root: Path) -> List[dict]:
             cwd=repo_root,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
-        logger.warning(
+        logging.getLogger(__name__).warning(
             "gh pr list failed: %s",
             exc,
             extra={"error": str(exc)},
         )
         return []
     if result.returncode != 0:
-        logger.warning(
+        logging.getLogger(__name__).warning(
             "gh pr list returned %d: %s",
             result.returncode, result.stderr.strip(),
             extra={"stderr": result.stderr.strip(), "returncode": result.returncode},
@@ -71,7 +69,7 @@ def _fetch_open_prs(repo_root: Path) -> List[dict]:
     try:
         data = json.loads(result.stdout) if result.stdout.strip() else []
     except json.JSONDecodeError as exc:
-        logger.warning(
+        logging.getLogger(__name__).warning(
             "gh pr list returned non-JSON: %s",
             exc,
             extra={"error": str(exc)},

--- a/src/atdd/coach/validators/test_pr_base_branch.py
+++ b/src/atdd/coach/validators/test_pr_base_branch.py
@@ -1,0 +1,148 @@
+"""
+PR base-branch validator (issue #477).
+
+Phase 2 of the orphan-merge guard. Phase 1 (CLI) is at
+``src/atdd/coach/commands/pr.py``: it rejects ``atdd pr <N> --base <X>``
+when ``X`` is not the repo default. But agents that bypass ``atdd pr``
+and run ``gh pr create`` directly (the lived case for #475) can still
+land a PR on a sibling-PR's branch — when that branch is deleted, the
+merge orphans onto a phantom ref invisible to ``git log main``.
+
+This validator catches that path. It calls ``gh pr list --state open
+--json number,baseRefName,headRefName`` and emits one
+``Violation(rule_id="coach.pr.base-must-be-default-branch")`` per open
+PR whose ``baseRefName`` ≠ resolved default branch.
+
+Convention: ``src/atdd/coach/conventions/rule-id.convention.yaml``
+            (rule ``coach.pr.base-must-be-default-branch``).
+
+Run: ``atdd validate coach``
+"""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+
+from atdd.coach.utils.default_branch import resolve_default_branch
+from atdd.coach.utils.disposition_gate import assert_disposition_satisfied
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.utils.rule_binding import bind_rule
+from atdd.coach.validators._violation import Violation
+
+pytestmark = [pytest.mark.coach, pytest.mark.github_api]
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = find_repo_root()
+
+_RULE = bind_rule("coach.pr.base-must-be-default-branch")
+
+_VALIDATOR_ID = "pr_base_branch"
+
+
+def _fetch_open_prs(repo_root: Path) -> List[dict]:
+    """Return ``[{number, baseRefName, headRefName}, ...]`` for every open PR."""
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "list", "--state", "open",
+             "--json", "number,baseRefName,headRefName"],
+            capture_output=True, text=True, timeout=30,
+            cwd=repo_root,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as exc:
+        logger.warning(
+            "gh pr list failed: %s",
+            exc,
+            extra={"error": str(exc)},
+        )
+        return []
+    if result.returncode != 0:
+        logger.warning(
+            "gh pr list returned %d: %s",
+            result.returncode, result.stderr.strip(),
+            extra={"stderr": result.stderr.strip(), "returncode": result.returncode},
+        )
+        return []
+    try:
+        data = json.loads(result.stdout) if result.stdout.strip() else []
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "gh pr list returned non-JSON: %s",
+            exc,
+            extra={"error": str(exc)},
+        )
+        return []
+    return data or []
+
+
+def evaluate_base_violations(
+    open_prs: List[dict],
+    default_branch: str,
+) -> List[Violation]:
+    """Pure evaluator: emit one Violation per PR with non-default base.
+
+    Pure function — no GitHub access — so the helper-tests file can drive
+    it from synthetic fixtures without hitting the network.
+    """
+    violations: List[Violation] = []
+    for pr in open_prs:
+        number = pr.get("number")
+        base = pr.get("baseRefName")
+        head = pr.get("headRefName")
+        if not number or not base:
+            continue
+        if base == default_branch:
+            continue
+        violations.append(
+            Violation(
+                rule_id=_RULE.rule_id,
+                severity=_RULE.severity,
+                location=f"PR#{number}",
+                detail=(
+                    f"PR #{number} (head={head!r}) targets base "
+                    f"{base!r} but the repo default branch is "
+                    f"{default_branch!r}. Re-target via "
+                    f"`gh pr edit {number} --base {default_branch}` "
+                    f"or close + re-open with --force if the non-default "
+                    f"base is intentional. See issue #477 + #475."
+                ),
+                fix_hint_ref=getattr(_RULE, "fix_hint_ref", None),
+            )
+        )
+    return violations
+
+
+def scan_open_prs_for_base_violations(
+    repo_root: Optional[Path] = None,
+) -> List[Violation]:
+    """End-to-end scanner: fetch PRs, resolve default, emit Violations."""
+    root = repo_root or REPO_ROOT
+    default_branch = resolve_default_branch(root)
+    open_prs = _fetch_open_prs(root)
+    return evaluate_base_violations(open_prs, default_branch)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_every_open_pr_targets_default_branch():
+    """
+    SPEC: ``rule-id.convention.yaml::rules[coach.pr.base-must-be-default-branch]``.
+
+    Given:  Every open PR returned by ``gh pr list --state open``.
+    When:   Comparing ``baseRefName`` against the resolved default branch.
+    Then:   No PR targets a non-default base. Mistargeted PRs surface as
+            structured ``Violation`` records the disposition gate fails on.
+    """
+    violations = scan_open_prs_for_base_violations(REPO_ROOT)
+    assert_disposition_satisfied(
+        validator_id=_VALIDATOR_ID,
+        violations=violations,
+    )

--- a/src/atdd/coach/validators/tests/test_pr_base_branch_helpers.py
+++ b/src/atdd/coach/validators/tests/test_pr_base_branch_helpers.py
@@ -1,0 +1,86 @@
+"""
+Pure-evaluator unit tests for the PR base-branch validator (issue #477).
+
+Co-located with the other validator helper tests under
+``src/atdd/coach/validators/tests/``. These tests exercise
+``evaluate_base_violations`` directly with synthetic ``gh pr list``
+payloads — no network, no marker, no disposition-gate.
+"""
+from __future__ import annotations
+
+import pytest
+
+from atdd.coach.validators._violation import Violation
+from atdd.coach.validators.test_pr_base_branch import (
+    _RULE,
+    evaluate_base_violations,
+)
+
+
+def test_evaluate_returns_empty_when_every_pr_targets_default():
+    """No Violations when every open PR's baseRefName == default branch."""
+    open_prs = [
+        {"number": 1, "baseRefName": "main", "headRefName": "feat/a"},
+        {"number": 2, "baseRefName": "main", "headRefName": "fix/b"},
+    ]
+    violations = evaluate_base_violations(open_prs, default_branch="main")
+    assert violations == []
+
+
+def test_evaluate_emits_structured_violation_for_non_default_base():
+    """A non-default baseRefName produces one Violation with rule_id bound."""
+    open_prs = [
+        {
+            "number": 475,
+            "baseRefName": "fix/473-init-template-fix",
+            "headRefName": "feat/473-phase-2-3",
+        },
+    ]
+    violations = evaluate_base_violations(open_prs, default_branch="main")
+
+    assert len(violations) == 1
+    v = violations[0]
+    assert isinstance(v, Violation)
+    assert v.rule_id == _RULE.rule_id == "coach.pr.base-must-be-default-branch"
+    assert v.severity == _RULE.severity
+    assert "475" in v.location
+    assert "fix/473-init-template-fix" in v.detail
+    assert "main" in v.detail
+    assert "#477" in v.detail
+
+
+def test_evaluate_emits_one_violation_per_offending_pr():
+    """Multiple mistargeted PRs each produce their own Violation."""
+    open_prs = [
+        {"number": 10, "baseRefName": "main", "headRefName": "feat/x"},
+        {"number": 11, "baseRefName": "develop", "headRefName": "feat/y"},
+        {"number": 12, "baseRefName": "release/v3", "headRefName": "feat/z"},
+    ]
+    violations = evaluate_base_violations(open_prs, default_branch="main")
+
+    assert len(violations) == 2
+    locations = {v.location for v in violations}
+    assert "PR#11" in locations
+    assert "PR#12" in locations
+
+
+def test_evaluate_skips_records_missing_required_fields():
+    """Defensive: malformed gh-pr-list rows don't blow up the scanner."""
+    open_prs = [
+        {"number": None, "baseRefName": "feat/x"},
+        {"baseRefName": "feat/x"},
+        {"number": 99},
+    ]
+    violations = evaluate_base_violations(open_prs, default_branch="main")
+    assert violations == []
+
+
+def test_evaluate_respects_arbitrary_default_branch_name():
+    """Helper is name-agnostic — works for `master`, `trunk`, etc."""
+    open_prs = [
+        {"number": 1, "baseRefName": "master", "headRefName": "feat/a"},
+        {"number": 2, "baseRefName": "main", "headRefName": "feat/b"},
+    ]
+    violations = evaluate_base_violations(open_prs, default_branch="master")
+    assert len(violations) == 1
+    assert violations[0].location == "PR#2"


### PR DESCRIPTION
Closes #477

## Phase 1 — \`atdd pr\` CLI guard
- Added \`force: bool = False\` to the \`pr\` signature at \`src/atdd/coach/commands/pr.py\`.
- Validation block before \`gh pr create\` invocation: resolves default branch, rejects mismatch unless \`--force\`.
- Error path prints a numbered, runnable Fix hint that satisfies #467 contract C1-C4.
- Wired \`--force\` flag through \`src/atdd/cli.py\`.
- 5 unit fixtures in \`src/atdd/coach/commands/tests/test_pr_base_validation.py\` (default implicit, default explicit, mismatch rejected, --force accepted, helper fallback chain).

## Phase 2 — coach validator + rule declaration
- New validator \`src/atdd/coach/validators/test_pr_base_branch.py\` (\`@pytest.mark.github_api\`): \`gh pr list --state open --json number,baseRefName,headRefName\` → emit one structured \`Violation(rule_id="coach.pr.base-must-be-default-branch")\` per mistargeted PR.
- Rule declared in EXISTING \`src/atdd/coach/conventions/rule-id.convention.yaml::rules:\` (sibling to the 6 existing rules — coherence pattern from #467/#473). NO new convention file.
- 5 helper fixtures in \`src/atdd/coach/validators/tests/test_pr_base_branch_helpers.py\` exercise \`evaluate_base_violations\` directly (no network).

## Phase 3 — CLAUDE.md prohibition strengthen
- \`issues.prohibited_commands\` redirected from \`atdd branch <N>\` → \`atdd pr <N>\` for the gh-pr-create entry.
- Added a multi-line context note citing the #475 lived incident (orphan-merge onto a deleted sibling-PR branch; \`Closes #473\` fired without the v3.11.0 work shipping).
- Synced both \`src/atdd/coach/templates/ATDD.md\` and \`CLAUDE.md\`.

## Cross-coordination with #478
- First-mover check at session start: \`src/atdd/coach/utils/default_branch.py\` did not exist on \`origin/main\`, so this PR **introduces** the shared helper.
- Helper resolution order: \`.atdd/config.yaml::github.default_branch\` → \`gh repo view --json defaultBranchRef\` → literal \`"main"\` with a \`::warning::\`.
- #478 should \`from atdd.coach.utils.default_branch import resolve_default_branch\` and replace the hardcoded \`"main"\` at \`branch.py:73\`. After both PRs land, the helper has one canonical home with no duplication.

## Coherence statement
- NO new convention file (extension only). The new rule sits in \`rule-id.convention.yaml::rules:\` as a sibling to the 6 existing rules. Same pattern as #467 / #470 / #473.
- Substrates untouched: \`rule_binding.py\`, \`disposition_gate.py\`, \`rule_validator_binding\` validator, etc.

## Eat-own-dogfood
- This PR was opened via \`atdd pr 477\` (NOT \`gh pr create\` directly). Invocation: \`PYTHONPATH=src python3 -m atdd pr 477\` (since the system-installed \`atdd\` is still on v3.11.0; the local source carries the \`--force\` signature this PR introduces). The base-validation guard accepted the implicit default.
- Three commits, one per phase, plus the version bump (\`3.11.0\` → \`3.12.0\`, MINOR per release.change_class — new flag + new validator + new rule + new shared helper).

## Verification (local)
- 5 + 1 + 5 fixtures green: \`pytest src/atdd/coach/commands/tests/test_pr_base_validation.py src/atdd/coach/validators/test_pr_base_branch.py src/atdd/coach/validators/tests/test_pr_base_branch_helpers.py -v\` → 11 passed.
- Reverse-coherence green: \`pytest src/atdd/coach/validators/test_rule_validator_binding.py -v\` → 1 passed.
- Fix-hint completeness green: \`pytest src/atdd/coach/validators/test_fix_hint_completeness.py -v\` → 1 passed.
- Full coach validator suite (local source, \`-m "not github_api"\`): 376 passed; 2 pre-existing failures on \`test_open_issue_compliance\` + \`test_required_label_set\` are about GitHub-side label hygiene on issues #477/#478/#326, unrelated to the changes here.