### PR TITLE
feat(coach): coach v9 — dispatch-validators wagon

### DIFF
--- a/.coach-v9-bootstrap/bodies/m1.md
+++ b/.coach-v9-bootstrap/bodies/m1.md
@@ -1,0 +1,89 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-m1-git-watcher-trailers` |
+| Archetypes | `coach` + `tester` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `dispatch-validators` |
+| Internal-Spec-Id | `M1` |
+| Feature | Git watcher emits commit_observed events with parsed trailers (Phase, WMBT-Urn, Agent-Id, Issue) and downstream validation_pending events; missing trailers route a coach.commit-trailers.* violation through tier-1. |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements spec §6.4 step 1 (commit observation) and step 2 (trailer parsing → validation_pending event keying). This is the entry point of the tier-1 validator pipeline: every observed commit on a coach-watched worktree must produce a structured event the rest of the pipeline (#M2 collector, #M3 selection, #M4 suppression, #M5 risk score) can consume.
+
+- **Git watcher** at `src/atdd/coach/runtime/git_watcher.py` — inotify/fswatch-backed observer that detects HEAD advancement on registered worktrees. Complements the broader runtime watcher delivered by `#J5` (the runtime watcher owns inotify/fswatch+git+liveness; this issue delivers the commit-specific path inside it). Coordinates registration via `.atdd/runtime/agents/<id>/manifest.json`.
+- **Commit-observed event emission**: on HEAD advance, emit a `commit_observed` event with payload `{worktree, sha, parent_sha}` to the agent's `events.jsonl`. Event shape conforms to `runtime-event.schema.json` (frozen by C0).
+- **Trailer parsing** via `git log -1 --format=%B <sha>`: extract `Phase`, `WMBT-Urn`, `Agent-Id`, `Issue` trailers per spec §7.3 (commit trailers — mechanically enforced).
+- **Validation-pending event emission**: emit a `validation_pending` event keyed by the trailer-resolved `(phase, scope)` so #M3's selection resolver can pick up the work.
+- **`coach.commit-trailers.*` rule family** at `src/atdd/coach/conventions/commit-trailers.convention.yaml` (or sibling location). One rule per required trailer (`coach.commit-trailers.phase-required`, `coach.commit-trailers.wmbt-urn-required`, `coach.commit-trailers.agent-id-required`, `coach.commit-trailers.issue-required`) plus malformed-value checks. Disposition: `strict` for production. The pre-commit hook already catches these in production; tier-1 emits the same family for completeness and audit trail.
+- **Latency budget**: from HEAD advance to `commit_observed` event emission ≤ 1s. Verified by an integration test under `src/atdd/coach/runtime/tests/`.
+- **Watcher lifecycle**: registers watches when an agent's worktree manifest appears under `.atdd/runtime/agents/<id>/`; tears down on `agent_terminated` event.
+
+### Out of Scope
+
+- The full runtime watcher (inotify/fswatch + git + liveness): owned by `#J5`. This issue delivers only the commit-observation path; `#J5` integrates it with the broader watcher.
+- Pytest plugin for Violation collection: owned by `#M2`. M1 emits events; M2 captures the validators that run downstream.
+- Per-phase validator selection (which validators run on the resolved `(phase, scope)`): owned by `#M3`.
+- Suppression scanner integration: owned by `#M4`.
+- Risk score computation: owned by `#M5`.
+- The pre-commit hook that already enforces trailers in production (existing machinery; this issue mirrors its rule-IDs in the runtime registry but does not replace it).
+- Worktree creation, registration, two-phase commit dispatch: owned by `#J4` and `#K1`.
+
+### Dependencies
+
+- `#J1` — coach state machine skeleton; this issue's watcher coordinates with the state machine via the runtime layout.
+- `#J3` — decision/judgment durability (`decisions.jsonl`); the watcher's events feed this layer.
+- `src/atdd/coach/schemas/runtime-event.schema.json` (committed by `#C0` — already merged on the parent branch).
+- `src/atdd/coach/schemas/runtime-layout.md` (committed by `#C0`).
+- Substrate v12 `Violation` and `RuleMetadata` dataclasses (existing; not redefined here).
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Commit observation | `atdd babysit` polls workspace state (`_screen_hash`); commit transitions are detected lossily and slowly | Event-driven git watcher emits `commit_observed` within 1s of HEAD advancing on a registered worktree | Polling is the structural limit coach v9 was designed to obsolete (spec §1) — without event-driven commit observation, the rest of the tier-1 pipeline cannot be deterministic |
+| Trailer parsing surface | The pre-commit hook validates trailers at the producer side; runtime has no parsed view | Watcher parses Phase/WMBT-Urn/Agent-Id/Issue from `git log -1 --format=%B <sha>` and surfaces them on the event | Without parsed trailers in the runtime layer, #M3's per-phase dispatch has no input to scope on |
+| Missing-trailer feedback | Pre-commit hook blocks at producer; if a commit somehow lands without trailers, runtime is silent | `coach.commit-trailers.*` violations emitted via tier-1 with rule-IDed feedback | Defense in depth — and a uniform feedback channel (pre-commit and runtime use the same rule-IDs) |
+| Validation-pending signaling | No artifact tells #M3 that a commit needs validator dispatch | `validation_pending` event keyed by `(phase, scope)` is emitted alongside `commit_observed` | Without an explicit signal, #M3's selection resolver would have to poll the watcher's state — re-introducing the pattern coach v9 obsoletes |
+
+### User Impact
+
+The "user" is every agent under coach orchestration plus the coach state machine itself. Per spec §6.4 step 1, when an agent commits, coach must observe the commit, parse trailers, and dispatch phase-scoped validators. Today, `atdd babysit` polls and `_screen_hash` infers state — slow, lossy, fragile. After M1, coach has a deterministic, event-driven first link in the tier-1 chain: every commit on a watched worktree produces a `commit_observed` event with fully parsed trailers within 1s, feeding `#M2`'s collector and `#M3`'s selection resolver via a `validation_pending` event.
+
+Per spec §7.3, commit trailers are mechanically enforced at the producer side by the pre-commit hook. M1 mirrors that enforcement at the runtime side by emitting `coach.commit-trailers.*` violations through tier-1 — a uniform rule-ID surface for both producer-time blocks and runtime-time observation. The agent sees the same rule-IDs in either context, which keeps spawn-feedback templates coherent (per spec §7.6).
+
+### Design Anchor
+
+The file at `src/atdd/coach/runtime/git_watcher.py` is the runtime-tier seam between "git advanced HEAD" (an OS-level event) and "coach has structured commit-shaped data" (a `commit_observed` event conforming to the C0-frozen schema). Trailers turn unstructured commit messages into the keys that downstream issues (`#M3` selection, `#M4` suppression, `#M5` risk score, `#L1` correction injection) need to act. This issue is the boundary that makes the rest of the tier-1 chain deterministic.
+
+---
+
+## Acceptance
+
+- `acc:dispatch-validators:M001-UNIT-001-commit-observed-event-emitted`: A new commit on a watched branch triggers a coach event with parsed trailers within 1s of HEAD advancing. The `commit_observed` event payload contains `worktree, sha, parent_sha`; trailers are parsed from `git log -1 --format=%B <sha>` into `Phase`, `WMBT-Urn`, `Agent-Id`, `Issue`; a downstream `validation_pending` event is emitted keyed by the trailer-resolved `(phase, scope)`; both events validate against `runtime-event.schema.json` (frozen by C0).
+- `acc:dispatch-validators:M001-UNIT-002-missing-trailers-violation-routed-tier-1`: A commit with one or more required trailers absent produces a `Violation` whose `rule_id` is under the `coach.commit-trailers.*` family; the violation is routed via the tier-1 pipeline (collected by the violation_collector pytest plugin or directly by the watcher's emit path) and conforms to `validator-result.schema.json`.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §3.2 (runtime folder layout — `agents/<id>/events.jsonl`), §4.4 (event sources), §6.4 (real-time tier-1 validator dispatch — steps 1, 2), §7.3 (commit trailers — mechanically enforced)
+- `atdd-coach-issues-v3.md` issue `#M1`
+- Wagon manifest: `plan/dispatch_validators/_dispatch_validators.yaml`
+- Feature: `plan/dispatch_validators/features/tier_1_validator_pipeline.yaml`
+- WMBT: `plan/dispatch_validators/M001.yaml`
+- Predecessor issues: `#J1`, `#J3`
+- Sibling wagon (frozen contracts): `plan/freeze_runtime_contracts/_freeze_runtime_contracts.yaml`

--- a/.coach-v9-bootstrap/bodies/m2.md
+++ b/.coach-v9-bootstrap/bodies/m2.md
@@ -1,0 +1,88 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-m2-violation-collector` |
+| Archetypes | `coach` + `tester` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `dispatch-validators` |
+| Internal-Spec-Id | `M2` |
+| Feature | Custom pytest plugin (coach.runtime.violation_collector) captures Violation records emitted via assert_disposition_satisfied and writes JSONL conforming to validator-result.schema.json. |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements spec §6.4 step 4 (Violation collection during validator dispatch). Coach invokes pytest as a subprocess against the validators selected for the current `(phase, scope)`; this issue delivers the plugin that captures the `Violation` records emitted by those validators.
+
+- **Plugin module** at `src/atdd/coach/runtime/violation_collector.py`. Registered as a pytest plugin via the entry-point name `atdd.coach.runtime.violation_collector` so coach can attach it explicitly (`pytest -p atdd.coach.runtime.violation_collector ...`) under `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` (per `validator-invocation.md` from `#C0`).
+- **Hook implementation**: `pytest_runtest_logreport` captures `Violation` records that validators emit via the substrate's `assert_disposition_satisfied()` helper. The plugin keeps an in-memory accumulator keyed by sha during the run, and flushes to disk in `pytest_sessionfinish`.
+- **JSONL writer**: writes one `Violation` per line to `.atdd/runtime/validations/<sha>/violations.jsonl`. The output directory is created on first write (per `runtime-layout.md` from `#C0`).
+- **Field alignment**: each line carries `validator_id` (composed from `validator_module + validator_function`), `rule_id`, `severity`, `location`, `detail`, plus the optional `fix_hint_ref`, `validator_module`, `validator_function` per spec §7.5. **Disposition is NOT serialized** on the violation record — it is a registry property of the rule, read at routing time via `bind_rule(rule_id).disposition`.
+- **Coach invocation glue**: the entry point that coach uses to invoke pytest with the plugin against a given validator set and sha. Lives in `src/atdd/coach/runtime/dispatcher.py` (or sibling); receives the validator set built by `#M3`.
+- **Loss-protection**: the plugin must never silently drop a `Violation`. If serialization fails for one record, the failure is logged as a coach-internal error and the remaining records still flush. A successful `pytest_sessionfinish` implies all observed `Violation` records are persisted.
+
+### Out of Scope
+
+- Validator selection per phase (which validators are invoked): owned by `#M3`. M2 is the collection layer; M3 picks the inputs.
+- Suppression filtering and the `suppressed.jsonl` output: owned by `#M4`.
+- Risk score computation reading `violations.jsonl`: owned by `#M5`.
+- Substrate's `Violation` dataclass and `assert_disposition_satisfied` (existing — substrate v12); this issue captures records that machinery already emits.
+- The `validator-result.schema.json` itself: frozen by `#C0` on the parent branch.
+- Pytest plugin auto-discovery via setuptools entry points: explicit `-p` is the contract (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` policy from `validator-invocation.md`).
+- Reviewer (tier-2) inputs: owned by Track N.
+
+### Dependencies
+
+- `#M1` — `commit_observed` and `validation_pending` events feed the dispatcher; no point capturing without the trigger.
+- `src/atdd/coach/schemas/validator-result.schema.json` (committed by `#C0`).
+- `src/atdd/coach/schemas/validator-invocation.md` (committed by `#C0`) — defines the pytest invocation contract this plugin operates under.
+- Substrate v12 `Violation` dataclass and `assert_disposition_satisfied` — existing.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Violation capture during runtime | `atdd validate` runs pytest with the substrate plugin and surfaces violations to the operator; coach has no equivalent runtime path | Custom pytest plugin captures every `Violation` from a runtime dispatch into `.atdd/runtime/validations/<sha>/violations.jsonl` | Without it, coach has no machine-readable record of what failed for `#M3` selection, `#M4` suppression, `#M5` risk score, or `#L1` correction injection to act on |
+| JSONL output shape | No persisted artifact today; `_screen_hash` infers state | Each line conforms to `validator-result.schema.json` (frozen by `#C0`) | A schema-conformant artifact lets reviewer (#N2), risk-score (#M5), and suppression (#M4) consume the same record |
+| Disposition handling | Existing toolkit conventions encode disposition in convention YAMLs and the registry | Plugin writes the violation without disposition; coach reads disposition via `bind_rule(rule_id).disposition` at routing time | Per spec §7.5: disposition is a rule property, not a violation property — keeps the violation record minimal and the registry the source of truth |
+| Plugin loading policy | `atdd validate` activates plugins via project config | Coach invokes with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` and explicit `-p atdd.coach.runtime.violation_collector` | Determinism: the runtime dispatch must not silently inherit unrelated pytest plugins from the worktree's environment |
+
+### User Impact
+
+The "user" is every downstream consumer of `violations.jsonl`: `#M3` (selects further validators), `#M4` (filters suppressed), `#M5` (scores risk), `#N2` (reviewer prompt), `#L1` (correction injector). Today, no such artifact exists; coach v9 introduces it as the canonical machine-readable record of every tier-1 dispatch outcome. After M2, every coach-observed commit produces a `validations/<sha>/violations.jsonl` whose lines validate against `validator-result.schema.json` and whose contents the rest of the pipeline can consume without re-running pytest or re-parsing screens.
+
+Per spec §6.4 step 4, "validators emit them via `assert_disposition_satisfied()`; coach intercepts via a custom pytest plugin (`coach.runtime.violation_collector`) that writes to `validations/<sha>/violations.jsonl`." That sentence is the contract — M2 implements it.
+
+### Design Anchor
+
+The plugin sits at the seam between "pytest is running" (existing substrate machinery) and "coach has a JSONL of every Violation that occurred" (the C0-frozen contract). It does not reimplement violation generation — substrate's `Violation` dataclass and `assert_disposition_satisfied` already produce the records — it captures and persists them. The architecture choice "explicit `-p` + `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`" mirrors the substrate's own runtime invocation discipline: deterministic plugin set, no environment-dependent surprises.
+
+---
+
+## Acceptance
+
+- `acc:dispatch-validators:E001-UNIT-001-pytest-plugin-captures-all-violations`: A pytest run with `-p atdd.coach.runtime.violation_collector` against the selected validator paths captures every `Violation` emitted via `assert_disposition_satisfied()` in that run; every captured violation is written to `.atdd/runtime/validations/<sha>/violations.jsonl` (one Violation per JSON line, no losses, no duplicates); each line carries `validator_id` (composed from `validator_module + validator_function`), `rule_id`, `severity`, `location`, `detail` plus optional fields per spec §7.5; the plugin operates under `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` and registers solely via the explicit `-p` flag.
+- `acc:dispatch-validators:E001-CONTRACT-001-violations-jsonl-schema-conformant`: Every line in `violations.jsonl` is valid JSON and validates against `validator-result.schema.json` with zero schema errors; required fields `rule_id, severity, location, detail` are present on every record; optional fields `fix_hint_ref, validator_module, validator_function` follow the schema's optional contract; **disposition is NOT present on the violation record** (per §7.5: it is a registry property of the rule, not the violation).
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §6.4 (real-time tier-1 validator dispatch — steps 3, 4), §7.5 (validator output schema)
+- `atdd-coach-issues-v3.md` issue `#M2`
+- Wagon manifest: `plan/dispatch_validators/_dispatch_validators.yaml`
+- Feature: `plan/dispatch_validators/features/tier_1_validator_pipeline.yaml`
+- WMBT: `plan/dispatch_validators/E001.yaml`
+- Predecessor issue: `#M1`
+- Frozen-by-C0 artifacts: `src/atdd/coach/schemas/validator-result.schema.json`, `src/atdd/coach/schemas/validator-invocation.md`
+- Substrate v12: `Violation` dataclass, `assert_disposition_satisfied`

--- a/.coach-v9-bootstrap/bodies/m3.md
+++ b/.coach-v9-bootstrap/bodies/m3.md
@@ -1,0 +1,102 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-m3-validator-selection` |
+| Archetypes | `coach` + `tester` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `dispatch-validators` |
+| Internal-Spec-Id | `M3` |
+| Feature | Per-phase validator selection: union of toolkit conventions per §6.5 mapping table (incl. substrate enforcement at PLANNED) and every repo.* rule whose RuleMetadata.phase matches the current coach phase, overrideable via .atdd/coach/config.yaml::coach.validators.selection. |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements spec §6.5 phase-driven dispatch and aligns with substrate v12 §8.1 (substrate enforcement at PLANNED). When coach reaches a phase, this issue's resolver builds the validator set that `#M2`'s plugin will run against the current sha.
+
+- **Resolver module** at `src/atdd/coach/runtime/validator_selection.py`. Public API: `build_validator_set(phase: CoachPhase, scope: ValidationScope, config: CoachConfig) -> ValidatorSet`.
+- **Toolkit slice** — per-archetype validators per phase per the §6.5 mapping table:
+  - `PLANNED`: `atdd.planner.validators.*` (acceptance, criteria, wmbt) **plus** `atdd.tester.validators.acceptance-violation.*` (substrate enforcement: the five rules from `src/atdd/tester/conventions/acceptance-violation.convention.yaml` — `acceptance-must-be-measurable`, `acceptance-must-declare-phase`, `disposition-must-not-be-declared`, `validator-binding-must-be-bidirectional`, `metric-implementation-must-exist`).
+  - `RED`: `atdd.tester.validators.*` (red, filename, security) + `coach.rule-id-uniqueness`.
+  - `GREEN`: `atdd.coder.validators.*` (dead-code, dto, error-response, frontend, presentation) + structural conventions (boundaries, design).
+  - `SMOKE`: `atdd.tester.validators.smoke.*` + integration smoke harness from `validators/fixtures/`.
+  - `REFACTOR`: all `atdd.coder.validators.*` with `disposition: strict` + architecture-lint-only sweep.
+- **Repo-rule slice** (substrate v12) — every rule from the repo registry whose `bind_rule(rule_id).phase` matches the current coach phase, regardless of source kind. Coach iterates over `WMBTResolver`, `TrainResolver`, `SecurityResolver` (already shipped per spec §0.1) and reads `RuleMetadata.phase` per rule.
+- **Union semantics**: the selected set is `toolkit_slice ∪ repo_slice` with no de-duplication concern — toolkit and repo namespaces are disjoint by construction.
+- **REFACTOR additionally sweeps** every strict-disposition rule from both registries as a regression check before COMPLETE (per spec §6.5).
+- **Override** via `.atdd/coach/config.yaml::coach.validators.selection`. Override semantics:
+  - Override sets the **toolkit slice** for the named phase (override is exhaustive for that phase — defaults are NOT additionally unioned in).
+  - Override does NOT change the repo-rule slice (which always derives from `bind_rule(rule_id).phase`).
+  - Phases not present in the override fall back to the §6.5 default mapping.
+  - Config loader extension lives in `#P4`; this issue consumes the loader's output.
+
+### Out of Scope
+
+- Capturing the violations the selected validators emit: owned by `#M2`.
+- Suppression filtering and active-set computation: owned by `#M4`.
+- Risk-score breakdown by archetype: owned by `#M5`.
+- Convention authorship for the toolkit validators per phase: existing machinery (already shipped per spec §0.1).
+- Substrate v12 walker that sets `disposition: strict` for repo rules: existing.
+- Decommissioning legacy `atdd validate` selection paths: not needed — `atdd validate` continues to work; coach consumes the same registry under different invocation rules.
+- The `coach.*` config block schema: owned by `#P4`. M3 reads the loaded config; it does not define the schema.
+
+### Dependencies
+
+- `#M2` — coach must have the violation collector plugin to act on the selected set.
+- `src/atdd/coach/schemas/validator-invocation.md` (committed by `#C0`) — defines invocation contract.
+- Substrate v12 walker + `RuleMetadata.phase` (existing).
+- `src/atdd/tester/conventions/acceptance-violation.convention.yaml` (existing — substrate enforcement convention).
+- Toolkit conventions for planner/tester/coder validators (existing — per spec §0.1).
+- Eventually `#P4` for the `coach.validators.selection` config schema; M3 reads the loaded value via the loader API even if `#P4` lands later (override defaults to "no override" in absence).
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Per-phase validator dispatch | `atdd validate` selects validators by archetype, not by coach phase | Resolver returns a phase-keyed `ValidatorSet` per the §6.5 mapping table, ready for #M2's plugin to run | Without phase-keyed selection, coach cannot run "the right validators at the right phase"; per-phase dispatch is the structural fix for "validator hose at every commit" |
+| Substrate v12 alignment | Repo rules live in a separate registry; toolkit selection ignores them | Resolver reads `bind_rule(rule_id).phase` for every repo rule and unions matching rules into the selected set | Without it, repo-rule violations would be invisible to coach's tier-1 dispatch — the substrate's selling point (strict acceptance gates) would not engage at the right phase |
+| PLANNED-time substrate enforcement | The `acceptance-violation.*` convention exists but coach has no rule routing it to PLANNED specifically | PLANNED unions `atdd.tester.validators.acceptance-violation.*` into the toolkit slice | Without it, malformed acceptances ship to RED before the substrate enforcement even runs — the chronic substrate-v12 trap |
+| Project-specific overrides | `atdd validate` has no per-phase override surface | `.atdd/coach/config.yaml::coach.validators.selection` overrides the toolkit slice per phase | Some projects need to add or replace toolkit validators per phase — the override unblocks them without forking |
+
+### User Impact
+
+The "user" is the coach state machine and, transitively, every agent under coach orchestration. After M3, coach can answer "what validators run at this phase, for this scope?" deterministically. Per spec §6.5: "Selection is a union of two sources, both resolved per coach phase." This issue is that resolver. Today no such resolver exists — `atdd validate` runs everything per archetype, which is the right design for operator-driven validation but the wrong shape for coach-driven runtime dispatch.
+
+The substrate v12 alignment matters concretely: a repo rule whose `RuleMetadata.phase` is `GREEN` (because its bound acceptance lives at GREEN) MUST be selected when coach is at GREEN — and only at GREEN. If the resolver ignored substrate v12, every repo-rule violation would either fire at every phase (noisy, false-positive at PLANNED/RED) or never (silent, the failure mode v12 was designed to fix). M3 binds coach phase to repo-rule phase via `bind_rule(rule_id).phase` — a single source of truth.
+
+### Design Anchor
+
+The resolver lives at the seam between "what phase coach is in" (state-machine output, owned by `#J1`) and "what validators run on the next commit" (input to `#M2`'s plugin). The §6.5 mapping table is the toolkit half; substrate v12 §8.1 is the repo half. The override is a project-level escape hatch that does not break the contract — repo rules are uniformly strict and always selected by phase, never overridden (per substrate v12 §2's unsuppressibility property). Overrides apply to the toolkit slice only, by design: projects should never bypass repo-rule contracts because that would defeat the substrate's strict-by-construction guarantee.
+
+---
+
+## Acceptance
+
+- `acc:dispatch-validators:D001-UNIT-001-green-phase-selects-all-green-repo-rules`: A coach session at GREEN selects every `repo.*` rule whose `bind_rule(rule_id).phase == GREEN`, regardless of source kind (WMBT-acceptance, train-acceptance, security all considered); the toolkit GREEN mapping (`atdd.coder.validators.*` dead-code/dto/error-response/frontend/presentation + boundaries + design) is also included; no repo rules with `phase != GREEN` are included.
+- `acc:dispatch-validators:D001-UNIT-002-planned-runs-substrate-enforcement`: A coach session at PLANNED runs the substrate enforcement validators — all five `atdd.tester.validators.acceptance-violation.*` validators (`acceptance-must-be-measurable`, `acceptance-must-declare-phase`, `disposition-must-not-be-declared`, `validator-binding-must-be-bidirectional`, `metric-implementation-must-exist`) plus all `atdd.planner.validators.*` (acceptance, criteria, wmbt) per the §6.5 PLANNED row.
+- `acc:dispatch-validators:D001-UNIT-003-config-override-substitutes-selection`: When `.atdd/coach/config.yaml::coach.validators.selection` overrides the §6.5 default for a given phase, the **toolkit slice** of the selected set equals the override's explicit list (defaults are NOT additionally unioned in for that phase); the **repo-rule slice** is unaffected by the override (still computed from `bind_rule(rule_id).phase` per substrate v12); phases not present in the override fall back to the §6.5 default mapping.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §0.1 (substrate substrate v12 alignment), §6.5 (validator selection per phase), §7.7 (schema inventory)
+- `atdd-coach-issues-v3.md` issue `#M3`
+- `atdd-repo-substrate-spec-v12.md` §8.1 (substrate enforcement at PLANNED), §2 (uniform strict / unsuppressible repo rules)
+- Wagon manifest: `plan/dispatch_validators/_dispatch_validators.yaml`
+- Feature: `plan/dispatch_validators/features/tier_1_validator_pipeline.yaml`
+- WMBT: `plan/dispatch_validators/D001.yaml`
+- Predecessor issue: `#M2`
+- Existing convention: `src/atdd/tester/conventions/acceptance-violation.convention.yaml`
+- Frozen-by-C0 artifact: `src/atdd/coach/schemas/validator-invocation.md`
+- Related issue: `#P4` (config loader extensions for `coach.*` block)

--- a/.coach-v9-bootstrap/bodies/m4.md
+++ b/.coach-v9-bootstrap/bodies/m4.md
@@ -1,0 +1,92 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-m4-suppression-scanner` |
+| Archetypes | `coach` + `tester` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `dispatch-validators` |
+| Internal-Spec-Id | `M4` |
+| Feature | Suppression scanner integration: find_suppressions() moves matching toolkit suppress-and-clean violations into suppressed.jsonl; repo.* rules bypass suppression (always strict per substrate v12 §2); find_stale_suppressions() populates stale-suppressions.jsonl. |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements spec §6.4 step 5 (apply suppression scanner) and §6.6 (suppression markers honored end-to-end — toolkit conventions only). When `#M2` has written `violations.jsonl` for a commit, this issue's filter splits that record set into the active set (used for blocking decisions), the suppressed set (audit trail), and the stale-marker set (cleanup nudge).
+
+- **Filter module** at `src/atdd/coach/runtime/suppression_filter.py`. Public API: `apply_suppression(violations: List[Violation], worktree: Path, sha: str) -> SuppressionResult` returning `{active, suppressed, stale_suppressions}`.
+- **find_suppressions() invocation** over the worktree using the existing `suppression_scanner` (substrate v12 §0.1 — already shipped). For each violation in `violations.jsonl`:
+  - If `bind_rule(violation.rule_id).disposition == suppress-and-clean` AND `(rule_id, location)` matches a marker `# atdd:suppress(<rule_id>) [UNTIL=YYYY-MM-DD]` whose `UNTIL` is in the future → move to suppressed.
+  - Otherwise → keep in active set.
+- **Repo-rule bypass**: repo.* rules from substrate v12 are uniformly `strict` (walker-set per §0.1, §2); their disposition will never be `suppress-and-clean`, so the filter's existing logic naturally never moves them — **without special-casing**. The disposition_gate path (existing) appends failures unconditionally for strict; coach does not consult the suppression scanner for strict rules. This emerges from the existing machinery; this issue documents and tests that emergent behavior, it does not implement special handling.
+- **Suppressed.jsonl writer**: appends absorbed violations to `.atdd/runtime/validations/<sha>/suppressed.jsonl`. Each record carries enough metadata to audit the absorption: `rule_id`, `location`, marker text, parsed `UNTIL` date.
+- **find_stale_suppressions() invocation** over the worktree (existing — substrate v12 §0.1). Markers whose `UNTIL` date is in the past are written to `.atdd/runtime/validations/<sha>/stale-suppressions.jsonl` (one record per stale marker; no losses).
+- **Marker grammar validation** (per spec §6.6): markers that do not parse, or reference unknown rule-IDs (per `bind_rule`), are surfaced as warnings (logged via coach's runtime log; not a blocker on the current commit).
+- **Active set** is the input to `#M5`'s risk score computation — `#M5` consumes `(active_set, stale_suppressions)` to populate its breakdown.
+
+### Out of Scope
+
+- The `suppression_scanner` itself (`find_suppressions`, `is_suppressed`, `find_stale_suppressions`): existing — substrate v12 §0.1.
+- The `disposition_gate.assert_disposition_satisfied` strict-unconditional path: existing — substrate v12.
+- Risk score computation (which consumes the active set): owned by `#M5`.
+- Observer rule `10-stale-suppression-detected` (the agent-facing nudge for stale markers in the diff scope): owned by `#L5` (track L, substrate-aware rules).
+- The `--allow-stale-suppressions=false` block-on-COMPLETE flag: owned by Track Q (`#Q1`, integration acceptance) and the coach config schema (`#P4`).
+- Walker-set strict disposition for repo rules: existing substrate v12 machinery.
+
+### Dependencies
+
+- `#M2` — `violations.jsonl` is the input to this filter.
+- `#M3` — disposition is read via `bind_rule(rule_id).disposition`, which the resolver already touches; no new graph traversal here.
+- Substrate v12 `suppression_scanner` (existing, per spec §0.1).
+- Substrate v12 `bind_rule()`, `disposition_gate.assert_disposition_satisfied` (existing).
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| End-to-end suppression honoring | `atdd validate` honors suppressions; coach has no equivalent runtime path | `apply_suppression()` runs after every `violations.jsonl` write, splitting active / suppressed / stale | Without it, coach would block on suppress-and-clean violations that operators have already triaged — undermining the existing suppression contract |
+| Repo-rule unsuppressibility | Substrate v12 §2 mandates repo rules are unsuppressible; coach must NOT special-case this | Existing `disposition_gate` strict-unconditional path naturally bypasses scanner for repo.* rules — coach reuses it | The architectural goal is "uniform routing per disposition with strict/unsuppressible behavior emerging from the gate's existing logic" (spec §6.6) — re-implementing the bypass would create drift |
+| Stale marker visibility | Stale markers are only surfaced when an operator runs `atdd validate`; runtime is silent | `stale-suppressions.jsonl` is written on every commit; `#L5` consumes it for the agent-facing nudge | Without runtime visibility, stale markers accumulate and `#Q1`'s `--allow-stale-suppressions=false` would block COMPLETE without warning |
+| Audit trail of absorptions | No artifact today says which violations were absorbed by which markers | `suppressed.jsonl` carries `rule_id`, `location`, marker text, `UNTIL` date | Reviewer (#N2) and judge (#O2) can inspect what coach absorbed without re-running pytest |
+
+### User Impact
+
+The "user" is the coach state machine, the reviewer (`#N2`), the judge (`#O2`), and indirectly every agent under coach orchestration. Per spec §6.4 step 5 and §6.6: the suppression scanner runs after the validator dispatch; suppressed-by-marker violations move to `suppressed.jsonl`; the active set is what coach routes on. Today no such runtime split exists; coach v9 introduces it. After M4, the active set used for blocking decisions excludes operator-triaged debt, the audit trail is complete, and stale markers are surfaced for cleanup.
+
+The repo-rule bypass is structurally important: substrate v12 §2 establishes that repo-rule contracts (WMBT-acceptance, train-acceptance, security-derived) are **unsuppressible** — tightening or relaxing happens by editing the YAML, not by markers. Coach must respect that without special-casing — and per spec §6.6, "the suppression scanner runs on every commit (existing toolkit machinery) but the suppressed pool for repo rules is always empty. Coach does not special-case this — it routes per disposition and the strict/unsuppressible behavior emerges from the gate's existing logic." This issue tests that emergent behavior to lock it down.
+
+### Design Anchor
+
+The filter sits at the seam between "every Violation pytest emitted" (`violations.jsonl` from `#M2`) and "the active set coach routes on" (input to `#M5`'s risk score). The `find_suppressions` and `find_stale_suppressions` calls are existing substrate machinery — this issue invokes them in the runtime path and persists the resulting tri-split to disk. The repo-rule bypass-by-emergence pattern is load-bearing: re-implementing strict-bypass in the filter would create a second source of truth and risk drift from substrate v12 §2's invariant.
+
+---
+
+## Acceptance
+
+- `acc:dispatch-validators:C001-UNIT-001-toolkit-suppression-marker-absorbs-violation`: A `suppress-and-clean` toolkit violation with a matching marker (`# atdd:suppress(<rule_id>) [UNTIL=YYYY-MM-DD]` with future `UNTIL` date) on the offending file/line is removed from the active set and appended to `.atdd/runtime/validations/<sha>/suppressed.jsonl`; the suppressed.jsonl record carries `rule_id`, `location`, marker text, `UNTIL` date.
+- `acc:dispatch-validators:C001-UNIT-002-repo-rule-violation-never-suppressed`: A repo-rule violation (substrate v12; walker-set `disposition: strict`) remains in the active set even when a `# atdd:suppress(<repo-rule-id>) [UNTIL=...]` marker exists on the offending line; `suppressed.jsonl` contains zero records whose `rule_id` resolves to a `repo.*` rule, even when markers are present; this emerges from the existing `disposition_gate` strict-unconditional path — coach does not special-case repo rules in the filter.
+- `acc:dispatch-validators:C001-UNIT-003-stale-suppressions-populated`: A worktree with at least one `# atdd:suppress(<rule_id>) [UNTIL=YYYY-MM-DD]` marker whose `UNTIL` date is in the past produces `.atdd/runtime/validations/<sha>/stale-suppressions.jsonl` containing one record per stale marker with `rule_id`, `location`, parsed `UNTIL` date, marker text; no stale-marker record is dropped.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §6.4 (real-time tier-1 validator dispatch — step 5), §6.6 (suppression markers honored end-to-end — toolkit conventions only)
+- `atdd-coach-issues-v3.md` issue `#M4`
+- `atdd-repo-substrate-spec-v12.md` §2 (uniform strict / unsuppressible repo rules), §0.1 (`suppression_scanner` substrate)
+- Wagon manifest: `plan/dispatch_validators/_dispatch_validators.yaml`
+- Feature: `plan/dispatch_validators/features/tier_1_validator_pipeline.yaml`
+- WMBT: `plan/dispatch_validators/C001.yaml`
+- Predecessor issue: `#M3`
+- Substrate v12: `find_suppressions`, `is_suppressed`, `find_stale_suppressions`, `disposition_gate.assert_disposition_satisfied` (existing)
+- Related issue: `#L5` (substrate-aware observer rules including `10-stale-suppression-detected`)

--- a/.coach-v9-bootstrap/bodies/m5.md
+++ b/.coach-v9-bootstrap/bodies/m5.md
@@ -1,0 +1,100 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-m5-risk-score` |
+| Archetypes | `coach` + `tester` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `dispatch-validators` |
+| Internal-Spec-Id | `M5` |
+| Feature | Risk score per phase exit: sum(severity for active_violations) plus by_severity / by_archetype (incl. repo slice with substrate v12 severity mapping) / by_disposition / stale_suppressions, written and schema-validated at write time to .atdd/runtime/validations/<sha>/risk-score.json. |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements spec §6.8 (risk score per phase exit). When `#M4` has produced the active violation set and the stale-suppression set, this issue computes the per-commit risk score and breakdown, validates it against `risk-score.schema.json` (frozen by `#C0`), and writes it to `.atdd/runtime/validations/<sha>/risk-score.json`.
+
+- **Computer module** at `src/atdd/coach/runtime/risk_score.py`. Public API: `compute_risk_score(active_violations, stale_suppressions, scope) -> RiskScore`.
+- **Total**: `risk_score = sum(severity for active_violations)` (active = post-suppression-filter, per `#M4`).
+- **Breakdown**:
+  - `by_severity`: `{1: count, 2: count, 3: count, 4: count, 5: count}`.
+  - `by_archetype`: counts and severity sums per archetype, including `coder`, `tester`, `planner`, `coach`, **and `repo`** (the substrate v12 slice).
+  - `by_disposition`: `{strict: count, "suppress-and-clean": count, advisory: count}` — read via `bind_rule(rule_id).disposition`.
+  - `stale_suppressions`: count of stale markers from `#M4`'s stale-suppressions.jsonl.
+- **Repo slice severity mapping** (substrate v12, per spec §6.8):
+  - WMBT-acceptance and train-acceptance: severity is constant `4`.
+  - Security-derived: severity mapped from `abuse_case.severity` — `low → 2`, `medium → 3`, `high → 4`, `critical → 5`.
+  - The `by_archetype.repo` slice sums severity contributions across these three repo-rule source kinds.
+- **Schema validation at write time** against `risk-score.schema.json` (committed by `#C0`). On schema violation: abort the write, emit a coach-internal error to the runtime log; no malformed `risk-score.json` is ever persisted. On success: atomic write to `.atdd/runtime/validations/<sha>/risk-score.json`.
+- **PR-description integration on COMPLETE** (verified by `#Q1` end-to-end): coach renders the PR description embedding `risk_score` sum and `by_archetype` / `by_severity` breakdown, with a link to `.atdd/runtime/validations/<sha>/` for full artifacts. The PR-rendering call site lives in coach's COMPLETE handler (track J/Q); this issue produces the artifact, the renderer reads it.
+- **Risk-threshold routing**: coach reads `risk_score.sum` against `coach.risk_threshold_block.<phase>` (config; defaults `PLANNED=∞`, `RED=∞`, `GREEN=10`, `SMOKE=15`, `REFACTOR=5`) and blocks `COMPLETE` if exceeded. The threshold-comparison logic lives in coach's COMPLETE handler; M5 produces the score the handler reads.
+- **Judge input integration**: `risk-score.json` is part of every `atdd judge` call's context (per spec §6.9); `#O1`'s judge core reads the file. M5 produces; #O1 consumes.
+
+### Out of Scope
+
+- The active violation set and stale-suppression set inputs: produced by `#M4`.
+- The `risk-score.schema.json` itself: frozen by `#C0`.
+- `coach.risk_threshold_block.<phase>` config schema: owned by `#P4`. M5 reads the loaded value via the config loader.
+- COMPLETE-time PR description rendering: owned by Track J/Q (the COMPLETE handler). M5 produces the artifact the renderer embeds.
+- Judge call sites that consume the score (judge call site #1 at borderline tier-1, judge call site #2 at reviewer concern, judge call site #4 at cross-phase regression): owned by `#O2`. M5 produces; `#O2` consumes.
+- Reviewer prompt that surfaces the score: owned by `#N3` (per-phase reviewer prompts).
+- The `--risk-threshold-block N` CLI flag: owned by `#J1` (coach state machine flags); M5 consumes the resolved value.
+
+### Dependencies
+
+- `#M4` — active violation set and stale-suppression set are inputs.
+- `src/atdd/coach/schemas/risk-score.schema.json` (committed by `#C0`).
+- `bind_rule(rule_id).disposition` and `RuleMetadata.archetype` (existing — substrate v12).
+- `abuse_case.severity` resolution for security-derived rules (existing — substrate v12).
+- Eventually `#P4` for `coach.risk_threshold_block.<phase>` config; reading a default value is fine in absence.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Per-commit risk quantification | No artifact today summarizes "how risky is this commit" | `risk-score.json` with `sum`, `by_severity`, `by_archetype` (incl. repo slice), `by_disposition`, `stale_suppressions` | Without it, coach cannot block COMPLETE on configurable thresholds, judge cannot weigh risk, reviewer cannot prioritize, PR description cannot summarize |
+| Repo-archetype visibility | Toolkit-conventions and repo-rule violations are stored together; severity is summed per rule but not per archetype | `by_archetype.repo` slice surfaces substrate v12 contributions distinctly | Per spec §6.8: "The `repo` slice lets PR reviewers see at a glance whether a PR's debt is in toolkit conventions or in failing repo contracts" — without it, reviewers conflate categories that have very different remediation paths |
+| Schema enforcement at write time | No artifact today; if added without schema validation, malformed payloads ship downstream | Validation runs synchronously at write time; on failure, write aborts and a coach-internal error is emitted | Without it, downstream consumers (judge, reviewer, PR renderer) would silently break when the payload drifts |
+| Severity mapping for security rules | Substrate v12 maps `abuse_case.severity` (low/medium/high/critical) per rule; coach has no aggregation | M5 maps low→2, medium→3, high→4, critical→5 and sums into `by_archetype.repo` | Without consistent mapping, security severity disappears in aggregation; the substrate's risk signal is lost |
+
+### User Impact
+
+The "user" is the coach state machine (for COMPLETE blocking), the judge (for ambiguous decisions per spec §6.9), the reviewer (for prioritization per `#N3`), and the PR reader (for at-a-glance debt visibility per spec §6.8). Per spec §6.8: "Surfaced in: Coach routing (`--risk-threshold-block N` blocks `COMPLETE` if score > N); Judge inputs (risk score is part of every `atdd judge` call's context); PR description (the PR opened on `COMPLETE` includes the score and a link to `validations/<sha>/`); Reviewer prompt (sees the tier-1 risk score and can prioritize)." Today, none of these are possible — there is no risk artifact. After M5, every commit produces one.
+
+The substrate v12 `repo` slice is the most consequential addition: a PR with `by_archetype.coder = 18` and `by_archetype.repo = 0` is technical debt the team can eat; a PR with `by_archetype.coder = 0` and `by_archetype.repo = 8` is a failing strict contract that must be resolved. Same total, different remediation. M5 makes that visible.
+
+### Design Anchor
+
+The computer sits at the seam between "filtered violation records" (`#M4` outputs) and "all the consumers that need a single number plus a structured breakdown" (coach routing, judge, reviewer, PR description). Schema validation at write time enforces the C0-frozen contract — no consumer ever sees a malformed payload. The repo-slice severity mapping is the substrate v12 alignment that makes the artifact useful as a coach-routing signal: WMBT-acceptance and train-acceptance get a constant `4` because they are strict-by-construction and uniformly load-bearing; security gets a mapped value because abuse-case severity is the canonical scale.
+
+---
+
+## Acceptance
+
+- `acc:dispatch-validators:E002-UNIT-001-mixed-toolkit-and-repo-breakdown`: A run with mixed toolkit and repo violations produces a breakdown with both slices: `risk_score == sum(severity for active_violations)`; `by_archetype` contains a non-zero `repo` slice and at least one non-zero toolkit archetype slice; `by_severity`, `by_disposition`, `stale_suppressions` counts are populated; `by_archetype.repo` correctly sums severity contributions across WMBT-acceptance, train-acceptance, and security-derived rules per the spec §6.8 mapping.
+- `acc:dispatch-validators:E002-CONTRACT-001-risk-score-schema-validated-at-write`: Schema validation against `risk-score.schema.json` (frozen by `#C0`) runs synchronously at write time; on schema violation, the write is aborted and a coach-internal error is emitted (no malformed `risk-score.json` is ever persisted); on success, the file is atomically written to `.atdd/runtime/validations/<sha>/risk-score.json` containing all required fields: `sum`, `by_severity`, `by_archetype` (with `repo` slice key), `by_disposition`, `stale_suppressions`.
+- `acc:dispatch-validators:E002-INTEGRATION-001-pr-description-includes-score-on-complete`: When an issue reaches COMPLETE and coach opens a PR, the PR description embeds the latest commit's `risk_score` sum and the `by_archetype` / `by_severity` breakdown; the description links to `.atdd/runtime/validations/<sha>/` for full artifacts; this rendering is verified end-to-end at the `#Q1` integration cycle.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §6.8 (risk score per phase exit), §6.9 (judge inputs include risk score), §11.5 (self-hosting inflection — risk score gates COMPLETE)
+- `atdd-coach-issues-v3.md` issue `#M5`
+- `atdd-repo-substrate-spec-v12.md` (substrate severity mapping for repo rules; WMBT/train constant 4; security mapped from abuse_case.severity)
+- Wagon manifest: `plan/dispatch_validators/_dispatch_validators.yaml`
+- Feature: `plan/dispatch_validators/features/tier_1_validator_pipeline.yaml`
+- WMBT: `plan/dispatch_validators/E002.yaml`
+- Predecessor issue: `#M4` (active violation set + stale-suppressions input — coach phase order; spec §6.4 step 5 → §6.8). Per the v3 issues table this issue formally `Dependencies: #M3`; the in-pipeline data dependency is on `#M4`'s active set, which itself depends on `#M3`.
+- Frozen-by-C0 artifact: `src/atdd/coach/schemas/risk-score.schema.json`
+- Related issues: `#P4` (config loader for `coach.risk_threshold_block`), `#O1`/`#O2` (judge consumers), `#N3` (reviewer prompt consumer), `#Q1` (end-to-end verification of PR rendering)

--- a/plan/dispatch_validators/C001.yaml
+++ b/plan/dispatch_validators/C001.yaml
@@ -1,0 +1,74 @@
+urn: "wmbt:dispatch-validators:C001"
+step: "confirm"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "unfiltered-suppressed-violations-in-the-active-set"
+context_clarifier: "when violations.jsonl has been written for a commit and coach must apply find_suppressions() over the worktree to move suppress-and-clean toolkit violations whose offending line carries a `# atdd:suppress(<rule_id>) [UNTIL=YYYY-MM-DD]` marker into suppressed.jsonl, while strict repo.* rules from substrate v12 bypass suppression entirely (markers ignored — disposition_gate enforces strict unconditionally), and stale UNTIL-past markers found via find_stale_suppressions() are written to stale-suppressions.jsonl"
+lens: "functional.effectiveness"
+statement: "minimize quantity of unfiltered-suppressed-violations-in-the-active-set when violations.jsonl has been written for a commit and coach must apply find_suppressions() to move suppress-and-clean toolkit violations into suppressed.jsonl while strict repo.* rules bypass suppression and stale markers populate stale-suppressions.jsonl"
+acceptances:
+  - identity:
+      urn: "acc:dispatch-validators:C001-UNIT-001-toolkit-suppression-marker-absorbs-violation"
+      id: "AC-UNIT-001"
+      purpose: "A suppress-and-clean toolkit violation with a matching marker moves to suppressed.jsonl"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "violations.jsonl contains at least one violation whose rule_id is registered with disposition: suppress-and-clean as a toolkit convention"
+        - "The offending file/line carries `# atdd:suppress(<rule_id>) [UNTIL=YYYY-MM-DD]` with a future UNTIL date"
+    when:
+      abstract: "The suppression filter calls find_suppressions() over the worktree and reconciles markers against the active violations"
+    then:
+      abstract:
+        - "The suppressed violation is removed from the active set used for blocking decisions"
+        - "The suppressed violation is appended to .atdd/runtime/validations/<sha>/suppressed.jsonl"
+        - "The suppressed.jsonl record carries enough metadata to audit the absorption (rule_id, location, marker text, UNTIL date)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:dispatch-validators:C001-UNIT-002-repo-rule-violation-never-suppressed"
+      id: "AC-UNIT-002"
+      purpose: "A repo-rule violation never appears in suppressed.jsonl even if a marker exists"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "violations.jsonl contains a violation whose rule_id is a repo.* rule (substrate v12; walker-set disposition: strict)"
+        - "The offending file/line carries `# atdd:suppress(<repo-rule-id>) [UNTIL=...]`"
+    when:
+      abstract: "The suppression filter runs end-to-end on the violations.jsonl"
+    then:
+      abstract:
+        - "The repo-rule violation remains in the active set (NOT moved to suppressed.jsonl)"
+        - "suppressed.jsonl contains zero records whose rule_id resolves to a repo.* rule, even when markers are present"
+        - "This emerges from the existing disposition_gate strict-unconditional path; coach does not special-case repo rules in the filter"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:dispatch-validators:C001-UNIT-003-stale-suppressions-populated"
+      id: "AC-UNIT-003"
+      purpose: "Stale suppression markers populate stale-suppressions.jsonl"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The worktree contains at least one `# atdd:suppress(<rule_id>) [UNTIL=YYYY-MM-DD]` marker whose UNTIL date is in the past"
+    when:
+      abstract: "The suppression filter calls find_stale_suppressions() over the worktree"
+    then:
+      abstract:
+        - "Each stale marker is written as a record to .atdd/runtime/validations/<sha>/stale-suppressions.jsonl"
+        - "Each record carries rule_id, location, the parsed UNTIL date, and the marker text"
+        - "No stale-marker record is dropped (one record per stale marker discovered)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/dispatch_validators/D001.yaml
+++ b/plan/dispatch_validators/D001.yaml
@@ -1,0 +1,76 @@
+urn: "wmbt:dispatch-validators:D001"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "ambiguity-in-per-phase-validator-selection"
+context_clarifier: "when coach is at a known phase (PLANNED / RED / GREEN / SMOKE / REFACTOR) and must build the validator set to dispatch as a union of (a) toolkit conventions per the §6.5 mapping table — including substrate enforcement validators (atdd.tester.validators.acceptance-violation.*) at PLANNED — and (b) every repo.* rule whose bind_rule(rule_id).phase matches the current coach phase regardless of source kind (WMBT-acceptance, train-acceptance, security), with selection overrideable by .atdd/coach/config.yaml::coach.validators.selection"
+lens: "functional.adaptability"
+statement: "minimize likelihood of ambiguity-in-per-phase-validator-selection when coach is at a known phase and must build the validator set as a union of toolkit conventions per the §6.5 mapping table (incl. substrate enforcement at PLANNED) and every repo.* rule whose bind_rule(rule_id).phase matches the current coach phase, with override via .atdd/coach/config.yaml::coach.validators.selection"
+acceptances:
+  - identity:
+      urn: "acc:dispatch-validators:D001-UNIT-001-green-phase-selects-all-green-repo-rules"
+      id: "AC-UNIT-001"
+      purpose: "A coach session at GREEN selects all repo rules with phase: GREEN (WMBT, train, security all considered)"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The substrate v12 repo registry contains rules from all three source kinds (WMBT-acceptance, train-acceptance, security) with various phase values"
+        - "A subset of these rules has bind_rule(rule_id).phase == GREEN — including at least one WMBT, one train, and one security rule"
+        - "Coach is at the GREEN phase"
+    when:
+      abstract: "The validator selection resolver computes the validator set for the current phase"
+    then:
+      abstract:
+        - "The selected set includes every repo.* rule whose bind_rule(rule_id).phase == GREEN, regardless of source kind"
+        - "The selected set also includes the toolkit GREEN mapping (atdd.coder.validators.* dead-code/dto/error-response/frontend/presentation + boundaries + design)"
+        - "No repo rules with phase != GREEN are included"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:dispatch-validators:D001-UNIT-002-planned-runs-substrate-enforcement"
+      id: "AC-UNIT-002"
+      purpose: "A coach session at PLANNED runs the substrate enforcement validators (atdd.tester.validators.acceptance-violation.*)"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Coach is at the PLANNED phase"
+        - "src/atdd/tester/conventions/acceptance-violation.convention.yaml's five rules (acceptance-must-be-measurable, acceptance-must-declare-phase, disposition-must-not-be-declared, validator-binding-must-be-bidirectional, metric-implementation-must-exist) are registered as toolkit conventions"
+    when:
+      abstract: "The validator selection resolver computes the validator set for the PLANNED phase"
+    then:
+      abstract:
+        - "All five substrate enforcement validators (atdd.tester.validators.acceptance-violation.*) are present in the selected set"
+        - "All atdd.planner.validators.* (acceptance, criteria, wmbt) are present"
+        - "Toolkit mapping for PLANNED matches the §6.5 table union"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:dispatch-validators:D001-UNIT-003-config-override-substitutes-selection"
+      id: "AC-UNIT-003"
+      purpose: "Override path correctly substitutes a project-specific selection"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - ".atdd/coach/config.yaml exists with coach.validators.selection overriding the §6.5 default mapping for at least one phase"
+        - "The override defines an explicit list of toolkit validator modules for that phase"
+    when:
+      abstract: "The validator selection resolver computes the validator set for the overridden phase"
+    then:
+      abstract:
+        - "The toolkit slice of the selected set equals the override's explicit list (defaults are NOT additionally unioned in for that phase)"
+        - "The repo rules slice is unaffected by the override (still computed from bind_rule(rule_id).phase per substrate v12)"
+        - "Phases not present in the override fall back to the §6.5 default mapping"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/dispatch_validators/E001.yaml
+++ b/plan/dispatch_validators/E001.yaml
@@ -1,0 +1,56 @@
+urn: "wmbt:dispatch-validators:E001"
+step: "execute"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "lost-violation-records-during-pytest-execution"
+context_clarifier: "when coach runs phase-selected validators as a pytest subprocess against the worktree and must capture every Violation record that validators emit via assert_disposition_satisfied(), serializing them to .atdd/runtime/validations/<sha>/violations.jsonl in a shape that conforms to validator-result.schema.json (frozen by C0) and aligns with substrate's Violation dataclass"
+lens: "functional.effectiveness"
+statement: "minimize quantity of lost-violation-records-during-pytest-execution when coach runs phase-selected validators as a pytest subprocess and must capture every Violation record into .atdd/runtime/validations/<sha>/violations.jsonl conforming to validator-result.schema.json"
+acceptances:
+  - identity:
+      urn: "acc:dispatch-validators:E001-UNIT-001-pytest-plugin-captures-all-violations"
+      id: "AC-UNIT-001"
+      purpose: "A pytest run with the violation_collector plugin captures all Violation records emitted in that run"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/runtime/violation_collector.py exists as a pytest plugin"
+        - "The plugin implements pytest_runtest_logreport, capturing Violation records emitted via assert_disposition_satisfied()"
+        - "A test run includes validators that emit a known set of Violation records (mixed strict, suppress-and-clean, advisory)"
+    when:
+      abstract: "Coach invokes pytest with `-p atdd.coach.runtime.violation_collector` against the selected validator paths for the current commit's sha"
+    then:
+      abstract:
+        - "Every Violation emitted in that run is written to .atdd/runtime/validations/<sha>/violations.jsonl, one Violation per JSON line"
+        - "The set of captured violations equals the set emitted (no losses, no duplicates)"
+        - "Each line carries validator_id (validator_module + validator_function), rule_id, severity, location, detail, and any optional fields per spec §7.5"
+        - "The plugin operates under PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 and registers solely via the explicit -p flag (per validator-invocation.md)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:dispatch-validators:E001-CONTRACT-001-violations-jsonl-schema-conformant"
+      id: "AC-CONTRACT-001"
+      purpose: "violations.jsonl content matches the schema at validator-result.schema.json"
+      phase: "GREEN"
+    harness:
+      type: "contract"
+      category: "contract"
+    given:
+      abstract:
+        - "validator-result.schema.json is the C0-frozen schema at src/atdd/coach/schemas/"
+        - "A pytest run completes and writes violations.jsonl"
+    when:
+      abstract: "A schema validator parses each line of violations.jsonl and validates it against validator-result.schema.json"
+    then:
+      abstract:
+        - "Every line is valid JSON and validates with zero schema errors"
+        - "Required fields rule_id, severity, location, detail are present on every record"
+        - "Optional fields fix_hint_ref, validator_module, validator_function follow the schema's optional contract"
+        - "Disposition is NOT present on the violation record (per §7.5: it is a registry property of the rule, not the violation)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/dispatch_validators/E002.yaml
+++ b/plan/dispatch_validators/E002.yaml
@@ -1,0 +1,77 @@
+urn: "wmbt:dispatch-validators:E002"
+step: "execute"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "commits-without-a-conformant-risk-score-artifact"
+context_clarifier: "when violations.jsonl and suppressed.jsonl have been written for a commit and coach must compute the per-commit risk score as `sum(severity for active_violations)` plus a breakdown by_severity / by_archetype (incl. the `repo` slice for substrate v12 rules: WMBT-acceptance and train-acceptance severity = 4 constant; security severity mapped from abuse_case.severity low→2/medium→3/high→4/critical→5) / by_disposition / stale_suppressions, write it to .atdd/runtime/validations/<sha>/risk-score.json, and validate it against risk-score.schema.json (frozen by C0) at write time"
+lens: "functional.effectiveness"
+statement: "minimize quantity of commits-without-a-conformant-risk-score-artifact when violations.jsonl and suppressed.jsonl have been written for a commit and coach must compute the risk score and breakdown (by_severity, by_archetype incl. repo slice, by_disposition, stale_suppressions), write it to .atdd/runtime/validations/<sha>/risk-score.json, and validate against risk-score.schema.json at write time"
+acceptances:
+  - identity:
+      urn: "acc:dispatch-validators:E002-UNIT-001-mixed-toolkit-and-repo-breakdown"
+      id: "AC-UNIT-001"
+      purpose: "A run with mixed toolkit and repo violations produces a breakdown with both slices"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "An active set of violations contains at least one toolkit-archetype violation (e.g., coder.*, tester.*, planner.*, coach.*) and at least one repo.* violation (substrate v12)"
+        - "Severities are known per spec §6.8 (1..5 for toolkit; 4 constant for repo WMBT/train acceptance; mapped from abuse_case.severity for repo security)"
+    when:
+      abstract: "The risk score computer runs against the active violations and produces risk-score.json"
+    then:
+      abstract:
+        - "risk_score equals sum(severity for active_violations)"
+        - "by_archetype breakdown contains both a non-zero `repo` slice and at least one non-zero toolkit archetype slice"
+        - "by_severity, by_disposition, stale_suppressions counts are populated"
+        - "by_archetype.repo correctly sums severity contributions across WMBT-acceptance, train-acceptance, and security-derived rules"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:dispatch-validators:E002-CONTRACT-001-risk-score-schema-validated-at-write"
+      id: "AC-CONTRACT-001"
+      purpose: "Schema validation runs at write time"
+      phase: "GREEN"
+    harness:
+      type: "contract"
+      category: "contract"
+    given:
+      abstract:
+        - "risk-score.schema.json is the C0-frozen schema at src/atdd/coach/schemas/"
+        - "The risk score computer is about to write .atdd/runtime/validations/<sha>/risk-score.json"
+    when:
+      abstract: "The computer validates the in-memory risk score document against risk-score.schema.json before writing"
+    then:
+      abstract:
+        - "Validation runs synchronously at write time (not deferred)"
+        - "On schema violation, the write is aborted and a coach-internal error is emitted (no malformed risk-score.json is ever persisted)"
+        - "On success, the file is atomically written to .atdd/runtime/validations/<sha>/risk-score.json"
+        - "The persisted file contains all required fields: sum, by_severity, by_archetype (with repo slice key), by_disposition, stale_suppressions"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:dispatch-validators:E002-INTEGRATION-001-pr-description-includes-score-on-complete"
+      id: "AC-INTEGRATION-001"
+      purpose: "PR description includes the score and breakdown when COMPLETE (verified at #Q1 integration)"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "An issue has reached COMPLETE and a PR is being opened by coach"
+        - "risk-score.json has been written for the latest commit on the COMPLETE worktree"
+    when:
+      abstract: "Coach renders the PR description on COMPLETE"
+    then:
+      abstract:
+        - "The PR description embeds the latest commit's risk_score sum and the by_archetype / by_severity breakdown"
+        - "The description links to .atdd/runtime/validations/<sha>/ for full artifacts"
+        - "The PR description rendering is verified end-to-end at the #Q1 integration cycle"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/dispatch_validators/M001.yaml
+++ b/plan/dispatch_validators/M001.yaml
@@ -1,0 +1,55 @@
+urn: "wmbt:dispatch-validators:M001"
+step: "monitor"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "unobserved-commits-on-watched-worktrees"
+context_clarifier: "when an agent commits on a coach-watched worktree and the runtime tier-1 dispatch must observe the commit, parse the conventional trailers (Phase, WMBT-Urn, Agent-Id, Issue) from `git log -1 --format=%B <sha>`, and emit a commit_observed event plus a downstream validation_pending event keyed by the resolved (phase, scope) within 1 second of HEAD advancing"
+lens: "functional.effectiveness"
+statement: "minimize quantity of unobserved-commits-on-watched-worktrees when an agent commits on a coach-watched worktree and the runtime tier-1 dispatch must observe the commit, parse trailers, and emit commit_observed plus validation_pending events within 1 second of HEAD advancing"
+acceptances:
+  - identity:
+      urn: "acc:dispatch-validators:M001-UNIT-001-commit-observed-event-emitted"
+      id: "AC-UNIT-001"
+      purpose: "A new commit on a watched branch triggers a coach event with parsed trailers within 1s of HEAD advancing"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A worktree is registered with the coach runtime watcher under .atdd/runtime/agents/<id>/"
+        - "The agent makes a new commit on the watched branch with trailers Phase/WMBT-Urn/Agent-Id/Issue populated"
+    when:
+      abstract: "The git watcher detects HEAD advancement on the worktree"
+    then:
+      abstract:
+        - "A commit_observed event is appended to the agent's events.jsonl within 1 second"
+        - "The event payload contains worktree, sha, parent_sha"
+        - "Trailers are parsed from `git log -1 --format=%B <sha>` into Phase, WMBT-Urn, Agent-Id, Issue"
+        - "A downstream validation_pending event is emitted, keyed by the trailer-resolved (phase, scope)"
+        - "Both events validate against runtime-event.schema.json (frozen by C0)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:dispatch-validators:M001-UNIT-002-missing-trailers-violation-routed-tier-1"
+      id: "AC-UNIT-002"
+      purpose: "Missing trailers produce a coach.commit-trailers.* violation routed via tier-1 (in production this is also caught by the pre-commit hook; coach captures it for completeness)"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A commit lands on the watched branch with one or more required trailers absent (Phase, WMBT-Urn, Agent-Id, or Issue)"
+        - "The coach.commit-trailers.* rule family is registered in the runtime registry"
+    when:
+      abstract: "The git watcher parses the commit message"
+    then:
+      abstract:
+        - "A Violation is emitted with rule_id under the coach.commit-trailers.* family"
+        - "The violation is routed via the tier-1 pipeline (collected by the violation_collector pytest plugin or directly by the watcher's emit path)"
+        - "The violation conforms to validator-result.schema.json"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/dispatch_validators/_dispatch_validators.yaml
+++ b/plan/dispatch_validators/_dispatch_validators.yaml
@@ -1,0 +1,94 @@
+wagon: dispatch-validators
+urn: "wagon:dispatch-validators"
+name: "Dispatch Validators"
+description: "Implements coach v9's real-time tier-1 validator pipeline (spec §6.4–§6.6, §6.8): a git watcher emits commit_observed events with parsed Phase/WMBT-Urn/Agent-Id trailers; a pytest plugin (coach.runtime.violation_collector) captures Violation records into validations/<sha>/violations.jsonl; per-phase validator selection unions toolkit conventions with substrate v12 repo.* rules whose RuleMetadata.phase matches the current coach phase; the suppression scanner separates suppressed and stale-suppression violations into suppressed.jsonl and stale-suppressions.jsonl while strict repo rules bypass suppression; risk score with by_archetype (incl. repo slice), by_severity, by_disposition, and stale_suppressions is computed and written to risk-score.json. Together these deliver the deterministic feedback loop that coach uses to route GREEN/SMOKE/REFACTOR phase exits and to block COMPLETE on configurable risk thresholds."
+theme: commons
+
+subject: "agent:coach"
+context: "in-runtime-tier-1-dispatch, when-an-agent-commits-on-a-watched-worktree-and-coach-must-evaluate-the-commit-against-phase-scoped-validators-before-routing-the-next-action"
+action: "watches commits, dispatches phase-selected validators in subprocess, collects Violation records via the substrate-aligned pytest plugin, applies suppression-scanner end-to-end (toolkit only, repo rules bypass), and computes the per-commit risk score with archetype slices"
+goal: "ensure every commit on a coach-watched worktree produces a deterministic, schema-conformant validation record set (violations.jsonl, suppressed.jsonl, stale-suppressions.jsonl, risk-score.json) within the §6.4 grace window so coach can route the agent without trust-based polling"
+outcome: "for every observed commit on a watched worktree, .atdd/runtime/validations/<sha>/ contains four artifacts conforming to C0-frozen schemas, plus a validation_complete event on the agent's events.jsonl carrying the summary; coach can route GREEN/SMOKE/REFACTOR exits and block COMPLETE on configurable risk thresholds"
+
+features:
+  - urn: "feature:dispatch-validators:tier-1-validator-pipeline"
+
+produce:
+  - name: commons:coach:git-watcher
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:commit-observed-event
+    contract: "contract:commons:coach:runtime-event"
+    telemetry: null
+    to: external
+  - name: commons:coach:validation-pending-event
+    contract: "contract:commons:coach:runtime-event"
+    telemetry: null
+    to: external
+  - name: commons:coach:validation-complete-event
+    contract: "contract:commons:coach:runtime-event"
+    telemetry: null
+    to: external
+  - name: commons:coach:commit-trailers-rule-family
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:violation-collector-pytest-plugin
+    contract: "contract:commons:coach:validator-result"
+    telemetry: null
+    to: external
+  - name: commons:coach:violations-jsonl-artifact
+    contract: "contract:commons:coach:validator-result"
+    telemetry: null
+    to: external
+  - name: commons:coach:validator-selection-resolver
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:validator-selection-config-block
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:suppression-filter
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:suppressed-jsonl-artifact
+    contract: "contract:commons:coach:validator-result"
+    telemetry: null
+    to: external
+  - name: commons:coach:stale-suppressions-jsonl-artifact
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:risk-score-computer
+    contract: "contract:commons:coach:risk-score"
+    telemetry: null
+    to: external
+  - name: commons:coach:risk-score-json-artifact
+    contract: "contract:commons:coach:risk-score"
+    telemetry: null
+    to: external
+
+consume:
+  - name: commons:coach:runtime-event-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:validator-result-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:risk-score-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:runtime-layout-doc
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:validator-invocation-doc
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:event-semantics-doc
+    from: wagon:freeze-runtime-contracts
+
+wmbt:
+  total: 5
+  M001: "minimize quantity of unobserved-commits-on-watched-worktrees"
+  E001: "minimize loss of violation-records-during-pytest-execution"
+  D001: "minimize ambiguity-in-per-phase-validator-selection"
+  C001: "minimize quantity of unfiltered-suppressed-violations-blocking-phase-exit"
+  E002: "minimize quantity of commits-without-a-conformant-risk-score-artifact"

--- a/plan/dispatch_validators/features/tier_1_validator_pipeline.yaml
+++ b/plan/dispatch_validators/features/tier_1_validator_pipeline.yaml
@@ -1,0 +1,43 @@
+urn: "feature:dispatch-validators:tier-1-validator-pipeline"
+wagon: "wagon:dispatch-validators"
+description: "Coach v9's real-time tier-1 validator pipeline (spec §6.4–§6.6, §6.8): a git watcher emits commit_observed events with parsed Phase/WMBT-Urn/Agent-Id trailers (#M1); a custom pytest plugin captures Violation records to validations/<sha>/violations.jsonl (#M2); per-phase validator selection unions toolkit conventions with repo.* rules whose RuleMetadata.phase matches (#M3); the suppression scanner separates suppressed and stale-suppression violations end-to-end with repo rules bypassing suppression (#M4); risk score with by_archetype (incl. repo slice), by_severity, by_disposition, and stale_suppressions is computed and written to risk-score.json (#M5)."
+sizing:
+  wmbts: 5
+  footprint_score: 12
+  footprint_size: "M"
+wmbts:
+  - "wmbt:dispatch-validators:M001"
+  - "wmbt:dispatch-validators:E001"
+  - "wmbt:dispatch-validators:D001"
+  - "wmbt:dispatch-validators:C001"
+  - "wmbt:dispatch-validators:E002"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 0
+        rationale: "No HTTP/CLI surface introduced; integration is event-driven, invoked by the runtime watcher (J5) and pytest subprocess invocation"
+    application:
+      - type: "use_cases"
+        count: 5
+        rationale: "Five orchestrators: observe-commit (M1), collect-violations (M2), select-validators-for-phase (M3), filter-and-classify-suppressions (M4), compute-risk-score (M5)"
+    domain:
+      - type: "value_objects"
+        count: 4
+        rationale: "ParsedCommitTrailers, ValidatorSet (toolkit ∪ repo), SuppressionDecision, RiskBreakdown — all immutable derivations from substrate Violation/RuleMetadata + commit metadata"
+    integration:
+      - type: "subprocess_invokers"
+        count: 1
+        rationale: "Pytest invocation harness for tier-1 dispatch (validator-invocation.md compliant: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1, per-phase timeouts, subprocess-crash vs test-failure retry distinction)"
+      - type: "watchers"
+        count: 1
+        rationale: "Git watcher (inotify/fswatch) emitting commit_observed events; lives in src/atdd/coach/runtime/git_watcher.py, complements the broader runtime watcher owned by #J5"
+      - type: "pytest_plugins"
+        count: 1
+        rationale: "src/atdd/coach/runtime/violation_collector.py — pytest_runtest_logreport hook capturing Violation records via assert_disposition_satisfied and writing JSONL to validations/<sha>/violations.jsonl"
+      - type: "artifact_writers"
+        count: 4
+        rationale: "violations.jsonl, suppressed.jsonl, stale-suppressions.jsonl, risk-score.json — schema-validated at write time per validator-result.schema.json and risk-score.schema.json"
+      - type: "rule_families"
+        count: 1
+        rationale: "coach.commit-trailers.* — emits violations when commit trailers are missing or malformed; complements the existing pre-commit hook"


### PR DESCRIPTION
## Summary

Authors the `dispatch-validators` wagon (Track M, spec §6.4–§6.6, §6.8) for coach v9 — the real-time tier-1 validator pipeline. Targets `feat/coach-v9-bootstrap`, **not** `main`.

This PR delivers `plan/` scaffolding only — no runtime code, no issues filed. A later sequential pass files the `M1`..`M5` issues with dependency rewriting.

### Deliverables

- `plan/dispatch_validators/_dispatch_validators.yaml` — wagon manifest (theme: commons, subject: agent:coach, consumes 6 frozen contracts/docs from `wagon:freeze-runtime-contracts`)
- `plan/dispatch_validators/features/tier_1_validator_pipeline.yaml` — feature spanning all 5 WMBTs
- `plan/dispatch_validators/{M001,E001,D001,C001,E002}.yaml` — 5 WMBTs (one per spec issue M1..M5):
  - **M001** (monitor): git watcher + commit trailer parsing → `commit_observed` + `validation_pending` events (M1)
  - **E001** (execute): `coach.runtime.violation_collector` pytest plugin → `violations.jsonl` (M2)
  - **D001** (define): per-phase validator selection (toolkit ∪ repo.* by `bind_rule(rule_id).phase`) (M3)
  - **C001** (confirm): suppression scanner end-to-end; repo rules bypass via existing `disposition_gate` (M4)
  - **E002** (execute): risk score with `by_archetype.repo` slice (substrate v12 severity mapping) → `risk-score.json` (M5)
- `.coach-v9-bootstrap/bodies/{m1,m2,m3,m4,m5}.md` — compliant issue bodies, predecessor refs as `#<INTERNAL_ID>` placeholders (filer pane rewrites to GH numbers)

### Inheritance

- Train `0002-coach-drives-lifecycle`, the 9-wagon registry, and `wagon:freeze-runtime-contracts` are inherited from the parent branch — untouched.

### Validation

`atdd validate planner --quick` passes for this wagon's contributions. The remaining `test_rule_id_uniqueness` failure is pre-existing (duplicates in `rule-id.convention.yaml`, `naming.convention.yaml`, `orchestration.convention.yaml`) and unrelated to this PR. Failure count went from 6 → 1 after adopting authorized WMBT vocabulary (dimension `likelihood`, lens `functional.effectiveness`/`functional.adaptability`).

## Test plan

- [ ] `atdd validate planner --quick` passes for `plan/dispatch_validators/*` (no new failures)
- [ ] Filer pane consumes the 5 bodies in topological order (wave w2) and rewrites `#<INTERNAL_ID>` → GH numbers
- [ ] Each `acc:dispatch-validators:*` URN in body Acceptance sections resolves to a YAML in `plan/dispatch_validators/`