### PR TITLE
feat(coach): coach v9 — integrate-end-to-end wagon

### DIFF
--- a/.coach-v9-bootstrap/bodies/q1.md
+++ b/.coach-v9-bootstrap/bodies/q1.md
@@ -1,0 +1,115 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-q1-end-to-end-cycle` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `integrate-end-to-end` |
+| Internal-Spec-Id | `Q1` |
+| Feature | End-to-end coach-driven cycle on a real issue from `atdd coach <N>` through `COMPLETE` with PR opened, capturing every substrate↔coach handoff at INFO level and inventorying first-contact integration bugs as follow-ups |
+
+---
+
+## Scope
+
+### In Scope
+
+This is coach v9's done-line — analogous to substrate v12 #17. It is also the **first time the substrate v12 ↔ coach v9 integration surface runs end-to-end**. Substrate is shipped, coach v9 components ship individually with unit tests, but the integration surface between them is unproven until #Q1 runs. Per spec §11.6, bugs are expected; the issue's job is to surface and document them, not to engineer them away upfront.
+
+Concretely, #Q1 delivers:
+
+- **Selection of the worked-example issue.** Pick one real GitHub issue with small scope and a single WMBT, ideally one that exercises both `harness.type` and `signal.metric` so both substrate runner modes fire (`test_metric_runner::test_metric_threshold_satisfied` and `test_security_ref_binding::test_acceptance_ref_resolves_and_passes`). Document the rationale in the worked-example doc.
+- **Run `atdd coach <N>` end-to-end.** Drive the chosen issue from `INIT` through `COMPLETE` with a PR opened on the default branch. The cycle exercises every state transition in spec §4.1 (`INIT → PLANNED → RED → GREEN → SMOKE → REFACTOR → COMPLETE`) and every substrate↔coach boundary that downstream tracks integrated piecemeal.
+- **Verbose substrate↔coach boundary logging at INFO level.** Hook every handoff so that `.atdd/runtime/coach/integration.log` contains one structured (JSON Lines) INFO entry per crossing across the four boundary classes:
+  - **Validator invocation** — coach → substrate pytest plugin (`coach.runtime.violation_collector`). Log the validator id, rule id, phase, commit SHA, outcome.
+  - **`bind_rule` lookup** — coach → rule registry. Log the rule id and the resolved `RuleMetadata` reference.
+  - **Spawn-harness block rendering** — coach → `render_security_rules_block` / `render_wmbt_rules_block` / `render_train_rules_block` (per spec §7.1). Log the renderer name and the persona being spawned.
+  - **Gate verdict consumption** — coach → `disposition_gate.assert_disposition_satisfied`. Log the disposition tier, pass/fail, and the violations driving the verdict.
+- **Verify cycle artifact completeness.** Confirm the cycle produces:
+  - `.atdd/runtime/coach/decisions.jsonl` conforming to the schema frozen by #C0.
+  - `.atdd/runtime/coach/judgments.jsonl` for every `atdd judge` call site exercised (per spec §6.9).
+  - `.atdd/runtime/validations/<sha>/violations.jsonl`, `suppressed.jsonl`, `stale-suppressions.jsonl`, `risk-score.json` per commit.
+  - Risk score with a `repo`-archetype slice if any repo-archetype rules trigger (per spec §6.8).
+  - One reviewer report per enabled phase under `.atdd/runtime/agents/<id>/reviews/<review-id>.json`.
+  - PR description that includes the risk-score breakdown.
+- **Worked-example narrative at `docs/coach-worked-example.md`.** Human-readable account of the cycle: chosen issue (with GH URL), state-machine path, artifacts produced, replay instructions for a reader who only has the runtime artifacts. References `atdd-coach-spec-v9.md` §11.5 (self-hosting inflection) and §11.6 (integration-bug observation).
+- **Integration-bug inventory in the worked-example doc.** A `## Integration bugs discovered` section enumerates every cross-boundary issue found during the cycle. Each entry: one-line summary, boundary class crossed (validator-invocation / bind_rule-lookup / spawn-harness-rendering / gate-verdict-consumption / runtime-watcher / suppression-marker), link to the follow-up GH issue filed against the appropriate track (J/K/L/M/N/O/P). An empty section with the literal text `No integration bugs surfaced during the worked example.` is acceptable; a missing section is not.
+- **Production-readiness disclaimer.** A `## Production-readiness expectation` section states that coach v9 may need an integration-hardening milestone (sequence of follow-up PRs) before being declared production-ready beyond this worked example, with a direct reference to `atdd-coach-spec-v9.md` §11.6.
+- **Follow-up issues.** Each integration bug discovered becomes a GH issue against the appropriate track with the `integration` label and a link back to `docs/coach-worked-example.md` as the source of discovery. The list of follow-ups (zero or more) is the integration-hardening milestone backlog.
+
+### Out of Scope
+
+- **Engineering the bugs out before they surface.** The point of #Q1 is to *find* the integration bugs that no individual issue's tests can catch. Bugs surfaced during the cycle are filed as follow-ups, not blockers for closing #Q1.
+- **The integration-hardening milestone PRs themselves.** #Q1 produces the inventory and the follow-up issues; the actual bug-fix PRs are deliberate follow-ups against tracks J/K/L/M/N/O/P, not part of #Q1's scope.
+- **Choosing a complex issue to maximize coverage.** A small-scope, single-WMBT issue is required; pursuit of breadth is a follow-up worked example, not #Q1.
+- **Decommissioning legacy commands.** `atdd orchestrate` and `atdd babysit` decommissioning is owned by `#P5` and `#P6` (with `#K5` and `#L8` as gating parity tests). #Q1 assumes those have shipped.
+- **Changing any contract or schema.** Schemas frozen by `#C0` are immutable for #Q1; if the cycle reveals a schema gap, file it as a follow-up against `freeze-runtime-contracts`, do not modify the schema in this PR.
+- **Dashboard or richer observability.** `atdd observer status` (#L6) suffices for the worked example; richer dashboard work is spec §12.4 future scope.
+- **Cross-issue orchestration.** Multi-issue runs (`atdd coach <N1> <N2> …`) are validated by track J's tests, not by #Q1.
+
+### Dependencies
+
+- `#C0` — runtime schemas + runtime-layout + validator-invocation + event-semantics docs (frozen contracts).
+- `#J1`, `#J2`, `#J3`, `#J4`, `#J5`, `#J6` — coach state machine, agent CLI, decisions/judgments durability, two-phase commit, runtime watcher, resume.
+- `#K1`, `#K2`, `#K3`, `#K4`, `#K5` — spawn skeleton, substrate spawn-harness blocks, naming + layout pass, per-LLM convention integration, orchestrate parity tests.
+- `#L1`, `#L2`, `#L3`, `#L4`, `#L5`, `#L6`, `#L7`, `#L8` — observer skeleton, all 17 default observer rules, dashboard, aggregate-approve, babysit parity tests.
+- `#M1`, `#M2`, `#M3`, `#M4`, `#M5` — git watcher, pytest violation-collector plugin, validator selection per phase, suppression scanner integration, risk score with `repo` slice.
+- `#N1`, `#N2`, `#N3`, `#N4`, `#N5` — reviewer persona, review-report schema, per-phase reviewer prompts, judge call site #2, `atdd agent review`.
+- `#O1`, `#O2`, `#O3`, `#O4`, `#O5` — `atdd judge` core and call sites, `atdd issue review` multi-pass.
+- `#P1`, `#P2`, `#P3`, `#P4`, `#P5`, `#P6` — `atdd rules` discovery, per-LLM convention generation, config loader, decommission of `atdd orchestrate` and `atdd babysit`.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Substrate↔coach integration surface | Substrate v12 shipped; coach v9 components ship individually with unit tests; integration surface unproven | One real GitHub issue driven from `INIT` to `COMPLETE` with PR opened via `atdd coach <N>`, exercising every boundary class | Per spec §11.6, first contact with reality always reveals coordination details that survive the spec; #Q1 is the controlled first contact |
+| Substrate↔coach handoff observability | Boundary crossings (validator invocation, `bind_rule`, spawn-harness rendering, gate verdict) are silent or per-component | `.atdd/runtime/coach/integration.log` contains one structured INFO entry per handoff during the cycle | Without per-handoff logging, an integration bug is reproducible but not diagnosable from artifacts alone, defeating the audit-trail purpose of `decisions.jsonl` |
+| Worked-example documentation | No human-readable narrative of a coach-driven cycle exists | `docs/coach-worked-example.md` narrates the cycle with chosen-issue rationale, state-machine path, artifact pointers, and replay instructions | Coach v9's value is auditable orchestration; an unwritten worked example leaves operators without a reference for "what does a clean cycle look like" |
+| Integration-bug inventory | Bugs discovered during integration would be triaged ad hoc and risk being lost | A `## Integration bugs discovered` section in the worked-example doc inventories every cross-boundary issue with a follow-up GH link | Per spec §11.6, the integration-hardening milestone needs an explicit backlog; without inventory, the production-readiness assessment loses its evidence trail |
+| Production-readiness expectation | Implicit assumption that coach v9 ships production-ready after #Q1 | Explicit disclaimer in the worked-example doc that an integration-hardening milestone may be needed before production readiness | Honesty about integration risk per spec §11.6: the architecture is sound, but reality reveals coordination details no spec can preempt |
+
+### User Impact
+
+The "user" of #Q1 is every coach v9 operator and downstream consumer of the runtime artifacts. Until #Q1 passes, **coach is not done** — even if all upstream issues are individually closed. Per spec §11.4, six agents producing roughly 42 issues will produce 42–60 PRs, and every one of those PRs touches a slice of the substrate↔coach boundary. #Q1 is where those slices first run together against a real GitHub issue with the full state machine, real validators, real reviewer prompts, and a real PR.
+
+Per spec §11.6, the architecture is sound (per the teammate review), but first contact with reality always reveals coordination details that survive the spec — duplicate event handling, replay re-fire, suppression-marker drift, rule-ID resolution lag, watcher reattachment after restart. #Q1 surfaces these in a controlled run against a small-scope worked-example issue rather than during dogfooding when the failure mode is "operator can't tell why coach stopped." Each bug becomes a follow-up issue against the appropriate track, forming the integration-hardening backlog.
+
+The downstream consumer benefit is concrete: after #Q1 lands, an operator can read `docs/coach-worked-example.md`, follow the state-machine path, open the runtime artifacts referenced by relative path, and reconstruct any decision the coach made. The integration log makes any cross-boundary anomaly diagnosable from logs alone. The production-readiness disclaimer sets honest expectations for the next milestone.
+
+### Design Anchor
+
+#Q1 is the boundary between "components shipped" and "system proven." The chosen-issue selection criterion (small scope, single WMBT, both substrate runner modes exercised) is engineered to maximize integration-coverage-per-cycle without inflating the worked-example narrative beyond what an operator can read in one sitting. The integration-bug-inventory section is what makes the cycle's failure modes durable; spec §11.6 is explicit that an empty inventory is acceptable but a missing section is not — the structural commitment to surfacing bugs survives even a clean run.
+
+The "schemas freeze shape, docs freeze semantics, integration log freezes evidence" layering matches the rationale already encoded by `freeze-runtime-contracts`: shape-only schemas would not catch divergent temporal assumptions across event types; per-handoff logs would not catch bugs across components. The combination is what unblocks the integration-hardening milestone from being a hidden-bug minefield.
+
+---
+
+## Acceptance
+
+- `acc:integrate-end-to-end:E001-SMOKE-001-cycle-reaches-complete`: With all upstream coach v9 wagons merged and a small-scope single-WMBT real GitHub issue selected as the worked example, `atdd coach <N>` drives the chosen issue from `INIT` through `COMPLETE` without manual intervention beyond expected human escalations; a PR is opened against the default branch with the risk-score breakdown in the description; `.atdd/runtime/coach/decisions.jsonl` records every state transition under the schema frozen by `#C0`; per-commit `validations/<sha>/` outputs (`violations.jsonl`, `suppressed.jsonl`, `stale-suppressions.jsonl`, `risk-score.json`) are present; a reviewer report exists for each enabled phase (PLANNED, RED, GREEN, SMOKE; REFACTOR optional per spec §6.3); if any `repo`-archetype rules trigger, the risk score includes a `repo` archetype slice.
+- `acc:integrate-end-to-end:E001-SMOKE-002-artifacts-readable`: A reader (human or LLM) opening `decisions.jsonl`, `judgments.jsonl`, the per-commit `validations/<sha>/` artifacts, the per-agent `agents/<id>/` artifacts, and the reviewer reports in chronological order can reconstruct the full state-machine path the issue took, pair each validation with its commit SHA and recover which rules fired with which dispositions, pair each judgment with its call-site context per spec §6.9, and find no spec §3.2 artifact missing for the cycle.
+- `acc:integrate-end-to-end:M001-SMOKE-001-integration-log-covers-every-handoff`: With verbose integration logging enabled at the substrate↔coach boundary for the cycle, `.atdd/runtime/coach/integration.log` is non-empty and contains one structured (JSON Lines) INFO entry per handoff across four boundary classes — every validator invocation (validator id, rule id, phase, commit SHA, outcome), every `bind_rule` call from coach context (rule id, resolved `RuleMetadata` reference), every spawn-harness block rendering (renderer name `security_rules` / `wmbt_rules` / `train_rules`, persona being spawned), every gate verdict consumption (disposition tier, pass/fail, driving violations).
+- `acc:integrate-end-to-end:D001-UNIT-001-worked-example-doc-committed`: `docs/coach-worked-example.md` is committed and names the chosen issue (number and title) with its GitHub URL, summarizes the state-machine path, enumerates the artifacts produced (`decisions.jsonl`, `judgments.jsonl`, `validations/<sha>/` outputs, reviewer reports, `integration.log`) by relative path under `.atdd/runtime/`, and references `atdd-coach-spec-v9.md` §11.5 and §11.6.
+- `acc:integrate-end-to-end:D001-UNIT-002-integration-bugs-section-present`: `docs/coach-worked-example.md` contains an `## Integration bugs discovered` section listing each integration bug found with a one-line summary, boundary class crossed, and link to the GH follow-up issue filed against the appropriate track; an empty section with the literal text `No integration bugs surfaced during the worked example.` is acceptable; a missing section fails the acceptance; each follow-up issue carries the `integration` label and references `docs/coach-worked-example.md` as its source of discovery.
+- `acc:integrate-end-to-end:D001-UNIT-003-production-readiness-disclaimer-noted`: `docs/coach-worked-example.md` contains a `## Production-readiness expectation` section stating that coach v9 may need an integration-hardening milestone before being declared production-ready beyond this worked example, with a direct reference to `atdd-coach-spec-v9.md` §11.6.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §11.5 (self-hosting inflection), §11.6 (integration-bug observation in #Q1), §4.1 (per-issue states), §6.3 (per-phase adversarial review), §6.8 (risk score per phase exit), §6.9 (`atdd judge` call sites), §3.2 (runtime folder layout), §7.1 (spawn harness with rule-ID-aware context preload), full spec
+- `atdd-coach-issues-v3.md` issue `#Q1`
+- Wagon manifest: `plan/integrate_end_to_end/_integrate_end_to_end.yaml`
+- Feature: `plan/integrate_end_to_end/features/end_to_end_coach_cycle.yaml`
+- WMBTs: `plan/integrate_end_to_end/E001.yaml`, `plan/integrate_end_to_end/M001.yaml`, `plan/integrate_end_to_end/D001.yaml`
+- Train: `plan/_trains/0002-coach-drives-lifecycle.yaml`
+- Predecessors: `#C0`, `#J1`, `#J2`, `#J3`, `#J4`, `#J5`, `#J6`, `#K1`, `#K2`, `#K3`, `#K4`, `#K5`, `#L1`, `#L2`, `#L3`, `#L4`, `#L5`, `#L6`, `#L7`, `#L8`, `#M1`, `#M2`, `#M3`, `#M4`, `#M5`, `#N1`, `#N2`, `#N3`, `#N4`, `#N5`, `#O1`, `#O2`, `#O3`, `#O4`, `#O5`, `#P1`, `#P2`, `#P3`, `#P4`, `#P5`, `#P6`
+- Substrate v12 spec: `Violation`, `RuleMetadata`, `bind_rule`, `disposition_gate.assert_disposition_satisfied`, suppression scanner — referenced as the substrate side of every boundary class

--- a/plan/integrate_end_to_end/D001.yaml
+++ b/plan/integrate_end_to_end/D001.yaml
@@ -1,0 +1,76 @@
+urn: "wmbt:integrate-end-to-end:D001"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "unrecorded-first-contact-integration-bugs"
+context_clarifier: "when the first end-to-end coach-driven cycle has run and the substrate v12 ↔ coach v9 integration surface has been exercised for the first time — any cross-boundary issue discovered during the cycle (concurrency bug, replay re-fire, watcher reattachment, suppression marker not honored end-to-end, rule-ID drift between coach and substrate) must be filed as a follow-up issue against the appropriate track and inventoried in the worked-example doc, otherwise the production-readiness assessment loses its evidence trail. Per spec §11.6, an empty inventory is acceptable but a missing inventory section is not"
+lens: "functional.adaptability"
+statement: "minimize quantity of unrecorded-first-contact-integration-bugs when the first end-to-end coach-driven cycle has exercised the substrate v12 ↔ coach v9 integration surface and any cross-boundary issue discovered during the run must be inventoried as follow-ups against the appropriate track"
+acceptances:
+  - identity:
+      urn: "acc:integrate-end-to-end:D001-UNIT-001-worked-example-doc-committed"
+      id: "AC-UNIT-001"
+      purpose: "docs/coach-worked-example.md is committed and narrates the end-to-end cycle including which issue was chosen, the state-machine path, the artifacts produced, and how a reader can replay the cycle from the runtime artifacts"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The end-to-end coach-driven cycle on the chosen issue has completed"
+        - "All runtime artifacts under .atdd/runtime/coach/ from the cycle are present and readable"
+    when:
+      abstract: "A linter test scans docs/coach-worked-example.md for the required sections"
+    then:
+      abstract:
+        - "docs/coach-worked-example.md exists in the repository"
+        - "The doc names the chosen issue (number and title) and links to its GitHub URL"
+        - "The doc summarizes the state-machine path the issue took (which transitions fired, in what order)"
+        - "The doc enumerates the artifacts produced (decisions.jsonl, judgments.jsonl, validations/<sha>/ outputs, reviewer reports, integration.log) with relative paths under .atdd/runtime/"
+        - "The doc references atdd-coach-spec-v9.md §11.5 (self-hosting inflection) and §11.6 (integration-bug observation)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:integrate-end-to-end:D001-UNIT-002-integration-bugs-section-present"
+      id: "AC-UNIT-002"
+      purpose: "docs/coach-worked-example.md contains an integration-bugs-discovered section that inventories every cross-boundary bug observed during the cycle and links each to a follow-up issue against the appropriate track. An empty section is acceptable; a missing section is not"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "docs/coach-worked-example.md exists (per acc:integrate-end-to-end:D001-UNIT-001-worked-example-doc-committed)"
+        - "The end-to-end cycle has surfaced zero or more integration bugs at the substrate↔coach boundary"
+    when:
+      abstract: "A linter test scans docs/coach-worked-example.md for the integration-bugs-discovered section"
+    then:
+      abstract:
+        - "An '## Integration bugs discovered' section is present in docs/coach-worked-example.md"
+        - "Each integration bug is listed with a one-line summary, the boundary class it crossed (validator invocation / bind_rule lookup / spawn-harness block rendering / gate verdict consumption / runtime watcher / suppression marker), and a link to the GH issue filed against the appropriate track (J/K/L/M/N/O/P)"
+        - "An empty section with the literal text 'No integration bugs surfaced during the worked example.' is acceptable; a missing section fails the acceptance"
+        - "The follow-up issues each carry the integration label and reference docs/coach-worked-example.md as their source of discovery"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:integrate-end-to-end:D001-UNIT-003-production-readiness-disclaimer-noted"
+      id: "AC-UNIT-003"
+      purpose: "docs/coach-worked-example.md notes the explicit expectation that coach v9 may need an integration-hardening milestone (sequence of follow-up PRs) before being declared production-ready beyond this worked example"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "docs/coach-worked-example.md exists"
+    when:
+      abstract: "A linter test scans docs/coach-worked-example.md for the production-readiness disclaimer"
+    then:
+      abstract:
+        - "The doc contains a section titled 'Production-readiness expectation' (or equivalent) that states coach v9 may need an integration-hardening milestone before being declared production-ready beyond this worked example"
+        - "The disclaimer references atdd-coach-spec-v9.md §11.6 directly so the reader can follow the rationale upstream"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/integrate_end_to_end/E001.yaml
+++ b/plan/integrate_end_to_end/E001.yaml
@@ -1,0 +1,57 @@
+urn: "wmbt:integrate-end-to-end:E001"
+step: "execute"
+direction: "maximize"
+dimension: "likelihood"
+object_of_control: "one-real-issue-completing-coach-driven-cycle-to-complete-state"
+context_clarifier: "when all upstream coach v9 wagons (freeze-runtime-contracts, drive-state-machine, spawn-agents, observe-and-correct, dispatch-validators, review-phase-boundaries, judge-ambiguous-decisions, discover-and-decommission) have merged and one small-scope real GitHub issue (single WMBT, ideally exercising both harness.type and signal.metric so both substrate runner modes fire) is selected as the worked example for the first end-to-end coach-driven cycle"
+lens: "functional.effectiveness"
+statement: "maximize likelihood of one-real-issue-completing-coach-driven-cycle-to-complete-state when all upstream coach v9 wagons have merged and one small-scope issue is selected as the worked example for the first end-to-end run"
+acceptances:
+  - identity:
+      urn: "acc:integrate-end-to-end:E001-SMOKE-001-cycle-reaches-complete"
+      id: "AC-SMOKE-001"
+      purpose: "atdd coach <N> drives the chosen issue from INIT through COMPLETE with a PR opened, exercising every state transition in the spec §4.1 state machine"
+      phase: "GREEN"
+    harness:
+      type: "smoke"
+      category: "backend"
+    given:
+      abstract:
+        - "All upstream coach v9 wagons have merged to main (freeze-runtime-contracts, drive-state-machine, spawn-agents, observe-and-correct, dispatch-validators, review-phase-boundaries, judge-ambiguous-decisions, discover-and-decommission)"
+        - "A small-scope real GitHub issue is selected with a single WMBT, ideally exercising both harness.type and signal.metric so both substrate runner modes fire"
+    when:
+      abstract: "atdd coach <N> is invoked from the main worktree to drive the chosen issue end-to-end"
+    then:
+      abstract:
+        - "The state machine reaches COMPLETE for the chosen issue without manual intervention beyond expected human escalations"
+        - "A PR is opened against the default branch with the risk-score breakdown included in the description"
+        - "The cycle records every state transition in .atdd/runtime/coach/decisions.jsonl with the schema frozen by freeze-runtime-contracts"
+        - "Per-commit validator outputs land at .atdd/runtime/coach/validations/<sha>/ with violations.jsonl, suppressed.jsonl, stale-suppressions.jsonl, and risk-score.json present"
+        - "A reviewer report exists for each enabled phase (PLANNED, RED, GREEN, SMOKE; REFACTOR optional per spec §6.3)"
+        - "If any repo-archetype rules trigger, the risk score includes a repo archetype slice"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:integrate-end-to-end:E001-SMOKE-002-artifacts-readable"
+      id: "AC-SMOKE-002"
+      purpose: "An agent (human or LLM) can read the runtime artifacts produced during the cycle and reconstruct what happened without consulting any other source"
+      phase: "GREEN"
+    harness:
+      type: "smoke"
+      category: "backend"
+    given:
+      abstract:
+        - "The end-to-end coach-driven cycle on the chosen issue has completed (acc:integrate-end-to-end:E001-SMOKE-001-cycle-reaches-complete passes)"
+        - "All runtime artifacts under .atdd/runtime/coach/, .atdd/runtime/agents/<id>/, .atdd/runtime/validations/<sha>/, and .atdd/runtime/issue-reviews/<issue-N>/ are present"
+    when:
+      abstract: "A reader (human or LLM) opens decisions.jsonl, judgments.jsonl, the per-commit validations/<sha>/ artifacts, the per-agent agents/<id>/ artifacts, and the reviewer reports in chronological order"
+    then:
+      abstract:
+        - "The reader can reconstruct the full state-machine path the issue took (which transitions fired, in what order, on what evidence)"
+        - "The reader can pair each validation with its commit SHA and recover which rules fired with which dispositions"
+        - "The reader can pair each judgment with its call-site context per spec §6.9"
+        - "No artifact required by spec §3.2 is missing for the cycle"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/integrate_end_to_end/M001.yaml
+++ b/plan/integrate_end_to_end/M001.yaml
@@ -1,0 +1,34 @@
+urn: "wmbt:integrate-end-to-end:M001"
+step: "monitor"
+direction: "maximize"
+dimension: "frequency"
+object_of_control: "substrate-coach-handoffs-logged-at-info-level"
+context_clarifier: "when the first end-to-end coach-driven cycle is running and the substrate↔coach integration surface is unproven beyond unit tests — the four boundary classes (validator invocation through the substrate pytest plugin, bind_rule lookups from coach context, spawn-harness block rendering via render_security_rules_block / render_wmbt_rules_block / render_train_rules_block, gate verdict consumption from disposition_gate.assert_disposition_satisfied) must each emit a structured INFO entry to .atdd/runtime/coach/integration.log so that any cross-boundary bug is reconstructable from the log alone"
+lens: "functional.effectiveness"
+statement: "maximize frequency of substrate-coach-handoffs-logged-at-info-level when the first end-to-end coach-driven cycle is running and integration risk is concentrated at the four substrate↔coach boundary classes"
+acceptances:
+  - identity:
+      urn: "acc:integrate-end-to-end:M001-SMOKE-001-integration-log-covers-every-handoff"
+      id: "AC-SMOKE-001"
+      purpose: ".atdd/runtime/coach/integration.log contains an INFO-level entry for every substrate↔coach handoff observed during the cycle, with no boundary class silent"
+      phase: "GREEN"
+    harness:
+      type: "smoke"
+      category: "backend"
+    given:
+      abstract:
+        - "Verbose integration logging is enabled at the substrate↔coach boundary for the duration of the end-to-end run"
+        - "The four boundary classes are: validator invocation (coach → substrate pytest plugin), bind_rule lookup (coach → rule registry), spawn-harness block rendering (coach → render_security_rules_block / render_wmbt_rules_block / render_train_rules_block), gate verdict consumption (coach → disposition_gate.assert_disposition_satisfied)"
+    when:
+      abstract: "The end-to-end coach-driven cycle on the chosen issue runs from INIT to COMPLETE"
+    then:
+      abstract:
+        - ".atdd/runtime/coach/integration.log exists and is non-empty"
+        - "Every validator invocation by coach is logged at INFO with the validator id, rule id, phase, commit SHA, and outcome"
+        - "Every bind_rule call from coach context is logged at INFO with the rule id and resolved RuleMetadata reference"
+        - "Every spawn-harness block rendering call is logged at INFO with the renderer name (security_rules / wmbt_rules / train_rules) and the persona being spawned"
+        - "Every gate verdict consumption is logged at INFO with the disposition tier, pass/fail, and the violations driving the verdict"
+        - "Each entry is structured (parseable as JSON Lines) so a downstream tool can compute boundary-class coverage automatically"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/integrate_end_to_end/_integrate_end_to_end.yaml
+++ b/plan/integrate_end_to_end/_integrate_end_to_end.yaml
@@ -1,0 +1,76 @@
+wagon: integrate-end-to-end
+urn: "wagon:integrate-end-to-end"
+name: "Integrate End To End"
+description: "Coach v9 done-line: drives one real GitHub issue end-to-end through atdd coach <N> from INIT to COMPLETE with PR opened, captures every substrate↔coach handoff (validator invocation, bind_rule lookups, spawn-harness block rendering, gate verdict consumption) at INFO level in .atdd/runtime/coach/integration.log, and inventories first-contact integration bugs as follow-up issues against the appropriate track. Produces docs/coach-worked-example.md including an integration-bugs-discovered section and a coach-v9 production-readiness disclaimer."
+theme: commons
+
+subject: "agent:coach"
+context: "in-coach-v9-done-line, all-eight-upstream-wagons-merged-substrate-coach-integration-surface-still-unproven"
+action: "executes the first end-to-end coach-driven cycle on a real issue under verbose substrate-coach boundary logging and inventories integration bugs as follow-ups"
+goal: "prove the substrate v12 ↔ coach v9 integration surface works on a real issue and surface the bugs that no individual issue's tests can catch"
+outcome: "a closed coach-driven PR for the chosen issue, .atdd/runtime/coach/integration.log populated with every substrate↔coach handoff, docs/coach-worked-example.md committed with an integration-bugs-discovered section, and follow-up integration-hardening issues filed against the appropriate tracks"
+
+features:
+  - urn: "feature:integrate-end-to-end:end-to-end-coach-cycle"
+
+produce:
+  - name: commons:coach:end-to-end-coach-driven-cycle
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:integration-log
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:worked-example-doc
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:integration-bug-inventory
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:integration-hardening-followups
+    contract: null
+    telemetry: null
+    to: external
+
+consume:
+  - name: commons:coach:runtime-event-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:decision-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:judgment-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:correction-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:validator-result-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:risk-score-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:runtime-layout-doc
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:validator-invocation-doc
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:event-semantics-doc
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:state-machine-and-agent-cli
+    from: wagon:drive-state-machine
+  - name: commons:coach:spawn-and-harness
+    from: wagon:spawn-agents
+  - name: commons:coach:observer-and-corrections
+    from: wagon:observe-and-correct
+  - name: commons:coach:tier-1-validator-dispatch
+    from: wagon:dispatch-validators
+  - name: commons:coach:reviewer-and-review-reports
+    from: wagon:review-phase-boundaries
+  - name: commons:coach:judge-and-issue-review
+    from: wagon:judge-ambiguous-decisions
+  - name: commons:coach:rules-discovery-and-decommission
+    from: wagon:discover-and-decommission
+
+wmbt:
+  total: 3
+  E001: "maximize likelihood of one-real-issue-completing-coach-driven-cycle-to-complete-state"
+  M001: "maximize frequency of substrate-coach-handoffs-logged-at-info-level"
+  D001: "minimize quantity of unrecorded-first-contact-integration-bugs"

--- a/plan/integrate_end_to_end/features/end_to_end_coach_cycle.yaml
+++ b/plan/integrate_end_to_end/features/end_to_end_coach_cycle.yaml
@@ -1,0 +1,35 @@
+urn: "feature:integrate-end-to-end:end-to-end-coach-cycle"
+wagon: "wagon:integrate-end-to-end"
+description: "Run one real GitHub issue end-to-end through atdd coach <N> (INIT → COMPLETE with PR opened), with verbose INFO-level logging at every substrate↔coach boundary (validator invocation, bind_rule lookup from coach context, spawn-harness block rendering, gate verdict consumption) into .atdd/runtime/coach/integration.log, and inventory all first-contact integration bugs as follow-up issues. Produces docs/coach-worked-example.md including an integration-bugs-discovered subsection (empty acceptable, missing not) plus a noted expectation that coach v9 may need an integration-hardening milestone before being declared production-ready beyond this worked example."
+sizing:
+  wmbts: 3
+  footprint_score: 9
+  footprint_size: "M"
+wmbts:
+  - "wmbt:integrate-end-to-end:E001"
+  - "wmbt:integrate-end-to-end:M001"
+  - "wmbt:integrate-end-to-end:D001"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 0
+        rationale: "Q1 is an integration-execution + observation issue; no new CLI surface beyond what tracks J/K/L/M/N/O/P already deliver"
+    application:
+      - type: "use_cases"
+        count: 1
+        rationale: "Integration-logging hook that wraps every substrate↔coach handoff (bind_rule lookups, validator invocations, spawn-harness block rendering, gate verdict consumption) and writes structured INFO entries to .atdd/runtime/coach/integration.log"
+    domain:
+      - type: "value_objects"
+        count: 0
+        rationale: "Q1 reuses the artifact contracts frozen by freeze-runtime-contracts; introduces no new domain concepts"
+    integration:
+      - type: "logs"
+        count: 1
+        rationale: ".atdd/runtime/coach/integration.log: append-only INFO-level log of every substrate↔coach boundary crossing observed during the end-to-end run"
+      - type: "docs"
+        count: 1
+        rationale: "docs/coach-worked-example.md: human-readable narrative of the cycle including an integration-bugs-discovered section linking to follow-up issues and a production-readiness disclaimer"
+      - type: "followup-issues"
+        count: 0
+        rationale: "Number of follow-up integration-hardening issues is data-dependent (zero is acceptable), but the inventory section in the worked-example doc must exist regardless"


### PR DESCRIPTION
## Summary

Authors the **integrate-end-to-end** wagon for coach v9 — coach's done-line per spec §11.6 / Track Q.

- **Wagon manifest** `plan/integrate_end_to_end/_integrate_end_to_end.yaml` — declares produces (end-to-end coach cycle, integration log, worked-example doc, integration-bug inventory, follow-up issues) and consumes (every upstream coach v9 wagon: freeze-runtime-contracts, drive-state-machine, spawn-agents, observe-and-correct, dispatch-validators, review-phase-boundaries, judge-ambiguous-decisions, discover-and-decommission).
- **Feature** `plan/integrate_end_to_end/features/end_to_end_coach_cycle.yaml` — sizing M, 3 WMBTs.
- **3 WMBTs**:
  - **E001** (execute, maximize likelihood) — one real issue completes a coach-driven cycle to COMPLETE with PR opened; runtime artifacts populated and reader-reconstructable. Two SMOKE acceptances.
  - **M001** (monitor, maximize frequency) — every substrate↔coach handoff (validator invocation, `bind_rule`, spawn-harness rendering, gate-verdict consumption) emits a structured INFO entry to `.atdd/runtime/coach/integration.log`. One SMOKE acceptance.
  - **D001** (define, minimize quantity of unrecorded integration bugs) — `docs/coach-worked-example.md` exists with an `## Integration bugs discovered` section (empty acceptable, missing not) and a `## Production-readiness expectation` disclaimer. Three UNIT acceptances.
- **Issue body markdown** `.coach-v9-bootstrap/bodies/q1.md` — compliant per `briefing/compliant-issue-template.md`. References predecessors by `#<INTERNAL_ID>` placeholder; the filer pane rewrites to GH numbers later.

Acceptance bullets in the body lift verbatim from the v3-spec Q1 acceptance criteria and prepend the matching `acc:integrate-end-to-end:…` URN created in the WMBT YAMLs.

`atdd validate planner --quick` passes for all WMBT vocabulary checks introduced by this wagon. The pre-existing `test_rule_id_uniqueness` failure (toolkit conventions) is unrelated to this wagon.

## Test plan

- [ ] `plan/integrate_end_to_end/_integrate_end_to_end.yaml` mirrors `plan/freeze_runtime_contracts/_freeze_runtime_contracts.yaml` shape exactly.
- [ ] All three WMBT YAMLs validate via `atdd validate planner --quick`.
- [ ] Acceptance URNs in `.coach-v9-bootstrap/bodies/q1.md` resolve to YAMLs in `plan/integrate_end_to_end/`.
- [ ] Issue body length is in 80–250 line range and follows the compliant-issue-template structure.
- [ ] Mapping file `.coach-v9-bootstrap/mapping/internal-to-gh.json` is unchanged (filer updates it).
- [ ] No `gh issue create` or `atdd issue` was invoked from this wagon-authoring session — filing is the sequential filer pane's job.