### PR TITLE
feat(coach): coach v9 — judge-ambiguous-decisions wagon

### DIFF
--- a/.coach-v9-bootstrap/bodies/o1.md
+++ b/.coach-v9-bootstrap/bodies/o1.md
@@ -1,0 +1,101 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-o1-atdd-judge-core` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `judge-ambiguous-decisions` |
+| Internal-Spec-Id | `O1` |
+| Feature | `atdd judge` core CLI: prompt-template + JSON-Schema response contract + judgments.jsonl audit trail + conservative fail-open fallback that downstream call sites (#O2, #O3, #O4) build on |
+
+---
+
+## Scope
+
+### In Scope
+
+`atdd judge` is the single boundary at which coach v9 calls a structured-output LLM for genuinely ambiguous routing decisions. Per spec §6.9, coach is deterministic Python for the structural skeleton; the discipline of "deterministic-first ordering (tier-1 → operator escalation → judge)" is load-bearing. Without `atdd judge` as a single, schema-validated, audit-logged boundary, every ambiguity becomes a bespoke LLM call and routing logic gradually migrates into prompts — the failure mode §6.9 is designed to prevent.
+
+This issue ships the core. Call sites land in `#O2`, `#O3`, `#O4`.
+
+- Create `src/atdd/coach/commands/judge.py` with the `atdd judge` subcommand:
+  - Signature: `atdd judge --prompt-template <yaml-path> --schema <json-schema-path> --inputs key1=val1 key2=@file2 [--llm <id>]` per spec §5.5.
+  - Reads the prompt template YAML, fills inputs (`@file` resolves to file contents), calls the configured LLM, validates the response against the supplied JSON Schema, prints the structured response to stdout on success, exits non-zero with a clear validation error on schema violation.
+- Wire the `coach.judge.fail_open` config (§6.9, default `false`):
+  - `fail_open=false` (default): on LLM-unavailable, return the conservative fallback (escalate / block / retry per call site) and exit 0.
+  - `fail_open=true`: return null and exit non-zero so coach surfaces the gap.
+  - Both behaviors logged with the same `call_site` identifier so the audit trail does not lose the attempt.
+- Audit-trail discipline (§6.9):
+  - Every invocation appends exactly one JSONL line to `.atdd/runtime/coach/judgments.jsonl`.
+  - Each line conforms to `coach-judgment.schema.json` (frozen by `#C0`): `judgment_id`, `timestamp`, `call_site`, `inputs_hash`, `response`, `cached`, `outcome` ∈ {`ok`, `schema_violation`, `llm_unavailable`, `fail_open_fallback`}.
+  - Inputs are hashed by default; full inputs go to a gitignored cache only when `coach.judge.cache_inputs=true`.
+- Pluggable LLM client wired by `--llm <id>`: registry of clients shared with `atdd issue review` (#O5).
+- Rule-ID emitted by validators in this PR: `coach.judge.cli-contract` for surface conformance.
+
+### Out of Scope
+
+- The six v1 call sites themselves — those land in `#O2` (sites 1, 3, 4), `#O3` (site 5), `#O4` (site 6). Call site #2 (reviewer concern) is wired in track N's review pipeline.
+- `atdd issue review` (`#O5`) — uses the same LLM client registry but a different command and aggregation flow.
+- The discipline doc gating new call sites (`judge-call-site-discipline.md`) — authored alongside `#O2` once the first call sites land.
+- Rule-ID consolidation logic (`#O4`) — depends on this core but ships its own response schema.
+- LLM-side prompt engineering — coach owns the contract surface; prompt templates are conventions edited by track owners.
+
+### Dependencies
+
+- `#C0` (`#483`) — `coach-judgment.schema.json` and runtime layout for `judgments.jsonl`.
+- `#J1` — coach state machine skeleton through which judge is invoked. Pre-filing draft uses placeholder `#J1`; the filer pane substitutes the real GH number.
+- `bind_rule()` / `RuleMetadata` (substrate v12) — referenced for rule-ID-aware logging.
+- `.atdd/coach/config.yaml` loader (track P) — required for `coach.judge.fail_open`. Pre-filing placeholder: `#P4`.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Ambiguous routing decisions | None — coach v8 doesn't exist; today's `orchestrate`/`babysit` have no judgment surface | Single boundary: `atdd judge` with prompt-template + schema + audit trail | Without a single boundary, every ambiguity becomes a bespoke LLM call and routing logic migrates into prompts |
+| LLM-unavailable behavior | N/A — no judgment surface today | Conservative fail-open governed by `coach.judge.fail_open` (default `false`) | Without an explicit policy, LLM outages would silently change coach behavior |
+| Audit trail of LLM-influenced decisions | N/A | `judgments.jsonl` append-only with frozen schema, every invocation logged | Without it, post-incident review of "why did coach decide X" is impossible |
+| Schema-violating LLM responses | N/A | Validate against caller-supplied JSON Schema before returning; loud failure on violation | Without validation, downstream coach routing reads malformed responses and produces non-deterministic transitions |
+
+### User Impact
+
+The "user" of this issue is every downstream coach v9 implementer (tracks O2–O5, plus track N's reviewer concern call site #2). They each need a single, reliable boundary to call when a decision is genuinely ambiguous. Per spec §6.9, the deterministic-first ordering (tier-1 → operator escalation → judge) is load-bearing: if `atdd judge` does not exist as a single, schema-validated, audit-logged boundary, the temptation for each call site to inline its own LLM call becomes overwhelming, and coach v9's "mechanical floor + probabilistic ceiling" architectural principle (§2) collapses.
+
+The lived problem `atdd judge` solves: today, coach orchestration patterns that need LLM judgment have nowhere to put it. The contract this issue ships — prompt-template YAML, JSON Schema response, audit-logged JSONL, conservative fail-open — is what unblocks every other O-track issue and the #N3 reviewer concern call site.
+
+Per spec §6.9 fourth paragraph: "Without this justification, every ambiguity becomes a judge call and routing logic gradually migrates into prompts — the failure mode this section is designed to prevent." This issue ships the boundary; the discipline doc (`#O2`-adjacent) ships the gate.
+
+### Design Anchor
+
+`atdd judge` deliberately mirrors the substrate's `bind_rule()` shape: a thin CLI surface over a structured contract. The boundary is narrow on purpose — prompt-template path + schema path + inputs is the entire surface. Anything richer would invite call-site-specific knobs and erode the deterministic-first ordering. The audit trail (`judgments.jsonl`) sits alongside `decisions.jsonl` (frozen by `#C0`) precisely so post-incident review can join LLM-influenced decisions to the structural decisions they fed.
+
+The `coach.judge.fail_open` config defaults to `false` (conservative) for the same reason coach's tier-1 dispositions default to strict: an outage should not silently change behavior.
+
+---
+
+## Acceptance
+
+- `acc:judge-ambiguous-decisions:D001-UNIT-001-judge-cli-returns-structured-or-fails-loud`: `atdd judge --prompt-template <fixture-yaml> --schema <fixture-json> --inputs sha=abc123` invoked with a stub LLM that returns a schema-conformant payload exits 0 and prints the response; a schema-violating payload exits non-zero with a clear validation error referencing the offending field; `key=@file` inputs resolve to file contents before prompt template rendering.
+- `acc:judge-ambiguous-decisions:D001-UNIT-002-fail-open-matches-config`: `coach.judge.fail_open=false` (default) returns the conservative fallback (e.g., `decision=escalate` for retry-vs-escalate; `decision=block` for reviewer concern) with `fail_open_used=true` and exits 0; `fail_open=true` returns no response and exits non-zero with a clear LLM-unavailable error; both behaviors log to `judgments.jsonl` with the same `call_site` identifier.
+- `acc:judge-ambiguous-decisions:D001-UNIT-003-every-call-writes-judgments-jsonl`: every `atdd judge` invocation (success, schema-violation, LLM-unavailable, fail-open fallback) appends exactly one line to `.atdd/runtime/coach/judgments.jsonl` validating against `coach-judgment.schema.json`; each line carries `judgment_id`, `timestamp`, `call_site`, `inputs_hash`, `response`, `cached`, and `outcome`; inputs are hashed by default and full inputs go to a gitignored cache only when `coach.judge.cache_inputs=true`.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §5.5 (`atdd judge` CLI surface), §6.9 (judgment call sites and discipline)
+- `atdd-coach-issues-v3.md` issue `#O1`
+- Wagon manifest: `plan/judge_ambiguous_decisions/_judge_ambiguous_decisions.yaml`
+- Feature: `plan/judge_ambiguous_decisions/features/judge_and_issue_review.yaml`
+- WMBT: `plan/judge_ambiguous_decisions/D001.yaml`
+- Predecessor: `#483` (#C0 — `coach-judgment.schema.json` and runtime layout)
+- Predecessor (placeholder): `#J1` (coach state-machine skeleton)
+- Predecessor (placeholder): `#P4` (`.atdd/coach/config.yaml` loader for `coach.judge.fail_open`)
+- Substrate v12: `bind_rule()`, `RuleMetadata`

--- a/.coach-v9-bootstrap/bodies/o2.md
+++ b/.coach-v9-bootstrap/bodies/o2.md
@@ -1,0 +1,92 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-o2-judge-call-sites-1-3-4` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `judge-ambiguous-decisions` |
+| Internal-Spec-Id | `O2` |
+| Feature | Judge call sites #1 (borderline tier-1), #3 (retry-vs-escalate), #4 (cross-phase regression) wired into coach routing with frozen response schemas, integration parity with the spec §6.9 trigger pre-conditions, and a discipline doc gating new call sites |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements three of the six v1 judge call sites per spec §6.9. Each has its own pre-condition predicate, its own JSON Schema response contract, and its own coach-routing branch.
+
+- **Call site #1 — borderline tier-1 result.** Fires when tier-1 returns mixed pass/fail with ambiguous severity, OR when `suppress-and-clean` rule violations cluster around recently-edited lines (might be migration in flight). Response schema at `src/atdd/coach/schemas/judge-borderline-tier1.response.schema.json` per spec §6.9 #1: `{decision: pass|respawn|annotate, confidence: 0..1, rationale}`.
+- **Call site #3 — retry-vs-escalate at threshold.** Fires before consuming the final retry (i.e., when `retry_count == max_retries - 1`). Response schema at `judge-retry-vs-escalate.response.schema.json` per spec §6.9 #3: `{decision: retry|escalate, reasoning}`.
+- **Call site #4 — cross-phase regression risk.** Fires when tier-1 in a later phase reveals a regression in earlier-phase work (i.e., violations that did not exist at the predecessor phase's exit commit). Response schema at `judge-cross-phase-regression.response.schema.json` per spec §6.9 #4: `{decision: fix_in_place|reopen_prior_phase|escalate, target_phase, rationale}`.
+- **Trigger predicates** codified in `src/atdd/coach/commands/judge_call_sites.py` — one predicate per call site, each pure over runtime context (no I/O), each tested under fixture matrices that exercise pre-condition met / not met.
+- **Coach routing per response** wired into the state machine (`#J1`-derived skeleton): `respawn` triggers spawn-feedback (#K1); `annotate` continues with PR annotation; `escalate` transitions to BLOCKED with operator notification; `fix_in_place` stays in current phase; `reopen_prior_phase` rolls back to the named target phase.
+- **Discipline doc** at `src/atdd/coach/schemas/judge-call-site-discipline.md` per spec §6.9 fourth paragraph: criteria for proposing a new call site (deterministic check insufficient, operator escalation insufficient, response schema specified, audit-trail expectation specified). The doc is the gate; new call sites require an explicit PR meeting these criteria.
+- **Decisions.jsonl ↔ judgments.jsonl linkage** — every coach decision that consumed a judgment references the `judgment_id` so post-incident review can join the two logs.
+
+### Out of Scope
+
+- Call site #2 (reviewer concern verdict) — owned by track N's review pipeline; coach surfaces the response there.
+- Call site #5 (issue review aggregate ambiguity) — owned by `#O3`.
+- Call site #6 (superseded rule-ID consolidation) — owned by `#O4`.
+- The `atdd judge` core — shipped by `#O1`; this issue calls it.
+- The pre-coach issue review surface (`#O5`) — this issue's call sites fire post-PLANNED, not pre-coach.
+- The reviewer persona prompt for tier-2 review — owned by track N.
+
+### Dependencies
+
+- `#O1` — `atdd judge` core CLI and `judgments.jsonl` audit trail.
+- `#M5` (placeholder) — tier-1 dispatch produces the `Violation` records call site #1 and #4 read.
+- `#J1` (placeholder) — coach state-machine routing surface this issue extends.
+- `#K1` (placeholder) — spawn-feedback consumer for `respawn` decisions.
+- `#C0` (`#483`) — `validator-result.schema.json` (substrate `Violation` shape) and `coach-decision.schema.json`.
+- `bind_rule()` / `RuleMetadata.disposition` (substrate v12) — for `suppress-and-clean` clustering in call site #1.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Borderline tier-1 results | Block on any non-pass; no nuance for `suppress-and-clean` clusters near migration edits | Call site #1 lets coach pass/respawn/annotate based on signal | Without it, coach over-blocks during migrations and under-blocks when severity is genuinely ambiguous |
+| Retry-vs-escalate at the wall | Coach hits `max_retries` and fails; no chance to escalate proactively | Call site #3 evaluates one retry early, before consuming the final attempt | Without it, escalation always happens *after* the loss-of-progress |
+| Cross-phase regressions | Tier-1 fails in a later phase have no semantic story (could be in-place fix or rollback) | Call site #4 distinguishes `fix_in_place` from `reopen_prior_phase` | Without it, a SMOKE-phase regression silently corrupts the prior GREEN's claims-of-correctness |
+| New call sites discipline | Unspecified — anyone could propose one | `judge-call-site-discipline.md` enumerates the gate | Without the gate, routing logic migrates into prompts (the §6.9 failure mode) |
+
+### User Impact
+
+The "user" of this issue is coach itself, plus the operator who will read `decisions.jsonl` post-incident. Per spec §6.9, the three call sites covered here are exactly the ones where deterministic routing has insufficient signal *and* operator escalation is too high-frequency to dominate operator attention. Call sites #1 and #4 fire on tier-1 results (high-frequency, deterministic-first preferred); call site #3 fires once-per-retry-budget (lower frequency but deterministic check insufficient since "is this attempt likely to succeed" requires semantic judgment).
+
+The discipline doc (`judge-call-site-discipline.md`) is what protects the coach v9 architectural principle of "mechanical floor + probabilistic ceiling" (§2): without it, every future ambiguity becomes a judge call, and the deterministic-first ordering collapses. The doc is part of this issue precisely because shipping three call sites without the gate would normalize ad-hoc additions.
+
+### Design Anchor
+
+Each call site's response schema is deliberately narrow — a small enum for `decision` and a free-form `rationale` (or `reasoning`) string. The narrowness forces coach routing to remain deterministic Python: the LLM picks a branch from a fixed set; coach executes the branch. Any temptation to add per-call-site control fields (e.g., "and also do X") is rejected as routing logic migration into the prompt. The only out-of-band field is `confidence` on call site #1, used to gate `respawn` vs `annotate` deterministically.
+
+The integration test exercises every decision branch end-to-end so the linkage `judgments.jsonl ↔ decisions.jsonl` is verified, not assumed.
+
+---
+
+## Acceptance
+
+- `acc:judge-ambiguous-decisions:D002-UNIT-001-call-site-trigger-conditions-precise`: each of call sites #1, #3, #4 fires exactly when its pre-conditions are met and never otherwise: #1 only on mixed pass/fail with ambiguous severity OR `suppress-and-clean` cluster touching recently-edited lines; #3 only when `retry_count == max_retries - 1`; #4 only when later-phase tier-1 reveals violations not present at the predecessor phase's exit commit; when pre-conditions are not met, no judge call is made and no `judgments.jsonl` line is appended.
+- `acc:judge-ambiguous-decisions:D002-UNIT-002-response-schemas-frozen-and-validate`: `judge-borderline-tier1.response.schema.json`, `judge-retry-vs-escalate.response.schema.json`, and `judge-cross-phase-regression.response.schema.json` exist with their required fields per spec §6.9; valid responses pass schema validation and feed coach routing; invalid responses (missing fields, decision values outside the enum, confidence out of range) fail validation loudly and coach falls back per `coach.judge.fail_open`; each schema has at least one valid example fixture committed.
+- `acc:judge-ambiguous-decisions:D002-INTEGRATION-001-coach-routes-per-response`: an end-to-end coach run with fixture LLM responses exercises every decision branch; each `decisions.jsonl` entry references the upstream `judgments.jsonl` `judgment_id`; state transitions follow the response (`respawn` → spawn-feedback, `escalate` → BLOCKED, `reopen_prior_phase` → revert to named phase, `fix_in_place` → no transition); PR annotations carry the `rationale` text from the judge response.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §6.9 (call sites #1, #3, #4 and the discipline-for-adding-new-call-sites paragraph)
+- `atdd-coach-issues-v3.md` issue `#O2`
+- Wagon manifest: `plan/judge_ambiguous_decisions/_judge_ambiguous_decisions.yaml`
+- WMBT: `plan/judge_ambiguous_decisions/D002.yaml`
+- Predecessor: `#O1` (`atdd judge` core), `#M5` (tier-1 dispatch), `#J1` (state machine), `#K1` (spawn-feedback)
+- `#483` (#C0 — `validator-result.schema.json`, `coach-decision.schema.json`)
+- Substrate v12: `RuleMetadata.disposition` for `suppress-and-clean` clustering

--- a/.coach-v9-bootstrap/bodies/o3.md
+++ b/.coach-v9-bootstrap/bodies/o3.md
@@ -1,0 +1,95 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-o3-judge-issue-review-aggregate` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `judge-ambiguous-decisions` |
+| Internal-Spec-Id | `O3` |
+| Feature | Judge call site #5 (issue review aggregate ambiguity): when atdd issue review returns mixed pass/concern across passes, coach calls judge once per aggregate to consolidate, with frozen response schema, exactly-once audit-trail, and routing per `accept` / `request_revision` / `escalate` |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements judge call site #5 per spec §6.9 #5 and the §6.10 pre-coach precondition consumer side.
+
+- **Trigger predicate** in `src/atdd/coach/commands/judge_call_sites.py`:
+  - Reads `.atdd/runtime/issue-reviews/<N>/aggregate.json` (produced by `#O5`).
+  - Fires call site #5 when (a) at least one pass returns `concern` AND at least one pass returns `pass`, OR (b) any single pass flags a systemic concern (per §6.10, systemic concerns dominate).
+  - Unanimous-pass aggregates produce zero judge calls; the §4.2 pre-coach precondition routes directly to coach-ready.
+- **Response schema** at `src/atdd/coach/schemas/judge-issue-review-aggregate.response.schema.json` per spec §6.9 #5: `{decision: accept|request_revision|escalate, consolidated_feedback: string, dominant_dimensions: [systemic|ambiguities|gap|regression|comprehensiveness]}`.
+- **Coach routing per response**:
+  - `accept` → emit a coach-ready decision in `decisions.jsonl` referencing the `judgment_id`.
+  - `request_revision` → post `consolidated_feedback` as a GitHub comment on the issue, emit a `pre_coach_paused` decision.
+  - `escalate` → transition issue state to BLOCKED with the rationale visible in the operator notification.
+- **Exactly-once discipline** — one judge invocation per (issue_number, aggregate_inputs_hash) pair; re-runs against the same aggregate are cache-resolvable so coach `--resume` is idempotent.
+- **Audit-trail linkage** — `judgments.jsonl` entry carries `call_site=issue_review_aggregate` and the `decisions.jsonl` entry references it.
+
+### Out of Scope
+
+- Producing the aggregate.json — owned by `#O5` (`atdd issue review` multi-pass cross-LLM).
+- The other five judge call sites — `#O2` (1, 3, 4) and `#O4` (6); call site #2 lives in track N.
+- Posting the consolidated feedback as a PR comment — `request_revision` posts to the *issue*, not the PR (the PR doesn't exist yet at pre-coach time).
+- The §4.2 pre-coach precondition wiring itself — owned by `#J1`-derived state machine; this issue extends the routing branch only.
+- Re-running passes — `--force` flag on `atdd issue review` (`#O5`) handles re-runs.
+
+### Dependencies
+
+- `#O1` — `atdd judge` core CLI.
+- `#O5` — `atdd issue review` produces `aggregate.json` consumed here.
+- `#J1` (placeholder) — coach state-machine `pre_coach` phase that this issue's routing extends.
+- `#C0` (`#483`) — `coach-judgment.schema.json`, `coach-decision.schema.json`.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Mixed pass/concern across passes | `atdd issue review` aggregate has no consumer; mixed verdicts fall through | Call site #5 consolidates and routes via `accept` / `request_revision` / `escalate` | Without it, `#O5`'s output is unread and the §4.2 pre-coach precondition has no decision boundary |
+| Single-pass systemic concern | Would be lost in a majority-vote aggregation | Systemic concerns dominate per §6.10; one pass is enough to fire call site #5 | Without explicit handling, training-data-bias-induced systemic concerns disappear into the noise floor |
+| Exactly-once judge invocations on `--resume` | No discipline; `--resume` could re-prompt | Cache key `(issue_number, aggregate_inputs_hash)` ensures one judgment per aggregate | Without it, audit trail explodes and judge cost compounds on every resume |
+| GitHub-issue feedback channel | Coach has no way to surface pre-coach concerns to the issue author | `request_revision` posts `consolidated_feedback` as a GitHub comment | Without it, blocked issues sit silently with no actionable feedback |
+
+### User Impact
+
+The "user" of this issue is twofold: (a) coach, which needs a single decision boundary on mixed-verdict aggregates; (b) the issue author, who needs actionable consolidated feedback when their issue is held at the §4.2 pre-coach precondition.
+
+Per spec §6.10: "Aggregation logic and judge call site #5 unchanged from v5." The job here is to wire the call site to the §4.2 surface and the GitHub comment channel without bypassing the deterministic-first ordering: unanimous-pass aggregates skip judge entirely, and mixed verdicts go through judge exactly once.
+
+The systemic-concerns-dominate rule (per §6.10) is critical: the whole point of N-pass cross-LLM (`#O5`) is to surface bias-induced misses. If majority-vote aggregation buried single-pass systemic findings, the discipline of multi-LLM review would be wasted. Call site #5 honors that contract.
+
+### Design Anchor
+
+`request_revision` posts to the *GitHub issue*, not to a PR or a runtime file, because pre-coach is the boundary at which we still expect the human author to engage. The issue is the durable, reviewable surface; runtime files are gitignored and not visible to issue authors. The `consolidated_feedback` string is the LLM's job to produce; coach simply forwards it.
+
+The cache discipline `(issue_number, aggregate_inputs_hash)` is why `inputs_hash` is on the judgment schema (`#C0`-frozen): so resume-safety is a property of the audit trail, not bolted on.
+
+---
+
+## Acceptance
+
+- `acc:judge-ambiguous-decisions:D003-UNIT-001-mixed-verdict-fires-call-site-once`: mixed-verdict aggregates (mixed pass/concern, OR single-pass systemic concern) fire exactly one call to `atdd judge` with `--prompt-template judge-issue-review-aggregate.prompt.yaml` and `--schema judge-issue-review-aggregate.response.schema.json`; unanimous-pass produces zero judge calls; `judgments.jsonl` receives exactly one line per mixed-verdict review with `call_site=issue_review_aggregate`.
+- `acc:judge-ambiguous-decisions:D003-UNIT-002-aggregate-response-schema`: `judge-issue-review-aggregate.response.schema.json` is committed with required fields `{decision: accept|request_revision|escalate, consolidated_feedback: non-empty string, dominant_dimensions: non-empty subset of the five §6.10 dimensions}`; invalid values fail validation loudly; at least one valid example fixture is committed.
+- `acc:judge-ambiguous-decisions:D003-INTEGRATION-001-coach-routes-aggregate-decision`: end-to-end pre-coach run with fixture aggregate.json and stub LLM exercises all three decision branches; `accept` emits a `coach_ready` decision referencing the `judgment_id`; `request_revision` posts the `consolidated_feedback` as a GitHub comment and emits a `pre_coach_paused` decision; `escalate` transitions issue state to BLOCKED with the rationale visible in the operator notification.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §6.9 (call site #5), §6.10 (pre-coach issue review), §4.2 (pre-coach precondition)
+- `atdd-coach-issues-v3.md` issue `#O3`
+- Wagon manifest: `plan/judge_ambiguous_decisions/_judge_ambiguous_decisions.yaml`
+- WMBT: `plan/judge_ambiguous_decisions/D003.yaml`
+- Predecessor: `#O1` (`atdd judge` core), `#O5` (`atdd issue review` aggregate)
+- Predecessor (placeholder): `#J1` (coach state-machine `pre_coach` phase)
+- `#483` (#C0 — `coach-judgment.schema.json`, `coach-decision.schema.json`)

--- a/.coach-v9-bootstrap/bodies/o4.md
+++ b/.coach-v9-bootstrap/bodies/o4.md
@@ -1,0 +1,93 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-o4-judge-superseded-rule-consolidation` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `judge-ambiguous-decisions` |
+| Internal-Spec-Id | `O4` |
+| Feature | Judge call site #6 (superseded rule-ID consolidation): when a tier-1 Violation references a legacy alias whose canonical rule has `superseded_by` set, judge produces consolidated migration guidance for the next respawn's spawn-feedback |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements judge call site #6 per spec §6.7 and §6.9 #6.
+
+- **Trigger predicate** in `src/atdd/coach/commands/judge_call_sites.py`:
+  - For each active `Violation` in `validations/<sha>/violations.jsonl`, resolve `rule_id` via `bind_rule()` and inspect `RuleMetadata.superseded_by`.
+  - Fire call site #6 when the violation's `rule_id` is a legacy alias AND the canonical rule has `superseded_by` set.
+  - Cache key `(legacy_alias, target_commit_sha)` — repeated violations of the same alias on the same commit produce one judge call, not N.
+  - Non-superseded canonical violations and bare aliases without `superseded_by` do not trigger.
+- **Response schema** at `src/atdd/coach/schemas/judge-superseded-rule-consolidation.response.schema.json` per spec §6.9 #6: `{guidance: string, suggested_aliases: [string], canonical_rule_id: string, fix_hint: string}`.
+- **Spawn-feedback integration** — the consolidated guidance is embedded in the `prior_attempt` block of the next respawn (per spec §7.6):
+  - `guidance` replaces the raw `detail` text under the offending `Violation`.
+  - `suggested_aliases` are listed under `legacy_aliases` on the entry.
+  - `canonical_rule_id` replaces the legacy alias in the `rule_id` field.
+  - `fix_hint` (judge-produced) augments or replaces the registry's default `fix_hint`.
+- **Audit-trail linkage** — `judgments.jsonl` carries `call_site=superseded_rule_consolidation` and `inputs_hash` includes the canonical rule, the legacy alias, and the violation location so deduplication is precise.
+
+### Out of Scope
+
+- Modifying the rule registry — `superseded_by` is set by rule authors in the convention YAML, not by this issue.
+- The other five judge call sites — `#O2`, `#O3`, plus call site #2 in track N.
+- The legacy-alias resolution logic itself in `bind_rule()` — substrate v12 ships it; this issue consumes it.
+- The spawn-feedback rendering pipeline — owned by `#K1` (track K); this issue produces the consolidated payload that `#K1` injects.
+- General fix-hint engineering — this issue handles the *consolidated* fix-hint produced by judge for superseded rules; per-rule fix-hints in conventions are not in scope.
+
+### Dependencies
+
+- `#O1` — `atdd judge` core CLI.
+- `#K1` (placeholder) — spawn-feedback consumer that injects the consolidated payload into `prior_attempt`.
+- `#M5` (placeholder) — tier-1 dispatch produces the `Violation` records this issue's predicate scans.
+- `#C0` (`#483`) — `coach-judgment.schema.json`, `validator-result.schema.json` (Violation shape).
+- Substrate v12 — `bind_rule()`, `RuleMetadata.superseded_by`, alias resolution.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Legacy-alias violations in agent feedback | Raw legacy ID surfaces; agent applies cached/outdated fixes | Consolidated migration guidance with canonical ID + suggested aliases | Without it, the rule rename mechanism leaks training-data drift into agent behavior |
+| Superseded canonical rule semantics | `superseded_by` is set in registry but never reaches the agent | Judge emits the migration narrative the registry implies | Without it, `superseded_by` is registry metadata that nobody reads |
+| Cache discipline on alias hits | None — re-running validators against the same commit would re-fire judge per violation | `(legacy_alias, target_commit_sha)` cache key collapses repeats | Without it, audit trail explodes on stale-violation iteration |
+| Spawn-feedback fidelity | Agents see legacy IDs and revert to outdated fixes from training data | `canonical_rule_id` replaces legacy in `rule_id`; `legacy_aliases` listed under the entry | Without it, the rule-ID-grammar contract (spec §7.1) is violated at the prompt boundary |
+
+### User Impact
+
+The "user" of this issue is the next-respawn agent (a coder or tester), and indirectly the coach operator who reviews `decisions.jsonl` for "why did the agent get respawned with this guidance". Per spec §6.7: "Legacy alias resolution in feedback" — the spawn-feedback must present the canonical rule, the canonical fix-hint, and the legacy aliases the agent is likely to recall from training data. Without the consolidation, the agent receives the raw legacy alias, recognises it as familiar, and applies a fix that the canonical rule has already deprecated.
+
+The decision is high-frequency (every legacy-alias hit) so operator escalation is the wrong answer. The decision is genuinely about *what to do* (which canonical rule, which fix-hint, which suggested-aliases for the agent to recognise as deprecated) so a deterministic check cannot resolve it. Both bars from §6.9's discipline-for-adding-new-call-sites are met; the discipline doc landing in `#O2` lists this call site as one of the original six.
+
+### Design Anchor
+
+The consolidation is a single judgment per `(legacy_alias, target_commit_sha)` precisely because the canonical rule is fixed and the violation location does not affect the *consolidation* (only its *display*). Caching at the alias-and-commit level keeps the audit trail proportional to "rules touched", not "violations counted". The judge response carries the canonical_rule_id and fix_hint as separate fields rather than rolling them into `guidance` so the spawn-feedback renderer (`#K1`) can field-map directly without re-parsing prose.
+
+---
+
+## Acceptance
+
+- `acc:judge-ambiguous-decisions:D004-UNIT-001-legacy-alias-triggers-call-site`: a Violation whose `rule_id` is a legacy alias with `superseded_by` set on the canonical rule fires call site #6 exactly once per `(legacy_alias, target_commit)` pair; non-superseded canonical violations and bare aliases without `superseded_by` do not trigger; repeated violations of the same alias on the same commit produce one judge call.
+- `acc:judge-ambiguous-decisions:D004-UNIT-002-consolidation-response-schema`: `judge-superseded-rule-consolidation.response.schema.json` exists with required fields `{guidance: non-empty migration narrative referencing both legacy and canonical, suggested_aliases: [string], canonical_rule_id: registry-resolvable string, fix_hint: string}`; at least one valid example fixture is committed.
+- `acc:judge-ambiguous-decisions:D004-INTEGRATION-001-feeds-spawn-feedback`: end-to-end coach run reaching respawn after a tier-1 fail referencing a superseded legacy alias produces a spawn-feedback whose `prior_attempt` block carries the judge-produced `guidance` under `fix_hint`, lists `suggested_aliases` as `legacy_aliases` on the Violation entry, replaces the legacy alias with `canonical_rule_id` in the `rule_id` field, and the `judgments.jsonl` audit-trail line is referenced by `judgment_id` in `decisions.jsonl`.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §6.7 (legacy alias resolution), §6.9 (call site #6), §7.1 (rule-ID grammar in spawn harness), §7.6 (spawn-feedback templates)
+- `atdd-coach-issues-v3.md` issue `#O4`
+- Wagon manifest: `plan/judge_ambiguous_decisions/_judge_ambiguous_decisions.yaml`
+- WMBT: `plan/judge_ambiguous_decisions/D004.yaml`
+- Predecessor: `#O1` (`atdd judge` core), `#K1` (spawn-feedback consumer), `#M5` (tier-1 dispatch)
+- `#483` (#C0 — `validator-result.schema.json`, `coach-judgment.schema.json`)
+- Substrate v12: `bind_rule()`, `RuleMetadata.superseded_by`, alias resolution

--- a/.coach-v9-bootstrap/bodies/o5.md
+++ b/.coach-v9-bootstrap/bodies/o5.md
@@ -1,0 +1,103 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-o5-atdd-issue-review-multipass` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `judge-ambiguous-decisions` |
+| Internal-Spec-Id | `O5` |
+| Feature | `atdd issue review` multi-pass cross-LLM CLI: N independent passes (default 3, min 2) by distinct LLMs, five-dimension evaluation (systemic, ambiguities, gap, regression, comprehensiveness), aggregate at `.atdd/runtime/issue-reviews/<N>/aggregate.json` consumed by the §4.2 pre-coach precondition |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements `atdd issue review` per spec §5.6 and §6.10.
+
+- **CLI** at `src/atdd/coach/commands/issue_review.py`:
+  - Signature: `atdd issue review <issue-number> [--passes 3] [--llms claude-haiku,gpt-5-mini,gemini-flash] [--dimensions systemic,ambiguities,gap,regression,comprehensiveness] [--show] [--force]` per spec §5.6.
+  - `--passes` default 3; minimum 2 (single-LLM bias inadmissible per §6.10); `--passes > len(--llms)` fails loudly.
+  - `--llms` accepts comma-separated LLM IDs registered in the same client registry as `#O1`; pass `i` uses LLM `i`.
+  - `--dimensions` defaults to all five (systemic, ambiguities, gap, regression, comprehensiveness) per §6.10.
+  - `--show` posts the aggregate to the GitHub issue as a comment (operator-visible review surface).
+  - `--force` re-runs all passes; without `--force`, existing pass files are reused (idempotency for `--resume` discipline).
+- **N independent passes** — each pass writes `.atdd/runtime/issue-reviews/<N>/pass-<i>-<llm>.json` conforming to `src/atdd/coach/schemas/issue-review-pass.response.schema.json`:
+  - Per-dimension `{verdict: pass|concern, findings: [{rule_id?: string, severity: int, detail: string}]}`.
+  - When a finding maps to a known rule-ID via `bind_rule()`, the `rule_id` field is populated; otherwise `null`.
+- **Aggregate** at `.atdd/runtime/issue-reviews/<N>/aggregate.json` conforming to `src/atdd/coach/schemas/issue-review-aggregate.schema.json`:
+  - Per-dimension aggregate verdict (any-pass `concern` aggregates to `concern`; systemic concerns dominate per §6.10).
+  - List of all findings across passes, deduplicated by `(rule_id, detail)` when both are populated.
+  - Pass identities (`pass_id`, `llm`, `timestamp`) recorded so re-runs are reproducible.
+- **§4.2 pre-coach precondition consumer** — coach state machine reads `aggregate.json` at the pre-coach phase entry and routes per the aggregate verdict (mixed verdicts trigger judge call site #5 per `#O3`; unanimous-pass proceeds; unanimous-concern transitions to BLOCKED).
+- **GitHub-issue surface** — when `--show` is set (or coach surfaces on `request_revision` per `#O3`), the aggregate per-dimension verdicts and findings post as a structured GitHub comment with rule-ID context where applicable per spec §6.10.
+
+### Out of Scope
+
+- Judge call site #5 invocation — owned by `#O3`; this issue produces the aggregate it consumes.
+- The other judge call sites — `#O2`, `#O4`, plus call site #2 in track N.
+- Prompt-template engineering for the per-pass review prompt — coach owns the contract surface; the prompt lives in conventions edited by track owners.
+- LLM client implementations — the registry from `#O1` is reused.
+- Posting to a PR — pre-coach review posts to the *issue*, not a PR (the PR doesn't exist yet at pre-coach time).
+
+### Dependencies
+
+- `#O1` — LLM client registry shared with `atdd judge`.
+- `#J1` (placeholder) — coach state-machine pre-coach phase that reads `aggregate.json`.
+- `#C0` (`#483`) — runtime layout under `.atdd/runtime/issue-reviews/<N>/`.
+- `#P4` (placeholder) — `.atdd/coach/config.yaml` loader for default `--llms` list.
+- `bind_rule()` (substrate v12) — for rule-ID resolution on findings.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Single-LLM bias on issue review | No issue review surface today; if added, single-LLM-once would inherit training-data biases | N independent passes by distinct LLMs (default 3, min 2) | Without N-pass cross-LLM, training-data bias propagates as missed concerns into every downstream phase |
+| Per-dimension evaluation | Unspecified — would default to free-form prose | Five fixed dimensions (systemic, ambiguities, gap, regression, comprehensiveness) per pass | Without explicit dimensions, comparisons across passes are not aggregable |
+| Pre-coach decision boundary | The §4.2 precondition has no input | `aggregate.json` per-dimension verdicts feed §4.2 routing | Without it, coach starts work on issues with latent ambiguities or systemic concerns |
+| Resume idempotency | No state | Existing per-pass JSONs are reused; `--force` re-runs | Without it, `coach --resume` would re-run all passes and explode LLM cost |
+
+### User Impact
+
+The "user" of this issue is twofold: (a) coach itself, which reads `aggregate.json` at the §4.2 pre-coach precondition and decides whether to proceed, request revision, or escalate (via `#O3` for mixed verdicts); (b) the issue author, who receives a structured GitHub comment surfacing per-dimension verdicts and findings when revision is requested.
+
+Per spec §6.10: "N independent passes (default 3, min 2), each by a different LLM. Each pass evaluates the issue across five dimensions." The discipline of N-pass cross-LLM is what protects against single-LLM training-data biases. The aggregation rule "systemic concerns dominate" is what ensures that a single LLM catching a structural issue is not buried by majority vote — exactly the case where multi-LLM is meant to add value.
+
+The minimum-2 floor on `--passes` is non-negotiable: a single pass is, by construction, single-LLM; it does not satisfy the spec's "N independent passes" contract. The CLI fails loudly rather than degrading to a single pass.
+
+### Design Anchor
+
+The CLI is deliberately thin: pass count, LLM list, dimensions, show flag, force flag. The shape mirrors `atdd judge` (`#O1`) so the operator's mental model is consistent across both LLM-touching commands. The aggregate file is the boundary at which structured-output review meets coach routing — it sits in `.atdd/runtime/issue-reviews/<N>/` (frozen by `#C0`) precisely so coach doesn't need to re-prompt LLMs on resume.
+
+The GitHub-comment surface uses a structured comment (per-dimension verdicts in a markdown table, findings with rule-IDs as code spans) so the operator-visible review is auditable, not free-form prose.
+
+---
+
+## Acceptance
+
+- `acc:judge-ambiguous-decisions:D005-UNIT-001-multi-pass-cross-llm-discipline`: `atdd issue review 358 --passes 3 --llms claude-haiku,gpt-5-mini,gemini-flash` runs three independent reviews and writes `pass-1-claude-haiku.json`, `pass-2-gpt-5-mini.json`, `pass-3-gemini-flash.json` under `.atdd/runtime/issue-reviews/358/`; `--passes 1` exits non-zero with a min-2 error; `--passes 4` with three `--llms` exits non-zero with an insufficient-llms error; `--force` re-runs all passes while without `--force` existing pass files are reused.
+- `acc:judge-ambiguous-decisions:D005-UNIT-002-five-dimensions-per-pass`: each per-pass response includes per-dimension `{verdict: pass|concern, findings: [{rule_id?: string, severity: int, detail: string}]}` validating against `issue-review-pass.response.schema.json`; findings mapping to known rule-IDs via `bind_rule()` populate the `rule_id` field; per-dimension verdicts and findings aggregate into `.atdd/runtime/issue-reviews/<N>/aggregate.json`.
+- `acc:judge-ambiguous-decisions:D005-INTEGRATION-001-aggregate-feeds-pre-coach`: end-to-end pre-coach run reads `aggregate.json`; unanimous-pass proceeds without judge involvement; mixed-verdict triggers exactly one judge call site #5 invocation per `#O3`'s contract; systemic concerns surfaced in any pass dominate the aggregate verdict per spec §6.10; with `--show`, the per-dimension aggregate verdicts post as a GitHub comment.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §5.6 (`atdd issue review` CLI), §6.10 (pre-coach issue review aggregation), §4.2 (pre-coach precondition)
+- `atdd-coach-issues-v3.md` issue `#O5`
+- Wagon manifest: `plan/judge_ambiguous_decisions/_judge_ambiguous_decisions.yaml`
+- WMBT: `plan/judge_ambiguous_decisions/D005.yaml`
+- Predecessor: `#O1` (LLM client registry)
+- Predecessor (placeholder): `#J1` (coach pre-coach phase consumer), `#P4` (config loader for default `--llms`)
+- `#483` (#C0 — runtime layout under `.atdd/runtime/issue-reviews/<N>/`)
+- Substrate v12: `bind_rule()`
+- Successor: `#O3` (judge call site #5 consumer of mixed-verdict aggregates)

--- a/plan/judge_ambiguous_decisions/D001.yaml
+++ b/plan/judge_ambiguous_decisions/D001.yaml
@@ -1,0 +1,78 @@
+urn: "wmbt:judge-ambiguous-decisions:D001"
+step: "define"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "unstructured-coach-decisions-bypassing-deterministic-routing"
+context_clarifier: "when coach v9 reaches a routing decision that the deterministic substrate (tier-1 validators + state machine) cannot resolve and that is too high-frequency to escalate to a human operator — coach must call a structured-output LLM (atdd judge) with a prompt template + JSON Schema response contract + logged inputs/outputs, rather than allowing routing logic to migrate ad-hoc into prompts. Per spec §6.9, atdd judge is the single boundary; without it, every ambiguity becomes a bespoke LLM call and the deterministic-first ordering collapses"
+lens: "functional.effectiveness"
+statement: "minimize quantity of unstructured-coach-decisions-bypassing-deterministic-routing when coach v9 must resolve genuinely ambiguous routing decisions through a single structured-output LLM boundary (atdd judge) with prompt-template + JSON-Schema response contract + judgments.jsonl audit trail and conservative fail-open fallback"
+acceptances:
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D001-UNIT-001-judge-cli-returns-structured-or-fails-loud"
+      id: "AC-UNIT-001"
+      purpose: "atdd judge --prompt-template <yaml> --schema <json> --inputs key=val ... returns a schema-conformant structured response or fails loudly with a non-zero exit and a human-readable error; the response is validated against the supplied JSON Schema before being printed"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/commands/judge.py exposes the atdd judge subcommand"
+        - "A valid prompt template YAML exists at a fixture path with placeholders for the inputs"
+        - "A valid JSON Schema exists at a fixture path describing the expected response shape"
+    when:
+      abstract: "atdd judge --prompt-template <fixture-yaml> --schema <fixture-json> --inputs sha=abc123 is invoked with a stub LLM that returns a schema-conformant payload"
+    then:
+      abstract:
+        - "The command exits 0 and prints the structured response to stdout"
+        - "The response validates against the supplied JSON Schema with zero errors"
+        - "When the stub LLM returns a schema-violating payload, the command exits non-zero with a clear validation error referencing the offending field"
+        - "Inputs of the form key=@file resolve to file contents before prompt template rendering"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D001-UNIT-002-fail-open-matches-config"
+      id: "AC-UNIT-002"
+      purpose: "When the LLM is unavailable (network error, auth failure, configured-LLM unknown), atdd judge follows the coach.judge.fail_open config: fail_open=false (default) returns the conservative fallback (escalate / block / retry per call site) and exits 0; fail_open=true returns null and exits non-zero so coach surfaces the gap"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "coach.judge.fail_open is read from .atdd/coach/config.yaml with default false per spec §6.9"
+        - "A stub LLM client raises a network-unavailable exception"
+    when:
+      abstract: "atdd judge runs against the stub with each fail_open setting"
+    then:
+      abstract:
+        - "fail_open=false produces a deterministic conservative-fallback response (e.g., decision=escalate for retry-vs-escalate; decision=block for reviewer concern) with a fail_open_used=true marker in the response and exits 0"
+        - "fail_open=true returns no response and exits non-zero with a clear LLM-unavailable error"
+        - "Both behaviors are logged to judgments.jsonl with the same call_site identifier so the audit trail does not lose the attempt"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D001-UNIT-003-every-call-writes-judgments-jsonl"
+      id: "AC-UNIT-003"
+      purpose: "Every atdd judge invocation (success, schema-violation, LLM-unavailable, fail-open fallback) writes exactly one line to .atdd/runtime/coach/judgments.jsonl conforming to the judgment schema frozen by C0"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/schemas/coach-judgment.schema.json is the authoritative judgment-record schema"
+        - ".atdd/runtime/coach/ exists per the runtime-layout doc"
+    when:
+      abstract: "atdd judge is invoked across the success, schema-violation, LLM-unavailable, and fail-open scenarios"
+    then:
+      abstract:
+        - "Exactly one judgments.jsonl line is appended per invocation"
+        - "Each line validates against coach-judgment.schema.json"
+        - "Each line carries judgment_id, timestamp, call_site, inputs_hash, response (or null), cached, and outcome (ok / schema_violation / llm_unavailable / fail_open_fallback)"
+        - "Inputs are hashed (not stored full) by default; full inputs go to a gitignored cache only when coach.judge.cache_inputs=true"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/judge_ambiguous_decisions/D002.yaml
+++ b/plan/judge_ambiguous_decisions/D002.yaml
@@ -1,0 +1,76 @@
+urn: "wmbt:judge-ambiguous-decisions:D002"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "judge-call-site-misfire-on-tier1-retry-or-regression"
+context_clarifier: "when coach v9 must distinguish three high-frequency ambiguous-routing scenarios — (1) borderline tier-1 result where mixed pass/fail with ambiguous severity or suppress-and-clean rules clustered around recently-edited lines should not auto-block, (3) retry-vs-escalate at threshold where the next attempt would consume the final retry, (4) cross-phase regression risk where tier-1 in a later phase reveals a regression in earlier-phase work — each call site must trigger exactly when its conditions are met (not before, not after) and route per the response. Misfire (fire when conditions not met, or fail to fire when met) is the failure mode this WMBT controls"
+lens: "functional.reliability"
+statement: "minimize likelihood of judge-call-site-misfire-on-tier1-retry-or-regression when coach must route call sites #1 (borderline tier-1), #3 (retry-vs-escalate), and #4 (cross-phase regression) — each with its own pre-conditions, response schema, and post-routing behavior"
+acceptances:
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D002-UNIT-001-call-site-trigger-conditions-precise"
+      id: "AC-UNIT-001"
+      purpose: "Each of call sites #1, #3, #4 fires exactly when its pre-conditions are met and never otherwise"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Coach state machine (track J) emits tier-1 results, retry counts, and per-phase regression deltas into runtime context"
+        - "Pre-condition predicates for the three call sites are codified per spec §6.9"
+    when:
+      abstract: "Coach evaluates routing across a fixture matrix that exercises pre-conditions met / not met for each call site"
+    then:
+      abstract:
+        - "Call site #1 fires only when tier-1 has mixed pass/fail with ambiguous severity, OR a suppress-and-clean rule cluster touches recently-edited lines"
+        - "Call site #3 fires only when the next attempt would consume the final retry (retry_count == max_retries - 1)"
+        - "Call site #4 fires only when tier-1 in a later phase reveals violations that did not exist at the predecessor phase's exit commit"
+        - "When pre-conditions are not met, no judge call is made and no judgments.jsonl line is appended"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D002-UNIT-002-response-schemas-frozen-and-validate"
+      id: "AC-UNIT-002"
+      purpose: "Each call site has a frozen JSON Schema response contract committed at src/atdd/coach/schemas/ and the LLM response validates against it before coach acts"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/schemas/judge-borderline-tier1.response.schema.json exists with required fields { decision: pass|respawn|annotate, confidence: 0..1, rationale }"
+        - "src/atdd/coach/schemas/judge-retry-vs-escalate.response.schema.json exists with required fields { decision: retry|escalate, reasoning }"
+        - "src/atdd/coach/schemas/judge-cross-phase-regression.response.schema.json exists with required fields { decision: fix_in_place|reopen_prior_phase|escalate, target_phase, rationale }"
+    when:
+      abstract: "atdd judge is invoked at each call site with stub LLM responses covering valid and invalid shapes"
+    then:
+      abstract:
+        - "Valid responses pass schema validation and feed coach routing"
+        - "Invalid responses (missing fields, decision values outside the enum, confidence out of range) fail validation loudly and coach falls back per coach.judge.fail_open"
+        - "Each schema has at least one valid example fixture committed at src/atdd/coach/schemas/fixtures/"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D002-INTEGRATION-001-coach-routes-per-response"
+      id: "AC-INTEGRATION-001"
+      purpose: "Coach state machine consumes the structured response and transitions accordingly: respawn fires the spawn-feedback path; annotate continues with PR annotation; escalate transitions to BLOCKED with operator notification; fix_in_place stays in current phase; reopen_prior_phase rolls back to the named target phase"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "An end-to-end coach run with fixture LLM responses exercising every decision branch for the three call sites"
+    when:
+      abstract: "Coach completes the run and emits decisions.jsonl entries"
+    then:
+      abstract:
+        - "Each decision in decisions.jsonl references the upstream judgments.jsonl entry by judgment_id"
+        - "State transitions follow the response: respawn → spawn (track K), escalate → BLOCKED, reopen_prior_phase → revert to named phase, fix_in_place → no transition"
+        - "PR annotations (annotate / annotate_and_continue) carry the rationale text from the judge response"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/judge_ambiguous_decisions/D002.yaml
+++ b/plan/judge_ambiguous_decisions/D002.yaml
@@ -4,7 +4,7 @@ direction: "minimize"
 dimension: "likelihood"
 object_of_control: "judge-call-site-misfire-on-tier1-retry-or-regression"
 context_clarifier: "when coach v9 must distinguish three high-frequency ambiguous-routing scenarios — (1) borderline tier-1 result where mixed pass/fail with ambiguous severity or suppress-and-clean rules clustered around recently-edited lines should not auto-block, (3) retry-vs-escalate at threshold where the next attempt would consume the final retry, (4) cross-phase regression risk where tier-1 in a later phase reveals a regression in earlier-phase work — each call site must trigger exactly when its conditions are met (not before, not after) and route per the response. Misfire (fire when conditions not met, or fail to fire when met) is the failure mode this WMBT controls"
-lens: "functional.reliability"
+lens: "functional.availability"
 statement: "minimize likelihood of judge-call-site-misfire-on-tier1-retry-or-regression when coach must route call sites #1 (borderline tier-1), #3 (retry-vs-escalate), and #4 (cross-phase regression) — each with its own pre-conditions, response schema, and post-routing behavior"
 acceptances:
   - identity:

--- a/plan/judge_ambiguous_decisions/D003.yaml
+++ b/plan/judge_ambiguous_decisions/D003.yaml
@@ -4,7 +4,7 @@ direction: "minimize"
 dimension: "likelihood"
 object_of_control: "issue-review-aggregate-judgment-without-audit-trail"
 context_clarifier: "when atdd issue review (§5.6, §6.10) returns a mixed pass/concern verdict across N independent passes — the per-pass verdicts disagree about whether the issue is ready for coach — coach calls judge call site #5 to aggregate. The aggregate judgment must be triggered exactly once per mixed-verdict review (not per pass, not per dimension), the response must conform to a frozen schema, and the call-plus-response must be logged to judgments.jsonl with a stable inputs_hash so re-runs against the same review aggregate are cache-resolvable. Without this contract, coach would either (a) ignore the disagreement and route on majority vote (losing systemic-concern signal), or (b) re-prompt per pass and explode the audit trail"
-lens: "functional.reliability"
+lens: "functional.availability"
 statement: "minimize likelihood of issue-review-aggregate-judgment-without-audit-trail when atdd issue review returns mixed pass/concern across passes and coach must consolidate via judge call site #5 with a frozen response schema and exactly-once audit-trail discipline"
 acceptances:
   - identity:

--- a/plan/judge_ambiguous_decisions/D003.yaml
+++ b/plan/judge_ambiguous_decisions/D003.yaml
@@ -1,0 +1,75 @@
+urn: "wmbt:judge-ambiguous-decisions:D003"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "issue-review-aggregate-judgment-without-audit-trail"
+context_clarifier: "when atdd issue review (§5.6, §6.10) returns a mixed pass/concern verdict across N independent passes — the per-pass verdicts disagree about whether the issue is ready for coach — coach calls judge call site #5 to aggregate. The aggregate judgment must be triggered exactly once per mixed-verdict review (not per pass, not per dimension), the response must conform to a frozen schema, and the call-plus-response must be logged to judgments.jsonl with a stable inputs_hash so re-runs against the same review aggregate are cache-resolvable. Without this contract, coach would either (a) ignore the disagreement and route on majority vote (losing systemic-concern signal), or (b) re-prompt per pass and explode the audit trail"
+lens: "functional.reliability"
+statement: "minimize likelihood of issue-review-aggregate-judgment-without-audit-trail when atdd issue review returns mixed pass/concern across passes and coach must consolidate via judge call site #5 with a frozen response schema and exactly-once audit-trail discipline"
+acceptances:
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D003-UNIT-001-mixed-verdict-fires-call-site-once"
+      id: "AC-UNIT-001"
+      purpose: "A mixed-verdict issue review (at least one pass returns concern AND at least one pass returns pass, or any single pass flags a systemic concern) fires call site #5 exactly once; a unanimous-pass review fires zero judge calls"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd issue review has produced .atdd/runtime/issue-reviews/<N>/aggregate.json from N independent passes"
+        - "Coach reads the aggregate during the §4.2 pre-coach precondition"
+    when:
+      abstract: "Coach evaluates the aggregate across a fixture matrix: unanimous-pass, unanimous-concern, mixed-pass-concern, single-pass-systemic-concern"
+    then:
+      abstract:
+        - "Unanimous-pass produces zero judge calls and routes to coach-ready"
+        - "Mixed verdict produces exactly one call to atdd judge with --prompt-template judge-issue-review-aggregate.prompt.yaml and --schema judge-issue-review-aggregate.response.schema.json"
+        - "Single-pass systemic concern fires call site #5 even when the other passes return pass (systemic concerns dominate per spec §6.10)"
+        - "judgments.jsonl receives exactly one line per mixed-verdict review with call_site=issue_review_aggregate"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D003-UNIT-002-aggregate-response-schema"
+      id: "AC-UNIT-002"
+      purpose: "src/atdd/coach/schemas/judge-issue-review-aggregate.response.schema.json freezes the response contract { decision: accept|request_revision|escalate, consolidated_feedback: string, dominant_dimensions: [systemic|ambiguities|gap|regression|comprehensiveness] }"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The schema is committed at src/atdd/coach/schemas/judge-issue-review-aggregate.response.schema.json"
+    when:
+      abstract: "Stub LLM responses covering valid and invalid shapes are validated against the schema"
+    then:
+      abstract:
+        - "decision is one of accept, request_revision, escalate (any other value fails validation)"
+        - "consolidated_feedback is a non-empty string"
+        - "dominant_dimensions is a non-empty subset of the five dimensions defined in spec §6.10"
+        - "At least one valid example fixture is committed at src/atdd/coach/schemas/fixtures/judge-issue-review-aggregate/"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D003-INTEGRATION-001-coach-routes-aggregate-decision"
+      id: "AC-INTEGRATION-001"
+      purpose: "Coach routes per the aggregate decision: accept proceeds to issue-coached; request_revision posts the consolidated_feedback to the GitHub issue and pauses pre-coach; escalate transitions to BLOCKED with operator notification"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "An end-to-end pre-coach run with fixture aggregate.json and a stub LLM that returns each of the three decision branches"
+    when:
+      abstract: "Coach completes the §4.2 pre-coach precondition"
+    then:
+      abstract:
+        - "accept emits a coach-ready decision in decisions.jsonl referencing the judgment_id"
+        - "request_revision posts the consolidated_feedback as a GitHub comment on the issue and emits a pre-coach-paused decision"
+        - "escalate transitions issue state to BLOCKED with the rationale visible in the operator notification"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/judge_ambiguous_decisions/D004.yaml
+++ b/plan/judge_ambiguous_decisions/D004.yaml
@@ -1,0 +1,75 @@
+urn: "wmbt:judge-ambiguous-decisions:D004"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "legacy-rule-alias-violation-without-consolidated-migration-guidance"
+context_clarifier: "when a tier-1 Violation references a legacy alias (e.g., DEAD-CODE-REACHABILITY-001) whose canonical rule (e.g., coder.dead-code.reachability) has superseded_by set in the rule registry — coach must call judge call site #6 (per §6.7, §6.9) to produce a single consolidated migration guidance message embedded in the spawn-feedback for the next respawn (#K1). Without this consolidation, the agent receives the raw legacy ID and either ignores the migration or applies an outdated fix from cached training data. The decision is high-frequency (every legacy-alias hit) so operator escalation is the wrong answer; the decision is genuinely about *what to do* (which canonical rule, which fix-hint, which suggested-aliases) so a deterministic check cannot resolve it"
+lens: "functional.adaptability"
+statement: "minimize likelihood of legacy-rule-alias-violation-without-consolidated-migration-guidance when a tier-1 Violation references a legacy alias whose canonical rule has superseded_by set, and coach must call judge call site #6 to produce migration guidance for the next respawn's spawn-feedback"
+acceptances:
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D004-UNIT-001-legacy-alias-triggers-call-site"
+      id: "AC-UNIT-001"
+      purpose: "A Violation whose rule_id is a legacy alias with superseded_by set on the canonical rule triggers call site #6 exactly once per (legacy_alias, target_commit) pair; non-superseded canonical violations and bare aliases without superseded_by do not trigger"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Rule registry exposes RuleMetadata.superseded_by and the alias-to-canonical resolution via bind_rule()"
+        - "A fixture set of Violation records covering: (a) legacy alias whose canonical has superseded_by set, (b) canonical rule with superseded_by set, (c) canonical rule without superseded_by, (d) legacy alias whose canonical has no superseded_by"
+    when:
+      abstract: "Coach scans active violations and decides whether to call judge for consolidation"
+    then:
+      abstract:
+        - "Case (a) fires call site #6 with --prompt-template judge-superseded-rule-consolidation.prompt.yaml"
+        - "Cases (b), (c), (d) do not fire call site #6"
+        - "Cache key is (legacy_alias, target_commit_sha) — repeated violations of the same alias on the same commit produce one judge call, not N"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D004-UNIT-002-consolidation-response-schema"
+      id: "AC-UNIT-002"
+      purpose: "src/atdd/coach/schemas/judge-superseded-rule-consolidation.response.schema.json freezes the response contract { guidance: string, suggested_aliases: [string], canonical_rule_id: string, fix_hint: string }"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The schema is committed at src/atdd/coach/schemas/judge-superseded-rule-consolidation.response.schema.json"
+    when:
+      abstract: "Stub LLM responses covering valid and invalid shapes are validated against the schema"
+    then:
+      abstract:
+        - "guidance is a non-empty migration narrative referencing both the legacy alias and the canonical rule_id"
+        - "suggested_aliases lists zero or more deprecated IDs the agent is likely to hit in cached training data"
+        - "canonical_rule_id resolves through bind_rule() (registry presence is enforced at validation time)"
+        - "At least one valid example fixture is committed at src/atdd/coach/schemas/fixtures/judge-superseded-rule-consolidation/"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D004-INTEGRATION-001-feeds-spawn-feedback"
+      id: "AC-INTEGRATION-001"
+      purpose: "On the next respawn (#K1), the spawn-feedback's prior_attempt block includes the consolidated guidance under the offending Violation, replacing the raw legacy-alias detail"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "An end-to-end coach run reaches respawn after a tier-1 fail referencing a superseded legacy alias"
+    when:
+      abstract: "Coach assembles the spawn-feedback for the respawn (per spec §7.6)"
+    then:
+      abstract:
+        - "The Violation's section in the prior_attempt block carries the judge-produced guidance under fix_hint"
+        - "suggested_aliases are listed as legacy_aliases on the Violation entry"
+        - "canonical_rule_id replaces the legacy alias in the rule_id field"
+        - "The judgments.jsonl audit-trail line for this call site is referenced by judgment_id in decisions.jsonl"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/judge_ambiguous_decisions/D005.yaml
+++ b/plan/judge_ambiguous_decisions/D005.yaml
@@ -1,0 +1,75 @@
+urn: "wmbt:judge-ambiguous-decisions:D005"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "single-llm-bias-in-pre-coach-issue-review"
+context_clarifier: "when atdd issue review (§5.6, §6.10) must produce a meta-review of an issue body before coach starts work — running a single LLM once would inherit that LLM's training-data biases (missed ambiguities, missed regression risks, missed comprehensiveness gaps). The contract is N independent passes (default 3, min 2), each by a *different* LLM, each evaluating the same five dimensions (systemic, ambiguities, gap, regression, comprehensiveness). Aggregation produces .atdd/runtime/issue-reviews/<N>/aggregate.json which the §4.2 pre-coach precondition reads. Without N-pass cross-LLM discipline, single-LLM bias propagates as missed concerns into every downstream phase"
+lens: "functional.adaptability"
+statement: "minimize likelihood of single-llm-bias-in-pre-coach-issue-review when atdd issue review must produce a meta-review of an issue body that the §4.2 pre-coach precondition consumes — by enforcing N independent passes (default 3, min 2) across distinct LLMs and aggregating across five dimensions"
+acceptances:
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D005-UNIT-001-multi-pass-cross-llm-discipline"
+      id: "AC-UNIT-001"
+      purpose: "atdd issue review <N> --passes 3 --llms claude-haiku,gpt-5-mini,gemini-flash runs three independent reviews, one per --llms entry; --passes < 2 fails loudly; passes > len(--llms) fails loudly; pass identities are recorded so re-runs are reproducible"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/commands/issue_review.py exposes the atdd issue review subcommand"
+        - "Stub LLM clients are registered for claude-haiku, gpt-5-mini, gemini-flash"
+    when:
+      abstract: "atdd issue review 358 --passes 3 --llms claude-haiku,gpt-5-mini,gemini-flash is invoked"
+    then:
+      abstract:
+        - "Three independent pass files are written: pass-1-claude-haiku.json, pass-2-gpt-5-mini.json, pass-3-gemini-flash.json under .atdd/runtime/issue-reviews/358/"
+        - "--passes 1 exits non-zero with min-2 error message"
+        - "--passes 4 with three --llms entries exits non-zero with insufficient-llms error message"
+        - "--force re-runs all passes; without --force, existing pass files are reused (idempotency)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D005-UNIT-002-five-dimensions-per-pass"
+      id: "AC-UNIT-002"
+      purpose: "Each pass evaluates the issue across the five dimensions defined in spec §6.10 (systemic, ambiguities, gap, regression, comprehensiveness); each pass response carries per-dimension verdicts and rule-IDs when a finding maps to a registry rule"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/schemas/issue-review-pass.response.schema.json freezes the per-pass response shape"
+    when:
+      abstract: "Stub LLM responses are validated against the per-pass schema"
+    then:
+      abstract:
+        - "Each pass response includes per-dimension { verdict: pass|concern, findings: [{rule_id?: string, severity: int, detail: string}] }"
+        - "When a finding maps to a known rule-ID via bind_rule(), the rule_id field is populated; otherwise rule_id is null"
+        - "Per-dimension verdicts and findings are aggregated across passes into .atdd/runtime/issue-reviews/<N>/aggregate.json"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:judge-ambiguous-decisions:D005-INTEGRATION-001-aggregate-feeds-pre-coach"
+      id: "AC-INTEGRATION-001"
+      purpose: "The aggregate.json identifies systemic concerns across passes and the §4.2 pre-coach precondition reads it; mixed-verdict aggregates trigger judge call site #5 (per D003) for consolidation"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "An end-to-end pre-coach run reads .atdd/runtime/issue-reviews/<N>/aggregate.json"
+    when:
+      abstract: "atdd issue review has produced an aggregate covering unanimous-pass, mixed-verdict, and systemic-concern fixtures"
+    then:
+      abstract:
+        - "Unanimous-pass aggregates allow coach to proceed without judge involvement"
+        - "Mixed-verdict aggregates trigger exactly one judge call site #5 invocation per the D003 contract"
+        - "Systemic concerns surfaced in any pass dominate the aggregate verdict per spec §6.10"
+        - "GitHub issue receives a comment summarizing per-dimension aggregate verdicts when --show is supplied (or coach posts on request_revision)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/judge_ambiguous_decisions/_judge_ambiguous_decisions.yaml
+++ b/plan/judge_ambiguous_decisions/_judge_ambiguous_decisions.yaml
@@ -1,0 +1,70 @@
+wagon: judge-ambiguous-decisions
+urn: "wagon:judge-ambiguous-decisions"
+name: "Judge Ambiguous Decisions"
+description: "Coach v9 LLM-judgment surface and pre-coach issue review: atdd judge core (§5.5) with six v1 call sites (§6.9: borderline tier-1, reviewer concern, retry-vs-escalate, cross-phase regression, issue review aggregate, superseded rule-ID consolidation), six call-site response schemas, audit trail in judgments.jsonl, discipline criteria for adding new call sites, and atdd issue review multi-pass cross-LLM (§5.6, §6.10) with N-pass aggregation feeding the pre-coach precondition (§4.2)"
+theme: commons
+
+subject: "agent:coach"
+context: "in-coach-v9-execution, deterministic-routing-cannot-resolve-genuinely-ambiguous-decisions"
+action: "calls a structured-output LLM to judge ambiguous coach decisions and runs pre-coach multi-pass cross-LLM issue reviews"
+goal: "preserve the deterministic-first ordering (tier-1 → operator escalation → judge) while letting LLM judgment break ties at well-defined call sites without letting routing logic migrate into prompts"
+outcome: "atdd judge command, six v1 call sites wired into coach routing, six response schemas at src/atdd/coach/schemas/, atdd issue review command, judgments.jsonl audit trail per call, conservative fail-open fallback governed by coach.judge.fail_open, and a written discipline doc for proposing new call sites"
+
+features:
+  - urn: "feature:judge-ambiguous-decisions:judge-and-issue-review"
+
+produce:
+  - name: commons:coach:atdd-judge-cli
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:judge-borderline-tier1-response-schema
+    contract: "contract:commons:coach:judge-borderline-tier1-response"
+    telemetry: null
+    to: external
+  - name: commons:coach:judge-retry-vs-escalate-response-schema
+    contract: "contract:commons:coach:judge-retry-vs-escalate-response"
+    telemetry: null
+    to: external
+  - name: commons:coach:judge-cross-phase-regression-response-schema
+    contract: "contract:commons:coach:judge-cross-phase-regression-response"
+    telemetry: null
+    to: external
+  - name: commons:coach:judge-issue-review-aggregate-response-schema
+    contract: "contract:commons:coach:judge-issue-review-aggregate-response"
+    telemetry: null
+    to: external
+  - name: commons:coach:judge-superseded-rule-consolidation-response-schema
+    contract: "contract:commons:coach:judge-superseded-rule-consolidation-response"
+    telemetry: null
+    to: external
+  - name: commons:coach:atdd-issue-review-cli
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:issue-review-aggregate-schema
+    contract: "contract:commons:coach:issue-review-aggregate"
+    telemetry: null
+    to: external
+  - name: commons:coach:judge-call-site-discipline-doc
+    contract: null
+    telemetry: null
+    to: external
+
+consume:
+  - name: commons:coach:judgment-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:decision-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:runtime-layout-doc
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:validator-result-schema
+    from: wagon:freeze-runtime-contracts
+
+wmbt:
+  total: 5
+  D001: "minimize quantity of unstructured-coach-decisions-bypassing-deterministic-routing"
+  D002: "minimize likelihood of judge-call-site-misfire-on-tier1-retry-or-regression"
+  D003: "minimize likelihood of issue-review-aggregate-judgment-without-audit-trail"
+  D004: "minimize likelihood of legacy-rule-alias-violation-without-consolidated-migration-guidance"
+  D005: "minimize likelihood of single-llm-bias-in-pre-coach-issue-review"

--- a/plan/judge_ambiguous_decisions/features/judge_and_issue_review.yaml
+++ b/plan/judge_ambiguous_decisions/features/judge_and_issue_review.yaml
@@ -1,0 +1,37 @@
+urn: "feature:judge-ambiguous-decisions:judge-and-issue-review"
+wagon: "wagon:judge-ambiguous-decisions"
+description: "Coach v9 LLM-judgment surface plus pre-coach multi-pass cross-LLM issue review: atdd judge core wired to six v1 call sites with structured response schemas, an audit trail in judgments.jsonl, conservative fail-open fallback, a discipline doc gating new call sites, and atdd issue review running N independent passes across distinct LLMs to aggregate dimensions (systemic, ambiguities, gap, regression, comprehensiveness) for the §4.2 pre-coach precondition."
+sizing:
+  wmbts: 5
+  footprint_score: 14
+  footprint_size: "M"
+wmbts:
+  - "wmbt:judge-ambiguous-decisions:D001"
+  - "wmbt:judge-ambiguous-decisions:D002"
+  - "wmbt:judge-ambiguous-decisions:D003"
+  - "wmbt:judge-ambiguous-decisions:D004"
+  - "wmbt:judge-ambiguous-decisions:D005"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 2
+        rationale: "Two CLI commands: atdd judge (src/atdd/coach/commands/judge.py) and atdd issue review (src/atdd/coach/commands/issue_review.py)"
+    application:
+      - type: "use_cases"
+        count: 6
+        rationale: "Six judge call sites (borderline tier-1, reviewer concern, retry-vs-escalate, cross-phase regression, issue review aggregate, superseded rule-ID consolidation) — each its own application-layer use case dispatched from coach state machine"
+    domain:
+      - type: "value_objects"
+        count: 7
+        rationale: "Six call-site response value objects plus the issue-review-aggregate value object — each a frozen response shape consumed by coach routing"
+    integration:
+      - type: "schemas"
+        count: 7
+        rationale: "Six call-site response schemas plus issue-review-aggregate schema committed at src/atdd/coach/schemas/"
+      - type: "docs"
+        count: 1
+        rationale: "judge-call-site-discipline.md gating the addition of new call sites per §6.9"
+      - type: "llm_clients"
+        count: 1
+        rationale: "Pluggable LLM client wired by --llm <id>; reused across judge and issue-review commands"


### PR DESCRIPTION
## Summary

Authors the `judge-ambiguous-decisions` wagon for coach v9 (Track O):

- Wagon manifest: `plan/judge_ambiguous_decisions/_judge_ambiguous_decisions.yaml` (mirrors `freeze-runtime-contracts` shape; consumes judgment / decision / runtime-layout / validator-result artifacts from #C0)
- Feature: `plan/judge_ambiguous_decisions/features/judge_and_issue_review.yaml`
- 5 WMBTs (D001–D005) covering: `atdd judge` core (O1), call sites #1/#3/#4 (O2), call site #5 issue-review aggregate (O3), call site #6 superseded rule-ID consolidation (O4), `atdd issue review` multi-pass cross-LLM (O5)
- 5 compliant issue body markdowns under `.coach-v9-bootstrap/bodies/o{1,2,3,4,5}.md` (filing happens in a later sequential pass)

Filing is intentionally deferred — bodies use `#<INTERNAL_ID>` placeholders for cross-track predecessors so the filer pane can rewrite to GH numbers in topological order.

## Test plan

- [ ] Sequential filer pane files `O1` → `O5` per topological order (waves w1, w1b, w2, w3)
- [ ] Filer rewrites `#J1`, `#K1`, `#M5`, `#P4`, `#O5` placeholders to real GH numbers per `internal-to-gh.json`
- [ ] `atdd validate planner --quick` continues to pass on the merged result

🤖 Generated with [Claude Code](https://claude.com/claude-code)