### PR TITLE
feat(coach): coach v9 — discover-and-decommission wagon

### DIFF
--- a/.coach-v9-bootstrap/bodies/p1.md
+++ b/.coach-v9-bootstrap/bodies/p1.md
@@ -1,0 +1,92 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-p1-rules-show-where-grep` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `discover-and-decommission` |
+| Internal-Spec-Id | `P1` |
+| Feature | `atdd rules` discovery surface — show, where, grep — that resolves toolkit and substrate-derived `repo.*` rules transparently per spec §5.7 |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements the first three subcommands of `atdd rules` per spec §5.7. Each is a thin CLI wrapper over existing utilities: `bind_rule()` resolution, the substrate registry iterator (substrate v12), and rule-id alias resolution.
+
+- **`atdd rules show <rule-id>`** — resolves the canonical or legacy rule-id via `bind_rule()` and prints full `RuleMetadata` fields: severity, description, disposition, validator, fix_hint, recipe, introduced_in, source convention path. Substrate-derived `repo.*` rules also display the bound `acceptance_urn`. Legacy aliases display both the legacy and canonical forms (so callers learn the canonical name while still understanding the alias).
+- **`atdd rules where <rule-id>`** — prints the validator `<module>::<function>` reference and the import path inferred from the archetype (e.g., `coder.dead-code.reachability` → `src/atdd/coder/validators/test_dead_code.py::test_module_reachable`; `repo.*` → substrate dispatcher). Rules with multiple bindings list every callsite, one per line.
+- **`atdd rules grep <pattern>`** — case-insensitive substring search over rule-id, description, and aliases. Output: rule-id, severity, disposition, one-line description per match. Searches both toolkit and `repo.*` registries via the same uniform iterator.
+- New CLI module under `src/atdd/coach/commands/rules.py` (or extends the existing rules module if one exists post-#J1) registering the three subcommands.
+- Co-located unit tests covering: toolkit-rule lookup, `repo.*` rule lookup, legacy-alias resolution, unknown-id error path, multi-binding `where` output, and grep over a fixture registry.
+
+### Out of Scope
+
+- The remaining three subcommands (`disposition`, `archetype`, `suppressions`) — those are #P2.
+- The per-LLM convention-file regeneration that consumes `atdd rules` output — that's #P3.
+- Adding new rule-ids or extending the rule-id grammar — governed by `SPEC-COACH-RULEID-0001..0007`, not coach v9.
+- Rendering rule-id metadata into spawn-harness blocks — that lives in `src/atdd/coach/commands/spawn_harness_blocks.py` (Track K).
+- Validator-side enforcement of `bind_rule()` contracts — already shipped in the substrate.
+- Modifying `bind_rule()` or `RuleMetadata` themselves — these are stable substrate dataclasses; this issue only consumes them.
+
+### Dependencies
+
+- `#J1` — coach state machine MVP and `atdd` CLI registry must exist for `rules` to register subcommands cleanly.
+- `bind_rule()` — already shipped; no upstream work required.
+- Substrate v12 registry iterator — already shipped (`atdd repo` graph queries already use it).
+- `suppression_scanner` — referenced by `#P2` (`suppressions` subcommand), not by this issue.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Rule-id metadata access | Operators grep convention YAMLs; agents read whole convention files; `bind_rule()` is reachable only from Python | `atdd rules show <id>` returns severity, disposition, validator, fix_hint, recipe, source convention from one CLI call | Without it, escalation triage and agent self-correction both require multi-step lookups; rule-id grammar adoption stalls because the discovery surface doesn't exist |
+| Validator callsite for a rule-id | Manual grep across `src/atdd/*/validators/` for `bind_rule("<id>")` calls | `atdd rules where <id>` returns `<module>::<function>` per binding | Reverse-coherence (#467 contract) is not user-friendly without a CLI; agents respawning under feedback need to find the validator that emitted the violation |
+| Cross-archetype rule discovery | Toolkit conventions and substrate `repo.*` rules live in separate stores; no uniform browse surface | `atdd rules grep <pattern>` walks both registries | Without it, agents and operators write tooling that drifts apart per archetype; the integration surface is hidden |
+| Legacy-alias visibility | `get_canonical_id()` resolves aliases internally but the mapping isn't exposed at the CLI | `atdd rules show <legacy-alias>` prints both legacy and canonical forms | Agents see legacy callsites in violations and need to learn the canonical form without reading source |
+
+### User Impact
+
+The "user" of this issue is every coach operator triaging a CI failure, every agent respawning under reviewer feedback, and every toolkit debugger investigating why a rule is binding the way it does. Today, the rule-id substrate exists in code (`bind_rule()`, `RuleMetadata`, the substrate v12 registry) but has no human-facing discovery surface — the data structures are reachable only from Python REPL or by walking convention YAMLs. Per spec §5.7, this is the "discovery commands" gap that escalation triage, agent context preload, and human debugging all hit.
+
+After this issue lands, an operator hitting `coach.dead-code.reachability sev=2 strict` in a CI failure can run `atdd rules show coder.dead-code.reachability` and immediately read the canonical fix_hint and the convention path. Agents respawning under reviewer feedback (per spec §6.7) can run `atdd rules where <id>` to locate the validator that emits the rule and inspect its assertions. Both surfaces are wraps over already-shipped utilities — the cost of NOT shipping them is hidden friction at every escalation, every respawn, every debug session.
+
+### Design Anchor
+
+Per spec §5.7, "These wrap existing utilities (`bind_rule`, `find_suppressions`, `find_stale_suppressions`) — thin CLI surface." The architectural choice is exactly that: thin CLI controllers that dispatch to existing application logic, no new domain types. This matches the substrate v12 design where the registry iterator is the canonical access path; `atdd rules` exposes it without re-implementing it.
+
+The split between this issue (#P1) and #P2 follows the natural boundary between "lookup a known rule-id" (`show`, `where`, `grep`) and "enumerate by attribute" (`disposition`, `archetype`, `suppressions`). The two halves can ship independently — #P1 is wave-w0 (parallel with C0); #P2 is wave-w0 too but depends on #P1 for shared CLI scaffolding.
+
+---
+
+## Acceptance
+
+- `acc:discover-and-decommission:L001-UNIT-001-rules-show-resolves-toolkit-and-repo`: `atdd rules show <rule-id>` resolves toolkit and substrate-derived `repo.*` rules transparently and prints full `RuleMetadata` fields (severity, description, disposition, validator, fix_hint, recipe, introduced_in, source convention path); legacy aliases resolve to canonical and display both forms; substrate `repo.*` rules display the bound `acceptance_urn`; unknown rule-ids exit non-zero with a clear error message.
+- `acc:discover-and-decommission:L001-UNIT-002-rules-where-prints-validator-callsite`: `atdd rules where <rule-id>` prints `<module>::<function>` with the import path inferred from the archetype; rules with multiple bindings list every callsite; unknown rule-ids exit non-zero.
+- `acc:discover-and-decommission:L001-UNIT-003-rules-grep-searches-id-description-alias`: `atdd rules grep <pattern>` searches across rule-id, description, and aliases case-insensitively; each line shows rule-id, severity, disposition, and a one-line description; empty result exits non-zero; surface is consistent across toolkit and `repo.*` archetypes.
+- All three subcommands resolve toolkit and repo rules transparently per the v3-spec acceptance ("All three subcommands resolve toolkit and repo rules transparently").
+- `atdd rules show repo.govern-lifecycle.D003-acc-unit-001` returns substrate-derived metadata (the v3-spec smoke check).
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §5.7 (`atdd rules` discovery commands), §6.7 (legacy-alias resolution in feedback)
+- `atdd-coach-issues-v3.md` issue `#P1`
+- Wagon manifest: `plan/discover_and_decommission/_discover_and_decommission.yaml`
+- Feature: `plan/discover_and_decommission/features/rules_discovery.yaml`
+- WMBT: `plan/discover_and_decommission/L001.yaml`
+- Train: `plan/_trains/0002-coach-drives-lifecycle.yaml`
+- Predecessor: `#J1` (coach state machine MVP / CLI registry)
+- Substrate v12 — `bind_rule()`, `RuleMetadata`, registry iterator
+- Sibling issue: `#P2` (remaining `atdd rules` subcommands)

--- a/.coach-v9-bootstrap/bodies/p2.md
+++ b/.coach-v9-bootstrap/bodies/p2.md
@@ -1,0 +1,96 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-p2-rules-disposition-archetype-suppressions` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `discover-and-decommission` |
+| Internal-Spec-Id | `P2` |
+| Feature | `atdd rules` discovery surface — disposition, archetype, suppressions — that enumerates rules by attribute and surfaces active or stale suppression markers per spec §5.7 |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements the remaining three subcommands of `atdd rules` per spec §5.7. Builds on the CLI scaffolding from `#P1` and reuses the same registry iterator over toolkit and substrate-derived `repo.*` rules.
+
+- **`atdd rules disposition <strict|suppress-and-clean|advisory|documentation-only>`** — lists every rule with the given disposition. Toolkit conventions declare per-rule disposition; `repo.*` rules are uniformly `strict` per substrate v12 §2 (so `disposition repo.* strict` returns the full repo registry; `suppress-and-clean`, `advisory`, and `documentation-only` return only toolkit rules).
+- **`atdd rules archetype <coder|coach|tester|planner|repo>`** — lists every rule under the given archetype, sorted by rule-id for stable diffing. `archetype repo` lists every substrate-derived rule (WMBT-acceptance, train-acceptance, security-derived) per substrate v12.
+- **`atdd rules suppressions [--stale-only] [--rule <id>]`** — delegates to `find_suppressions()` and `find_stale_suppressions()`. Output: file path, line, rule-id, UNTIL date per active marker. `--stale-only` filters to markers whose UNTIL date has passed today. `--rule <id>` filters to markers for the given rule-id. Markers referencing `repo.*` rules are surfaced as warnings (substrate-unsuppressible per substrate v12 §2).
+- Each line of every list output shows rule-id plus enough context (archetype, severity, one-line description) to make the listing self-explanatory at a glance.
+- Co-located unit tests covering: each disposition value, each archetype value, mixed active/stale suppressions, `--rule` filter, repo-rule suppression-warning case.
+
+### Out of Scope
+
+- The first three `atdd rules` subcommands (`show`, `where`, `grep`) — those are `#P1`.
+- Adding new dispositions or extending the disposition vocabulary — governed by `acceptance-violation.convention.yaml`, not coach v9.
+- Changing repo-rule unsuppressibility — that's substrate v12 §2 policy; this issue surfaces it via warnings only.
+- Per-LLM convention regeneration that consumes these listings — that's `#P3`.
+- `atdd rules health` (rule-ID health metrics) — explicitly future work per spec §12.9.
+- Auto-fixing or auto-removing stale suppressions — out of scope; observer rule `10-stale-suppression-detected` (Track L) does the nudge, but mutation is operator-owned.
+
+### Dependencies
+
+- `#P1` — shared CLI scaffolding under `src/atdd/coach/commands/rules.py`; this issue extends the same module with three additional subcommands.
+- `find_suppressions()` and `find_stale_suppressions()` — already shipped in the existing toolkit machinery (referenced by `atdd validate` and observer rule `10-stale-suppression-detected`).
+- `bind_rule()` — already shipped; consumed via the registry iterator.
+- Substrate v12 §2 (repo rules unsuppressible) — surfaced via warnings only.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Enumerate rules by disposition | Operators grep convention YAMLs for `disposition: strict`; substrate `repo.*` rules require knowing the archetype is uniformly strict | `atdd rules disposition strict` lists every strict rule across both registries | Without it, risk-triage at PR time and convention authoring both miss the cross-registry view; CI failures don't show the operator the disposition-set context |
+| Enumerate rules by archetype | No CLI surface; operators read multiple convention files to find related rules | `atdd rules archetype repo` returns the full substrate registry; `atdd rules archetype coder` returns the coder convention rules | The substrate v12 registry has rich structure (WMBT-acceptance, train-acceptance, security) but no flat browse; the right "what's active for this archetype" answer is hidden |
+| Active and stale suppression markers | `find_suppressions()` is reachable only from Python; observer rule `10` nudges per-violation but no enumeration surface exists | `atdd rules suppressions --stale-only` lists every UNTIL-past marker | Stale suppressions silently drift past their UNTIL date; without a CLI list, the team doesn't see the debt accumulating |
+| Repo-rule unsuppressibility surfacing | A marker like `# atdd:suppress(repo.foo.D003-acc-unit-001)` is silently ignored by the gate | `atdd rules suppressions` warns when it finds such a marker | Operators write the marker expecting it to absorb a violation, but it doesn't; without surfacing, the misapplication is invisible until the next CI run |
+
+### User Impact
+
+The "user" is the coach operator triaging suppression debt before COMPLETE, the agent reading risk-score breakdown by disposition, and the toolkit author auditing which rules belong to which archetype. Per spec §6.6, suppressions block COMPLETE when stale (`--allow-stale-suppressions=false` is the default); without `atdd rules suppressions --stale-only`, the operator can't quickly enumerate what's blocking and decide whether to extend the UNTIL or fix the underlying issue.
+
+The lived problem: the existing toolkit detects stale suppressions on every `atdd validate` run but only at the per-violation granularity. A team accumulates 12 stale suppressions across 8 files; the COMPLETE block fires; the operator wants a single-CLI answer to "which markers are stale, in which files, on which rule-ids." This issue ships that answer.
+
+Per spec §6.8, risk score is broken down by disposition; the reviewer prompt sees the breakdown and prioritizes accordingly. `atdd rules disposition strict` gives reviewers and agents the full strict-rule context without leaving the CLI.
+
+Per substrate v12 §2, `repo.*` rules are uniformly strict and unsuppressible. The "warn on `repo.*` suppression markers" output is small but load-bearing — it converts a silent misapplication into a visible warning the operator can act on.
+
+### Design Anchor
+
+This issue is the second half of the "thin CLI over existing utilities" architecture from `#P1`. Together, `#P1` (lookup) and `#P2` (enumerate) deliver spec §5.7's full discovery surface. The split exists for review-window reasons (six subcommands in one PR is large; three + three is reviewable) — there is no design seam between them.
+
+The repo-rule unsuppressibility warning is intentionally a CLI concern, not a substrate concern. Substrate v12 §2 silently ignores the markers (correct: gate logic is unconditional for strict). The CLI's job is to surface the misapplication so operators don't write markers expecting absorption that won't happen.
+
+---
+
+## Acceptance
+
+- `acc:discover-and-decommission:L002-UNIT-001-rules-disposition-lists-strict-and-others`: `atdd rules disposition strict` lists every strict rule across both registries; `disposition suppress-and-clean / advisory / documentation-only` list only toolkit rules (since `repo.*` are uniformly strict per substrate v12 §2); each line shows rule-id, archetype, severity, and a one-line description; invalid disposition exits non-zero listing the four valid options.
+- `acc:discover-and-decommission:L002-UNIT-002-rules-archetype-lists-coder-coach-tester-planner-repo`: `atdd rules archetype repo` lists every substrate-derived rule; `archetype coder/coach/tester/planner` each list their respective toolkit rules; output is sorted by rule-id within an archetype; unknown archetype exits non-zero listing the five valid options.
+- `acc:discover-and-decommission:L002-UNIT-003-rules-suppressions-delegates-to-scanner`: `atdd rules suppressions` lists every active suppression marker (file path, line, rule-id, UNTIL); `--stale-only` filters to UNTIL-past; `--rule <id>` filters to one rule-id; markers referencing `repo.*` rules are surfaced as warnings; empty result exits zero.
+- `atdd rules archetype repo` lists all substrate-derived rules (per the v3-spec smoke check).
+- `atdd rules disposition strict` lists all strict rules across registries (per the v3-spec smoke check).
+- `atdd rules suppressions --stale-only` lists all expired markers (per the v3-spec smoke check).
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §5.7 (`atdd rules` discovery commands), §6.6 (suppression markers honored end-to-end), §6.8 (risk score breakdown by disposition)
+- `atdd-coach-issues-v3.md` issue `#P2`
+- Wagon manifest: `plan/discover_and_decommission/_discover_and_decommission.yaml`
+- Feature: `plan/discover_and_decommission/features/rules_discovery.yaml`
+- WMBT: `plan/discover_and_decommission/L002.yaml`
+- Predecessor: `#P1` (shared CLI scaffolding for `atdd rules`)
+- Substrate v12 §2 (repo rules unsuppressible)
+- Existing utilities: `find_suppressions()`, `find_stale_suppressions()`, `bind_rule()`, registry iterator

--- a/.coach-v9-bootstrap/bodies/p3.md
+++ b/.coach-v9-bootstrap/bodies/p3.md
@@ -1,0 +1,92 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-p3-sync-per-llm-convention-files` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `discover-and-decommission` |
+| Internal-Spec-Id | `P3` |
+| Feature | `atdd sync` regenerates per-LLM convention files (CLAUDE.md, AGENTS.md, GLM.md, GEMINI.md) idempotently from the K4 spawn-harness templates per spec §7.1 |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements §7.1 sync integration with the per-LLM convention templates from `#K4`. The spawn harness loads the persona convention file as Section 1 of the bundled context (`include: ${persona_convention_file}`); this issue keeps those files in sync with the templates so that every persona that spawns under coach v9 reads identical rule-id grammar and `bind_rule()` contract sections.
+
+- Hook the existing `atdd sync` command to a new step that regenerates each per-LLM convention file (`CLAUDE.md`, `AGENTS.md`, `GLM.md`, `GEMINI.md` at the repo root) from the corresponding K4 template.
+- Render the rule-id grammar block (`<archetype>.<convention_short_name>.<rule_name>` per `SPEC-COACH-RULEID-0001`) and the `bind_rule()` contract block per spec §7.1.
+- Render the forbidden / required protocol sections per the persona convention.
+- Preserve existing sync-managed-region semantics: only the managed region inside each file is regenerated; per-LLM hand-edits outside the managed region are preserved verbatim.
+- Make the regeneration **idempotent**: a second `atdd sync` invocation against an unchanged template produces zero file changes (verified via `git status`).
+- Stable ordering of rule-ids, conventions, and sections across runs (the test bar is "CI can run `atdd sync --check` as a verification step without producing a noisy diff").
+- Co-located tests covering: first-run regeneration, idempotent rerun, hand-edit preservation, template-change propagation, and stable ordering.
+
+### Out of Scope
+
+- Authoring the per-LLM templates themselves — that's `#K4` (Track K, spawn-agents wagon).
+- The `atdd rules` discovery commands that templates may reference at render time — those ship in `#P1` and `#P2`.
+- The `coach.*` config block schema that templates may reference — that's `#P4`.
+- Rendering the substrate `wmbt_rules` / `train_rules` / `security_rules` blocks at spawn time — that's `#K2` (`spawn_harness_blocks.py` extension).
+- Adding new per-LLM target files beyond the four already enumerated — additive change goes through a follow-up issue.
+
+### Dependencies
+
+- `#K4` — per-LLM convention templates must exist for `atdd sync` to render against them.
+- `atdd sync` command — already shipped (this issue extends it).
+- Per-LLM file existence at repo root — `CLAUDE.md`, `AGENTS.md`, `GLM.md`, `GEMINI.md` already exist with `# --- ATDD:BEGIN/END ---` managed regions; this issue regenerates inside those regions.
+- `#P1`, `#P2` — only relevant if the templates reference `atdd rules` examples; not a hard dep.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Per-LLM convention drift | Each per-LLM file is hand-edited or partially synced from a base; rule-id grammar guidance varies across files | All four files regenerate from the K4 template; rule-id grammar and `bind_rule()` contract sections are identical across personas | Persona drift means an agent spawning as `claude-code` and one spawning as `glm` see different rule-id guidance; spawn-harness contract from §7.1 is undermined |
+| Sync idempotency | Existing `atdd sync` may produce churn diffs when run twice | A second `atdd sync` against unchanged templates produces zero diffs | Without idempotency, CI cannot use `atdd sync --check` as a gate; operators see noisy PRs from running sync defensively |
+| Template-to-file propagation | Template edits don't automatically reach the per-LLM files | `atdd sync` regenerates on every invocation; CI runs sync as a verification step | Without propagation, K4 template changes drift from the rendered per-LLM files; agents read stale guidance |
+| Hand-edit preservation | Unmanaged regions are not formally protected — sync risks overwriting per-LLM-specific notes | Sync only writes inside `# --- ATDD:BEGIN/END ---` managed regions | Operators add per-LLM notes (e.g., Claude Code-specific keybindings) and need them to survive sync runs |
+
+### User Impact
+
+The "user" of this issue is every persona that spawns under coach v9. Per spec §7.1, the spawn harness includes Section 1 — the persona convention file — as the first context block the agent reads. If those files drift across personas, agents form different mental models of the rule-id grammar and the `bind_rule()` contract; respawn feedback (per §6.7) becomes harder to interpret because the legacy-alias resolution example is missing or incorrectly formatted.
+
+The lived target: an operator updates the K4 template to add a new forbidden command, runs `atdd sync`, and all four per-LLM files reflect the change. CI runs `atdd sync --check` (or similar) as a no-op verification; the gate fails if the template drifts from the rendered files.
+
+The idempotency bar matters because of how often `atdd sync` runs in practice. Per the existing toolkit, sync runs at the end of most planning sessions, in CI on every PR, and ad-hoc when conventions change. A sync that produces churn diffs trains operators to ignore the output; an idempotent sync trains them to trust it.
+
+### Design Anchor
+
+The architecture matches the existing `atdd sync` pattern: a controller orchestrates per-target regeneration; templates live alongside the producing wagon (here, `#K4` ships templates for spawn agents); idempotency is a property of the renderer, not the controller. Per spec §7.1, the rule-id grammar and `bind_rule()` contract are first-class concerns of the persona convention; this issue makes them mechanically consistent across the four target files.
+
+The hand-edit preservation pattern (managed regions delimited by `# --- ATDD:BEGIN/END ---`) is already established in the existing CLAUDE.md (this very repo's CLAUDE.md uses it for the agent-specific addition). The issue does not introduce a new pattern, only extends it to the K4 templates.
+
+---
+
+## Acceptance
+
+- `acc:discover-and-decommission:P001-UNIT-001-sync-regenerates-per-llm-convention-files`: `atdd sync` regenerates `CLAUDE.md`, `AGENTS.md`, `GLM.md`, and `GEMINI.md` from the K4 templates into each file's sync-managed region; rule-id grammar and `bind_rule()` contract sections render correctly with substrate-derived examples; forbidden/required sections render correctly per the persona convention; files outside the sync-managed region (per-LLM hand-edits) are preserved verbatim.
+- `acc:discover-and-decommission:P001-UNIT-002-sync-is-idempotent`: a second `atdd sync` invocation against unchanged templates produces zero file changes (`git status` shows no diff); stable ordering of rule-ids, conventions, and sections across runs; CI can run `atdd sync` as a verification step without producing a noisy diff.
+- `atdd sync` regenerates `CLAUDE.md`, `AGENTS.md`, `GLM.md` from templates (per the v3-spec smoke check; this issue extends the bar to also cover `GEMINI.md`).
+- Repeated runs are idempotent (per the v3-spec smoke check).
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §7.1 (spawn harness — Section 1: persona convention file), §6.7 (legacy alias resolution in feedback)
+- `atdd-coach-issues-v3.md` issue `#P3`
+- Wagon manifest: `plan/discover_and_decommission/_discover_and_decommission.yaml`
+- Feature: `plan/discover_and_decommission/features/convention_sync_and_config_loader.yaml`
+- WMBT: `plan/discover_and_decommission/P001.yaml`
+- Predecessor: `#K4` (per-LLM convention templates in spawn-agents wagon)
+- Existing `atdd sync` command surface and managed-region pattern

--- a/.coach-v9-bootstrap/bodies/p4.md
+++ b/.coach-v9-bootstrap/bodies/p4.md
@@ -1,0 +1,103 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-p4-coach-config-loader` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `discover-and-decommission` |
+| Internal-Spec-Id | `P4` |
+| Feature | Extend `load_atdd_config` to parse the `coach.*` configuration block per spec §10 with documented defaults and loud errors on invalid fields |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements §10 config loader. Coach reads `.atdd/config.yaml::coach` at startup; this issue freezes the parser so that every spec §10 field has a documented default and every invalid input fails loudly. Without this, misconfigured fields silently degrade coach behavior (e.g. a missing `risk_thresholds.green` becomes implicit-`None`-becomes-`infinity`-becomes-no-block).
+
+- Extend `load_atdd_config` (existing function in the toolkit's config layer) to parse the `coach:` block per the spec §10 example.
+- Apply defaults for missing fields per the §10 reference values:
+  - `default_llm: claude-code`; `judge_llm: claude-haiku`; `persona_llm` defaults to `claude-code` for `planner/tester/coder` and `gpt-5` for `reviewer`.
+  - `observer.activity_silence_seconds: 90`; `observer.process_silence_seconds: 30`; `observer.rules_dir: .atdd/observer/rules`.
+  - `review.enabled: true`; `review.phases: [planned, red, green, smoke]`; `review.same_model_warning: true`; `review.same_model_allowed: false`.
+  - `validators.enabled: true`; `validators.grace_window_seconds: 30`; `validators.selection: default`; `validators.pytest_args: ["-x", "--tb=short"]`.
+  - `suppressions.honor: true`; `suppressions.block_on_stale: true`; `suppressions.grace_days: 7`.
+  - `risk_thresholds.planned: null`; `risk_thresholds.red: null`; `risk_thresholds.green: 10`; `risk_thresholds.smoke: 15`; `risk_thresholds.refactor: 5`; `risk_thresholds.complete: 0`.
+  - `judge.enabled: true`; `judge.fail_open: false`; `judge.log_full_inputs: false`.
+  - `issue_review.passes: 3`; `issue_review.llms: [claude-haiku, gpt-5-mini, gemini-flash]`; `issue_review.dimensions: [systemic, ambiguities, gap, regression, comprehensiveness]`; `issue_review.require_for_coach: warn`; `issue_review.stale_after_days: 14`.
+  - `escalation.channel: file`; `escalation.slack_webhook: null`; `escalation.github_label: coach-escalation`.
+  - `retries.per_state_machine: 3`; `retries.per_agent: 2`.
+  - `token_alert_threshold: 400000`.
+- Validate types and ranges: risk thresholds non-negative (null allowed where listed), seconds non-negative integers, enums match the documented set, lists contain the right element types.
+- Reject **unknown top-level keys** under `coach.*` (typoed keys must fail loudly, not be silently dropped).
+- Surface the spec §10 reference in error messages so operators can find the canonical schema quickly.
+- A `CoachConfig` value object captures the parsed block (immutable; used everywhere coach reads config).
+- Co-located unit tests covering: empty `coach:` block applies all defaults; partial overrides merge with defaults; invalid types raise loud errors; out-of-range numbers raise loud errors; unknown keys raise loud errors; null-allowed fields accept null where the spec lists it.
+
+### Out of Scope
+
+- The `coach:` block schema itself — already defined in spec §10; this issue parses it.
+- Live-reload semantics — coach reads config once at startup per the existing `load_atdd_config` contract.
+- Migration from v5/v6/v7/v8 config shapes — coach v9 is a hard cut; legacy fields are rejected as unknown keys.
+- Per-repo config overlays beyond the existing `.atdd/config.yaml` mechanism.
+- Validating the `sync.agents` block (already shipped, unchanged).
+- Editing the `coach.*` block in YAML programmatically — read-only this issue.
+
+### Dependencies
+
+- `#J1` — coach state machine MVP must exist for the parsed `CoachConfig` to be consumed by anything.
+- `load_atdd_config` — already shipped in the toolkit; this issue extends it.
+- Spec §10 — the canonical schema for the `coach.*` block.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Coach config defaults | Spec §10 documents reference values; no parser applies them | `load_atdd_config` returns a `CoachConfig` populated with every default per spec §10 | Without it, partial configs silently leave fields as `None`, breaking risk-routing and validator selection |
+| Invalid-field detection | Existing loaders silently drop unknown YAML keys | Unknown `coach.*` keys raise loud errors at load time | Typos like `risk_threshhold.green` (note doubled-h) silently inherit defaults; the operator's intent is lost |
+| Range validation | No validation on numeric fields | Risk thresholds non-negative, seconds non-negative; out-of-range raises | Negative threshold or seconds value silently wraps or short-circuits coach logic; misconfiguration surfaces only at runtime |
+| Spec-cross-reference in errors | None | Error messages cite spec §10 | Operators hitting a config error don't know where to find the canonical schema |
+
+### User Impact
+
+The "user" is every coach operator who edits `.atdd/config.yaml::coach` and every coach run that reads it. Per spec §10, the block shapes risk-routing (`risk_thresholds`), suppression policy (`suppressions.honor`, `block_on_stale`), validator dispatch (`validators.selection`, `pytest_args`, `grace_window_seconds`), reviewer behavior (`review.same_model_allowed`, `phases`), judge behavior (`judge.fail_open`), issue-review behavior (`issue_review.passes`, `llms`), and escalation channels. A misparse anywhere in the block silently degrades coach in a specific phase of the lifecycle — the failure mode is invisible until the wrong-phase action fires.
+
+The lived target: an operator copies the §10 example into `.atdd/config.yaml`, removes the fields they don't need, and trusts that defaults apply. A typo in `risk_thresholds.green` becomes an immediate config error citing the spec, not a silent default. A misspelled enum (e.g. `escalation.channel: silack`) fails loudly. Without this issue, every misconfiguration becomes a debug-after-the-fact incident.
+
+The unknown-keys policy is the load-bearing detail. Permissive parsers train operators to trust YAML they haven't validated; strict parsers catch typos at the moment of edit. Coach v9 takes the strict path because the cost of a silent misconfiguration in a coach driving multiple parallel issues is high — a wrong `risk_thresholds.green` blocks COMPLETE for hours before someone reads the routing log carefully.
+
+### Design Anchor
+
+The architecture is a single `CoachConfig` value object materialized from YAML at startup. Defaults live in the value object's constructor (or a sibling defaults module); validation lives in the parser. Coach consumes `CoachConfig` everywhere — there is no second source of truth. This matches how the existing toolkit's config types work (`AtddConfig`, `RepoConfig`) and avoids the failure mode of "default scattered across consumers."
+
+Strict unknown-key rejection is the inverse of the substrate's flexible-by-design YAML-loader pattern. Coach config is closed-schema (every valid key is named in spec §10); contract YAMLs are open-schema (downstream consumers extend them). The two patterns coexist in the toolkit.
+
+---
+
+## Acceptance
+
+- `acc:discover-and-decommission:P002-UNIT-001-load-atdd-config-parses-coach-block`: `load_atdd_config` parses the `coach.*` block per spec §10 and applies defaults for missing fields; an empty coach block returns a `CoachConfig` populated with every default; overridden fields take effect and unmentioned fields fall back to spec §10 defaults; `risk_thresholds`, `validators`, `suppressions`, `judge`, `issue_review`, and `token_alert_threshold` defaults match spec §10 exactly.
+- `acc:discover-and-decommission:P002-UNIT-002-invalid-fields-raise-loud-errors`: invalid types, out-of-range numbers, mistyped scalars, and unknown enumeration values each raise a configuration error naming the offending key and its expected type or enumeration; risk-threshold values are checked for non-negativity (null allowed where spec lists it); unknown top-level keys under `coach.*` fail loudly rather than being silently dropped; error messages reference spec §10.
+- Coach reads config from `.atdd/config.yaml::coach` and applies defaults for missing fields (per the v3-spec smoke check).
+- Invalid fields raise loud errors (per the v3-spec smoke check).
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §10 (`coach.*` configuration block — canonical schema)
+- `atdd-coach-issues-v3.md` issue `#P4`
+- Wagon manifest: `plan/discover_and_decommission/_discover_and_decommission.yaml`
+- Feature: `plan/discover_and_decommission/features/convention_sync_and_config_loader.yaml`
+- WMBT: `plan/discover_and_decommission/P002.yaml`
+- Predecessor: `#J1` (coach state machine MVP that consumes `CoachConfig`)
+- Existing `load_atdd_config` and `AtddConfig` value-object pattern in the toolkit

--- a/.coach-v9-bootstrap/bodies/p5.md
+++ b/.coach-v9-bootstrap/bodies/p5.md
@@ -1,0 +1,104 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-p5-decommission-orchestrate` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `discover-and-decommission` |
+| Internal-Spec-Id | `P5` |
+| Feature | Decommission `atdd orchestrate` per spec §11.3: archive source, replace CLI registry entry with a stub printing the migration message, gated on the `#K5` orchestrate-parity suite passing on CI |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements §11.3 decommissioning of `atdd orchestrate`. The hard-cut model from substrate v12 (CLI rename `atdd urn` → `atdd repo`) is the precedent: no `*-legacy` shim, the original entry point points at the migration message, the source is archived for parity-test reuse.
+
+- **Move source.** `commands/orchestrate.py` (~351 lines today; `build_plan`, `compute_waves`, `_create_worktree`, `_remove_worktree`, two-phase commit, multiplexer-mode dispatch, canonical naming + layout, launch-script generation) moves to `commands/_archived/orchestrate.py`. The `#K5` parity suite imports the archived module to run the side-by-side fixtures.
+- **Strip CLI registry.** Remove the `orchestrate` subcommand from the CLI registry (`commands/__init__.py` or wherever subcommands are registered) so it no longer dispatches to the legacy implementation.
+- **Install stub.** Add a stub at `commands/orchestrate.py` (the original path) that, when invoked, prints exactly:
+
+  > `atdd orchestrate has been removed in coach v9. Use 'atdd coach <issue-numbers>' instead. Migration: every flag maps directly per atdd-coach-spec-v9.md §5.1.`
+
+  and exits non-zero. The stub does **not** execute any orchestrate machinery (no worktree creation, no multiplexer launch).
+- **Update CHANGELOG.** Document the removal, link to spec §0.2 (absorption table) and §5.1 (CLI mapping).
+- **Verify no internal callsites.** Grep across the repository for `atdd orchestrate` invocations and direct imports of the archived module; assert zero non-archive callsites in shipped code (excluding `commands/_archived/`, the K5 parity suite, CHANGELOG, and migration docs).
+- **Convention file unchanged.** `src/atdd/coach/conventions/orchestration.convention.yaml` remains the rule-id home for all the absorbed rules; rule-ids continue to resolve via `bind_rule()`.
+- **K5 parity precondition.** PR opens only after the K5 orchestrate-parity suite is green; PR description references the K5 job name and run.
+
+### Out of Scope
+
+- Decommissioning `atdd babysit` — that's `#P6`. Same pattern, separate PR for review-window reasons and to map cleanly to the K5/L8 parity-suite split.
+- Editing the orchestration convention file — preserved unchanged; rule-id home for the absorbed observer/spawn machinery.
+- Authoring the K5 parity suite itself — that's spawn-agents wagon `#K5`.
+- Removing absorbed machinery from where `atdd coach` / `atdd spawn` / `atdd observer` consume it — those callsites are correct; only the legacy CLI surface is removed.
+- Backporting or rebuilding orchestrate-shaped behavior under a new flag — coach v9 is the replacement; flag mapping is in spec §5.1.
+- A migration-helper command — the stub is intentionally terminal so operators are routed to the spec.
+
+### Dependencies
+
+- `#J1` — `atdd coach` state machine MVP (the migration target).
+- `#J4` — two-phase commit absorbed from orchestrate.
+- `#K1` — `atdd spawn` skeleton (absorbs launch-prompt rendering).
+- `#K3` — canonical naming + layout pass at spawn time (absorbs `apply_canonical_name_and_layout`).
+- `#K5` — orchestrate-parity suite passing on CI (operationalized "behavior parity" gate; this is the merge precondition).
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| `atdd orchestrate` CLI surface | Active 351-line implementation; competes with coach for the orchestration role | Removed; entry point prints migration message and exits non-zero | Two orchestration entry points train operators to use whichever they remember; coach v9's deterministic state machine never fully takes over |
+| Behavior-parity claim | Reviewer judgment ("the absorbed machinery looks equivalent") | `#K5` fixture suite asserts equivalent observable behavior on every PR | Without parity tests, "absorbed" is a claim, not a contract; regressions surface only at the integration step |
+| Internal callsites | `atdd orchestrate` may be referenced from helper scripts, docs, or release tooling | Zero non-archive callsites; CHANGELOG documents the migration | Lingering callsites silently break after the cut; operators run the stub and don't know why their workflow broke |
+| Convention file (rule-id home) | Lives at `src/atdd/coach/conventions/orchestration.convention.yaml`; absorbed observer/spawn rules bind there | Unchanged; preserved as-is | Renaming or moving the convention file would break `bind_rule()` resolution for the absorbed rule-ids |
+
+### User Impact
+
+The "user" is every coach operator and every CI pipeline that today runs `atdd orchestrate <issue-numbers>`. Per spec §11.3, the migration is mechanical: every flag maps directly to `atdd coach` per spec §5.1; multiplexer-mode dispatch transfers to `atdd spawn`; canonical naming + layout transfers to `atdd spawn` and observer rules `14`/`15`. The stub's migration message names the replacement command and the spec section that documents the flag mapping — the operator's recovery path is one read.
+
+The lived target: an operator running `atdd orchestrate 358 359 360` after the cut sees the migration message, runs `atdd coach 358 359 360`, and gets identical observable behavior. The K5 parity suite is the contract that makes "identical observable behavior" a CI-enforced equivalence rather than a reviewer's word.
+
+The K5 gate is non-negotiable. Without it, decommissioning is a leap of faith — a reviewer reads the absorption claim in §0.2 and signs off. With it, every PR runs side-by-side fixtures and asserts equivalent worktree creation order, multiplexer dispatch, canonical naming application, state-file content (modulo the JSON-lines-vs-single-doc format change documented in §4.6), and session-prompt rendering. P5 references K5's green run in the PR description so the parity-evidence trail is durable.
+
+### Design Anchor
+
+The hard-cut precedent is substrate v12's `atdd urn` → `atdd repo` rename. No `*-legacy` shim shipped; the migration was mechanical (see `atdd-repo-substrate-spec-v12.md`). Coach v9 follows that pattern because every flag maps directly per spec §5.1 — there is no behavior under `atdd orchestrate` that requires a transition window.
+
+The "archive, don't delete" choice is intentional. `commands/_archived/orchestrate.py` keeps the legacy code reachable for the K5 fixture suite and for archaeology when a future regression points back at orchestrate-era behavior. Once the parity surface is fully proven across multiple cycles, the archive can be removed; that's a follow-up issue.
+
+---
+
+## Acceptance
+
+- `acc:discover-and-decommission:E001-UNIT-001-orchestrate-stub-prints-migration-message`: `atdd orchestrate <args>` prints the migration message exactly (`atdd orchestrate has been removed in coach v9. Use 'atdd coach <issue-numbers>' instead. Migration: every flag maps directly per atdd-coach-spec-v9.md §5.1.`) and exits non-zero; no orchestrate machinery executes.
+- `acc:discover-and-decommission:E001-UNIT-002-no-internal-orchestrate-callsites`: zero non-archive callsites of `atdd orchestrate` exist in shipped code (excluding `commands/_archived/`, the K5 parity suite, CHANGELOG, and migration docs); zero direct imports of `commands._archived.orchestrate` exist outside the K5 parity suite; the orchestration convention file (`src/atdd/coach/conventions/orchestration.convention.yaml`) is unchanged and rule-ids continue to resolve via `bind_rule()`.
+- `acc:discover-and-decommission:E001-INTEGRATION-001-k5-parity-precondition`: CI blocks the merge unless the `#K5` parity suite is green on the PR's HEAD; P5 PR description references the K5 parity-suite job name and the green run; if K5 fails after P5 merges, the regression is attributable to the spawn-agents wagon.
+- `atdd orchestrate <args>` prints the migration message and exits non-zero (per the v3-spec smoke check).
+- No internal toolkit code paths call `atdd orchestrate` anymore (per the v3-spec smoke check).
+- Orchestration convention file (rule-IDs) unchanged — still resolvable via `bind_rule()` (per the v3-spec smoke check).
+- `#K5` parity suite passing on CI is a precondition for merge — operationalized "behavior parity" check (per the v3-spec smoke check).
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §0.2 (what `atdd orchestrate` does today and what coach absorbs), §4.6 (two-phase commit), §5.1 (`atdd coach` CLI surface — flag mapping), §11.3 (decommissioning `atdd orchestrate` and `atdd babysit`)
+- `atdd-coach-issues-v3.md` issue `#P5`
+- Wagon manifest: `plan/discover_and_decommission/_discover_and_decommission.yaml`
+- Feature: `plan/discover_and_decommission/features/legacy_cli_decommission.yaml`
+- WMBT: `plan/discover_and_decommission/E001.yaml`
+- Predecessors: `#J1`, `#J4`, `#K1`, `#K3`, `#K5` (parity-suite green precondition)
+- Sibling: `#P6` (decommission `atdd babysit`)
+- Substrate v12 precedent: `atdd urn` → `atdd repo` hard-cut rename
+- Source to archive: `commands/orchestrate.py` (~351 lines) → `commands/_archived/orchestrate.py`
+- Convention preserved: `src/atdd/coach/conventions/orchestration.convention.yaml`

--- a/.coach-v9-bootstrap/bodies/p6.md
+++ b/.coach-v9-bootstrap/bodies/p6.md
@@ -1,0 +1,109 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-p6-decommission-babysit` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `discover-and-decommission` |
+| Internal-Spec-Id | `P6` |
+| Feature | Decommission `atdd babysit` per spec §11.3: archive source, replace CLI registry entry with a stub printing the migration message, gated on the `#L8` babysit-parity suite passing on CI |
+
+---
+
+## Scope
+
+### In Scope
+
+Implements §11.3 decommissioning of `atdd babysit`. Same pattern as `#P5`: hard-cut, no shim, source archived, parity suite gates the merge.
+
+- **Move source.** `commands/babysit.py` (~1043 lines today; `BashPattern`, `_load_bash_patterns`, `classify_prompt`, `aggregate_approve`, `correct_naming_drift`, `correct_layout_drift`, `detect_violation`, `process_workspace`, `_screen_hash`, `_fetch_phase_cache`, `_phase_from_labels`, `_render_dashboard`, `SurfaceRow`, `_format_hms`, `load_token_alert_threshold`, `read_token_count`, `check_token_threshold`) moves to `commands/_archived/babysit.py`. The `#L8` parity suite imports the archived module to run side-by-side fixtures.
+- **Strip CLI registry.** Remove the `babysit` subcommand from the CLI registry so it no longer dispatches to the legacy implementation.
+- **Install stub.** Add a stub at `commands/babysit.py` (the original path) that prints exactly:
+
+  > `atdd babysit has been removed in coach v9. Use 'atdd observer status' (dashboard), 'atdd observer aggregate-approve' (batch approve), or 'atdd coach' (end-to-end) per atdd-coach-spec-v9.md §0.2.`
+
+  and exits non-zero. The stub does **not** execute any babysit machinery (no token polling, no screen-hash comparison, no `_render_dashboard` invocation).
+- **Update CHANGELOG.** Document the removal, link to spec §0.2 (absorption table) and §5.4 (`atdd observer` CLI surface).
+- **Verify reverse mapping.** Per spec §0.2, every absorbed capability resolves to an observer subcommand or observer rule:
+  - Token-count alerting → observer rule `06-token-threshold`.
+  - Bash auto-approval → observer rule `13-bash-auto-approve`.
+  - Aggregate approval → `atdd observer aggregate-approve`.
+  - Naming/layout drift correction → observer rules `14-canonical-naming-drift`, `15-layout-drift`.
+  - Violation detection (`detect_violation`) → observer rules `04-out-of-scope-edit`, `16-smoke-skip`.
+  - Dashboard (`_render_dashboard`, `SurfaceRow`) → `atdd observer status`.
+  - Workspace-state polling → replaced by event-driven runtime watchers (no parity test by design).
+  - Phase-cache-via-GitHub-labels → replaced by coach state-machine ownership of phase (no parity test by design).
+- **L8 parity precondition.** PR opens only after the L8 babysit-parity suite is green; PR description references the L8 job name and run.
+
+### Out of Scope
+
+- Decommissioning `atdd orchestrate` — that's `#P5`.
+- Re-implementing observer rules or dashboard from scratch — those ship in Track L (`#L1`–`#L7`).
+- Authoring the L8 parity suite itself — that's observe-and-correct wagon `#L8`.
+- Removing absorbed machinery from observer-side callsites — those are correct; only the legacy CLI surface is removed.
+- Building parity tests for replaced (not absorbed) capabilities — workspace polling and phase-cache-via-labels are intentionally replaced by event-driven and state-machine-driven equivalents respectively, and have no parity test (per spec §0.2).
+- Migration helper for legacy `babysit` config — `atdd observer` reads its own config under `coach.observer` (spec §10), no migration needed.
+
+### Dependencies
+
+- All of `#L1`–`#L7` (observer absorption complete) — `atdd observer` must reach behavior parity with babysit before babysit's CLI surface can be cut.
+- `#L8` — babysit-parity suite passing on CI (operationalized "behavior parity" gate; merge precondition).
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| `atdd babysit` CLI surface | Active 1043-line implementation; competes with `atdd observer` for the per-agent runtime watch role | Removed; entry point prints migration message and exits non-zero | Two runtime-watch entry points train operators to keep using babysit's polling model after coach v9's event-driven model lands |
+| Behavior-parity claim | Reviewer judgment that the absorbed observer rules + dashboard + aggregate-approve match babysit's behavior | `#L8` fixture suite asserts equivalent token-alert firing, bash-pattern auto-approval, naming/layout drift correction, dashboard output | Without parity tests, the absorption is a claim, not a contract; the fixed-handful `detect_violation` model can re-emerge by accident |
+| Reverse mapping coverage | Each absorbed capability is documented in spec §0.2 but not asserted | Reverse-mapping test enumerates each capability and asserts reachability through `atdd observer` or observer rules | Without it, a capability could be silently dropped during the cut and surface only when an operator's workflow breaks |
+| Replaced-not-absorbed capabilities | `process_workspace` polling and `_fetch_phase_cache` GitHub-label polling are intentionally replaced, not absorbed | Documented in spec §0.2 as replaced; no parity test exists for them | Without explicit documentation, future maintainers might add parity tests for replaced capabilities and block the decommission unnecessarily |
+
+### User Impact
+
+The "user" is every coach operator who today runs `atdd babysit` to watch a multi-agent session and every CI pipeline that backstops them. Per spec §0.2, the absorbed capability set covers the load-bearing operator behaviors (token alerts, bash auto-approval, naming drift, layout drift, smoke-skip detection, dashboard, aggregate-approve); the replaced set (workspace polling, phase-via-labels) is precisely the behavior coach v9 was designed to obsolete (event-driven watchers, state-machine ownership of phase).
+
+The lived target: an operator running `atdd babysit` after the cut sees the migration message, picks the right replacement (`atdd observer status` for the dashboard, `atdd observer aggregate-approve` for batch approval, `atdd coach` for end-to-end orchestration), and finds equivalent or better behavior. The L8 parity suite is the CI-enforced contract that makes "equivalent" mechanical.
+
+The reverse-mapping bar matters because babysit's surface is wider than orchestrate's (eight absorbed capabilities, two replaced). The acceptance asserts that every absorbed item lands in the observer surface, not just that the CLI is gone.
+
+### Design Anchor
+
+Same hard-cut precedent as `#P5`: substrate v12's `atdd urn` → `atdd repo` rename. No shim. The split between "absorbed" and "replaced" capabilities (spec §0.2) is the load-bearing distinction:
+
+- **Absorbed** = behavior coach v9 wants and re-homes under a new abstraction (extensible observer rules instead of the fixed-handful `detect_violation` model). Parity tests verify equivalent observable behavior.
+- **Replaced** = behavior coach v9 was designed to obsolete (polling). No parity test by design — the new abstraction is qualitatively different (event-driven), not equivalent.
+
+The choice to split P5 (orchestrate) and P6 (babysit) into separate PRs follows the parity-suite split: K5 lives in the spawn-agents wagon and gates orchestrate; L8 lives in the observe-and-correct wagon and gates babysit. One PR per gate keeps each merge attributable.
+
+---
+
+## Acceptance
+
+- `acc:discover-and-decommission:E002-UNIT-001-babysit-stub-prints-migration-message`: `atdd babysit <args>` prints the migration message exactly (`atdd babysit has been removed in coach v9. Use 'atdd observer status' (dashboard), 'atdd observer aggregate-approve' (batch approve), or 'atdd coach' (end-to-end) per atdd-coach-spec-v9.md §0.2.`) and exits non-zero; no babysit machinery executes.
+- `acc:discover-and-decommission:E002-UNIT-002-babysit-machinery-reachable-via-coach-and-observer`: every absorbed capability listed in spec §0.2 resolves to an `atdd observer` subcommand or observer rule (token-count → rule `06`; bash auto-approval → rule `13`; aggregate approval → `atdd observer aggregate-approve`; naming/layout drift → rules `14`/`15`; violation detection → rules `04`/`16`; dashboard → `atdd observer status`); workspace-state polling has been replaced by event-driven runtime watchers (no parity test by design); phase-cache-via-GitHub-labels has been replaced by coach state-machine ownership of phase (no parity test by design).
+- `acc:discover-and-decommission:E002-INTEGRATION-001-l8-parity-precondition`: CI blocks the merge unless the `#L8` parity suite is green on the PR's HEAD; P6 PR description references the L8 parity-suite job name and run; L8 asserts equivalent token-alert firing, bash-pattern auto-approval, naming/layout drift correction, and dashboard output between babysit and observer.
+- `atdd babysit <args>` prints migration message and exits non-zero (per the v3-spec smoke check).
+- All babysit machinery accessible through `atdd observer` or `atdd coach` (per the v3-spec smoke check).
+- `#L8` parity suite passing on CI is a precondition for merge — operationalized parity check (per the v3-spec smoke check).
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §0.2 (what `atdd babysit` does today and what coach absorbs/replaces), §5.4 (`atdd observer` CLI surface), §8 (observer architecture — detect-and-correct), §11.3 (decommissioning)
+- `atdd-coach-issues-v3.md` issue `#P6`
+- Wagon manifest: `plan/discover_and_decommission/_discover_and_decommission.yaml`
+- Feature: `plan/discover_and_decommission/features/legacy_cli_decommission.yaml`
+- WMBT: `plan/discover_and_decommission/E002.yaml`
+- Predecessors: `#L1`–`#L7` (observer absorption), `#L8` (parity-suite green precondition)
+- Sibling: `#P5` (decommission `atdd orchestrate`)
+- Substrate v12 precedent: `atdd urn` → `atdd repo` hard-cut rename
+- Source to archive: `commands/babysit.py` (~1043 lines) → `commands/_archived/babysit.py`

--- a/.coach-v9-bootstrap/launch-wagon-discover-and-decommission.txt
+++ b/.coach-v9-bootstrap/launch-wagon-discover-and-decommission.txt
@@ -1,0 +1,181 @@
+You are the discover-and-decommission wagon-authoring agent for ATDD coach v9.
+
+Worktree: /Users/alecfokapu/Github/atdd/feat-coach-v9-wagon-discover-and-decommission
+Branch: feat/coach-v9-wagon-discover-and-decommission
+Wagon: discover-and-decommission
+Wagon URN: wagon:discover-and-decommission
+Wagon snake-case dir: plan/discover_and_decommission/
+Spec track letter: P
+Track issues to author: P1, P2, P3, P4, P5, P6
+Archetypes for this wagon's issues: coach
+
+The train (`0002-coach-drives-lifecycle`), the 9-wagon registry, and the
+`freeze-runtime-contracts` wagon are ALREADY DONE on the parent branch
+`feat/coach-v9-bootstrap`. You inherit them. DO NOT modify the train YAML,
+plan/_trains.yaml, plan/_wagons.yaml, or plan/freeze_runtime_contracts/.
+
+## Read first (in this order)
+
+1. .coach-v9-bootstrap/briefing/track-wagon-map.md — train + 9-wagon table
+2. .coach-v9-bootstrap/briefing/compliant-issue-template.md — body shape
+3. .coach-v9-bootstrap/briefing/spec.md — coach v9 spec. Read at minimum:
+   - §0.1 (existing substrate) — REQUIRED context for every wagon
+   - §0.2 (what's absorbed from orchestrate/babysit) — REQUIRED for J/K/L tracks
+   - §3 (folder structure)
+   - The §§ that map to your track:
+     - C: §6 generally
+     - J: §4, §5.1
+     - K: §5.2, §7.1, §7.1.5
+     - L: §5.4, §8
+     - M: §6.4, §6.5, §6.6, §6.8
+     - N: §6.3, §7.2, §7.4
+     - O: §5.5, §6.9, §5.6, §6.10
+     - P: §5.7, §10, §11.3
+     - Q: §11.5, §11.6, §12
+4. .coach-v9-bootstrap/briefing/issues-v3.md — find the section labeled
+   `Track P` and read every issue under it
+5. plan/freeze_runtime_contracts/_freeze_runtime_contracts.yaml — the
+   already-authored sibling wagon. This is your STRUCTURAL TEMPLATE — your
+   wagon manifest must mirror its shape (urn, name, description, theme,
+   subject, context, action, goal, outcome, produce[], consume[]).
+6. plan/freeze_runtime_contracts/D001.yaml, D002.yaml, D003.yaml, D004.yaml —
+   WMBT YAML schema reference for your WMBTs
+7. plan/freeze_runtime_contracts/features/runtime-schema-freeze.yaml —
+   feature YAML schema reference
+
+## Deliver — in this exact order
+
+### 1. Wagon manifest
+
+plan/discover_and_decommission/_discover_and_decommission.yaml
+
+Mirror plan/freeze_runtime_contracts/_freeze_runtime_contracts.yaml shape
+exactly. Required fields:
+- wagon: discover-and-decommission
+- urn: "wagon:discover-and-decommission"
+- name: "{Title-Case version of WAGON_NAME}"
+- description: <one paragraph capturing what this wagon delivers per the
+  spec sections you read>
+- theme: commons
+- subject: "agent:coach"
+- context: <when this wagon's work matters in the lifecycle>
+- action: <what the wagon DOES>
+- goal: <what the wagon ENSURES or ENABLES>
+- outcome: <observable end state when the wagon is done>
+- produce[]: each output artifact (rule-IDs introduced, schemas, CLI
+  surface, observer rules, etc.) named distinctly per spec
+- consume[]: which sibling wagons this wagon depends on. Reference
+  upstream wagons by urn; e.g.,
+    - name: <artifact>
+      from: wagon:freeze-runtime-contracts
+
+### 2. Feature YAML(s)
+
+plan/discover_and_decommission/features/<feature-slug>.yaml
+
+At minimum one feature; multiple if the track issues split cleanly into
+>1 feature (e.g., L track has observer-rules feature + dashboard feature).
+
+Each feature follows plan/freeze_runtime_contracts/features/runtime-schema-freeze.yaml shape:
+- urn: "feature:discover-and-decommission:<feature-slug>"
+- wagon: "wagon:discover-and-decommission"
+- description
+- sizing: { wmbts, footprint_score, footprint_size }
+- wmbts: [list of WMBT URNs]
+- components: { backend / frontend / contract per existing schema }
+
+### 3. WMBT YAMLs — one per spec issue in your track
+
+For each spec issue {INTERNAL_ID} in P1, P2, P3, P4, P5, P6, create
+plan/discover_and_decommission/<step-prefix><NNN>.yaml where step-prefix matches the
+WMBT's intent:
+- D = define (most decision/spec issues)
+- E = execute (issues that produce a runtime action)
+- C = confirm (validators, gating issues)
+- L = locate (discovery commands)
+- R = resolve (resume / recovery)
+- M = monitor (observers, watchers)
+- P = prepare (config loaders, scaffolding)
+
+Mirror plan/freeze_runtime_contracts/D001.yaml shape EXACTLY. Required
+fields per WMBT:
+- urn: "wmbt:discover-and-decommission:<step-prefix><NNN>"
+- step (define / execute / confirm / locate / resolve / monitor / prepare)
+- direction (minimize / maximize)
+- dimension (quantity / likelihood / effort / frequency / etc.)
+- object_of_control: <kebab-or-hyphen-snake describing the bad-state being
+  controlled>
+- context_clarifier: <when this WMBT applies>
+- lens (functional.<facet> matching repo precedent — effectiveness,
+  efficiency, adaptability, sustainability, reliability)
+- statement: full natural-language version (must include "minimize <dim> of
+  <object> when <context>" or "maximize <dim> of …")
+- acceptances[]: one or more, each with:
+  - identity { urn: "acc:discover-and-decommission:<WMBT-step><NNN>-<HARNESS>-<NUM>-<slug>",
+               id (e.g. AC-UNIT-001), purpose, phase: GREEN }
+  - harness { type: unit | integration | contract | smoke,
+              category: backend | frontend | api | contract }
+  - given.abstract[]
+  - when.abstract
+  - then.abstract[]
+  - metadata { author: "atdd:self-compliance", created: "2026-05-09" }
+
+Lift acceptance bullets from the v3-spec issue's "Acceptance criteria"
+section verbatim — these are the contract this WMBT enforces.
+
+### 4. Issue body markdown — one per spec issue in your track
+
+.coach-v9-bootstrap/bodies/{INTERNAL_ID}.md
+
+For each {INTERNAL_ID} in P1, P2, P3, P4, P5, P6, write the compliant body per
+.coach-v9-bootstrap/briefing/compliant-issue-template.md. The body MUST:
+
+- Carry the Issue Metadata table populated with:
+  - Date: 2026-05-09
+  - Status: INIT
+  - Type: implementation
+  - Branch: feat/coach-v9-{INTERNAL_ID-lowercase}-<slug>
+  - Archetypes: coach
+  - Train: 0002-coach-drives-lifecycle
+  - Wagon: discover-and-decommission
+  - Internal-Spec-Id: {INTERNAL_ID}
+  - Feature: <one-line summary, ideally matches feature YAML description>
+- Reference predecessor issues by `#<INTERNAL_ID>` placeholders (e.g. `#J1`,
+  `#C0`). The filer pane rewrites these to GH numbers later. DO NOT hand-edit
+  GH numbers.
+- Acceptance bullets MUST start with the matching `acc:discover-and-decommission:...` URN
+  you created in step 3.
+
+### 5. Commit and push — DO NOT file issues
+
+Commit message:
+  feat(coach): coach v9 plan/ scaffolding — discover-and-decommission wagon
+
+  Authors discover-and-decommission wagon manifest, features, {N} WMBTs, and {N} issue
+  body markdowns under .coach-v9-bootstrap/bodies/. Issues file in a
+  later sequential pass with dep rewriting.
+
+Push: `git push -u origin feat/coach-v9-wagon-discover-and-decommission`
+
+DO NOT call `gh issue create` or `atdd issue` to file. Filing is the
+sequential filer pane's job. Your output is the bodies on disk.
+
+### 6. Open PR (against feat/coach-v9-bootstrap, not main)
+
+`gh pr create --base feat/coach-v9-bootstrap --title "feat(coach): coach v9 — discover-and-decommission wagon" --body "<short summary>"`
+
+Report the PR URL.
+
+### 7. Final state
+
+When you exit:
+- mapping/internal-to-gh.json: UNCHANGED (filer updates it)
+- .coach-v9-bootstrap/bodies/: contains your track's {N} *.md files
+- plan/discover_and_decommission/: contains manifest + features/ + WMBTs
+- A PR open against feat/coach-v9-bootstrap
+
+Do not stop early. Run `atdd validate planner --quick` after authoring to
+verify schema compliance; fix any new violations introduced by your wagon.
+Pre-existing failures are not your problem.
+
+Begin.

--- a/plan/discover_and_decommission/E001.yaml
+++ b/plan/discover_and_decommission/E001.yaml
@@ -1,0 +1,73 @@
+urn: "wmbt:discover-and-decommission:E001"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "legacy-atdd-orchestrate-callsites-after-coach-v9"
+context_clarifier: "when coach v9 ships and atdd orchestrate must be removed from the CLI surface — its source archived to commands/_archived/orchestrate.py, the CLI registry stripped of the orchestrate entry, a stub installed at the original entry point that prints the migration message ('atdd orchestrate has been removed in coach v9. Use atdd coach <issue-numbers> instead. Migration: every flag maps directly per atdd-coach-spec-v9.md §5.1.') and exits non-zero — gated on the K5 orchestrate-parity suite passing on CI so that 'behavior parity' between orchestrate and coach is operationalized rather than reviewer judgment"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of legacy-atdd-orchestrate-callsites-after-coach-v9 when coach v9 ships and atdd orchestrate must be removed from the CLI surface, with parity preserved through the K5 fixture suite and migration guidance surfaced via a stub command"
+acceptances:
+  - identity:
+      urn: "acc:discover-and-decommission:E001-UNIT-001-orchestrate-stub-prints-migration-message"
+      id: "AC-UNIT-001"
+      purpose: "atdd orchestrate <args> prints the migration message and exits non-zero"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "commands/orchestrate.py is replaced by a stub and the original moved to commands/_archived/orchestrate.py"
+        - "The CLI registry no longer dispatches orchestrate to the legacy implementation"
+    when:
+      abstract: "atdd orchestrate is invoked with any arg combination"
+    then:
+      abstract:
+        - "stdout or stderr contains exactly the migration message: 'atdd orchestrate has been removed in coach v9. Use atdd coach <issue-numbers> instead. Migration: every flag maps directly per atdd-coach-spec-v9.md §5.1.'"
+        - "Process exit code is non-zero"
+        - "No orchestrate machinery executes (no worktree creation, no multiplexer launch)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:E001-UNIT-002-no-internal-orchestrate-callsites"
+      id: "AC-UNIT-002"
+      purpose: "No internal toolkit code paths call atdd orchestrate after decommissioning"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "K5 orchestrate-parity suite passes on CI before P5 lands"
+    when:
+      abstract: "A grep across the repository searches for 'atdd orchestrate' invocations and direct imports of the archived module"
+    then:
+      abstract:
+        - "Zero non-archive callsites of atdd orchestrate exist in shipped code (excluding commands/_archived/, parity tests, CHANGELOG, and documentation referencing the migration)"
+        - "Zero direct imports of commands._archived.orchestrate exist outside the K5 parity suite"
+        - "The orchestration convention file (src/atdd/coach/conventions/orchestration.convention.yaml) is unchanged and rule-ids continue to resolve via bind_rule()"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:E001-INTEGRATION-001-k5-parity-precondition"
+      id: "AC-INTEGRATION-001"
+      purpose: "The K5 parity suite passing on CI is a precondition for merging P5"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "K5 lives in the spawn-agents wagon and runs side-by-side fixtures comparing atdd orchestrate (preserved code path) and atdd coach equivalent invocations"
+    when:
+      abstract: "P5 is opened as a PR"
+    then:
+      abstract:
+        - "CI blocks the merge unless the K5 parity suite is green on the PR's HEAD"
+        - "P5 PR description references the K5 parity-suite job name and the green run"
+        - "If K5 fails after P5 merges, the regression is attributable to the spawn-agents wagon, not the decommissioning"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/discover_and_decommission/E002.yaml
+++ b/plan/discover_and_decommission/E002.yaml
@@ -1,0 +1,73 @@
+urn: "wmbt:discover-and-decommission:E002"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "legacy-atdd-babysit-callsites-after-coach-v9"
+context_clarifier: "when coach v9 ships and atdd babysit must be removed from the CLI surface — its source archived to commands/_archived/babysit.py, the CLI registry stripped, a stub installed at the original entry point that prints the migration message ('atdd babysit has been removed in coach v9. Use atdd observer status (dashboard), atdd observer aggregate-approve (batch approve), or atdd coach (end-to-end) per atdd-coach-spec-v9.md §0.2.') and exits non-zero — gated on the L8 babysit-parity suite passing on CI so that the absorbed observer rules / dashboard / aggregate-approve / drift correctors deliver behavior parity with the legacy babysit machinery"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of legacy-atdd-babysit-callsites-after-coach-v9 when coach v9 ships and atdd babysit must be removed from the CLI surface, with parity preserved through the L8 fixture suite and migration guidance surfaced via a stub command"
+acceptances:
+  - identity:
+      urn: "acc:discover-and-decommission:E002-UNIT-001-babysit-stub-prints-migration-message"
+      id: "AC-UNIT-001"
+      purpose: "atdd babysit <args> prints the migration message and exits non-zero"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "commands/babysit.py is replaced by a stub and the original moved to commands/_archived/babysit.py"
+        - "The CLI registry no longer dispatches babysit to the legacy implementation"
+    when:
+      abstract: "atdd babysit is invoked with any arg combination"
+    then:
+      abstract:
+        - "stdout or stderr contains exactly the migration message: 'atdd babysit has been removed in coach v9. Use atdd observer status (dashboard), atdd observer aggregate-approve (batch approve), or atdd coach (end-to-end) per atdd-coach-spec-v9.md §0.2.'"
+        - "Process exit code is non-zero"
+        - "No babysit machinery executes (no token polling, no screen-hash comparison, no _render_dashboard invocation)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:E002-UNIT-002-babysit-machinery-reachable-via-coach-and-observer"
+      id: "AC-UNIT-002"
+      purpose: "All babysit machinery is reachable through atdd observer or atdd coach equivalents"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Per spec §0.2, the absorbed mapping is: token-count alerting → observer rule 06; bash auto-approval → observer rule 13; aggregate approval → atdd observer aggregate-approve; naming/layout drift → observer rules 14/15; violation detection → observer rules 04/16; dashboard → atdd observer status"
+    when:
+      abstract: "A reverse mapping test enumerates each absorbed babysit capability and asserts reachability"
+    then:
+      abstract:
+        - "Every capability listed in spec §0.2 resolves to an atdd observer subcommand or observer rule"
+        - "Workspace-state polling has been replaced by event-driven runtime watchers from track L (no polling parity test exists by design)"
+        - "Phase-cache-via-GitHub-labels has been replaced by coach state-machine ownership of phase (no parity test exists by design)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:E002-INTEGRATION-001-l8-parity-precondition"
+      id: "AC-INTEGRATION-001"
+      purpose: "The L8 parity suite passing on CI is a precondition for merging P6"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "L8 lives in the observe-and-correct wagon and runs side-by-side fixtures comparing atdd babysit and atdd observer against fixture multiplexer states"
+    when:
+      abstract: "P6 is opened as a PR"
+    then:
+      abstract:
+        - "CI blocks the merge unless the L8 parity suite is green on the PR's HEAD"
+        - "P6 PR description references the L8 parity-suite job name and the green run"
+        - "L8 asserts equivalent token-alert firing, bash-pattern auto-approval, naming/layout drift correction, and dashboard output between babysit and observer"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/discover_and_decommission/L001.yaml
+++ b/plan/discover_and_decommission/L001.yaml
@@ -1,0 +1,75 @@
+urn: "wmbt:discover-and-decommission:L001"
+step: "locate"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "unsurfaced-rule-registry-entries-in-discovery-cli"
+context_clarifier: "when humans escalating a violation, agents needing rule context for self-correction, and toolkit debuggers all need to resolve a rule-id (or alias) into its severity, disposition, validator, fix_hint, recipe, source convention, and emitting validator module::function — across both toolkit-archetype rules and substrate-derived repo.* rules — without grepping the codebase or opening convention YAMLs"
+lens: "functional.effectiveness"
+statement: "minimize quantity of unsurfaced-rule-registry-entries-in-discovery-cli when humans, agents, and toolkit debuggers need to resolve a rule-id into its full metadata, locate the validator that emits it, or grep descriptions/IDs/aliases without leaving the CLI"
+acceptances:
+  - identity:
+      urn: "acc:discover-and-decommission:L001-UNIT-001-rules-show-resolves-toolkit-and-repo"
+      id: "AC-UNIT-001"
+      purpose: "atdd rules show <id> resolves toolkit and substrate-derived repo.* rules transparently and prints full RuleMetadata fields"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "bind_rule() resolves canonical rule-ids and legacy aliases (existing substrate)"
+        - "The rule registry contains both toolkit rules (e.g., coder.dead-code.reachability) and substrate-derived repo.* rules (e.g., repo.govern-lifecycle.D003-acc-unit-001)"
+    when:
+      abstract: "atdd rules show <rule-id> is invoked for a toolkit rule, a repo.* rule, and a legacy-alias rule-id"
+    then:
+      abstract:
+        - "Each invocation prints severity, description, disposition, validator, fix_hint, recipe, introduced_in, and source convention path"
+        - "Legacy aliases resolve to their canonical rule-id and display both forms"
+        - "Substrate repo.* rules resolve via the same surface and display the bound acceptance_urn"
+        - "Unknown rule-ids exit non-zero with a clear error message"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:L001-UNIT-002-rules-where-prints-validator-callsite"
+      id: "AC-UNIT-002"
+      purpose: "atdd rules where <id> prints the validator <module>::<function> reference and the import path inferred from the archetype"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Every rule-id has at least one validator that calls bind_rule(<id>) at module-import time per the rule-id substrate"
+    when:
+      abstract: "atdd rules where <rule-id> is invoked for toolkit and repo.* rule-ids"
+    then:
+      abstract:
+        - "The output is a single line of the form <module>::<function> with the import path derived from the archetype field (coder.* → src/atdd/coder/validators/, repo.* → substrate dispatcher)"
+        - "Rules with multiple bindings list every callsite, one per line"
+        - "Unknown rule-ids exit non-zero with a clear error message"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:L001-UNIT-003-rules-grep-searches-id-description-alias"
+      id: "AC-UNIT-003"
+      purpose: "atdd rules grep <pattern> searches across rule-id, description, and aliases and returns matching rules from both registries"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The rule registry exposes a uniform iterator over toolkit and repo.* rules"
+    when:
+      abstract: "atdd rules grep <pattern> is invoked with a substring pattern"
+    then:
+      abstract:
+        - "Output lists every rule whose rule-id, description, or alias contains the pattern (case-insensitive)"
+        - "Each line shows rule-id, severity, disposition, and a one-line description"
+        - "Empty result exits non-zero (no matches) without crashing"
+        - "The grep surface is consistent across toolkit and repo.* archetypes"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/discover_and_decommission/L002.yaml
+++ b/plan/discover_and_decommission/L002.yaml
@@ -1,0 +1,78 @@
+urn: "wmbt:discover-and-decommission:L002"
+step: "locate"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "unsurfaced-disposition-archetype-and-suppression-listings"
+context_clarifier: "when operators triaging CI failures, agents respawning under feedback, and reviewers prioritizing risk all need to enumerate every rule with a given disposition (strict / suppress-and-clean / advisory / documentation-only), every rule under a given archetype (coder / coach / tester / planner / repo), or every active or stale suppression marker in the working tree — without manually walking convention YAMLs or rerunning the suppression scanner"
+lens: "functional.effectiveness"
+statement: "minimize quantity of unsurfaced-disposition-archetype-and-suppression-listings when operators, agents, and reviewers need to enumerate rules by disposition or archetype and surface active or stale suppression markers from a single CLI"
+acceptances:
+  - identity:
+      urn: "acc:discover-and-decommission:L002-UNIT-001-rules-disposition-lists-strict-and-others"
+      id: "AC-UNIT-001"
+      purpose: "atdd rules disposition <strict|suppress-and-clean|advisory|documentation-only> lists every rule with the given disposition across toolkit and repo.* registries"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Toolkit conventions declare per-rule disposition; repo.* rules are uniformly strict per substrate v12 §2"
+    when:
+      abstract: "atdd rules disposition strict is invoked, then each of the other three dispositions"
+    then:
+      abstract:
+        - "atdd rules disposition strict lists every strict rule across both registries (toolkit + repo)"
+        - "atdd rules disposition suppress-and-clean lists every toolkit suppress-and-clean rule and lists zero repo.* rules"
+        - "atdd rules disposition advisory and documentation-only list only toolkit rules"
+        - "Each line shows rule-id, archetype, severity, and a one-line description"
+        - "Invalid disposition value exits non-zero with a list of the four valid options"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:L002-UNIT-002-rules-archetype-lists-coder-coach-tester-planner-repo"
+      id: "AC-UNIT-002"
+      purpose: "atdd rules archetype <coder|coach|tester|planner|repo> lists every rule under the given archetype"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "Rule-ids encode archetype as the first dotted segment per SPEC-COACH-RULEID-0001"
+    when:
+      abstract: "atdd rules archetype <name> is invoked for each of coder, coach, tester, planner, and repo"
+    then:
+      abstract:
+        - "atdd rules archetype repo lists every substrate-derived rule (WMBT-acceptance, train-acceptance, security)"
+        - "atdd rules archetype coder, coach, tester, planner each list their respective toolkit rules"
+        - "Output is sorted by rule-id within an archetype for stable diffing"
+        - "Unknown archetype exits non-zero listing the five valid options"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:L002-UNIT-003-rules-suppressions-delegates-to-scanner"
+      id: "AC-UNIT-003"
+      purpose: "atdd rules suppressions [--stale-only] [--rule <id>] delegates to find_suppressions / find_stale_suppressions and lists active markers"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "find_suppressions() and find_stale_suppressions() exist in the existing toolkit machinery"
+        - "The working tree contains a mix of active and UNTIL-past suppression markers across multiple files"
+    when:
+      abstract: "atdd rules suppressions is invoked with no flags, then with --stale-only, then with --rule <id>"
+    then:
+      abstract:
+        - "The default invocation lists every active suppression marker with file path, line, rule-id, UNTIL date"
+        - "--stale-only filters to markers whose UNTIL date has passed today"
+        - "--rule <id> filters to markers for the given rule-id"
+        - "Markers referencing repo.* rules are surfaced as warnings (substrate-unsuppressible per substrate v12 §2)"
+        - "Empty result exits zero (clean working tree is the success case)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/discover_and_decommission/P001.yaml
+++ b/plan/discover_and_decommission/P001.yaml
@@ -1,0 +1,54 @@
+urn: "wmbt:discover-and-decommission:P001"
+step: "prepare"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "ambiguity-in-per-llm-convention-file-regeneration"
+context_clarifier: "when atdd sync must regenerate per-LLM convention files (CLAUDE.md, AGENTS.md, GLM.md, GEMINI.md) from the K4 spawn-harness templates so that every persona that spawns under coach v9 reads identical rule-id grammar, bind_rule contract guidance, and forbidden/required sections — and repeated runs must be idempotent so that atdd sync never produces a noisy diff in CI when the templates have not changed"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of ambiguity-in-per-llm-convention-file-regeneration when atdd sync regenerates the per-LLM agent convention files from the K4 templates and CI must observe idempotent reruns"
+acceptances:
+  - identity:
+      urn: "acc:discover-and-decommission:P001-UNIT-001-sync-regenerates-per-llm-convention-files"
+      id: "AC-UNIT-001"
+      purpose: "atdd sync regenerates CLAUDE.md, AGENTS.md, GLM.md, and GEMINI.md from the K4 templates"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "K4 has shipped per-LLM convention templates that include rule-id grammar, bind_rule contract, and forbidden/required sections per spec §7.1"
+        - "Existing CLAUDE.md, AGENTS.md, GLM.md, GEMINI.md exist at the repo root with sync-managed regions"
+    when:
+      abstract: "atdd sync is invoked"
+    then:
+      abstract:
+        - "Each per-LLM file is regenerated from the corresponding K4 template into the file's sync-managed region"
+        - "Rule-id grammar and bind_rule contract sections render correctly with substrate-derived examples"
+        - "Forbidden and required sections render correctly per the persona convention"
+        - "Files outside the sync-managed region (per-LLM hand-edits) are preserved verbatim"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:P001-UNIT-002-sync-is-idempotent"
+      id: "AC-UNIT-002"
+      purpose: "Repeated atdd sync runs are idempotent — a second invocation produces no file changes when the templates have not changed"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd sync has been invoked once and produced the regenerated per-LLM files"
+        - "No template, rule-id, or convention file has changed between invocations"
+    when:
+      abstract: "atdd sync is invoked a second time"
+    then:
+      abstract:
+        - "git status shows zero changes after the second invocation"
+        - "Stable ordering of rule-ids, conventions, and sections is preserved across runs"
+        - "CI can run atdd sync as a verification step without producing a noisy diff"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/discover_and_decommission/P002.yaml
+++ b/plan/discover_and_decommission/P002.yaml
@@ -1,0 +1,58 @@
+urn: "wmbt:discover-and-decommission:P002"
+step: "prepare"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "unparsed-coach-config-fields"
+context_clarifier: "when coach reads .atdd/config.yaml::coach at startup and every field listed in spec §10 — default_llm, persona_llm, judge_llm, observer (rules_dir, activity_silence_seconds, process_silence_seconds), review (enabled, phases, same_model_warning, same_model_allowed), validators (enabled, grace_window_seconds, selection, pytest_args), suppressions (honor, block_on_stale, grace_days), risk_thresholds (planned/red/green/smoke/refactor/complete), judge (enabled, fail_open, log_full_inputs), issue_review (passes, llms, dimensions, require_for_coach, stale_after_days), escalation (channel, slack_webhook, github_label), retries (per_state_machine, per_agent), token_alert_threshold — must parse with documented defaults, while invalid or unknown fields must raise loud errors so misconfiguration cannot silently degrade coach behavior"
+lens: "functional.effectiveness"
+statement: "minimize quantity of unparsed-coach-config-fields when coach reads .atdd/config.yaml::coach at startup and every spec-§10 field must apply documented defaults while invalid or unknown fields raise loud errors"
+acceptances:
+  - identity:
+      urn: "acc:discover-and-decommission:P002-UNIT-001-load-atdd-config-parses-coach-block"
+      id: "AC-UNIT-001"
+      purpose: "load_atdd_config parses the coach.* block per spec §10 and applies defaults for missing fields"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "load_atdd_config exists and parses .atdd/config.yaml"
+        - "Spec §10 enumerates the required fields and their defaults"
+    when:
+      abstract: "load_atdd_config is invoked against a config that omits every coach.* field, then against a config that overrides a subset"
+    then:
+      abstract:
+        - "An empty coach block returns a CoachConfig populated with every default per spec §10"
+        - "Overridden fields take effect and unmentioned fields fall back to spec §10 defaults"
+        - "risk_thresholds defaults are planned: null, red: null, green: 10, smoke: 15, refactor: 5, complete: 0"
+        - "validators defaults are enabled: true, grace_window_seconds: 30, selection: default, pytest_args: ['-x', '--tb=short']"
+        - "suppressions defaults are honor: true, block_on_stale: true, grace_days: 7"
+        - "judge defaults are enabled: true, fail_open: false, log_full_inputs: false"
+        - "issue_review defaults are passes: 3, llms: [claude-haiku, gpt-5-mini, gemini-flash], dimensions: [systemic, ambiguities, gap, regression, comprehensiveness], require_for_coach: warn, stale_after_days: 14"
+        - "token_alert_threshold default is 400000"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:discover-and-decommission:P002-UNIT-002-invalid-fields-raise-loud-errors"
+      id: "AC-UNIT-002"
+      purpose: "Invalid or unknown coach.* fields raise loud errors at load time"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "load_atdd_config validates parsed coach.* values against the spec §10 schema"
+    when:
+      abstract: "load_atdd_config is invoked against a config containing typoed keys, out-of-range numbers, mistyped scalars, or unknown enumeration values"
+    then:
+      abstract:
+        - "Each invalid input raises a configuration error naming the offending key and its expected type or enumeration"
+        - "Risk-threshold values are checked for non-negativity (null is allowed where spec lists it)"
+        - "Unknown top-level keys under coach.* fail loudly rather than being silently dropped"
+        - "Error messages reference spec §10 so the operator can find the canonical schema"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/discover_and_decommission/_discover_and_decommission.yaml
+++ b/plan/discover_and_decommission/_discover_and_decommission.yaml
@@ -1,0 +1,95 @@
+wagon: discover-and-decommission
+urn: "wagon:discover-and-decommission"
+name: "Discover And Decommission"
+description: "Track P deliverables for coach v9: rule-registry discovery commands (atdd rules show / where / grep / disposition / archetype / suppressions), per-LLM convention file regeneration in atdd sync, the coach.* config loader, and the hard-cut decommissioning of atdd orchestrate (gated on K5 parity) and atdd babysit (gated on L8 parity)"
+theme: commons
+
+subject: "agent:coach"
+context: "in-coach-v9-execution, parity-test-suites-passing-on-ci"
+action: "exposes rule-registry discovery commands, regenerates per-LLM convention files from spawn-harness templates, parses the coach.* configuration block, and removes legacy orchestrate / babysit entry points from the CLI"
+goal: "give humans and agents discovery handles into the rule registry, freeze the configuration shape coach reads at runtime, and finalize the v9 hard cut from atdd orchestrate / atdd babysit to atdd coach + atdd observer + atdd spawn"
+outcome: "atdd rules subcommands resolve toolkit and repo rules transparently; atdd sync regenerates CLAUDE.md / AGENTS.md / GLM.md idempotently from the K4 templates; load_atdd_config parses the coach.* block per spec §10 with defaults applied and invalid fields rejected loudly; atdd orchestrate and atdd babysit print migration messages, exit non-zero, and have their source archived under commands/_archived/"
+
+features:
+  - urn: "feature:discover-and-decommission:rules-discovery"
+  - urn: "feature:discover-and-decommission:convention-sync-and-config-loader"
+  - urn: "feature:discover-and-decommission:legacy-cli-decommission"
+
+produce:
+  - name: cli:atdd-rules-show
+    contract: null
+    telemetry: null
+    to: external
+  - name: cli:atdd-rules-where
+    contract: null
+    telemetry: null
+    to: external
+  - name: cli:atdd-rules-grep
+    contract: null
+    telemetry: null
+    to: external
+  - name: cli:atdd-rules-disposition
+    contract: null
+    telemetry: null
+    to: external
+  - name: cli:atdd-rules-archetype
+    contract: null
+    telemetry: null
+    to: external
+  - name: cli:atdd-rules-suppressions
+    contract: null
+    telemetry: null
+    to: external
+  - name: cli:atdd-sync-per-llm-convention-file-generation
+    contract: null
+    telemetry: null
+    to: external
+  - name: config:coach-block-loader
+    contract: null
+    telemetry: null
+    to: external
+  - name: cli:atdd-orchestrate-decommission-stub
+    contract: null
+    telemetry: null
+    to: external
+  - name: cli:atdd-babysit-decommission-stub
+    contract: null
+    telemetry: null
+    to: external
+  - name: archive:commands-archived-orchestrate
+    contract: null
+    telemetry: null
+    to: external
+  - name: archive:commands-archived-babysit
+    contract: null
+    telemetry: null
+    to: external
+
+consume:
+  - name: commons:coach:runtime-event-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:decision-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:judgment-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:correction-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:validator-result-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:risk-score-schema
+    from: wagon:freeze-runtime-contracts
+  - name: spawn:per-llm-convention-templates
+    from: wagon:spawn-agents
+  - name: spawn:orchestrate-parity-suite
+    from: wagon:spawn-agents
+  - name: observer:babysit-parity-suite
+    from: wagon:observe-and-correct
+
+wmbt:
+  total: 6
+  L001: "minimize quantity of unsurfaced-rule-registry-entries-in-discovery-cli"
+  L002: "minimize quantity of unsurfaced-disposition-archetype-and-suppression-listings"
+  P001: "minimize ambiguity-in-per-llm-convention-file-regeneration"
+  P002: "minimize quantity of unparsed-coach-config-fields"
+  E001: "minimize likelihood of legacy-atdd-orchestrate-callsites-after-coach-v9"
+  E002: "minimize likelihood of legacy-atdd-babysit-callsites-after-coach-v9"

--- a/plan/discover_and_decommission/features/convention_sync_and_config_loader.yaml
+++ b/plan/discover_and_decommission/features/convention_sync_and_config_loader.yaml
@@ -1,0 +1,31 @@
+urn: "feature:discover-and-decommission:convention-sync-and-config-loader"
+wagon: "wagon:discover-and-decommission"
+description: "atdd sync regenerates per-LLM convention files (CLAUDE.md, AGENTS.md, GLM.md, GEMINI.md) from the K4 templates idempotently, and load_atdd_config parses the coach.* configuration block per spec §10 with defaults applied and invalid fields rejected. Together they freeze the spawn-time agent context and runtime configuration shape coach reads"
+sizing:
+  wmbts: 2
+  footprint_score: 4
+  footprint_size: "S"
+wmbts:
+  - "wmbt:discover-and-decommission:P001"
+  - "wmbt:discover-and-decommission:P002"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 1
+        rationale: "Extends the existing atdd sync command with per-LLM regeneration step (no new top-level command)"
+    application:
+      - type: "use_cases"
+        count: 2
+        rationale: "Per-LLM convention regeneration use-case + coach.* config-loader extension use-case"
+    domain:
+      - type: "value_objects"
+        count: 1
+        rationale: "CoachConfig value object capturing the parsed coach.* block (persona_llm, judge, observer, validators, suppressions, risk_thresholds, judge, issue_review, escalation, retries, token_alert_threshold)"
+    integration:
+      - type: "templates"
+        count: 4
+        rationale: "Per-LLM template files (CLAUDE.md, AGENTS.md, GLM.md, GEMINI.md) consumed from K4; this feature drives them through atdd sync"
+      - type: "config_schema"
+        count: 1
+        rationale: "Schema/validation for the coach.* block in .atdd/config.yaml"

--- a/plan/discover_and_decommission/features/legacy_cli_decommission.yaml
+++ b/plan/discover_and_decommission/features/legacy_cli_decommission.yaml
@@ -1,0 +1,31 @@
+urn: "feature:discover-and-decommission:legacy-cli-decommission"
+wagon: "wagon:discover-and-decommission"
+description: "Hard cut of atdd orchestrate and atdd babysit per spec §11.3. Source archived to commands/_archived/, CLI registry entries replaced by stubs that print migration messages and exit non-zero. Gated on the K5 orchestrate-parity suite and L8 babysit-parity suite passing on CI so that 'behavior parity' is operationalized rather than reviewer-judgment"
+sizing:
+  wmbts: 2
+  footprint_score: 5
+  footprint_size: "M"
+wmbts:
+  - "wmbt:discover-and-decommission:E001"
+  - "wmbt:discover-and-decommission:E002"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 2
+        rationale: "Two stub commands at the legacy entry points (atdd orchestrate, atdd babysit) that print migration messages and exit non-zero"
+    application:
+      - type: "use_cases"
+        count: 0
+        rationale: "Pure removal + stub; no new application logic"
+    domain:
+      - type: "value_objects"
+        count: 0
+        rationale: "No new domain types"
+    integration:
+      - type: "archives"
+        count: 2
+        rationale: "commands/_archived/orchestrate.py and commands/_archived/babysit.py preserve the legacy source for reference and for K5/L8 parity-suite reuse"
+      - type: "ci_gates"
+        count: 2
+        rationale: "K5 orchestrate-parity and L8 babysit-parity CI gates that must pass before P5/P6 can land"

--- a/plan/discover_and_decommission/features/rules_discovery.yaml
+++ b/plan/discover_and_decommission/features/rules_discovery.yaml
@@ -1,0 +1,28 @@
+urn: "feature:discover-and-decommission:rules-discovery"
+wagon: "wagon:discover-and-decommission"
+description: "atdd rules discovery surface — six subcommands (show, where, grep, disposition, archetype, suppressions) that wrap bind_rule(), the substrate registry, and find_suppressions()/find_stale_suppressions(). Resolves toolkit and substrate-derived repo.* rules transparently per spec §5.7"
+sizing:
+  wmbts: 2
+  footprint_score: 4
+  footprint_size: "S"
+wmbts:
+  - "wmbt:discover-and-decommission:L001"
+  - "wmbt:discover-and-decommission:L002"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 6
+        rationale: "Six CLI subcommand entry points under atdd rules: show, where, grep, disposition, archetype, suppressions"
+    application:
+      - type: "use_cases"
+        count: 6
+        rationale: "One use-case per subcommand orchestrating registry resolution, output formatting, and (for suppressions) suppression-scanner delegation"
+    domain:
+      - type: "value_objects"
+        count: 0
+        rationale: "Reuses existing RuleMetadata, Violation, and Suppression dataclasses — no new domain values introduced"
+    integration:
+      - type: "adapters"
+        count: 0
+        rationale: "Wraps existing utilities (bind_rule, find_suppressions, find_stale_suppressions, registry iterators) — no new external integration"


### PR DESCRIPTION
## Summary

Authors the `discover-and-decommission` wagon (Track P) of the coach v9 implementation. This wagon delivers:

- **`atdd rules` discovery commands** (P1, P2) — show, where, grep, disposition, archetype, suppressions wrapping `bind_rule()`, the substrate registry iterator, and `find_suppressions()` per spec §5.7.
- **Convention sync + config loader** (P3, P4) — per-LLM convention file regeneration in `atdd sync` from K4 templates (idempotent), and `load_atdd_config` extension for the `coach.*` block per spec §10 with documented defaults and loud errors on invalid fields.
- **Legacy CLI decommission** (P5, P6) — hard-cut of `atdd orchestrate` (gated on `#K5` parity) and `atdd babysit` (gated on `#L8` parity); source archived to `commands/_archived/`, stubs print migration messages, exit non-zero. Convention file (`orchestration.convention.yaml`) preserved as the rule-id home for absorbed rules.

## What's in this PR

- `plan/discover_and_decommission/_discover_and_decommission.yaml` — wagon manifest (subject/context/action/goal/outcome, three features, twelve produce[] artifacts, consumes from `freeze-runtime-contracts` / `spawn-agents` / `observe-and-correct`).
- `plan/discover_and_decommission/features/` — three feature YAMLs: `rules_discovery`, `convention_sync_and_config_loader`, `legacy_cli_decommission`.
- `plan/discover_and_decommission/{L001,L002,P001,P002,E001,E002}.yaml` — six WMBTs, one per spec issue (P1–P6), with full acceptance criteria lifted verbatim from `atdd-coach-issues-v3.md` Track P.
- `.coach-v9-bootstrap/bodies/{p1..p6}.md` — six issue body markdowns per the compliant template, with internal-spec dependencies referenced as `#J1`, `#K4`, `#K5`, `#L1–#L8` placeholders for the filer pane to rewrite to GH numbers.

## Step-prefix mapping (P-track WMBTs)

| Spec | WMBT | Step | Object of control |
|------|------|------|-------------------|
| P1 | L001 | locate | unsurfaced-rule-registry-entries-in-discovery-cli |
| P2 | L002 | locate | unsurfaced-disposition-archetype-and-suppression-listings |
| P3 | P001 | prepare | ambiguity-in-per-llm-convention-file-regeneration |
| P4 | P002 | prepare | unparsed-coach-config-fields |
| P5 | E001 | execute | legacy-atdd-orchestrate-callsites-after-coach-v9 |
| P6 | E002 | execute | legacy-atdd-babysit-callsites-after-coach-v9 |

## Notes

- Issues are NOT filed in this PR. The sequential filer pane consumes the bodies + WMBTs/manifest and rewrites `#<INTERNAL_ID>` → real GH numbers in topological order.
- Pre-existing planner-validator failures (project board, branch-on-meta-issue #386, sibling-PR base #485/#486, rule-uniqueness) are unrelated to this wagon's authored content.
- Base = `feat/coach-v9-bootstrap` per the parallel wagon-authoring session protocol.

## Test plan

- [ ] Filer pane processes `.coach-v9-bootstrap/bodies/{p1..p6}.md` and rewrites internal-spec deps after merging into `feat/coach-v9-bootstrap`.
- [ ] WMBT URNs and acceptance URNs in body files resolve against authored YAMLs in `plan/discover_and_decommission/`.
- [ ] `atdd validate planner --quick` introduces no new violations beyond the pre-existing baseline.