### PR TITLE
feat(coach): coach v9 — review-phase-boundaries wagon

### DIFF
--- a/.coach-v9-bootstrap/bodies/N1.md
+++ b/.coach-v9-bootstrap/bodies/N1.md
@@ -1,0 +1,89 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-n1-reviewer-persona-no-write` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `review-phase-boundaries` |
+| Internal-Spec-Id | `N1` |
+| Feature | Reviewer persona spawn-adapter variant that strips commit/edit tools, embeds a no-write system prompt, and bounds the reviewer's only output channel to `atdd agent review --target-commit <sha> --report-file <path>` |
+
+---
+
+## Scope
+
+### In Scope
+
+- A reviewer-persona variant of the spawn adapter shipped by `wagon:spawn-agents` (#K2). The variant layers over the base adapter to:
+  - Strip every commit/edit tool from the rendered tool allowlist (no `Edit`, `Write`, `NotebookEdit`, `MultiEdit`, `git commit`, or any other worktree-mutating surface).
+  - Embed a system prompt explicitly forbidding edits and naming `atdd agent review --target-commit <sha> --report-file <path>` as the sole output channel.
+  - Pass the rule-ID-aware context bundle so the reviewer can resolve canonical rule_ids per spec §7.2.
+- Persona registration: `--persona reviewer` must resolve through the spawn adapter, with the launch prompt rendered from the per-phase reviewer template (#N3).
+- Agent CLI guard: when persona=reviewer, `atdd agent commit` is rejected with a clear error citing the no-write reviewer constraint. `atdd agent review` is the only sanctioned write surface.
+- Coupling with observer rule `08-reviewer-edit-attempt` (already authored under `wagon:observe-and-correct`, #L2). The adapter is the structural defense; the observer rule is the runtime catch.
+- File path: `src/atdd/coach/spawn/reviewer_adapter.py` (or equivalent module) layered over the base adapter from #K2.
+
+### Out of Scope
+
+- The reviewer-prompt body itself — that's #N3 (per-phase prompts at `src/atdd/coach/prompts/persona/reviewer/<phase>.prompt.yaml`).
+- The review-report schema and intake validation — that's #N2.
+- The `atdd agent review` runtime command — that's #N5.
+- Judge call site #2 wiring on `verdict: concern` — that's #N4.
+- The base spawn adapter, multiplexer launch, canonical naming/layout — those live in `wagon:spawn-agents` (#K2, #K3, #K4).
+- Observer rule `08-reviewer-edit-attempt` — already authored in #L2.
+
+### Dependencies
+
+- `#K2` — base spawn adapter that the reviewer variant layers over.
+- `#M3` — tier-1 validator dispatch produces the `tier1_risk_score` and validator-result findings the reviewer's bundle references at intake (per spec §7.4).
+- `src/atdd/coach/schemas/runtime-event.schema.json` (from #C0) — for the events the reviewer emits.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Reviewer write authority | No reviewer persona exists; if added naively atop the base spawn adapter, the reviewer inherits Edit/Write/commit tools | A reviewer-persona spawn-adapter variant strips every worktree-mutating tool and embeds a no-write system prompt | A reviewer with edit authority can mutate the artifact under review, defeating adversarial review and biasing the verdict (spec §6.3 hard rule: "No write permission to the worktree") |
+| Reviewer output channel | Without a sanctioned channel, a reviewer might commit, comment, or escalate ad-hoc; coach has no parsable handle on the verdict | Only `atdd agent review --target-commit <sha> --report-file <path>` (per spec §5.3) is accepted; `atdd agent commit` is mechanically rejected | Coach state-machine routing depends on the report's `verdict` (#N2 schema). Ad-hoc output channels deny coach the structured verdict; ad-hoc edits violate the spec hard rule |
+| Reviewer-vs-author isolation | `coach.persona_llm.reviewer ≠ coach.persona_llm.<phase-agent>` is policy, not enforcement | Spawn adapter resolves the reviewer persona LLM separately from the phase-agent LLM | Without enforcement, an operator override could collapse reviewer and author into the same LLM, defeating adversarial review |
+| Defense-in-depth on edit attempts | Observer rule `08-reviewer-edit-attempt` (#L2) catches edits at runtime, but only after the fact | Adapter strip + system prompt makes edits structurally impossible; observer rule catches residual attempts | Single-layer defense (only observer) is fragile. Adapter strip is the hard floor; observer rule is the audit catch |
+
+### User Impact
+
+The "user" of #N1 is coach itself (driving the state machine) and every implementer of downstream wagons (#N2, #N3, #N4, #N5). Today a reviewer persona does not exist; coach cannot run an adversarial review at any phase boundary. Per spec §6.3, the reviewer is mandatory at the exit of PLANNED, RED, GREEN, SMOKE (and optional REFACTOR) — without #N1, the adversarial-review architecture from spec §2 ("Adversarial review at every meaningful phase boundary") is non-functional.
+
+Per spec §6.3, reviewer hard rules are absolute: a different LLM from the agent under review by default, no write permission to the worktree, and the only output channel is `atdd agent review`. #N1 enforces these mechanically; the observer rule from #L2 catches residual attempts. Together they implement the "mechanical floor + probabilistic ceiling" principle (spec §2).
+
+For the downstream wagons: #N2's review-report schema is the data contract, but #N1 is the agent contract — the schema can only be reasoned about under the assumption that the reviewer cannot mutate the worktree it is reviewing. Without #N1, every claim in #N2/#N5 about review integrity is hypothetical.
+
+### Design Anchor
+
+#N1 sits at the spawn-adapter boundary: the same surface that #K2 ships for phase agents. By implementing reviewer as an adapter variant — not as a separate spawn surface — the canonical naming, layout, runtime-folder layout, and event-emission contracts shipped under `wagon:spawn-agents` and `wagon:freeze-runtime-contracts` apply unchanged. Only the tool allowlist and system prompt diverge. This keeps the spec §6.3 hard rules in a small, auditable diff against #K2 rather than a parallel spawn pipeline.
+
+The choice of a system-prompt forbiddance plus tool-allowlist strip plus observer rule (#L2) is the layered enforcement the coach v9 architecture calls for: structural defense (adapter strip) + behavioral defense (system prompt) + audit defense (observer rule). All three layers are required because each can fail in distinct modes (operator override, prompt injection, late-binding tool registration).
+
+---
+
+## Acceptance
+
+- `acc:review-phase-boundaries:D001-UNIT-001-reviewer-cannot-write-worktree`: A reviewer agent spawned with `atdd spawn --persona reviewer` cannot run `git commit` or write to the worktree because the spawn adapter strips commit/edit tools (no `Edit`, `Write`, `NotebookEdit`, `MultiEdit`, `git-commit`, or other worktree-mutating surface in the rendered tool allowlist) and the system prompt embedded in the launch prompt explicitly forbids edits and names `atdd agent review --target-commit <sha> --report-file <path>` as the sole output channel; observer rule `08-reviewer-edit-attempt` (from #L2) is bound and will fire on residual attempts.
+- `acc:review-phase-boundaries:D001-UNIT-002-reviewer-output-channel-bounded`: For an agent process tagged persona=reviewer, `atdd agent review` succeeds when `--target-commit` and `--report-file` are provided, and `atdd agent commit` is rejected with a clear error citing the no-write reviewer persona constraint.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §5.3 (`atdd agent review` reviewer-only command), §6.3 (per-phase adversarial review, hard rules), §7.1 (spawn harness), §8.3 (observer rule `08-reviewer-edit-attempt`)
+- `atdd-coach-issues-v3.md` issue `#N1`
+- Wagon manifest: `plan/review_phase_boundaries/_review_phase_boundaries.yaml`
+- Feature: `plan/review_phase_boundaries/features/phase_boundary_review.yaml`
+- WMBT: `plan/review_phase_boundaries/D001.yaml`
+- Predecessor issues: `#K2` (base spawn adapter), `#M3` (tier-1 risk score)
+- Observer rule home: `wagon:observe-and-correct` (#L2)

--- a/.coach-v9-bootstrap/bodies/N2.md
+++ b/.coach-v9-bootstrap/bodies/N2.md
@@ -1,0 +1,92 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-n2-review-report-schema` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `review-phase-boundaries` |
+| Internal-Spec-Id | `N2` |
+| Feature | Rule-ID-first review-report schema with hard rules (verdict cannot be `pass` if any AC is `not_covered`; rule_id severity matches registry; verdict cannot be `pass` while any strict rule_id-bound finding remains) — enforced at coach intake |
+
+---
+
+## Scope
+
+### In Scope
+
+- New schema at `src/atdd/coach/schemas/review-report.schema.json`, JSON Schema draft-2020-12, declaring required fields per spec §7.4:
+  - `review_id`, `target_commit`, `reviewer_agent_id`, `wmbt_urn`, `phase`, `verdict` (enum `pass|concern|fail`), `tier1_risk_score` (sourced from `validations/<sha>/risk-score.json`).
+  - `findings[]` with `rule_id` (nullable, canonical resolvable via `bind_rule()`), `rule_id_legacy_alias` (optional), `severity` (1..5 per SPEC-COACH-RULEID-0003), `disposition` (when `rule_id != null`), `surface` (one of `convention|task|semantic|architecture`), `location`, `acceptance_ref`, `description`, `evidence`.
+  - `ac_coverage` map `acceptance_ref → covered|not_covered|partial`.
+  - `summary`, `recommendations[]`.
+- Cross-field hard rules enforced at coach intake (not all expressible in pure JSON Schema; the intake validator combines schema validation + cross-field checks):
+  1. `verdict` cannot be `pass` if any `ac_coverage[*] == not_covered` — mechanical defense against false-completion.
+  2. When `rule_id != null`, the finding's `severity` and `disposition` MUST match `bind_rule(rule_id)`. Mismatches are rejected.
+  3. `verdict` cannot be `pass` if any finding has `disposition: strict` AND `rule_id != null`.
+- Intake validator module emits rule-IDed errors for each violated hard rule; downstream consumers (`#N5`, coach state machine) parse the rejection structurally.
+- One or more example fixtures under `src/atdd/coach/schemas/fixtures/review-report/` covering: a clean `pass` report, a `concern` report, a `fail` report, plus negative fixtures triggering each of the three hard rules.
+
+### Out of Scope
+
+- The reviewer agent surface — that's #N1 (no-write spawn adapter).
+- Per-phase reviewer prompts that produce reports — that's #N3.
+- The runtime command that ingests the report — that's #N5 (`atdd agent review`).
+- Judge call site #2 schema for `verdict: concern` routing — that's #N4 (separate schema `judge-reviewer-concern.response.schema.json`).
+- Substrate dataclasses (`Violation`, `RuleMetadata`, `bind_rule`) — referenced but not redefined.
+- Schema for the runtime `review_complete` event — that lives in `runtime-event.schema.json`, frozen by #C0.
+
+### Dependencies
+
+- `#N1` — reviewer persona must exist for the schema to govern a real intake surface.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Review-report shape | Spec §7.4 names the shape in prose; no committed schema | `src/atdd/coach/schemas/review-report.schema.json` (JSON Schema draft-2020-12) declaring all required fields, including `findings[]` with rule_id-first shape and `ac_coverage` map | Without a schema, every consumer (`#N5` writer, coach intake, downstream judge call site #2 in `#N4`) re-derives the shape and they drift |
+| AC-coverage discipline | Spec §7.4 hard rule "verdict cannot be `pass` if any AC is `not_covered`" lives only in prose | Coach intake mechanically rejects `verdict=pass` reports with any `ac_coverage[*] == not_covered`, citing the offending acceptance_ref | Without enforcement, a reviewer (or its LLM) can mark `verdict=pass` while leaving acceptances uncovered, defeating the spec's mechanical floor against false-completion |
+| Strict-finding discipline | Spec §7.4 hard rule "verdict cannot be `pass` if any finding has `disposition: strict` AND `rule_id != null`" lives only in prose | Coach intake mechanically rejects such reports | Without enforcement, a reviewer can pass while a strict rule_id-bound violation remains, defeating substrate v12's strict-disposition discipline |
+| Rule-ID severity alignment | Reviewers may emit findings with rule_id but mismatched severity/disposition (LLM transcription error or stale knowledge) | Intake validates that severity/disposition match `bind_rule(rule_id)` and rejects on mismatch with the registry's expected values | Without alignment, downstream feedback templates (spec §7.6) emit inconsistent payloads, and the rule_id-bound risk model (#M5/#L4) double-counts or misclassifies |
+
+### User Impact
+
+The "user" is coach (the intake validator) and every reviewer agent emitting a report. Today no schema exists; the spec §7.4 shape is a paper contract. #N2 makes it executable: every review report goes through schema validation + cross-field hard rules, and only conforming reports advance routing.
+
+Per spec §6.3, reviewer routing on verdict is: `pass → next state`, `fail → respawn with feedback`, `concern → judge call site #2`. Each branch depends on a parsable verdict. #N2's hard rules ensure the verdict reflects ground truth: a `pass` cannot lie about AC coverage, cannot lie about rule_id severity, cannot lie about strict findings.
+
+For downstream consumers: #N5 (`atdd agent review`) is the write path, and it MUST validate against this schema before persisting. #N4 (judge call site #2) is the concern-routing path, and it consumes the report's findings + rationale. Both depend on #N2 freezing the schema before they begin.
+
+### Design Anchor
+
+The choice "schema validation + cross-field intake validator" reflects a JSON Schema limitation: cross-field constraints (`verdict=pass implies all ac_coverage are covered`) are not cleanly expressible in draft-2020-12. The intake validator complements the schema: schema enforces field-shape, intake enforces the three hard rules. This split keeps the schema readable and the validator localized to a single module that the spec §7.4 hard rules map onto 1-to-1.
+
+Anchoring `severity` and `disposition` to the registry (`bind_rule(rule_id)`) — rather than letting reviewers freely assign — is the rule-ID-first principle from spec §2 in practice: the registry is the single source of truth, and review reports are consumers, not authors, of severity/disposition for known rules. Null rule_ids preserve LLM-only findings with reviewer-assigned severity per the SPEC-COACH-RULEID-0003 1..5 scale.
+
+---
+
+## Acceptance
+
+- `acc:review-phase-boundaries:D002-UNIT-001-review-report-schema-committed`: `src/atdd/coach/schemas/review-report.schema.json` is committed and parses as JSON Schema draft-2020-12; required fields (`review_id`, `target_commit`, `reviewer_agent_id`, `wmbt_urn`, `phase`, `verdict`, `tier1_risk_score`, `findings[]`, `ac_coverage`, `summary`) are declared; each `findings[]` entry declares `rule_id` (nullable), `rule_id_legacy_alias` (optional), `severity` (1..5), `disposition` (when `rule_id != null`), `surface` (one of `convention|task|semantic|architecture`), `location`, `acceptance_ref`, `description`, `evidence`; `ac_coverage` is a map of acceptance_ref to `covered|not_covered|partial`; `verdict` is `pass|concern|fail`.
+- `acc:review-phase-boundaries:D002-UNIT-002-pass-blocked-when-ac-not-covered`: A review-report fixture with `verdict=pass` and at least one `ac_coverage` entry == `not_covered` is rejected at coach intake with an error citing `verdict cannot be pass when any AC is not_covered` and naming the offending acceptance_ref(s); the report is not written to `.atdd/runtime/agents/<id>/reviews/`.
+- `acc:review-phase-boundaries:D002-UNIT-003-pass-blocked-with-strict-finding`: A review-report fixture with `verdict=pass` and one or more findings carrying `rule_id != null` and `disposition: strict` is rejected at coach intake with an error citing `verdict cannot be pass while a strict rule_id-bound finding remains` and naming the offending rule_id(s).
+- `acc:review-phase-boundaries:D002-UNIT-004-rule-id-severity-matches-registry`: A review-report fixture whose finding cites a known canonical rule_id with severity/disposition diverging from `bind_rule(rule_id)` is rejected at coach intake with an error citing the rule_id and the registry-expected severity and disposition; conforming reports parse cleanly.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §6.3 (reviewer routing on verdict), §7.4 (review-report schema + hard rules), §7.7 (schema inventory)
+- `atdd-coach-issues-v3.md` issue `#N2`
+- Wagon manifest: `plan/review_phase_boundaries/_review_phase_boundaries.yaml`
+- Feature: `plan/review_phase_boundaries/features/phase_boundary_review.yaml`
+- WMBT: `plan/review_phase_boundaries/D002.yaml`
+- Predecessor issues: `#N1` (reviewer persona)
+- Substrate v12: `bind_rule()`, `RuleMetadata` (referenced but not redefined)

--- a/.coach-v9-bootstrap/bodies/N3.md
+++ b/.coach-v9-bootstrap/bodies/N3.md
@@ -1,0 +1,94 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-n3-per-phase-reviewer-prompts` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `review-phase-boundaries` |
+| Internal-Spec-Id | `N3` |
+| Feature | Per-phase reviewer prompt templates (PLANNED, RED, GREEN, SMOKE, REFACTOR) under `src/atdd/coach/prompts/persona/reviewer/` with phase-specific focus questions and the rule-resolution block |
+
+---
+
+## Scope
+
+### In Scope
+
+- Five YAML prompt templates at `src/atdd/coach/prompts/persona/reviewer/<phase>.prompt.yaml`:
+  - `planned.prompt.yaml` — focus: WMBT decomposition, acceptance specificity, dependency correctness.
+  - `red.prompt.yaml` — focus: each test exercises the WMBT contract (vs passing trivially), AC coverage, right-reason failure.
+  - `green.prompt.yaml` — focus: AC coverage, diff scope confined to declared targets, implementation addresses the WMBT.
+  - `smoke.prompt.yaml` — focus: smoke test exercises real infrastructure, flakiness sources controlled.
+  - `refactor.prompt.yaml` — focus: cleanup preserves semantics, regression risk, architectural concerns.
+- Each template embeds the rule-resolution block from spec §7.2:
+  - Check bundled `conventions[].rules_in_scope` for matching rule_ids.
+  - Prefer the most specific (lowest scope) candidate when multiple match.
+  - Emit `rule_id: null` plus a clear free-text description when no candidate matches.
+  - Severity is derived from the registry when `rule_id != null`; for null rule_id, reviewer assigns 1..5 per SPEC-COACH-RULEID-0003.
+  - Legacy alias instruction: include legacy IDs (e.g., `GREEN-URN-001`) under `legacy_alias` and coach resolves to canonical via `get_canonical_id()`.
+- Each template declares `persona: reviewer`, a `phase: <PLANNED|RED|GREEN|SMOKE|REFACTOR>` field matching the filename, and the `rules_in_scope` placeholder section computed by spawn (#K2).
+- Reviewer's review-report output expectation references `review-report.schema.json` (#N2) and the `atdd agent review` command surface (#N5) so the LLM produces a schema-conformant report directly.
+
+### Out of Scope
+
+- The reviewer spawn-adapter variant — that's #N1.
+- The review-report schema and intake validator — that's #N2.
+- The `atdd agent review` runtime command — that's #N5.
+- Judge call site #2 routing on `concern` verdicts — that's #N4.
+- Phase-agent persona prompts (planner/tester/coder) — those live elsewhere in the spawn-agents wagon.
+- Per-LLM persona convention files (CLAUDE.md, AGENTS.md, GLM.md, GEMINI.md) — those are inputs to the spawn harness from #K2/#K3, not authored here.
+
+### Dependencies
+
+- `#N1` — reviewer persona must exist for the prompts to govern.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Phase-specific reviewer focus | Spec §6.3 names per-phase focus questions in prose; no prompt templates exist | Five YAML prompt templates per phase, each embedding its phase's focus questions | A generic prompt misses phase-specific failure modes — e.g., RED reviewer wouldn't ask whether tests fail for the right reason; GREEN reviewer wouldn't enforce diff-scope |
+| Rule-ID resolution discipline | Spec §7.2 specifies the rule-resolution block; without it embedded per template, reviewers re-derive rule_ids inconsistently | Each per-phase template embeds the §7.2 rule-resolution block verbatim with the legacy_alias hook | Without the block, reviewer findings either skip rule_ids entirely or cite legacy aliases coach can't resolve, defeating the rule-ID-first feedback model in spec §7.6 |
+| Severity scale anchoring | Reviewers assign severity ad-hoc; the SPEC-COACH-RULEID-0003 1..5 scale is internal | Each template references the 1..5 scale for null rule_id findings | Without the anchor, reviewers emit incomparable severities; the risk model (spec §6.8) cannot aggregate cleanly |
+| Schema-conformant output expectation | Without an explicit instruction to produce schema-conformant output, the reviewer's report may be malformed and rejected by intake | Each template references `review-report.schema.json` and the `atdd agent review` channel as the only sanctioned output | Without the expectation, reviewers waste the cycle on a malformed report that intake rejects (#N2 hard rules + #N5 schema validation) |
+
+### User Impact
+
+The "user" of #N3 is the reviewer LLM — it reads the rendered prompt at spawn time and emits a review report. Without per-phase prompts, the reviewer applies one generic prompt to every phase, which collapses the spec §6.3 per-phase focus into a uniform critique that misses phase-specific failure modes. Per spec §6.3, the reviewer at PLANNED is asking different questions than the reviewer at GREEN; the same LLM with the same generic prompt produces qualitatively worse signal in both cases.
+
+The rule-resolution block (spec §7.2) is the bridge between probabilistic LLM critique and deterministic rule-ID-bound feedback. Without it, the reviewer either invents rule_ids that don't resolve (and downstream feedback templates from #L4 fail to render) or skips rule_ids entirely (collapsing every finding into the null-rule-id surface and losing the registry's severity/disposition discipline). With the block embedded per phase, the reviewer is primed to consult the bundled `rules_in_scope` first, fall back to free-text only when no rule applies, and reference the registry consistently.
+
+For implementers downstream: #N5 ingests the reports and validates against #N2's schema. #N4 routes `concern` verdicts to judge call site #2. Both depend on the reviewer producing well-formed, phase-appropriate reports — which is what #N3's per-phase prompts deliver.
+
+### Design Anchor
+
+The choice "five separate YAML files, one per phase" — rather than a single template parameterized by phase — reflects the spec §6.3 hard rule that the per-phase focus questions are qualitatively different. Parameterization would compress them into a single template with conditional branches; separate files keep each phase's prompt readable, reviewable, and independently editable when the spec evolves.
+
+Embedding the §7.2 rule-resolution block in every template — rather than including-by-reference — accepts a small amount of duplication for a large gain in legibility: a reviewer at PLANNED reads exactly the prompt that drives its run, with no outbound references. The trade-off is a five-place edit when the rule-resolution block changes; the spec authors deemed this acceptable given how rarely §7.2 should change.
+
+---
+
+## Acceptance
+
+- `acc:review-phase-boundaries:D003-UNIT-001-five-phase-prompts-committed`: Exactly five YAML files exist at `src/atdd/coach/prompts/persona/reviewer/`, named `planned.prompt.yaml`, `red.prompt.yaml`, `green.prompt.yaml`, `smoke.prompt.yaml`, `refactor.prompt.yaml`; each parses as valid YAML; each declares `persona: reviewer` and a `phase` field matching its filename uppercased.
+- `acc:review-phase-boundaries:D003-UNIT-002-per-phase-focus-matches-spec`: PLANNED prompt asks about WMBT decomposition, acceptance specificity, and dependency correctness; RED prompt asks whether each test exercises the WMBT contract (vs passing trivially), AC coverage, and right-reason failure; GREEN prompt asks about AC coverage, diff scope confined to declared targets, and implementation-addresses-WMBT; SMOKE prompt asks whether the smoke test exercises real infrastructure and whether flakiness sources are controlled; REFACTOR prompt asks about semantics preservation, regression risk, and architectural concerns.
+- `acc:review-phase-boundaries:D003-UNIT-003-rule-resolution-block-embedded`: Each per-phase prompt embeds rule_id_resolution guidance — check bundled `rules_in_scope` first, prefer most specific match, emit null + free-text when no match, severity derived from registry when `rule_id != null`; the `legacy_alias` instruction is present so reviewers can reference legacy IDs and coach resolves to canonical via `get_canonical_id()`; each prompt references the SPEC-COACH-RULEID-0003 1..5 severity scale for null rule_id findings.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §6.3 (per-phase reviewer focus table), §7.2 (persona prompt templates + rule-resolution block), §7.6 (spawn-feedback templates downstream)
+- `atdd-coach-issues-v3.md` issue `#N3`
+- Wagon manifest: `plan/review_phase_boundaries/_review_phase_boundaries.yaml`
+- Feature: `plan/review_phase_boundaries/features/phase_boundary_review.yaml`
+- WMBT: `plan/review_phase_boundaries/D003.yaml`
+- Predecessor issues: `#N1` (reviewer persona)
+- Sibling issues consuming the prompts: `#N5` (`atdd agent review`), `#N2` (review-report schema)

--- a/.coach-v9-bootstrap/bodies/N4.md
+++ b/.coach-v9-bootstrap/bodies/N4.md
@@ -1,0 +1,95 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-n4-judge-call-site-2-reviewer-concern` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `review-phase-boundaries` |
+| Internal-Spec-Id | `N4` |
+| Feature | Judge call site #2 wiring: a `concern` reviewer verdict triggers exactly one `atdd judge` call against `judge-reviewer-concern.response.schema.json`; the response (`block` or `annotate_and_continue`) routes coach state, and every judgment lands in `.atdd/runtime/coach/judgments.jsonl` |
+
+---
+
+## Scope
+
+### In Scope
+
+- New schema at `src/atdd/coach/schemas/judge-reviewer-concern.response.schema.json` (JSON Schema draft-2020-12) declaring required fields per spec §6.9 call site #2:
+  - `decision`: enum `block | annotate_and_continue`.
+  - `rationale`: non-empty string.
+  - `pr_annotation`: string (may be empty when `decision=block`; populated when `decision=annotate_and_continue`).
+- Coach routing logic on reviewer `verdict: concern`:
+  - Build structured judge inputs: review report, target commit, phase, WMBT URN, tier-1 risk score, findings summary.
+  - Invoke `atdd judge` exactly once with `--prompt-template judge-reviewer-concern.prompt.yaml --schema judge-reviewer-concern.response.schema.json --inputs ...`.
+  - Validate the response against the schema.
+  - On `decision=block`: respawn the phase agent with reviewer findings + judge rationale embedded in the spawn-feedback (per spec §7.6).
+  - On `decision=annotate_and_continue`: queue `pr_annotation` for inclusion in the COMPLETE-phase PR body (per spec §4.7).
+- Append-only judgment record to `.atdd/runtime/coach/judgments.jsonl` per the `coach-judgment.schema.json` frozen by `wagon:freeze-runtime-contracts` (#C0):
+  - `judgment_id`, `timestamp`, `call_site: "reviewer_concern"`, `inputs_hash`, `response`, `cached`.
+  - Written BEFORE the routing action runs (per spec §4.5 durable-decision-before-action discipline).
+- Companion judge-prompt template at `src/atdd/coach/prompts/judge/judge-reviewer-concern.prompt.yaml` that primes judge with: the review report, the target commit, the phase context, the tier-1 risk score, and the routing options.
+- One or more example fixtures at `src/atdd/coach/schemas/fixtures/judge-reviewer-concern/`: a `block` response, an `annotate_and_continue` response with `pr_annotation`, and a malformed-response negative fixture.
+
+### Out of Scope
+
+- The `atdd judge` core CLI itself — that's #O1 (`wagon:judge-ambiguous-decisions`).
+- Other judge call sites (#1 borderline tier-1, #3 retry-vs-escalate, #4 cross-phase regression, #5 issue-review aggregate, #6 superseded rule consolidation) — those are #O2/#O3/#O4/etc.
+- The reviewer persona, schema, prompts, runtime command — those are #N1/#N2/#N3/#N5.
+- The `coach-judgment.schema.json` (judgments.jsonl line shape) — frozen by #C0.
+- The `pr_annotation` rendering at COMPLETE-phase PR body — that's coach state-machine PR rendering, owned by `wagon:drive-state-machine`.
+
+### Dependencies
+
+- `#N1` — reviewer persona must exist for `concern` verdicts to be generated.
+- `#O1` — `atdd judge` CLI must exist for call site #2 to invoke.
+- `#C0` — `coach-judgment.schema.json` must be frozen so `judgments.jsonl` lines validate.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Concern-verdict routing | Spec §6.9 call site #2 names the routing decision in prose; no schema or wiring exists | `judge-reviewer-concern.response.schema.json` plus coach routing logic that invokes judge exactly once and parses the response | Without it, a `concern` verdict is unhandled — coach has only `pass`/`fail` branches and `concern` falls through to a default that erodes the spec §6.3 routing contract |
+| Judge response shape | Without a schema, judge output is free-text the LLM authors per call; coach cannot parse the routing decision structurally | Schema declares `decision` (enum), `rationale`, `pr_annotation`; coach validates before using | Without the schema, coach either trusts free-text (fragile) or imposes ad-hoc parsing (brittle to LLM rephrasing) |
+| Audit-trail discipline | Per spec §6.9, every judgment writes to `judgments.jsonl`; without explicit wiring on call site #2, the trail has gaps | Every call-site-2 invocation appends a `coach-judgment.schema.json`-conformant line BEFORE routing acts (spec §4.5) | Gaps in the audit trail defeat `--resume` semantics and make post-hoc forensics impossible |
+| One-call-per-concern discipline | Without enforcement, the routing logic could double-call judge (e.g., on retry) and double-bill judgments | Coach invokes judge exactly once per concern verdict; idempotency keyed by `(review_id, target_commit, phase)` | Double-calls inflate cost, pollute the audit trail, and risk divergent decisions across calls |
+
+### User Impact
+
+The "user" of #N4 is coach itself — when a reviewer returns `verdict: concern`, the coach state machine consults #N4's wiring to decide whether to respawn the phase agent or proceed with a PR annotation. Without #N4, `concern` is unhandled; the spec §6.3 three-way routing (`pass / concern / fail`) collapses to two-way routing, defeating the LLM-judgment ceiling on top of the deterministic floor.
+
+Per spec §6.9 ordering principle: "deterministic-first ordering (tier-1 → operator escalation → judge) is load-bearing." Call site #2 is judge-only because the decision is genuinely about *what to do* given a `concern` verdict, not *what is the case*. A tier-1 check cannot resolve "should we block on this concern or annotate-and-continue" because the answer depends on the concern's substance, which is by definition LLM-readable. #N4 implements that boundary.
+
+For implementers downstream: the COMPLETE-phase PR rendering consumes queued `pr_annotation` payloads for body inclusion (per spec §4.7); without #N4 producing them, the PR body has nothing concern-derived to annotate. The post-hoc forensics path (`--resume`, audit trail, regression analysis) consumes `judgments.jsonl` lines per #C0's `coach-judgment.schema.json`; without #N4 writing them, the audit trail has structural gaps that compound.
+
+### Design Anchor
+
+The choice "schema response + write-before-act + idempotency-keyed-by-tuple" reflects the spec §4.5 discipline: every state transition appended to `decisions.jsonl` *before* the action runs, with idempotent actions. Judgments are decisions about *how* to transition; they follow the same discipline against `judgments.jsonl`. Idempotency on `(review_id, target_commit, phase)` ensures that `--resume` after a crash mid-routing produces the same decision (or skips it as already-applied), not a fresh judge call with a possibly different LLM response.
+
+The choice "exactly one call per concern" — rather than retry-with-confidence-threshold — reflects the cost discipline of spec §6.9: judge is the LLM-judgment ceiling, used sparingly. If a single judgment is unactionable (low confidence, ambiguous rationale), the answer is escalation per call site #3 (retry-vs-escalate), not in-place retry of call site #2. This keeps each call site's responsibility narrow and the audit trail interpretable.
+
+---
+
+## Acceptance
+
+- `acc:review-phase-boundaries:D004-UNIT-001-judge-reviewer-concern-schema-committed`: `src/atdd/coach/schemas/judge-reviewer-concern.response.schema.json` is committed and parses as JSON Schema draft-2020-12; required fields are `decision`, `rationale`, `pr_annotation`; `decision` is constrained to `block | annotate_and_continue`; `rationale` is a non-empty string; `pr_annotation` is a string (may be empty when `decision=block`).
+- `acc:review-phase-boundaries:D004-INTEGRATION-001-concern-triggers-exactly-one-judge-call`: Given coach has just ingested a review report with `verdict=concern`, when coach handles the verdict per call-site-2 routing, then exactly one `atdd judge --prompt-template judge-reviewer-concern.prompt.yaml --schema judge-reviewer-concern.response.schema.json --inputs ...` invocation is made; the response validates against the schema before being used to route; on `decision=block` coach respawns the phase agent with reviewer findings, and on `decision=annotate_and_continue` coach proceeds with `pr_annotation` queued for COMPLETE-phase PR-body inclusion.
+- `acc:review-phase-boundaries:D004-INTEGRATION-002-judgment-logged-to-jsonl`: After judge invocation and response validation, a new line is appended to `.atdd/runtime/coach/judgments.jsonl` conforming to `coach-judgment.schema.json` (from #C0) with `judgment_id`, `timestamp`, `call_site: "reviewer_concern"`, `inputs_hash`, `response`, `cached`; the line is written before any routing action runs (durable-decision-before-action discipline from spec §4.5).
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §4.5 (decision durability), §4.7 (PR-based COMPLETE — pr_annotation inclusion), §6.3 (reviewer routing on `concern`), §6.9 call site #2, §7.6 (spawn-feedback templates on respawn), §7.7 (schema inventory)
+- `atdd-coach-issues-v3.md` issue `#N4`
+- Wagon manifest: `plan/review_phase_boundaries/_review_phase_boundaries.yaml`
+- Feature: `plan/review_phase_boundaries/features/phase_boundary_review.yaml`
+- WMBT: `plan/review_phase_boundaries/D004.yaml`
+- Predecessor issues: `#N1` (reviewer persona), `#O1` (`atdd judge` core), `#C0` (`coach-judgment.schema.json` frozen)

--- a/.coach-v9-bootstrap/bodies/N5.md
+++ b/.coach-v9-bootstrap/bodies/N5.md
@@ -1,0 +1,90 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-n5-atdd-agent-review` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `review-phase-boundaries` |
+| Internal-Spec-Id | `N5` |
+| Feature | `atdd agent review --target-commit <sha> --report-file <path>` runtime command — validates against `review-report.schema.json` plus the cross-field hard rules, persists to `.atdd/runtime/agents/<reviewer-id>/reviews/<review-id>.json`, emits a `review_complete` event |
+
+---
+
+## Scope
+
+### In Scope
+
+- New CLI subcommand `atdd agent review --target-commit <sha> --report-file <path>` per spec §5.3, registered under the existing `atdd agent` subcommand group:
+  - Resolves the calling agent's id from environment / runtime manifest; refuses to run unless the agent persona is `reviewer`.
+  - Reads the report file from `<path>`.
+  - Validates against `review-report.schema.json` (#N2) and applies the three cross-field hard rules from #N2 (AC coverage, rule-ID severity match, no-pass-with-strict-finding).
+  - On validation success: writes the report to `.atdd/runtime/agents/<reviewer-id>/reviews/<review-id>.json` (where `review-id` is taken from the report's `review_id` field) and appends a `review_complete` event to `.atdd/runtime/agents/<reviewer-id>/events.jsonl` per `runtime-event.schema.json` (frozen by #C0). Exits 0.
+  - On validation failure: exits non-zero with a clear, rule-IDed error citing the violated hard rule and offending field(s); writes nothing; emits no event.
+- Module path: `src/atdd/coach/commands/agent_review.py` (or equivalent); registered in the agent CLI dispatch table.
+- Integration test fixtures covering: a clean `pass` report, a `concern` report, a `fail` report, a malformed report (each of the three hard-rule violations), a non-reviewer caller (expects rejection), a missing-file path, a non-JSON-parseable file.
+
+### Out of Scope
+
+- The reviewer spawn-adapter variant — that's #N1.
+- The review-report schema itself — that's #N2 (this issue *consumes* it).
+- Per-phase reviewer prompts — that's #N3.
+- Judge call site #2 wiring on `concern` verdicts — that's #N4.
+- The `runtime-event.schema.json` itself — frozen by #C0 (this issue *consumes* it).
+- Other `atdd agent` subcommands (`heartbeat`, `event`, `commit`, `ask`, `escalate`, `done`, `context`) — those are wagon:drive-state-machine territory.
+
+### Dependencies
+
+- `#N1` — reviewer persona must exist; `atdd agent review` refuses non-reviewer callers.
+- `#N2` — `review-report.schema.json` and the cross-field intake validator must be available for `atdd agent review` to call into.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Reviewer's only output channel | Spec §5.3 names `atdd agent review --target-commit <sha> --report-file <path>` as the reviewer's only sanctioned output; no implementation exists | New CLI subcommand under `atdd agent` that validates, persists, and emits | Without the command, reviewers have no sanctioned output and #N1's no-write spawn adapter forces a dead-end; the adversarial-review architecture is non-functional |
+| Schema validation at the write boundary | A reviewer can produce a malformed report; without intake validation at the write boundary, malformed reports land on disk and downstream routing breaks | `atdd agent review` validates against `review-report.schema.json` plus the three #N2 hard rules at the write boundary; rejected reports are not persisted and emit no event | Validation deferred to read-time means malformed reports pollute the runtime tree and force every downstream consumer to re-validate |
+| Review-complete event emission | Spec §4.4 names the event-driven runtime watcher as the source of state-transition signals; without `review_complete` event emission, coach has no signal to advance the state machine on review completion | `atdd agent review` appends a `review_complete` event to the reviewer's `events.jsonl` per `runtime-event.schema.json` from #C0 | Without the event, coach state-machine routing reverts to polling — exactly the failure mode coach v9 is designed to obsolete (spec §1) |
+| Persona-bounded write authority | Without a persona check, any agent could write a review report and pretend to be a reviewer; this confuses routing and breaks the no-write reviewer contract from #N1 | `atdd agent review` refuses to run unless the calling agent's persona is `reviewer`; non-reviewer invocations are rejected with a clear error | Without the check, the no-write reviewer constraint is one-sided: reviewers can't write, but anyone else can write reviews — which defeats the intent |
+
+### User Impact
+
+The "user" is the reviewer agent. Per spec §6.3 hard rule "Only output channel: `atdd agent review --target-commit <sha> --report-file <path>`," the reviewer has no other sanctioned write surface. Today the command does not exist; without #N5, the reviewer in #N1 has nowhere to land its findings. The entire wagon's adversarial-review value depends on #N5 being the operational write path.
+
+For coach state-machine consumers (`wagon:drive-state-machine`): per spec §4.4 the runtime watcher consumes `events.jsonl` for transition signals. The `review_complete` event is the trigger for coach to ingest the review report and route per `verdict` (pass/concern/fail) per spec §6.3. Without #N5 emitting the event, coach has no signal; the only fallback is polling the reviews/ directory, which is exactly the polling pattern coach v9 is designed to obsolete.
+
+For implementers downstream: #N4's call-site-2 routing reads the review report's `verdict` to decide concern-routing. Both depend on #N5 producing schema-valid reports at the write boundary.
+
+### Design Anchor
+
+The choice "validate at the write boundary, not at the read boundary" pushes the integrity check as close to authorship as possible: the reviewer's command itself rejects malformed reports, with rule-IDed errors that point the reviewer to the violated hard rule. This minimizes downstream code that has to re-validate (DRY) and ensures the runtime tree contains only conforming reports — making `--resume` and post-hoc forensics safer.
+
+The choice "emit `review_complete` event at write success, not at intake" reflects spec §4.4's event-driven design: the writer is the authoritative signal of "review report exists and is well-formed." A read-side event would conflate "report observed" with "report well-formed," which is the original sin of polling-based observation. By coupling the event emission to validation success, coach can trust every `review_complete` event without re-validation; routing collapses to a single ingest pass.
+
+The choice "persona-bounded write authority" mirrors the reviewer's no-write spawn-adapter from #N1: just as the reviewer cannot mutate the worktree, no other persona can author a review. The two halves of the constraint live on opposite sides of the agent CLI but enforce the same architectural invariant: review authorship and worktree mutation are disjoint surfaces.
+
+---
+
+## Acceptance
+
+- `acc:review-phase-boundaries:E001-UNIT-001-conforming-report-persists-and-emits-event`: Given an agent process tagged persona=reviewer is registered under `.atdd/runtime/agents/<reviewer-id>/`, and a conforming review-report file exists at the path passed to `--report-file`, when the reviewer invokes `atdd agent review --target-commit <sha> --report-file <path>`, then the report is read and validated against `review-report.schema.json` plus the cross-field hard rules (AC coverage, rule-ID severity match, no-pass-with-strict-finding), the validated report is written to `.atdd/runtime/agents/<reviewer-id>/reviews/<review-id>.json`, a `review_complete` event conforming to `runtime-event.schema.json` (from #C0) is appended to `.atdd/runtime/agents/<reviewer-id>/events.jsonl`, and the command exits 0.
+- `acc:review-phase-boundaries:E001-UNIT-002-malformed-report-rejected-with-rule-id-error`: Given a reviewer agent and a malformed review-report fixture (e.g., `verdict=pass` with `ac_coverage` entry `not_covered`, OR `rule_id` finding whose severity diverges from registry, OR `verdict=pass` with strict rule_id-bound finding), when the reviewer invokes `atdd agent review --target-commit <sha> --report-file <path>` against the malformed fixture, then the command exits non-zero with a clear error citing the violated hard rule and the offending field(s); no file is written to `.atdd/runtime/agents/<reviewer-id>/reviews/`; no `review_complete` event is emitted; when the violation references a rule_id, the error includes the rule_id and the registry-expected severity/disposition.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §4.4 (event sources — runtime watcher), §5.3 (`atdd agent review` reviewer-only command), §6.3 (reviewer routing on verdict), §7.4 (review-report schema), §7.7 (schema inventory)
+- `atdd-coach-issues-v3.md` issue `#N5`
+- Wagon manifest: `plan/review_phase_boundaries/_review_phase_boundaries.yaml`
+- Feature: `plan/review_phase_boundaries/features/phase_boundary_review.yaml`
+- WMBT: `plan/review_phase_boundaries/E001.yaml`
+- Predecessor issues: `#N1` (reviewer persona), `#N2` (review-report schema + intake hard rules)
+- Consumed schemas: `src/atdd/coach/schemas/review-report.schema.json` (from #N2), `src/atdd/coach/schemas/runtime-event.schema.json` (from #C0)

--- a/plan/review_phase_boundaries/D001.yaml
+++ b/plan/review_phase_boundaries/D001.yaml
@@ -1,0 +1,51 @@
+urn: "wmbt:review-phase-boundaries:D001"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "write-permission-leak-from-reviewer-agent"
+context_clarifier: "when coach v9 spawns a reviewer persona at the exit of an enabled phase (PLANNED/RED/GREEN/SMOKE/optional REFACTOR) and the reviewer must not be able to mutate the worktree under review — its only output channel is `atdd agent review --target-commit <sha> --report-file <path>`, and observer rule 08-reviewer-edit-attempt (already authored under wagon:observe-and-correct) catches violations"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of write-permission-leak-from-reviewer-agent when coach v9 spawns a reviewer persona at the exit of an enabled phase and the reviewer must be confined to read-only review with `atdd agent review` as its only output channel"
+acceptances:
+  - identity:
+      urn: "acc:review-phase-boundaries:D001-UNIT-001-reviewer-cannot-write-worktree"
+      id: "AC-UNIT-001"
+      purpose: "A reviewer agent spawned with `atdd spawn --persona reviewer` cannot run `git commit` or write to the worktree because the spawn adapter strips commit/edit tools and the system prompt forbids edits"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The reviewer no-write spawn-adapter variant is layered over the base spawn adapter shipped by wagon:spawn-agents (#K2)"
+        - "An `atdd spawn --persona reviewer --target-commit <sha>` invocation is staged in test"
+    when:
+      abstract: "The spawn adapter resolves the reviewer persona and renders the launch prompt"
+    then:
+      abstract:
+        - "The rendered tool allowlist excludes every commit/edit tool — no Edit, Write, NotebookEdit, MultiEdit, git-commit, or other worktree-mutating surface is present"
+        - "The system prompt embedded in the launch prompt explicitly forbids edits and names `atdd agent review --target-commit <sha> --report-file <path>` as the sole output channel"
+        - "Observer rule 08-reviewer-edit-attempt (authored in wagon:observe-and-correct) is bound and will fire if the reviewer attempts an edit despite the adapter strip"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:review-phase-boundaries:D001-UNIT-002-reviewer-output-channel-bounded"
+      id: "AC-UNIT-002"
+      purpose: "Reviewer's only output channel is `atdd agent review --target-commit <sha> --report-file <path>`; any other emission (heartbeat aside) is rejected by the agent CLI when persona=reviewer"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "An agent process tagged persona=reviewer is registered in .atdd/runtime/agents/<id>/manifest.json"
+    when:
+      abstract: "The reviewer agent invokes `atdd agent review --target-commit <sha> --report-file <path>` and `atdd agent commit ...`"
+    then:
+      abstract:
+        - "`atdd agent review` succeeds when --target-commit and --report-file are provided"
+        - "`atdd agent commit` is rejected with a clear error citing the no-write reviewer persona constraint"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/review_phase_boundaries/D002.yaml
+++ b/plan/review_phase_boundaries/D002.yaml
@@ -1,0 +1,92 @@
+urn: "wmbt:review-phase-boundaries:D002"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "false-pass-verdict-on-uncovered-or-strict-findings"
+context_clarifier: "when coach v9 ingests a review report at phase boundary and routes the next coach action — pass/concern/fail — based on the report's `verdict`; the schema must mechanically prevent reviewers from emitting `verdict: pass` while leaving any AC `not_covered` or any strict-disposition rule_id-bound finding unaddressed"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of false-pass-verdict-on-uncovered-or-strict-findings when coach v9 ingests a review report and routes the next coach action; the review-report schema must enforce three hard rules at intake (AC coverage, rule-ID severity match, no-pass-with-strict-finding) so a malformed report is rejected before routing"
+acceptances:
+  - identity:
+      urn: "acc:review-phase-boundaries:D002-UNIT-001-review-report-schema-committed"
+      id: "AC-UNIT-001"
+      purpose: "review-report.schema.json is committed at src/atdd/coach/schemas/review-report.schema.json with the rule-ID-first shape per spec §7.4"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/schemas/review-report.schema.json exists in the repository"
+    when:
+      abstract: "A schema-validator test parses the schema as JSON Schema draft-2020-12 and inspects required fields"
+    then:
+      abstract:
+        - "The schema declares required fields: review_id, target_commit, reviewer_agent_id, wmbt_urn, phase, verdict, tier1_risk_score, findings[], ac_coverage, summary"
+        - "Each findings[] entry declares rule_id (nullable), rule_id_legacy_alias (optional), severity (1..5), disposition (when rule_id != null), surface (one of convention|task|semantic|architecture), location, acceptance_ref, description, evidence"
+        - "ac_coverage is a map of acceptance_ref to one of `covered|not_covered|partial`"
+        - "verdict is one of `pass|concern|fail`"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:review-phase-boundaries:D002-UNIT-002-pass-blocked-when-ac-not-covered"
+      id: "AC-UNIT-002"
+      purpose: "A review report with `verdict: pass` AND any `ac_coverage[*] == not_covered` is rejected at coach intake with a clear error referencing the offending acceptance_ref"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A review-report fixture with verdict=pass and at least one ac_coverage entry == not_covered"
+    when:
+      abstract: "Coach intake validates the report against review-report.schema.json plus the cross-field hard rules"
+    then:
+      abstract:
+        - "Intake rejects the report with an error citing `verdict cannot be pass when any AC is not_covered`"
+        - "The error names the offending acceptance_ref(s)"
+        - "The report is NOT written to .atdd/runtime/agents/<id>/reviews/<id>.json"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:review-phase-boundaries:D002-UNIT-003-pass-blocked-with-strict-finding"
+      id: "AC-UNIT-003"
+      purpose: "A review report with `verdict: pass` AND any finding having both `rule_id != null` and `disposition: strict` is rejected at coach intake"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A review-report fixture with verdict=pass and one or more findings carrying rule_id != null and disposition: strict"
+    when:
+      abstract: "Coach intake validates the report against review-report.schema.json plus the cross-field hard rules"
+    then:
+      abstract:
+        - "Intake rejects the report with an error citing `verdict cannot be pass while a strict rule_id-bound finding remains`"
+        - "The error names the offending rule_id(s)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:review-phase-boundaries:D002-UNIT-004-rule-id-severity-matches-registry"
+      id: "AC-UNIT-004"
+      purpose: "When `rule_id != null`, the finding's `severity` and `disposition` MUST match the registry binding from `bind_rule(rule_id)`; mismatches are rejected at intake"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A review-report fixture whose finding cites a known canonical rule_id but with severity/disposition diverging from `bind_rule(rule_id)`"
+    when:
+      abstract: "Coach intake validates the report"
+    then:
+      abstract:
+        - "Intake rejects the report citing the rule_id and the registry's expected severity and disposition"
+        - "Conforming reports (rule_id null OR rule_id with registry-matching severity/disposition) parse cleanly"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/review_phase_boundaries/D003.yaml
+++ b/plan/review_phase_boundaries/D003.yaml
@@ -1,0 +1,73 @@
+urn: "wmbt:review-phase-boundaries:D003"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "phase-mismatched-reviewer-focus"
+context_clarifier: "when coach v9 spawns a reviewer at the exit of a particular phase (PLANNED/RED/GREEN/SMOKE/REFACTOR), the reviewer must be primed with the phase-specific focus from spec §6.3 (PLANNED→WMBT decomposition + acceptance specificity; RED→test-actually-exercises-contract + right-reason failure; GREEN→AC-coverage + diff scope; SMOKE→real-infrastructure + flakiness; REFACTOR→semantics-preservation) plus the rule-resolution block from §7.2 — without per-phase prompts, the reviewer applies a generic prompt and misses phase-specific failure modes"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of phase-mismatched-reviewer-focus when coach v9 spawns a reviewer at a phase boundary; per-phase reviewer prompt templates with the rule-resolution block must exist for PLANNED, RED, GREEN, SMOKE, and REFACTOR"
+acceptances:
+  - identity:
+      urn: "acc:review-phase-boundaries:D003-UNIT-001-five-phase-prompts-committed"
+      id: "AC-UNIT-001"
+      purpose: "Five reviewer prompt templates exist at src/atdd/coach/prompts/persona/reviewer/<phase>.prompt.yaml — one per phase: PLANNED, RED, GREEN, SMOKE, REFACTOR"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/prompts/persona/reviewer/ exists in the repository"
+    when:
+      abstract: "A linter test enumerates files in the reviewer prompts directory"
+    then:
+      abstract:
+        - "Exactly five YAML files are present, named planned.prompt.yaml, red.prompt.yaml, green.prompt.yaml, smoke.prompt.yaml, refactor.prompt.yaml"
+        - "Each parses as valid YAML and declares persona=reviewer plus a phase field matching its filename (uppercase)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:review-phase-boundaries:D003-UNIT-002-per-phase-focus-matches-spec"
+      id: "AC-UNIT-002"
+      purpose: "Each per-phase prompt body embeds the spec §6.3 focus questions for its phase verbatim or paraphrased, so the reviewer is primed for phase-specific failure modes"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The five reviewer prompt templates exist"
+    when:
+      abstract: "A linter test inspects each prompt's body for the per-phase focus markers"
+    then:
+      abstract:
+        - "PLANNED prompt asks about WMBT decomposition, acceptance specificity, and dependency correctness"
+        - "RED prompt asks whether each test exercises the WMBT contract (vs passing trivially), AC coverage, and right-reason failure"
+        - "GREEN prompt asks about AC coverage, diff scope confined to declared targets, and implementation-addresses-WMBT"
+        - "SMOKE prompt asks whether the smoke test exercises real infrastructure and whether flakiness sources are controlled"
+        - "REFACTOR prompt asks about semantics preservation, regression risk, and architectural concerns"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:review-phase-boundaries:D003-UNIT-003-rule-resolution-block-embedded"
+      id: "AC-UNIT-003"
+      purpose: "Each per-phase prompt includes the rule-resolution block from spec §7.2 so the reviewer knows how to identify canonical rule_ids and emit `rule_id: null` with severity 1..5 when no rule applies"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The five reviewer prompt templates exist"
+    when:
+      abstract: "A linter test inspects each prompt for the §7.2 rule-resolution block"
+    then:
+      abstract:
+        - "Each prompt embeds rule_id_resolution guidance: check bundled rules_in_scope first, prefer most specific match, emit null + free-text when no match, severity derived from registry when rule_id != null"
+        - "The legacy_alias instruction is present so reviewers can reference legacy IDs (e.g., GREEN-URN-001) and coach resolves to canonical via get_canonical_id"
+        - "Each prompt references the SPEC-COACH-RULEID-0003 1..5 severity scale for null rule_id findings"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/review_phase_boundaries/D004.yaml
+++ b/plan/review_phase_boundaries/D004.yaml
@@ -1,0 +1,74 @@
+urn: "wmbt:review-phase-boundaries:D004"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "unaudited-concern-to-routing-decisions"
+context_clarifier: "when a reviewer returns `verdict: concern` at a phase boundary, coach must call `atdd judge` (call site #2 per spec §6.9) with structured context so a single judgment decides block-vs-annotate-and-continue and the decision is durably logged to judgments.jsonl; without a frozen response schema and the wiring, concern verdicts either short-circuit to one default (losing the LLM-routing intent) or invoke ad-hoc judge prompts whose outputs cannot be parsed"
+lens: "functional.adaptability"
+statement: "minimize likelihood of unaudited-concern-to-routing-decisions when a reviewer returns `verdict: concern`; coach must invoke judge call site #2 with a frozen response schema (decision/rationale/pr_annotation) and append the judgment to judgments.jsonl before routing"
+acceptances:
+  - identity:
+      urn: "acc:review-phase-boundaries:D004-UNIT-001-judge-reviewer-concern-schema-committed"
+      id: "AC-UNIT-001"
+      purpose: "judge-reviewer-concern.response.schema.json is committed at src/atdd/coach/schemas/judge-reviewer-concern.response.schema.json with required fields decision/rationale/pr_annotation"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/schemas/judge-reviewer-concern.response.schema.json exists in the repository"
+    when:
+      abstract: "A schema-validator test parses the schema as JSON Schema draft-2020-12"
+    then:
+      abstract:
+        - "The schema declares required fields: decision, rationale, pr_annotation"
+        - "decision is constrained to one of `block|annotate_and_continue`"
+        - "rationale is a non-empty string"
+        - "pr_annotation is a string (may be empty when decision=block)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:review-phase-boundaries:D004-INTEGRATION-001-concern-triggers-exactly-one-judge-call"
+      id: "AC-INTEGRATION-001"
+      purpose: "A reviewer `concern` verdict triggers exactly one `atdd judge` call against call site #2 with structured context and the response is parsed against judge-reviewer-concern.response.schema.json"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "Coach has just ingested a review-report with verdict=concern at a phase boundary"
+        - "atdd judge is available (provided by wagon:judge-ambiguous-decisions, #O1)"
+    when:
+      abstract: "Coach handles the concern verdict per the call-site-2 routing logic"
+    then:
+      abstract:
+        - "Exactly one `atdd judge --prompt-template judge-reviewer-concern.prompt.yaml --schema judge-reviewer-concern.response.schema.json --inputs ...` invocation is made"
+        - "The judge response validates against the schema before being used to route"
+        - "If decision=block, coach respawns the phase agent with reviewer findings; if decision=annotate_and_continue, coach proceeds with the pr_annotation queued for PR-body inclusion at COMPLETE"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:review-phase-boundaries:D004-INTEGRATION-002-judgment-logged-to-jsonl"
+      id: "AC-INTEGRATION-002"
+      purpose: "Every call-site-2 judgment is appended to .atdd/runtime/coach/judgments.jsonl per the coach-judgment schema frozen by wagon:freeze-runtime-contracts"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "Coach has invoked judge call site #2 and received a parsable response"
+    when:
+      abstract: "Coach records the judgment outcome"
+    then:
+      abstract:
+        - "A new line is appended to .atdd/runtime/coach/judgments.jsonl"
+        - "The line conforms to coach-judgment.schema.json from wagon:freeze-runtime-contracts (judgment_id, timestamp, call_site=`reviewer_concern`, inputs_hash, response, cached)"
+        - "The line is written before any routing action runs (durable-decision-before-action discipline from spec §4.5)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/review_phase_boundaries/E001.yaml
+++ b/plan/review_phase_boundaries/E001.yaml
@@ -1,0 +1,54 @@
+urn: "wmbt:review-phase-boundaries:E001"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "unrecorded-or-unvalidated-review-outcomes"
+context_clarifier: "when a reviewer agent finishes its review and the only sanctioned output channel is `atdd agent review --target-commit <sha> --report-file <path>` (per spec §5.3); the command must validate the report against review-report.schema.json + the cross-field hard rules from #N2, write it to .atdd/runtime/agents/<reviewer-id>/reviews/<review-id>.json, and emit a `review_complete` runtime event that downstream coach state-machine consumers can observe"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of unrecorded-or-unvalidated-review-outcomes when a reviewer agent emits a review report; `atdd agent review` must validate against review-report.schema.json + cross-field hard rules, persist to .atdd/runtime/agents/<id>/reviews/<id>.json, and emit a schema-conformant review_complete event"
+acceptances:
+  - identity:
+      urn: "acc:review-phase-boundaries:E001-UNIT-001-conforming-report-persists-and-emits-event"
+      id: "AC-UNIT-001"
+      purpose: "A reviewer agent calling `atdd agent review --target-commit <sha> --report-file <path>` with a conforming report writes the report to disk and emits a review_complete event"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "An agent process tagged persona=reviewer is registered under .atdd/runtime/agents/<reviewer-id>/"
+        - "A conforming review-report file exists at the path passed to --report-file"
+    when:
+      abstract: "The reviewer invokes `atdd agent review --target-commit <sha> --report-file <path>`"
+    then:
+      abstract:
+        - "The report is read, validated against review-report.schema.json plus the cross-field hard rules (AC coverage, rule-ID severity match, no-pass-with-strict-finding)"
+        - "The validated report is written to .atdd/runtime/agents/<reviewer-id>/reviews/<review-id>.json"
+        - "A review_complete event conforming to runtime-event.schema.json (frozen by wagon:freeze-runtime-contracts) is appended to .atdd/runtime/agents/<reviewer-id>/events.jsonl"
+        - "The command exits 0"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:review-phase-boundaries:E001-UNIT-002-malformed-report-rejected-with-rule-id-error"
+      id: "AC-UNIT-002"
+      purpose: "Schema validation rejects malformed reports with rule-ID-bound errors that name the violated hard rule and (where applicable) the offending acceptance_ref or rule_id"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A reviewer agent and a malformed review-report fixture (e.g., verdict=pass with ac_coverage entry not_covered, OR rule_id finding whose severity diverges from registry, OR verdict=pass with strict rule_id-bound finding)"
+    when:
+      abstract: "The reviewer invokes `atdd agent review --target-commit <sha> --report-file <path>` against the malformed fixture"
+    then:
+      abstract:
+        - "The command exits non-zero with a clear error citing the violated hard rule and the offending field(s)"
+        - "No file is written to .atdd/runtime/agents/<reviewer-id>/reviews/"
+        - "No review_complete event is emitted"
+        - "When the violation references a rule_id, the error includes the rule_id and the registry-expected severity/disposition"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/review_phase_boundaries/_review_phase_boundaries.yaml
+++ b/plan/review_phase_boundaries/_review_phase_boundaries.yaml
@@ -1,0 +1,64 @@
+wagon: review-phase-boundaries
+urn: "wagon:review-phase-boundaries"
+name: "Review Phase Boundaries"
+description: "Stands up the coach v9 adversarial reviewer surface that gates every meaningful phase boundary (PLANNED/RED/GREEN/SMOKE/optional REFACTOR): a no-write reviewer persona spawn adapter, a rule-ID-first review-report schema with hard rules forbidding false-pass on uncovered acceptances or strict findings, per-phase reviewer prompt templates with rule-resolution guidance, judge call site #2 wiring for concern verdicts, and the atdd agent review runtime command — all committed under src/atdd/coach/. Consumes the C0 frozen runtime contracts and the spawn-agents/judge/dispatch-validators surfaces."
+theme: commons
+
+subject: "agent:coach"
+context: "in-coach-v9, every-meaningful-phase-boundary-needs-adversarial-review-to-prevent-false-completion"
+action: "stands up the reviewer persona, review-report schema, per-phase prompts, judge call site #2 wiring, and atdd agent review runtime command for adversarial review at phase boundaries"
+goal: "ensure every phase boundary in coach v9 receives a rule-ID-aware adversarial review whose verdict cannot mechanically pass on uncovered acceptances or unaddressed strict findings"
+outcome: "a no-write reviewer persona spawn-adapter variant, a schema-validated review-report intake gate at src/atdd/coach/schemas/review-report.schema.json, five per-phase reviewer prompt templates at src/atdd/coach/prompts/persona/reviewer/<phase>.prompt.yaml with rule-resolution blocks, a judge-reviewer-concern.response.schema.json plus call site #2 routing logged to judgments.jsonl, and an atdd agent review --target-commit <sha> --report-file <path> command emitting review_complete events"
+
+features:
+  - urn: "feature:review-phase-boundaries:phase-boundary-review"
+
+produce:
+  - name: commons:coach:reviewer-persona-spawn-adapter
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:review-report-schema
+    contract: "contract:commons:coach:review-report"
+    telemetry: null
+    to: external
+  - name: commons:coach:reviewer-phase-prompts
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:judge-reviewer-concern-schema
+    contract: "contract:commons:coach:judge-reviewer-concern-response"
+    telemetry: null
+    to: external
+  - name: commons:coach:atdd-agent-review-command
+    contract: null
+    telemetry: null
+    to: external
+
+consume:
+  - name: commons:coach:runtime-event-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:judgment-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:validator-result-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:risk-score-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:runtime-layout-doc
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:event-semantics-doc
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:spawn-adapter
+    from: wagon:spawn-agents
+  - name: commons:coach:atdd-judge-core
+    from: wagon:judge-ambiguous-decisions
+  - name: commons:coach:tier1-validator-dispatch
+    from: wagon:dispatch-validators
+
+wmbt:
+  total: 5
+  D001: "minimize likelihood of write-permission-leak-from-reviewer-agent"
+  D002: "minimize likelihood of false-pass-verdict-on-uncovered-or-strict-findings"
+  D003: "minimize likelihood of phase-mismatched-reviewer-focus"
+  D004: "minimize likelihood of unaudited-concern-to-routing-decisions"
+  E001: "minimize likelihood of unrecorded-or-unvalidated-review-outcomes"

--- a/plan/review_phase_boundaries/features/phase_boundary_review.yaml
+++ b/plan/review_phase_boundaries/features/phase_boundary_review.yaml
@@ -1,0 +1,37 @@
+urn: "feature:review-phase-boundaries:phase-boundary-review"
+wagon: "wagon:review-phase-boundaries"
+description: "Coach v9 adversarial reviewer surface for every meaningful phase boundary (PLANNED/RED/GREEN/SMOKE/optional REFACTOR): a no-write reviewer persona spawn adapter (#N1), a rule-ID-first review-report schema with hard rules forbidding pass on uncovered acceptances or strict findings (#N2), five per-phase reviewer prompt templates with rule-resolution guidance (#N3), judge call site #2 wiring for concern verdicts with judgments.jsonl audit trail (#N4), and the atdd agent review runtime command emitting review_complete events (#N5)."
+sizing:
+  wmbts: 5
+  footprint_score: 8
+  footprint_size: "M"
+wmbts:
+  - "wmbt:review-phase-boundaries:D001"
+  - "wmbt:review-phase-boundaries:D002"
+  - "wmbt:review-phase-boundaries:D003"
+  - "wmbt:review-phase-boundaries:D004"
+  - "wmbt:review-phase-boundaries:E001"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 1
+        rationale: "atdd agent review CLI subcommand (#N5) is the single runtime surface; reviewer prompts and schemas have no runtime entry points of their own"
+    application:
+      - type: "use_cases"
+        count: 2
+        rationale: "Review-report intake (validate against schema, write to .atdd/runtime/agents/<id>/reviews/<id>.json, emit review_complete) and concern-to-judge routing (call site #2)"
+    domain:
+      - type: "value_objects"
+        count: 2
+        rationale: "Review report (rule-ID-first, AC-coverage-bound) and judge-reviewer-concern response (decision/rationale/pr_annotation) are value-object contracts whose shape is frozen here"
+    integration:
+      - type: "schemas"
+        count: 2
+        rationale: "review-report.schema.json (#N2) and judge-reviewer-concern.response.schema.json (#N4) under src/atdd/coach/schemas/"
+      - type: "prompts"
+        count: 5
+        rationale: "src/atdd/coach/prompts/persona/reviewer/<phase>.prompt.yaml for PLANNED, RED, GREEN, SMOKE, REFACTOR (#N3)"
+      - type: "spawn_adapter_variants"
+        count: 1
+        rationale: "Reviewer no-write adapter variant (#N1) layered over the base spawn adapter from wagon:spawn-agents — strips commit/edit tools, embeds no-write system prompt"


### PR DESCRIPTION
## Summary

Authors the `review-phase-boundaries` wagon (track N) for coach v9: a wagon manifest, one feature, 5 WMBTs (D001–D004 + E001), and 5 compliant issue body markdowns (N1–N5) under `.coach-v9-bootstrap/bodies/`.

This wagon stands up the coach v9 adversarial reviewer surface that gates every meaningful phase boundary (PLANNED/RED/GREEN/SMOKE/optional REFACTOR):

- **N1** — Reviewer persona + no-write spawn-adapter variant (strips commit/edit tools, embeds no-write system prompt, bounds output to `atdd agent review`).
- **N2** — Rule-ID-first review-report schema with three cross-field hard rules at coach intake (AC coverage, rule-ID severity match, no-pass-with-strict-finding).
- **N3** — Five per-phase reviewer prompt templates with the rule-resolution block embedded.
- **N4** — Judge call site #2 wiring: `concern` verdict triggers exactly one judge call against `judge-reviewer-concern.response.schema.json`; outcome logged to `judgments.jsonl`.
- **N5** — `atdd agent review --target-commit <sha> --report-file <path>` runtime command — validates, persists to `.atdd/runtime/agents/<id>/reviews/<id>.json`, emits `review_complete` event.

Consumes the C0 frozen runtime contracts (`runtime-event`, `coach-judgment`, `validator-result`, `risk-score`, `runtime-layout`, `event-semantics`) and the spawn-agents / dispatch-validators / judge-ambiguous-decisions sibling wagons by URN.

## Validation

- `atdd validate planner --quick` — 14 passed in `plan/`-scoped planner validators (WMBT vocabulary, hierarchy coverage, URN uniqueness, etc.). Pre-existing failures elsewhere (`test_open_issue_compliance`, `test_required_label_set`, `test_rule_id_uniqueness`, PR-base-branch on sibling wagon PRs) are not touched by this PR.
- WMBT lens vocabulary: all five WMBTs use `functional.effectiveness` or `functional.adaptability` (authorized lens attributes).

## Out of scope (filed in later passes)

- Issue filing — bodies are on disk under `.coach-v9-bootstrap/bodies/N{1..5}.md`; the sequential filer pane rewrites `#<INTERNAL_ID>` placeholders to GH numbers and creates the issues.
- Train YAML, 9-wagon registry, freeze-runtime-contracts wagon — inherited from `feat/coach-v9-bootstrap`; untouched.

## Test plan

- [ ] Filer pane resolves `#K2`, `#M3`, `#O1`, `#C0`, `#L2`, `#N1..#N5` to filed GH numbers
- [ ] `atdd validate planner` continues to pass on plan-scope validators after merge