### PR TITLE
feat(coach): coach v9 — drive-state-machine wagon

### DIFF
--- a/.coach-v9-bootstrap/bodies/J1.md
+++ b/.coach-v9-bootstrap/bodies/J1.md
@@ -1,0 +1,94 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-j1-state-machine-skeleton` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `drive-state-machine` |
+| Internal-Spec-Id | `J1` |
+| Feature | `atdd coach` MVP — state-machine skeleton (INIT|PLANNED|RED|GREEN|SMOKE|REFACTOR|COMPLETE|BLOCKED|MERGED) plus the §5.1 CLI argparse surface; intentionally narrow non-goals so every parallel coach v9 track has a stable hook point |
+
+---
+
+## Scope
+
+### In Scope
+
+J1 is the entry point of the `atdd coach` CLI and the durable orchestrator's skeleton. The other five J-track issues (#J2/#J3/#J4/#J5/#J6) and every other parallel track (#K1/#L1/#M1/#N1/#O1/#P1) hook into this skeleton; J1 itself ships only the parts that don't depend on those tracks.
+
+- **`src/atdd/coach/commands/coach.py`** — new module with the `atdd coach <issue-numbers...>` entry point. Argparse + dispatch only; no runtime side-effects beyond printing the planned state path and resolved configuration.
+- **State-machine enum** per spec §4.1: `INIT | PLANNED | RED | GREEN | SMOKE | REFACTOR | COMPLETE | BLOCKED | MERGED`. Implemented as a Python `Enum` with a stable string serialization for `decisions.jsonl` (consumed by #J3 once the durable log lands).
+- **State-transition table** per spec §4.1 — which states can transition to which (e.g., `PLANNED → RED|BLOCKED|OBSOLETE` per the lifecycle table). Pure data; loaded once at coach startup; no side-effects.
+- **CLI argparse skeleton** per spec §5.1: every flag listed in §5.1 parses correctly. Includes `--max-retries`, `--escalation-channel`, `--multiplexer`, `--multiplexer-mode`, `--auto-merge`, `--strict-deps`, `--llm`, `--persona-llm tester=...,coder=...,reviewer=...`, `--judge-llm`, `--require-issue-review {warn|block|auto}`, `--review-phases planned,red,green,smoke,refactor`, `--skip-review`, `--risk-threshold-block N`, `--allow-stale-suppressions`, `--resume <run-id>`, `--dry-run`. Unknown flags raise; `--persona-llm` parses to a per-persona dict; `--review-phases` parses to the enabled-phases set.
+- **`compute_waves` reuse** per spec §4.3: multi-issue invocations call `compute_waves()` from `src/atdd/coach/commands/orchestrate.py` (existing). No duplicate implementation; `commands/orchestrate.py` stays in place — #P5 owns its decommission.
+- **Unit tests** demonstrating: state-transition-table correctness across the full enum; argparse coverage for every §5.1 flag; `compute_waves` invocation with `--strict-deps` propagation.
+
+### Out of Scope
+
+J1 is intentionally narrow. The following are explicit non-goals — flagging them keeps the J1 PR free of drift into adjacent tracks:
+
+- **Watcher attachment** (`#J5`) — no `inotify`/`fswatch` imports, no git-refs watcher, no liveness timer.
+- **Validator dispatch** (`#M3`) — no pytest invocation, no `coach.runtime.violation_collector`, no suppression scanner integration.
+- **Observer integration** (`#L1`) — no correction injection, no observer rule loading.
+- **Spawn integration** (`#K1`) — no multiplexer dispatch, no `session_template.py::render` call, no `apply_canonical_name_and_layout`.
+- **Per-state transition logic** — the *table* ships in J1; the *handlers* land in per-state issues across tracks (e.g., spawning the planner at INIT lives in K-track follow-ups; running tier-1 validators at PLANNED lives in M-track).
+- **Two-phase commit** (`#J4`) — no `_create_worktree`/`_remove_worktree` absorption; that's E001's scope.
+- **Decision durability** (`#J3`) — the C0 schema (`coach-decision.schema.json`) informs the eventual record shape but no `decisions.jsonl` writes happen in J1. P001 owns the writer.
+- **Resume** (`#J6`) — `--resume <run-id>` parses but is not yet wired to reconstruction logic. R001 owns the resume runner.
+
+### Dependencies
+
+- `#C0` — `coach-decision.schema.json` and `runtime-event.schema.json` inform the in-memory shapes the J1 state machine carries (even though no durable writes happen yet).
+- Existing `compute_waves()` in `src/atdd/coach/commands/orchestrate.py` (substrate, untouched).
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Coach state-machine entry point | `atdd orchestrate` is a thin dispatcher; phase truth lives in agents and GitHub labels (lossy) | `atdd coach <issue-numbers...>` initializes a per-issue state machine in `INIT` and prints the planned state path | Without a single durable orchestrator entry point, every parallel J/K/L/M/N/O/P track invents its own coach-shaped harness |
+| §5.1 CLI surface | No `atdd coach` command exists; flag set is documented in spec only | All §5.1 flags parse and print resolved configuration | Tracks N (review), M (validators), L (observers), O (judge) all need this surface to be parsable before they can hook in |
+| Wave computation reuse | `compute_waves()` lives in `commands/orchestrate.py`; coach v9 must reuse it (per spec §0.2) without duplication | `coach.py` imports and calls `compute_waves()`; `--strict-deps` propagates | Reimplementing wave logic in coach would diverge from `orchestrate.py`'s tested behavior and break the absorption discipline in §2 |
+| Scope leak risk | Multi-track work tends to drift across modules during parallel implementation | Code review confirms no scope leak into J5/M3/L1/K1/J4/J3/J6 territory | Without explicit non-goals, J1's PR would absorb downstream-track concerns and serialize what should be parallel work |
+
+### User Impact
+
+The "user" of J1 is every coach v9 implementer working on parallel tracks. Per spec §11.1, tracks J/K/L/M/N/O/P all start in parallel after `#C0` lands; the J-track sequence (J1 → J2 → J3 → J4 → J5 → J6) is the spine. Without J1's skeleton, every other track has nothing concrete to import — they would each invent a coach-shaped harness or stub, diverging from spec §4 immediately.
+
+The lived problem: today `atdd orchestrate` + `atdd babysit` form a fragile two-system arrangement (per spec §1) where orchestrate dispatches and babysit polls; phase truth lives across agents + GitHub labels + screen hashes. Coach v9 deliberately replaces this with an event-driven, durable, observer-augmented orchestrator. J1 is the *first concrete commit* of that architecture — the state-machine skeleton + §5.1 CLI — and intentionally does *not* implement the watchers/validators/observers/spawn integrations that would otherwise dwarf it. That narrowness is the point: J1 must land cleanly so #J2/#J3/#J4/#J5/#J6 can extend it without rebasing through unrelated work.
+
+Per spec §4.3, multi-issue runs use `compute_waves()` from `commands/orchestrate.py`. J1 keeps `commands/orchestrate.py` in place (it's not yet decommissioned — `#P5` owns that) and reuses `compute_waves()` directly. The absorption-without-duplication discipline in §0.2 is the load-bearing principle: every absorbed function moves into coach modules with behavior preserved; nothing is rewritten.
+
+### Design Anchor
+
+J1's narrowness is a deliberate architectural choice, not an artifact of incremental scope. Spec §4 describes the per-issue state machine; spec §5.1 describes the CLI surface. Both are pure-data + pure-skeleton concerns — no I/O beyond argparse and `print`. By isolating them in J1, every downstream issue (#J2/#J3/#J4/#J5/#J6 and the K/L/M/N/O/P tracks) gets a stable hook-point: the state machine *exists* and the CLI *parses*, so concrete imports (`from atdd.coach.commands.coach import Phase, transition_table, parse_cli`) work for everyone in parallel.
+
+The non-goals list mirrors the issue list it points away from. Each `Out of Scope` bullet names the issue that owns that concern, so reviewers can verify scope without cross-referencing the full v3 spec.
+
+---
+
+## Acceptance
+
+- `acc:drive-state-machine:D001-UNIT-001-state-machine-skeleton`: `atdd coach 358` initializes a state machine in `INIT` for issue 358 and prints the planned state path without executing transitions; the §4.1 enum and transition table are present and consulted; no watcher / validator / observer / spawn / two-phase-commit / decision-durability / resume side-effects run.
+- `acc:drive-state-machine:D001-UNIT-002-flag-parsing`: All §5.1 flags parse correctly (`--max-retries`, `--escalation-channel`, `--multiplexer`, `--multiplexer-mode`, `--auto-merge`, `--strict-deps`, `--llm`, `--persona-llm tester=…,coder=…,reviewer=…`, `--judge-llm`, `--require-issue-review {warn|block|auto}`, `--review-phases planned,red,green,smoke,refactor`, `--skip-review`, `--risk-threshold-block N`, `--allow-stale-suppressions`, `--resume <run-id>`, `--dry-run`); unknown flags raise; resolved configuration is printable.
+- `acc:drive-state-machine:D001-UNIT-003-compute-waves-reuse`: `atdd coach 358 359 360 --strict-deps` resolves the dependency graph and computes waves by calling `compute_waves()` from `src/atdd/coach/commands/orchestrate.py` (no duplicate implementation); the resolved wave assignment is printed; `--strict-deps` propagates into the wave-transition gating policy.
+- `acc:drive-state-machine:D001-INTEGRATION-001-no-scope-leak`: Code review and unit-test coverage confirm no scope leak into `#J5`/`#M3`/`#L1`/`#K1`/`#J4`/`#J3`/`#J6` territory — no inotify/fswatch imports, no validator dispatch, no observer correction injection, no multiplexer/`session_template` calls, no worktree creation/rollback, no `decisions.jsonl`/`judgments.jsonl` writes, no resume reconstruction.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §4 (coach state machine), §4.1 (per-issue states), §4.3 (multi-issue orchestration via `compute_waves`), §5.1 (`atdd coach` CLI), §0.2 (absorption inventory — `compute_waves`)
+- `atdd-coach-issues-v3.md` issue `#J1`
+- Wagon manifest: `plan/drive_state_machine/_drive_state_machine.yaml`
+- Feature: `plan/drive_state_machine/features/coach_state_machine_and_runtime.yaml`
+- WMBT: `plan/drive_state_machine/D001.yaml`
+- Predecessor: `#C0` (runtime contract freeze — `coach-decision.schema.json`, `runtime-event.schema.json`)
+- Existing machinery: `compute_waves()` in `src/atdd/coach/commands/orchestrate.py`

--- a/.coach-v9-bootstrap/bodies/J2.md
+++ b/.coach-v9-bootstrap/bodies/J2.md
@@ -1,0 +1,97 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-j2-agent-cli-subcommands` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `drive-state-machine` |
+| Internal-Spec-Id | `J2` |
+| Feature | `atdd agent` CLI subcommands (heartbeat, event, commit, ask, escalate, done, context, review) writing to `.atdd/runtime/agents/<id>/` per spec §3.2; phase-aware commits with the four required trailers via `atdd checkpoint` |
+
+---
+
+## Scope
+
+### In Scope
+
+J2 ships the persona-agent side of the coach contract: the `atdd agent` CLI is how agents (planner/tester/coder/reviewer) emit heartbeats, runtime events, structured questions, escalations, done-signals, and phase-aware commits. Coach (the eventual reader, owned by `#J5`/M001) consumes these via the runtime watcher.
+
+- **`src/atdd/coach/commands/agent.py`** — new module with the `atdd agent <subcommand>` dispatcher per spec §5.3. Subcommands: `heartbeat`, `event`, `commit`, `ask`, `escalate`, `done`, `context`, and the reviewer-only `review`.
+- **Per-subcommand behavior** — all writes target `.atdd/runtime/agents/<id>/` per the spec §3.2 layout (formalized as `runtime-layout.md` in `#C0`):
+  - `atdd agent heartbeat [--current-step "..."]` writes/updates `heartbeat.json` with the current timestamp + optional current-step string.
+  - `atdd agent event <type> [--data '...']` appends a record to `events.jsonl` conformant to `runtime-event.schema.json` (`#C0`).
+  - `atdd agent ask --question "..." --type <choice|text|approval|confirmation>` appends a structured question to `questions.jsonl`. Coach answers via `answers/<question-id>.json`.
+  - `atdd agent escalate --reason "..." [--severity info|warn|block]` appends to `escalations.jsonl` with severity tagged.
+  - `atdd agent done [--summary "..."]` writes a final-summary record signaling persona completion.
+  - `atdd agent context` prints the current phase + WMBT context (read from the agent's spawn-time bundle).
+- **`atdd agent commit --phase <P> --message "..." [--wmbt-urn <urn>]`** — produces a phase-aware commit by delegating to the existing `atdd checkpoint` primitive. Commit message carries the four required trailers: `Agent-Id`, `Issue`, `WMBT-Urn`, `Phase` per spec §7.3. Phase value is validated against the §4.1 enum (RED|GREEN|SMOKE|REFACTOR); INIT/PLANNED/COMPLETE/BLOCKED/MERGED commits are not part of the agent surface.
+- **Reviewer subcommand** — `atdd agent review --target-commit <sha> --report-file <path>` writes review records to `.atdd/runtime/agents/<id>/reviews/<review-id>.json`. The full reviewer persona spawn (no-write adapter, etc.) is owned by `#N1`/`#N5`; J2 ships only the CLI surface so #N1/#N5 have a stable target.
+- **Runtime-layout adherence** — every write path is enumerated in `runtime-layout.md` (#C0). J2's tests verify each subcommand writes to the correct path with the correct file shape (single-doc vs JSON-lines, append-only vs rewritten).
+
+### Out of Scope
+
+- **Coach-side answer generation** — `atdd agent ask` writes the question; `answers/<question-id>.json` is written by the coach state machine. J2 ships the question-write side only; the answer-read contract is exercised in tests via fixtures.
+- **Reviewer no-write spawn adapter** (`#N1`) — the spawn-time tool stripping (no commit/edit) lives in N-track. J2 ships the `atdd agent review` CLI surface only.
+- **Observer correction injection** (`#L1`) — corrections targeted at agents are owned by the observer; J2 does not implement reading/applying corrections.
+- **Per-LLM convention file rendering** (`#K4`) — what gets bundled into the spawn harness is K-track concern; J2 reads context from whatever was bundled.
+- **Decisions/judgments durability** (`#J3`/P001) — agents write to per-agent runtime files; coach writes to `decisions.jsonl`/`judgments.jsonl`. J2 stays on the agent side.
+- **Existing `atdd checkpoint` internals** — J2 calls it; does not re-implement.
+
+### Dependencies
+
+- `#J1` — `atdd coach` skeleton must exist so `atdd agent commit` can validate that its phase trailer matches the coach's known phase enum.
+- `#C0` — `runtime-event.schema.json` (event payload shape), `runtime-layout.md` (file paths + roles).
+- Existing `atdd checkpoint` primitive (canonical commit-with-trailers).
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Per-agent runtime side-effects | Agents under `atdd orchestrate` write ad-hoc files (or none) — coach has no contract to read against | `atdd agent <subcommand>` writes every persona side-effect to `.atdd/runtime/agents/<id>/` per `runtime-layout.md` (#C0) | Without a unified CLI, the watcher (#J5) has no contract to parse; observer rules (#L1) have nothing to react to |
+| Commit trailer enforcement | Agents may or may not include `Agent-Id`/`Issue`/`WMBT-Urn`/`Phase`; trailer presence is hand-checked | `atdd agent commit` produces all four trailers via `atdd checkpoint`; pre-commit hook validates | Without trailers, the git watcher (#J5) can't route commit_observed events; tier-1 dispatch (#M3) can't resolve WMBT scope |
+| Question/answer round-trip | No structured channel for agent → coach questions; agents inline-ask via prompts (lossy) | `atdd agent ask` writes to `questions.jsonl`; coach replies in `answers/<question-id>.json` | Without a contract, escalation paths blur with normal flow; coach can't track per-question latency or aggregate ambiguity |
+| Reviewer surface | No CLI for reviewer to emit findings; reviewer writes free-form output | `atdd agent review --target-commit --report-file` is the only reviewer output channel (per spec §6.3 hard rules) | Without a single output channel, reviewer findings are fragile and unpartial-able by tools |
+
+### User Impact
+
+The "user" of J2 is every persona agent (planner/tester/coder/reviewer) under coach orchestration. Today, agents write ad-hoc files — phase progress lives across agent self-reports + GitHub labels + screen hashes (per spec §1's "trust-based protocol" critique). The lived consequence is the `detect_violation` machinery in `atdd babysit` (1043 lines, fixed-handful patterns): without a contract to parse, every detection is bespoke regex matching on screen hashes.
+
+J2 inverts this. The agent's only side-effect surface is `atdd agent <subcommand>`. Every write target, every file shape, every trailer is contract-bound. This is what makes the runtime watcher (#J5) deterministic, the observer rules (#L1) extensible, and the tier-1 validators (#M3) routable by WMBT scope.
+
+Per spec §7.3, `atdd agent commit` carries the four trailers `Agent-Id`, `Issue`, `WMBT-Urn`, `Phase`. The commit primitive itself is the existing `atdd checkpoint` — J2 does not re-implement git interaction; it wraps `atdd checkpoint` with trailer marshalling and phase-enum validation against the §4.1 set. That's the absorption discipline from spec §0.2: `atdd checkpoint` is shipped substrate; J2 calls it.
+
+The reviewer CLI (`atdd agent review`) is intentionally narrow in J2 — it ships the write path so `#N1` (reviewer persona + no-write spawn adapter) and `#N5` (`atdd agent review` review-emission semantics) have something concrete to build on. The output channel is the spec §6.3 hard rule: "Only output channel: `atdd agent review --target-commit <sha> --report-file <path>`."
+
+### Design Anchor
+
+Spec §5.3 + §3.2 together define a contract: agents write to per-agent runtime directories, with named files for each kind of side-effect. The CLI is the only sanctioned write path. By moving every write through `atdd agent`, J2 makes the watcher's parse job tractable: it reads from a known directory shape with known file types, not from arbitrary agent-written files.
+
+The four commit trailers (`Agent-Id`, `Issue`, `WMBT-Urn`, `Phase`) are the load-bearing primitive for tier-1 validator dispatch (#M3 / §6.4 step 1: "Parse commit trailers; extract Phase, WMBT-Urn, Agent-Id"). J2's correctness on trailers is what makes #M3 possible.
+
+---
+
+## Acceptance
+
+- `acc:drive-state-machine:D002-UNIT-001-subcommands-resolve`: All `atdd agent` subcommands (`heartbeat`, `event`, `commit`, `ask`, `escalate`, `done`, `context`, `review`) resolve and write the expected files under `.atdd/runtime/agents/<id>/` per spec §3.2 layout — `heartbeat.json` carries current timestamp; `events.jsonl` records conform to `runtime-event.schema.json`; `questions.jsonl`, `escalations.jsonl` carry the structured payloads; `done` writes a final-summary record; `context` prints the current phase + WMBT.
+- `acc:drive-state-machine:D002-UNIT-002-commit-trailers`: `atdd agent commit --phase <P> --message "..." --wmbt-urn <urn>` produces a commit with all four required trailers (`Agent-Id`, `Issue`, `WMBT-Urn`, `Phase`) per spec §7.3; the commit is produced via `atdd checkpoint` (no direct `git commit` reimplementation); phase value is validated against the §4.1 enum; the existing pre-commit hook still runs.
+- `acc:drive-state-machine:D002-UNIT-003-ask-answer-roundtrip`: `atdd agent ask --question "..." --type <choice|text|approval|confirmation>` produces a structured question in `questions.jsonl` with `question-id`, `type`, `question` text, and `timestamp`; coach's answer arrives at `answers/<question-id>.json` keyed by the same `question-id`; the round-trip path is the only contract (no shared mutable state between agent and coach).
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §3.2 (runtime folder layout), §5.3 (`atdd agent` subcommands), §7.3 (commit trailers), §6.3 (reviewer-only review output channel)
+- `atdd-coach-issues-v3.md` issue `#J2`
+- Wagon manifest: `plan/drive_state_machine/_drive_state_machine.yaml`
+- WMBT: `plan/drive_state_machine/D002.yaml`
+- Predecessor: `#J1` (state-machine + CLI skeleton)
+- Predecessor: `#C0` (`runtime-event.schema.json`, `runtime-layout.md`)
+- Existing machinery: `atdd checkpoint` (commit primitive, unchanged)

--- a/.coach-v9-bootstrap/bodies/J3.md
+++ b/.coach-v9-bootstrap/bodies/J3.md
@@ -1,0 +1,89 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-j3-decision-judgment-durability` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `drive-state-machine` |
+| Internal-Spec-Id | `J3` |
+| Feature | Append-only `decisions.jsonl` and `judgments.jsonl` writers under `.atdd/runtime/coach/`, conformant to the C0 schemas, with write-time validation and decision-precedes-action invariant — the durable substrate that makes `#J6` resume lossless |
+
+---
+
+## Scope
+
+### In Scope
+
+J3 ships the durable substrate for coach state. Spec §4.5 says "every state transition appended to `decisions.jsonl` *before* the action runs" — J3 makes that real. Spec §6.9 says "every judgment writes to `judgments.jsonl`" — J3 makes that real. Both files are the resume source of truth for `#J6`.
+
+- **`decisions.jsonl` writer** at `.atdd/runtime/coach/decisions.jsonl` per spec §3.2. Append-only; one JSON line per record; every record validated against `coach-decision.schema.json` (`#C0`) at write time.
+- **`judgments.jsonl` writer** at `.atdd/runtime/coach/judgments.jsonl` per spec §3.2. Append-only; one JSON line per record; every record validated against `coach-judgment.schema.json` (`#C0`).
+- **Decision-precedes-action invariant** (spec §4.5) — for every state transition, the decision is appended to `decisions.jsonl` BEFORE the action runs. Verified by tests that inject failure at action-time and observe the decision still recorded. This is the load-bearing invariant for `#J6` resume.
+- **Schema validation at write time** — both writers load their respective C0 schemas (`coach-decision.schema.json`, `coach-judgment.schema.json`) and reject malformed records before any bytes hit the file. The error names the missing/invalid field; the file is not partially written.
+- **Idempotency contract for actions** — every action whose decision is logged remains idempotent (the action recognizes "already logged" and skips re-execution). This is what makes `#J6` work without double-execution.
+- **`inputs_hash` discipline for judgments** — per spec §6.9, "Inputs hashed by default; full inputs in gitignored cache." The durable log carries `inputs_hash`; full inputs go to a gitignored cache directory. Audit trail without sensitive-input leakage into the durable log.
+- **Concurrent-safe append** — `O_APPEND` semantics; `fsync` after each record. Concurrent writes from the watcher (`#J5`) and the coach main loop don't interleave partial records (verified via the M001 acceptance for append-only no-interleave).
+
+### Out of Scope
+
+- **Defining the schemas themselves** — `coach-decision.schema.json` and `coach-judgment.schema.json` are owned by `#C0`. J3 consumes them; it doesn't redefine them.
+- **The state-machine driver that calls the writer** — `#J1` ships the state-machine skeleton. J3's writer is invoked by every state-transition handler that lands in subsequent issues across tracks; J3 ships the writer + its contract, not the call sites.
+- **Resume reconstruction** (`#J6` / R001) — J3 makes resume *possible* by ensuring the durable log is complete and idempotent; the actual reconstruction logic lives in `#J6`.
+- **Judge call site implementations** (`#O2`/`#O3`) — the six call sites in spec §6.9 are owned by O-track. J3 ships the writer that O-track calls.
+- **Two-phase commit log records** (`#J4` / E001) — `#J4` writes worktree-creation decisions; the writer it uses is the J3 writer.
+
+### Dependencies
+
+- `#J1` — coach state machine exists, so per-issue transitions have a place to be logged from.
+- `#C0` — `coach-decision.schema.json`, `coach-judgment.schema.json`, plus the `runtime-layout.md` doc that names `decisions.jsonl` and `judgments.jsonl` as append-only JSON-lines.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Coach state durability | `atdd orchestrate` keeps state in `.atdd/orchestrate-state.json` (single-document JSON, replaced wholesale on each transition); a kill mid-transition can lose state | `.atdd/runtime/coach/decisions.jsonl` carries every transition as an append-only JSON line; lossless across kill/restart | Without append-only durability, `#J6` resume is unreliable; "mechanical floor + probabilistic ceiling" (spec §2) collapses |
+| Decision-precedes-action ordering | Today's orchestrate writes state *after* the action; a crash between action and write can desync the durable log from observable side-effects | J3's writer records the decision *before* the action runs (spec §4.5); idempotent actions absorb replay | Without this invariant, replay can double-execute or skip-execute; this is the load-bearing principle for resume |
+| Judgment audit trail | `atdd judge` calls produce no durable record; rationale is lost | `judgments.jsonl` carries `judgment_id`, `timestamp`, `call_site`, `inputs_hash`, `response`, `cached` per spec §6.9 | Without an audit trail, the "deterministic-first" discipline in §6.9 has no enforcement surface — every judge call site claim is unverifiable |
+| Schema enforcement at write | Today's `orchestrate-state.json` has no schema; field-name drift is not detected | C0 schemas are loaded at writer init; every record validated before persistence | Without write-time validation, drift accumulates silently and only surfaces at `#Q1` integration |
+
+### User Impact
+
+The "user" of J3 is the entire downstream coach v9 implementation. Every state transition, every judge call, every two-phase-commit decision flows through J3's writer. Per spec §4.5: "Actions are idempotent." That property holds only if the durable log is the source of truth — and J3 is the writer that makes the log durable.
+
+The lived problem: today `.atdd/orchestrate-state.json` is replaced wholesale on each transition. A kill mid-rewrite can leave the file in a half-written state; `--resume` (today's flag in `orchestrate.py`) sometimes recovers, sometimes restarts. Coach v9 escapes this by moving to JSON-lines + append-only + fsync, with the C0 schema enforced at write time. Per spec §0.2: ".atdd/orchestrate-state.json with `decisions.jsonl` as the durable resume source" — J3 ships that replacement.
+
+The `inputs_hash` discipline (spec §6.9: "Inputs hashed by default; full inputs in gitignored cache") is a deliberate trade-off. The durable log lives in the repo's runtime directory (gitignored, per §3.3); full judge inputs may contain large prompts or sensitive context. By hashing in the durable log and caching elsewhere, J3 keeps the log compact and safe while still preserving full audit traceability through the cache.
+
+### Design Anchor
+
+Spec §4.5 ("Decision durability") and §6.9 ("Coach judgment via `atdd judge`") together define the durable substrate. The principle is that coach is *deterministic Python for the structural skeleton*; the durable log is what makes it deterministic across restarts. Append-only + fsync + write-time schema validation is the minimum-mechanism discipline that achieves this.
+
+J3's narrowness — it ships writers, not call sites — is what lets it land in wave w1 without blocking on every consumer. `#J4` (two-phase commit), `#J5` (watcher), `#J6` (resume), and the entire O track (judge call sites) all depend on J3, but J3 itself depends only on `#J1` + `#C0`.
+
+---
+
+## Acceptance
+
+- `acc:drive-state-machine:P001-UNIT-001-decisions-append-only`: A coach run writes every state transition to `.atdd/runtime/coach/decisions.jsonl` in append-only fashion BEFORE the action runs (verified by injecting a failure at action-time and observing the decision still recorded); records conform to `coach-decision.schema.json` from `#C0`; required fields `decision_id`, `timestamp`, `coach_run_id`, `issue_number`, `decision_type`, `inputs`, `outcome` are populated; the file is opened with `O_APPEND` semantics and concurrent writes don't corrupt records.
+- `acc:drive-state-machine:P001-UNIT-002-judgments-append-only`: A coach run that calls `atdd judge` writes every call to `.atdd/runtime/coach/judgments.jsonl` with records conforming to `coach-judgment.schema.json` from `#C0`; required fields `judgment_id`, `timestamp`, `call_site`, `inputs_hash`, `response`, `cached` are populated; `inputs_hash` is a content hash; full inputs go to the gitignored cache; `call_site` value is one of the six enumerated in spec §6.9.
+- `acc:drive-state-machine:P001-UNIT-003-schema-validation-at-write`: Schema validation runs at write time for both `decisions.jsonl` and `judgments.jsonl`; an attempt to write a record missing a required field is rejected with a schema-validation error before any bytes hit the file; the error names the missing/invalid field; the file is not partially written.
+- `acc:drive-state-machine:P001-UNIT-004-actions-idempotent`: All actions whose intent is durably logged remain idempotent; replaying a recorded `INIT→PLANNED` transition for an issue causes the action to be recognized as already executed (via the durable log) and skipped; no duplicate side-effects (no second commit, no second worktree, no second event emission); idempotency is the contract that makes `#J6` resume feasible.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §3.2 (runtime folder layout), §4.5 (decision durability), §6.9 (`atdd judge` and `judgments.jsonl`), §7.7 (validator-invocation contract — context for write-time validation discipline)
+- `atdd-coach-issues-v3.md` issue `#J3`
+- Wagon manifest: `plan/drive_state_machine/_drive_state_machine.yaml`
+- WMBT: `plan/drive_state_machine/P001.yaml`
+- Predecessor: `#J1` (coach state-machine skeleton)
+- Predecessor: `#C0` (`coach-decision.schema.json`, `coach-judgment.schema.json`, `runtime-layout.md`)

--- a/.coach-v9-bootstrap/bodies/J4.md
+++ b/.coach-v9-bootstrap/bodies/J4.md
@@ -1,0 +1,90 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-j4-two-phase-commit` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `drive-state-machine` |
+| Internal-Spec-Id | `J4` |
+| Feature | Two-phase commit absorbed from `commands/orchestrate.py` per spec §4.6 — Phase A creates worktrees with rollback-on-failure; Phase B launches sessions and writes a decision per success; `decisions.jsonl` replaces `.atdd/orchestrate-state.json` as the durable resume source |
+
+---
+
+## Scope
+
+### In Scope
+
+J4 absorbs `atdd orchestrate`'s two-phase-commit discipline into coach. The behavior is preserved verbatim per spec §0.2 ("Existing machinery absorbed, not duplicated"): the rollback semantics, the Phase A / Phase B split, the idempotency assumptions. Only the durable resume source changes (`.atdd/orchestrate-state.json` → `decisions.jsonl`).
+
+- **Phase A — Worktree creation** per spec §4.6. For each issue, call `_create_worktree` (absorbed from `src/atdd/coach/commands/orchestrate.py`). If any worktree creation fails, all already-created worktrees are rolled back via `_remove_worktree` (also absorbed). Errors return early; partial state is never persisted.
+- **Phase B — Session launch** per spec §4.6. With all worktrees created, render launch prompts (per `#K1`/`#K2` contract; J4 calls them) and dispatch via the multiplexer (per `#K1`). Each successful launch writes a decision to `decisions.jsonl` (the writer from `#J3` / P001). Failed launches log without rolling back already-launched siblings — the assumption being that a successfully-launched agent is recoverable on `--resume`, so we don't undo it.
+- **Resume source replacement** — `.atdd/orchestrate-state.json` (today's single-document JSON) is *no longer written by coach*. Resume now reads `decisions.jsonl` (the JSON-lines durable log from `#J3` / P001). Behavior identical: `--resume` reconstructs which worktrees exist (idempotent `_create_worktree` no-op for existing) and which sessions launched (idempotent spawn check).
+- **Verbatim absorption** — the helper functions (`_create_worktree`, `_remove_worktree`) and the Phase A creation loop with rollback move into a coach module with behavior preserved. No reimplementation; no re-test of orchestrate's existing semantics beyond parity.
+- **`commands/orchestrate.py` stays in place** — `#P5` owns the decommission. J4 wires coach against the absorbed machinery; `commands/orchestrate.py` continues to function for backward compatibility until `#P5` removes it.
+
+### Out of Scope
+
+- **Full session launch internals** (`#K1`) — the `atdd spawn` skeleton (multiplexer dispatch, `session_template.py::render`, prompt write) lives in K-track. J4 calls into that skeleton and records the decision.
+- **Canonical naming + layout** (`#K3`) — applied at spawn time inside `atdd spawn`; J4 doesn't re-implement.
+- **Resume reconstruction logic** (`#J6` / R001) — J4 makes resume *possible* by writing complete decisions; the actual `--resume` reconstruction lives in `#J6`.
+- **Decommission of `commands/orchestrate.py`** (`#P5`) — that module stays in place after J4 lands; only the resume-state-file replaces it.
+- **Watchers** (`#J5` / M001) — J4 does not start watchers; that's the watcher issue's job. J4 ships transactional launch only.
+- **Decision schema definition** (`#C0`) — J4 emits records conformant to the C0 schema; does not redefine.
+
+### Dependencies
+
+- `#J1` — coach state-machine skeleton + CLI must exist so multi-issue invocations have a place to dispatch from.
+- `#J3` (P001) — `decisions.jsonl` writer must exist so Phase B can record per-launch decisions.
+- Existing `_create_worktree`, `_remove_worktree`, Phase A loop, Phase B loop in `src/atdd/coach/commands/orchestrate.py` (absorbed verbatim).
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Multi-issue worktree creation | `atdd orchestrate` Phase A creates worktrees with rollback-on-any-failure; lives in `commands/orchestrate.py` | The same `_create_worktree`/`_remove_worktree` + Phase A loop lives in coach (absorbed verbatim per §0.2) | Without absorption, coach would either reimplement (drift) or shell out to orchestrate (extra process boundary, lost rollback fidelity) |
+| Phase B launch semantics | `atdd orchestrate` Phase B launches per-issue sessions with state recorded to `.atdd/orchestrate-state.json` | Phase B writes per-launch decisions to `decisions.jsonl` (the JSON-lines log from `#J3`); `.atdd/orchestrate-state.json` no longer written | Without the resume-source change, coach has two competing durable state files; the `decisions.jsonl` discipline from `#J3` / P001 is undermined |
+| Rollback discipline | Phase A's rollback is the load-bearing reliability invariant ("no partial worktrees persist") | Preserved verbatim; J4's tests assert it | Without explicit preservation, an absorption refactor can silently lose rollback fidelity (the failure mode is hidden until a creation fails for real) |
+| Resume reconstruction surface | `--resume` today reads `.atdd/orchestrate-state.json` | `--resume` reads `decisions.jsonl`; idempotent helpers (`_create_worktree`, spawn check) skip already-completed steps | Without this, `#J6` has nothing to reconstruct against |
+
+### User Impact
+
+The "user" of J4 is the coach operator running `atdd coach 358 359 360` and wanting reliability across kill-restart. Today's `atdd orchestrate` already does this for worktree creation and session launch — coach v9 absorbs that machinery so the same semantics survive. The lived problem isn't broken rollback; it's having two competing orchestrators (orchestrate + coach) with divergent state files. J4 collapses them: one orchestrator (coach), one durable log (`decisions.jsonl`).
+
+Per spec §0.2: "Two-phase commit (Phase A: worktrees, rollback on failure; Phase B: launch, state file `.atdd/orchestrate-state.json` for `--resume`). **Absorbed** by coach with the rollback discipline preserved (§4.6); state file replaced by `decisions.jsonl`." J4 is the literal execution of that absorption.
+
+The non-rollback for Phase B failures (per spec §4.6: "failed launches log without rolling back already-launched siblings") is intentional and inherited. The reasoning: a successfully-launched agent has spawned a process and may be doing real work; tearing it down on a sibling's failure loses progress. `--resume` instead picks up the un-launched siblings.
+
+### Design Anchor
+
+Spec §4.6 names this principle directly: "This replaces today's `.atdd/orchestrate-state.json` with `decisions.jsonl` as the durable resume-source. The behavior is identical: `--resume` reconstructs which worktrees exist and which sessions launched, skipping idempotent steps. The state-file format changes (JSON-lines instead of single-document JSON), but the rollback discipline is preserved verbatim."
+
+The architectural choice — two phases with asymmetric rollback (A rolls back, B doesn't) — is a tested heuristic from `atdd orchestrate`. J4 inherits it without modification because the alternative (rolling back launched agents) violates the "actions are idempotent on resume" principle in spec §4.5. Idempotency is what lets us not roll back; rollback is what lets us not corrupt.
+
+---
+
+## Acceptance
+
+- `acc:drive-state-machine:E001-INTEGRATION-001-phase-a-rollback`: Coach with multiple issues creates all worktrees in Phase A; if any fail, all already-created worktrees roll back via `_remove_worktree` before exit; `_create_worktree` and `_remove_worktree` from `src/atdd/coach/commands/orchestrate.py` are absorbed into coach per spec §4.6; coach returns a non-zero exit code with an error naming the failed issue; no partial state persists (no orphaned worktrees, no `decisions.jsonl` entries for the rolled-back creations).
+- `acc:drive-state-machine:E001-INTEGRATION-002-phase-b-launch`: After all worktrees succeed, Phase B launches sessions and writes a decision per success to `decisions.jsonl` (the writer from `#J3` / P001); when a launch fails, the failure is logged but already-launched siblings are NOT rolled back; coach records the partial-launch state durably so `--resume` can finish without restarting siblings; the rationale (a successfully-launched agent is recoverable on `--resume`; we don't undo it) is honored.
+- `acc:drive-state-machine:E001-INTEGRATION-003-resume-source-replaced`: `decisions.jsonl` replaces `.atdd/orchestrate-state.json` as the durable resume source; `coach --resume <run-id>` reads `decisions.jsonl` to reconstruct state, recognizes existing worktrees as already created (idempotent `_create_worktree` no-op), recognizes already-launched sessions (idempotent spawn check), and only re-launches the sessions that haven't run; `commands/orchestrate.py` is not yet decommissioned (`#P5` owns that); existing orchestrate behavior is preserved at parity.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §4.6 (two-phase commit), §0.2 (absorption inventory — `_create_worktree`, `_remove_worktree`, Phase A loop), §4.5 (decision durability — context for the resume-source change)
+- `atdd-coach-issues-v3.md` issue `#J4`
+- Wagon manifest: `plan/drive_state_machine/_drive_state_machine.yaml`
+- WMBT: `plan/drive_state_machine/E001.yaml`
+- Predecessor: `#J1` (coach state-machine skeleton)
+- Predecessor: `#J3` (`decisions.jsonl` writer / P001)
+- Existing machinery: `_create_worktree`, `_remove_worktree`, Phase A/B loops in `src/atdd/coach/commands/orchestrate.py` (absorbed)
+- `#P5` decommissions `commands/orchestrate.py` after J4 lands

--- a/.coach-v9-bootstrap/bodies/J5.md
+++ b/.coach-v9-bootstrap/bodies/J5.md
@@ -1,0 +1,100 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-j5-runtime-watcher` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `drive-state-machine` |
+| Internal-Spec-Id | `J5` |
+| Feature | Three concurrent event sources per spec §4.4 — runtime watcher (`inotify`/`fswatch` on `.atdd/runtime/agents/*/`), git watcher (`inotify` on `.git/refs/heads/` + `gh pr view` polling), 30s liveness checker — feeding a single coach event queue with the idempotency, ordering, and replay contracts from `event-semantics.md` |
+
+---
+
+## Scope
+
+### In Scope
+
+J5 ships the event-driven core that replaces `atdd babysit`'s polling. Per spec §4.4, three event sources run concurrently and feed a single coach event queue. The `event-semantics.md` doc from `#C0` is the contract J5 implements.
+
+- **Runtime watcher** — `inotify` (Linux) / `fswatch` (macOS) on `.atdd/runtime/agents/*/`. On file change, parse the file (`heartbeat.json`, `events.jsonl`, `escalations.jsonl`, `corrections.jsonl`) and push the parsed event to the coach event queue. Latency budget: ≤1s from file write to coach receiving the event. Event payloads conform to `runtime-event.schema.json` (`#C0`).
+- **Git watcher** — `inotify` on each worktree's `.git/refs/heads/`, plus `gh pr view` polling for PR state changes. On commit, emit a `commit_observed` event with new commit SHA, branch, worktree path, and parsed commit trailers (`Agent-Id`, `Issue`, `WMBT-Urn`, `Phase`) per spec §6.4 step 1. PR-state changes emit `pr_opened` / `pr_closed`.
+- **Liveness checker** — timer every 30s. Reads each agent's `process_heartbeat.json`; if elapsed > `coach.process_silence_seconds`, emit a `stuck` event with `agent-id`, `last-heartbeat-timestamp`, `elapsed-seconds`. Bounded emissions: one `stuck` per silence threshold, not one per timer tick (dedup at the consumer per `event-semantics.md`).
+- **Single event queue** — all three watchers feed one coach event queue (not per-watcher queues). Enforces the per-agent total ordering and cross-agent partial ordering specified in `event-semantics.md`.
+- **Watcher reattachment contract** (per `event-semantics.md`) — kill the watcher process mid-run, restart it; verify no events are lost from disk-persisted state; verify no duplicate emission for in-flight transitions whose handlers already completed.
+- **Duplicate-event suppression** under simulated event-burst conditions (rapid file writes) — each event arrives at the coach state machine exactly once per its idempotency contract from `event-semantics.md`. Events specified as exactly-once never re-fire; events specified as at-least-once trigger correct dedup at the consumer.
+- **Append-only fsync discipline on `decisions.jsonl`** — concurrent writes from the watcher and the coach main loop don't interleave partial records; readers see whole records or none.
+- **Replay-consistency on `--resume`** — the watcher reconstructs its position from on-disk files (per `event-semantics.md` per-event-type replay behavior) and resumes event delivery without re-emitting events whose handlers already completed.
+
+### Out of Scope
+
+- **Resume reconstruction itself** (`#J6` / R001) — J5 ships the watcher's reattachment+replay contract; `#J6` ships the coach-side reconstruction that consumes from disk-persisted state.
+- **Validator dispatch** (`#M3`) — `commit_observed` events fan out to validator dispatch; the dispatch logic itself lives in M-track. J5 ships the event emission only.
+- **Observer correction injection** (`#L1`) — observers consume runtime events; the consumer side is L-track. J5 ships event emission only.
+- **`gh auto-phase` integration** — J5 watches `gh pr view` for `pr_opened`/`pr_closed`; the `MERGED` state-machine transition that follows is owned downstream (not J5).
+- **Event-payload schema definition** (`#C0`) — `runtime-event.schema.json` is owned by C0; J5 emits records conformant to it.
+- **`event-semantics.md` itself** — J5 implements the per-event-type semantics that doc specifies; the doc is C0's deliverable.
+
+### Dependencies
+
+- `#J1` — coach state machine + CLI must exist so the event queue has a consumer.
+- `#J3` (P001) — `decisions.jsonl` writer must exist so the watcher's append-only discipline has something to coordinate against.
+- `#C0` — `runtime-event.schema.json`, `event-semantics.md`.
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Event observation model | `atdd babysit` polls workspaces every N seconds, hashes screen content (`_screen_hash`), reads back state from GitHub labels | Event-driven: `inotify`/`fswatch` triggers within 1s on file change; git-refs watcher emits on commit; 30s liveness for stuck detection | Polling is "lossy on transitions, slow, fragile" (spec §1); without event-driven observation, coach can't make routing decisions in real time |
+| Per-agent event ordering | Polling loses ordering between rapid events (one screen hash collapses N transitions) | Per-event-type idempotency contract from `event-semantics.md`; per-agent total order, cross-agent partial order | Without ordering guarantees, parallel-track concurrency bugs surface only at `#Q1` |
+| Watcher reattachment | `atdd babysit` restart loses in-flight observation; partial state is rebuilt by re-polling | Watcher reattaches by reading disk-persisted state; events whose handlers completed are not re-emitted; events not yet handled are delivered | Without reattachment, `#J6` resume can't trust the watcher to recover correctly; the "durable orchestrator" claim collapses |
+| Decisions.jsonl interleaving | N/A in the polling model (only one writer) | Watcher and main loop both write; `O_APPEND` + `fsync` discipline preserves whole records | Without this, concurrent writes corrupt the durable log and `#J6` resume fails on parse errors |
+
+### User Impact
+
+The "user" of J5 is coach itself — the durable orchestrator that needs to *know* when an agent commits, when a heartbeat goes silent, when a PR opens. Today, `atdd babysit` polls; coach v9 deliberately replaces this with event-driven observation. Per spec §1: "Polling-based observation. Lossy on transitions, slow, fragile." J5 is the spec's answer.
+
+The lived problem: with `atdd babysit`'s `_screen_hash` polling, two agent commits in rapid succession can collapse into one observed event. This breaks per-phase tier-1 dispatch (#M3) — the second commit's WMBT scope is lost. With `inotify` on `.git/refs/heads/`, every commit fires its own event, with the trailers parsed at emission time, so #M3 sees every (Phase, WMBT-Urn) pair.
+
+The watcher reattachment contract is the load-bearing reliability invariant. Per spec §4.5, "On `--resume <run-id>`, coach reconstructs state-machine positions from the log." That reconstruction depends on the watcher resuming event delivery without re-emitting handled events and without dropping unhandled ones. `event-semantics.md` (#C0) names the per-event-type replay behavior; J5 implements it.
+
+`event-semantics.md` is what makes the parallel-track model work. Schemas freeze *shape*; the doc freezes *semantics*. Without per-event idempotency and ordering contracts, every track (#L1 observer, #M3 validator dispatch, #N1 reviewer) would form different temporal assumptions and concurrency bugs would surface only at #Q1. J5 binds those assumptions to actual watcher behavior.
+
+### Design Anchor
+
+Spec §4.4 names three event sources because each covers a distinct observation surface:
+
+- **Runtime watcher** observes per-agent state — heartbeats, events, escalations, corrections. Granular, parsed.
+- **Git watcher** observes per-worktree commits — the trailer-parsed signal that drives tier-1 dispatch (#M3).
+- **Liveness checker** observes the negative space — agents that *aren't* writing process_heartbeat.json. The 30s timer is the timeout floor.
+
+The single shared queue (rather than per-watcher queues) is a deliberate choice: it forces the per-agent ordering contract from `event-semantics.md` to be enforced once, by the queue, instead of being negotiated per-consumer. The `O_APPEND` + `fsync` discipline on `decisions.jsonl` is the inverse — multiple writers, single file — and depends on POSIX append-atomicity.
+
+---
+
+## Acceptance
+
+- `acc:drive-state-machine:M001-INTEGRATION-001-runtime-event-latency`: A file change in `.atdd/runtime/agents/<id>/` triggers a coach event within 1s via the `inotify`/`fswatch` watcher; the event payload conforms to `runtime-event.schema.json` (`#C0`); events are pushed onto the single coach event queue (not per-watcher queues).
+- `acc:drive-state-machine:M001-INTEGRATION-002-git-watcher-commit-observed`: A git commit on a worktree branch triggers a `commit_observed` event with the new commit SHA, branch, worktree path, and parsed commit trailers (`Agent-Id`, `Issue`, `WMBT-Urn`, `Phase`) per spec §6.4 step 1; PR-state changes (`pr_opened`, `pr_closed`) are emitted via the `gh pr view` poller.
+- `acc:drive-state-machine:M001-INTEGRATION-003-liveness-stuck-detection`: An agent with no process heartbeat for > `coach.process_silence_seconds` triggers a `stuck` event via the 30s liveness timer; the event carries `agent-id`, `last-heartbeat-timestamp`, `elapsed-seconds`; emissions are bounded (one `stuck` per silence threshold, not one per timer tick — dedup at the consumer per `event-semantics.md`).
+- `acc:drive-state-machine:M001-INTEGRATION-004-watcher-reattachment`: Killing the watcher process mid-run and restarting it loses no events from disk-persisted state and emits no duplicates for in-flight transitions whose handlers already completed (per the `event-semantics.md` reattachment contract from `#C0`); events specified as exactly-once never re-fire; events specified as at-least-once trigger correct dedup at the consumer.
+- `acc:drive-state-machine:M001-INTEGRATION-005-append-only-no-interleave`: Concurrent writes to `decisions.jsonl` from the watcher and the coach main loop don't interleave partial records under simulated event-burst conditions (rapid file writes); records are written with `O_APPEND` + `fsync`; readers see whole records or none; each event arrives at the coach state machine exactly once per its idempotency contract from `event-semantics.md`.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §4.4 (event sources), §4.5 (decision durability — context for `--resume` replay), §6.4 step 1 (commit-trailer parsing fed by git watcher), §1 (motivation — polling is lossy)
+- `atdd-coach-issues-v3.md` issue `#J5`
+- Wagon manifest: `plan/drive_state_machine/_drive_state_machine.yaml`
+- WMBT: `plan/drive_state_machine/M001.yaml`
+- Predecessor: `#J1` (coach state-machine skeleton)
+- Predecessor: `#J3` (P001 — `decisions.jsonl` writer)
+- Predecessor: `#C0` (`runtime-event.schema.json`, `event-semantics.md`)

--- a/.coach-v9-bootstrap/bodies/J6.md
+++ b/.coach-v9-bootstrap/bodies/J6.md
@@ -1,0 +1,92 @@
+## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Date | `2026-05-09` |
+| Status | `INIT` |
+| Type | `implementation` |
+| Branch | `feat/coach-v9-j6-resume-from-decisions-log` |
+| Archetypes | `coach` |
+| Train | `0002-coach-drives-lifecycle` |
+| Wagon | `drive-state-machine` |
+| Internal-Spec-Id | `J6` |
+| Feature | `atdd coach --resume <run-id>` per spec §4.5 — reconstructs per-issue state-machine positions from `decisions.jsonl`, skips already-logged actions (idempotency from `#J3` / P001), re-attaches to runtime watchers (`#J5` / M001) without losing the event stream |
+
+---
+
+## Scope
+
+### In Scope
+
+J6 closes the durability loop. `#J3` made the durable log; `#J4` made worktree creation idempotent; `#J5` made the watcher reattachable. J6 ties these into a single `--resume` reconstruction that survives a coach kill and finishes the run without double-execution.
+
+- **`--resume <run-id>` reconstruction** per spec §4.5: coach reads `.atdd/runtime/coach/decisions.jsonl`, identifies all transitions for the run-id, and reconstructs the per-issue state-machine position (the most recent reached phase per issue).
+- **Action skip-on-already-logged** — for every reconstructed transition, the corresponding action is recognized as already executed (via the durable log's `outcome` field) and skipped. This is the consumer side of the idempotency contract from `#J3` (P001 AC-UNIT-004).
+- **Watcher reattachment** — coach re-attaches `#J5`'s runtime, git, and liveness watchers without losing the event stream. Per the `event-semantics.md` replay contract from `#C0`: events whose handlers already completed are NOT re-emitted; events that occurred during the kill window but whose handlers had not run are delivered now. Each event arrives at the coach state machine exactly once per its idempotency contract.
+- **No duplicate state transitions** — `decisions.jsonl` contains each transition exactly once across the original and resumed runs. The action-precedes-write invariant from P001 holds, but the resume logic prevents re-execution upstream so duplicates never reach the writer.
+- **Run completes** — a coach run killed mid-execution and resumed via `--resume <run-id>` reaches `COMPLETE` for the resumed issue without manual intervention.
+
+### Out of Scope
+
+- **Decisions.jsonl writer itself** (`#J3` / P001) — J6 reads from the writer; doesn't re-implement.
+- **Watcher implementation** (`#J5` / M001) — J6 calls into the watcher's reattachment surface; the watcher's internal reattachment logic lives in J5.
+- **Two-phase commit absorption** (`#J4` / E001) — J4 makes worktree creation idempotent; J6 consumes that idempotency.
+- **State-machine skeleton** (`#J1`) — J6 drives the skeleton; doesn't redefine.
+- **`commands/orchestrate.py` decommission** (`#P5`) — `commands/orchestrate.py` stays in place after J6 lands.
+- **Run-id assignment / lifecycle** — coach assigns a `run-id` at start and writes it as `coach_run_id` on every decision (per `#C0`'s `coach-decision.schema.json`); J6 reads the field but doesn't define run-id semantics beyond that.
+
+### Dependencies
+
+- `#J3` (P001) — `decisions.jsonl` writer + idempotency contract.
+- `#J4` (E001) — two-phase-commit absorption + idempotent `_create_worktree` / spawn checks.
+- `#J5` (M001) — watcher reattachment contract.
+- `#C0` — `coach-decision.schema.json` (`coach_run_id` field), `event-semantics.md` (per-event replay behavior).
+- `#J1` — state-machine skeleton (the thing being reconstructed).
+
+---
+
+## Context
+
+### Problem Statement
+
+| Aspect | Current | Target | Issue |
+|--------|---------|--------|-------|
+| Resume after coach kill | Today's `atdd orchestrate --resume` reads `.atdd/orchestrate-state.json` (single-document JSON, replaced wholesale); recovery is best-effort | `atdd coach --resume <run-id>` reads `decisions.jsonl` (append-only JSON-lines); reconstruction is deterministic per spec §4.5 | Without deterministic resume, "coach state is durable" (spec §2) is aspirational; a kill mid-run requires manual cleanup |
+| Action double-execution risk | A naive resume re-executes already-completed actions; for actions with side-effects (commits, spawns, PR creates), this causes duplicates | Idempotency contract from P001 holds; J6 enumerates the consumer side: `outcome` field on logged decisions signals "already done, skip" | Without enforcement, resume is unsafe; the durable log becomes a liability not an asset |
+| Watcher event loss across kill | `atdd babysit` restart loses observed-but-unhandled events (polling has no replay model) | Watcher reattaches via on-disk-persisted state per `event-semantics.md`; events whose handlers completed are not re-emitted; events not yet handled are delivered now | Without this, resume drops in-flight transitions; coach makes wrong routing decisions |
+| Run-id correlation | No run-id in today's orchestrate state file; matching transitions to a specific run is by-timestamp guesswork | `coach_run_id` is on every decision per `coach-decision.schema.json` (`#C0`); `--resume <run-id>` filters cleanly | Without correlation, multi-run sessions interleave decisions and resume can target the wrong run |
+
+### User Impact
+
+The "user" of J6 is the coach operator hitting Ctrl-C, the SREs facing a node restart, and `#J6`'s test fixtures simulating mid-run kills. Today, `atdd orchestrate --resume` works for the simple cases (worktrees exist, sessions launched) but loses fidelity around in-flight events. Coach v9's "durable orchestrator" claim (spec §2) only holds if `--resume` is provably lossless — J6 makes it provably lossless.
+
+The lived problem isn't that resume is impossible; it's that today's resume is hand-rolled and fragile, with no schema validation, no append-only durability, no event-semantics contract. Each kill-and-resume is a recovery that depends on operator intuition rather than the state file. Coach v9 inverts this: the state file is a contract (P001 + `#C0`), the watcher reattachment is a contract (M001 + `event-semantics.md`), and J6 is the orchestrator-side glue that consumes both.
+
+Per spec §4.5: "On `--resume <run-id>`, coach reconstructs state-machine positions from the log. Actions are idempotent." J6 is the literal execution. The acceptance contract is end-to-end: kill mid-run, run `--resume`, observe COMPLETE without duplicates.
+
+### Design Anchor
+
+The architectural ratio is "durable log + idempotent actions + reattachable watcher = lossless resume." J6 is the consumer that ties the three together; the producer side is split across `#J3`/`#J4`/`#J5`. This split is deliberate — each producer can land in wave w1 in parallel; J6 consumes them all in wave w2.
+
+The principle "actions are idempotent" (spec §4.5) means resume doesn't need to track "did the action complete." If the decision is logged and the action is idempotent, replaying is safe. If the action wasn't completed (process killed before it ran), the action runs now and its idempotency makes the second run a no-op. P001's `outcome` field on each decision lets J6 distinguish *logged-and-action-completed* from *logged-but-action-pending* without ambiguity.
+
+---
+
+## Acceptance
+
+- `acc:drive-state-machine:R001-INTEGRATION-001-resume-mid-run`: Coach killed mid-run resumes correctly with `atdd coach --resume <run-id>`, completing without re-executing already-logged transitions; `decisions.jsonl` from `#J3` / P001 is the durable transition log; the two-phase-commit absorption from `#J4` / E001 is in place (worktree creation idempotent); coach reads `decisions.jsonl`, reconstructs per-issue state, and proceeds from the reconstructed phase toward the next allowed transition per the §4.1 state-transition table.
+- `acc:drive-state-machine:R001-INTEGRATION-002-no-duplicate-transitions`: Duplicate state transitions are not written to `decisions.jsonl` during resume; append-only idempotency holds across the kill-restart boundary; `decisions.jsonl` contains each transition exactly once between the original and resumed runs; the action-precedes-write invariant from `#J3` / P001 holds but resume logic prevents re-execution upstream so duplicates never reach the writer; coach exits cleanly with the state machine at `COMPLETE` for the resumed issue.
+- `acc:drive-state-machine:R001-INTEGRATION-003-watcher-reconstruct`: Watcher state reconstructs from on-disk `.atdd/runtime/` during resume per the `event-semantics.md` replay contract from `#C0`; per-agent runtime state at `.atdd/runtime/agents/<id>/` (events.jsonl, heartbeat.json, escalations.jsonl, corrections.jsonl) is the source of truth; events whose handlers completed (visible via `decisions.jsonl`) are NOT re-emitted (replay-consistency); events that occurred during the kill window but whose handlers had not run are delivered now; the single coach event queue receives each event exactly once per its `event-semantics.md` idempotency contract.
+
+---
+
+## References
+
+- `atdd-coach-spec-v9.md` §4.5 (decision durability + `--resume` semantics), §4.1 (per-issue state-transition table), §2 (architectural principles — "Coach state is durable")
+- `atdd-coach-issues-v3.md` issue `#J6`
+- Wagon manifest: `plan/drive_state_machine/_drive_state_machine.yaml`
+- WMBT: `plan/drive_state_machine/R001.yaml`
+- Predecessor: `#J3` (P001 — `decisions.jsonl` writer + idempotency contract)
+- Predecessor: `#J4` (E001 — two-phase-commit + idempotent `_create_worktree`)
+- Predecessor: `#J5` (M001 — watcher reattachment contract)
+- Predecessor: `#C0` (`coach-decision.schema.json` — `coach_run_id`; `event-semantics.md` — per-event replay)

--- a/plan/drive_state_machine/D001.yaml
+++ b/plan/drive_state_machine/D001.yaml
@@ -1,0 +1,102 @@
+urn: "wmbt:drive-state-machine:D001"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "ad-hoc-coach-state-machine-without-shared-skeleton"
+context_clarifier: "when six parallel coach v9 tracks (J/K/L/M/N/O/P) need a stable per-issue state-machine entry point and CLI argparse surface — INIT|PLANNED|RED|GREEN|SMOKE|REFACTOR|COMPLETE|BLOCKED|MERGED phases plus the state-transition table — to hook into without each track inventing its own coach orchestrator. Skeleton ONLY: no watcher attachment (#J5), no validator dispatch (#M3), no observer (#L1), no spawn (#K1), no per-state transition logic, no two-phase commit (#J4), no decision durability (#J3), no resume (#J6)"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of ad-hoc-coach-state-machine-without-shared-skeleton when six parallel coach v9 tracks need a stable per-issue state-machine entry point and CLI argparse surface to hook into without each track inventing its own coach orchestrator"
+acceptances:
+  - identity:
+      urn: "acc:drive-state-machine:D001-UNIT-001-state-machine-skeleton"
+      id: "AC-UNIT-001"
+      purpose: "atdd coach <issue-number> initializes a state machine in INIT for the issue and prints the planned state path without executing transitions"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/commands/coach.py exists with the atdd coach <issue-numbers...> entry point"
+        - "The state-machine enum INIT|PLANNED|RED|GREEN|SMOKE|REFACTOR|COMPLETE|BLOCKED|MERGED is implemented per spec §4.1"
+        - "The state-transition table is implemented per spec §4.1 (which states can transition to which)"
+    when:
+      abstract: "atdd coach 358 is invoked"
+    then:
+      abstract:
+        - "A state machine is initialized in INIT for issue 358"
+        - "The planned state path is printed without executing transitions"
+        - "No watcher attachment, validator dispatch, observer integration, or spawn integration runs"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:D001-UNIT-002-flag-parsing"
+      id: "AC-UNIT-002"
+      purpose: "All flags from spec §5.1 parse correctly and the resolved configuration is printable"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "The atdd coach CLI argparse surface is implemented per spec §5.1"
+        - "Flags include --max-retries, --escalation-channel, --multiplexer, --multiplexer-mode, --auto-merge, --strict-deps, --llm, --persona-llm, --judge-llm, --require-issue-review, --review-phases, --skip-review, --risk-threshold-block, --allow-stale-suppressions, --resume, --dry-run"
+    when:
+      abstract: "atdd coach is invoked with flag combinations from §5.1 (including --persona-llm tester=claude-code,coder=codex,reviewer=gpt-5)"
+    then:
+      abstract:
+        - "Every flag is recognized; unknown flags raise argparse errors"
+        - "--persona-llm parses into a per-persona dict"
+        - "--review-phases parses into the enabled-phases set"
+        - "Resolved configuration matches §5.1's documented surface and can be dumped for inspection"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:D001-UNIT-003-compute-waves-reuse"
+      id: "AC-UNIT-003"
+      purpose: "Multi-issue invocations resolve the dependency graph and compute waves by reusing compute_waves() from commands/orchestrate.py per spec §4.3"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "compute_waves() exists in src/atdd/coach/commands/orchestrate.py"
+        - "Three GitHub issues (358, 359, 360) with declared dependencies are available in the test fixture"
+    when:
+      abstract: "atdd coach 358 359 360 --strict-deps is invoked"
+    then:
+      abstract:
+        - "compute_waves() is called from coach.py (no duplicate implementation)"
+        - "The resolved wave assignment is printed and matches the dependency-respecting topological order"
+        - "--strict-deps is propagated into the wave-transition gating policy"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:D001-INTEGRATION-001-no-scope-leak"
+      id: "AC-INTEGRATION-001"
+      purpose: "Code review and unit-test coverage confirm no scope leak into J5/M3/L1/K1/J4/J3/J6 territory"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/commands/coach.py is the only new file (plus its tests)"
+    when:
+      abstract: "Static analysis and code review run on the J1 PR"
+    then:
+      abstract:
+        - "No watcher (inotify/fswatch) imports — that lives in #J5"
+        - "No validator dispatch (pytest invocation, suppression scanner) — that lives in #M3"
+        - "No observer correction injection — that lives in #L1"
+        - "No spawn invocation (multiplexer, session_template render) — that lives in #K1"
+        - "No two-phase-commit worktree creation/rollback — that lives in #J4"
+        - "No decisions.jsonl/judgments.jsonl writes — that lives in #J3"
+        - "No --resume reconstruction — that lives in #J6"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/drive_state_machine/D002.yaml
+++ b/plan/drive_state_machine/D002.yaml
@@ -1,0 +1,79 @@
+urn: "wmbt:drive-state-machine:D002"
+step: "define"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "agent-runtime-side-effects-without-rule-ided-cli-surface"
+context_clarifier: "when persona agents (planner/tester/coder/reviewer) under coach orchestration must emit heartbeats, runtime events, structured questions, escalations, done-signals, and phase-aware commits with the four required trailers (Agent-Id, Issue, WMBT-Urn, Phase) into .atdd/runtime/agents/<id>/ per spec §3.2 — without each agent inventing its own write paths, file shapes, or trailer formats. Coach is the eventual reader; the CLI surface is the contract"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of agent-runtime-side-effects-without-rule-ided-cli-surface when persona agents under coach orchestration must emit heartbeats, events, questions, escalations, and phase-aware commits into .atdd/runtime/agents/<id>/ without inventing per-persona write paths or trailer formats"
+acceptances:
+  - identity:
+      urn: "acc:drive-state-machine:D002-UNIT-001-subcommands-resolve"
+      id: "AC-UNIT-001"
+      purpose: "All atdd agent subcommands resolve and write the expected files under .atdd/runtime/agents/<id>/ per spec §3.2 layout"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/commands/agent.py exists with subcommands heartbeat, event, commit, ask, escalate, done, context, review per spec §5.3"
+        - "Runtime layout under .atdd/runtime/agents/<id>/ matches the runtime-layout.md contract from #C0"
+    when:
+      abstract: "Each subcommand is invoked against a test runtime"
+    then:
+      abstract:
+        - "atdd agent heartbeat writes .atdd/runtime/agents/<id>/heartbeat.json with current timestamp"
+        - "atdd agent event <type> appends a record to .atdd/runtime/agents/<id>/events.jsonl conformant to runtime-event.schema.json"
+        - "atdd agent ask appends a structured question to .atdd/runtime/agents/<id>/questions.jsonl"
+        - "atdd agent escalate appends to .atdd/runtime/agents/<id>/escalations.jsonl with severity (info|warn|block)"
+        - "atdd agent done writes a final-summary record"
+        - "atdd agent context prints the current phase + WMBT context"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:D002-UNIT-002-commit-trailers"
+      id: "AC-UNIT-002"
+      purpose: "atdd agent commit produces a commit with all four required trailers (Agent-Id, Issue, WMBT-Urn, Phase) and delegates to the existing atdd checkpoint primitive"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd checkpoint exists and is the canonical commit primitive"
+        - "A worktree with an agent-id and issue is configured for the test"
+    when:
+      abstract: "atdd agent commit --phase RED --message \"...\" --wmbt-urn wmbt:drive-state-machine:D001 is invoked"
+    then:
+      abstract:
+        - "A commit is produced via atdd checkpoint (no direct git commit invocation duplicating its logic)"
+        - "The commit message carries trailers Agent-Id, Issue, WMBT-Urn, Phase per spec §7.3"
+        - "Phase value is one of RED|GREEN|SMOKE|REFACTOR (validated against spec §4.1 enum)"
+        - "Hook-validated trailer enforcement is preserved (the existing pre-commit hook still runs)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:D002-UNIT-003-ask-answer-roundtrip"
+      id: "AC-UNIT-003"
+      purpose: "atdd agent ask produces structured questions in questions.jsonl and coach answers via answers/<question-id>.json — the round-trip is contract-validated"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd agent ask --question \"...\" --type <choice|text|approval|confirmation> writes a question record"
+        - "Coach is configured to write answers to .atdd/runtime/agents/<id>/answers/<question-id>.json"
+    when:
+      abstract: "An agent asks a question and coach writes a corresponding answer file"
+    then:
+      abstract:
+        - "questions.jsonl contains a record with question-id, type, question text, and timestamp"
+        - "answers/<question-id>.json carries the coach response keyed by the same question-id"
+        - "The round-trip path is the only contract — no shared mutable state between agent and coach"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/drive_state_machine/E001.yaml
+++ b/plan/drive_state_machine/E001.yaml
@@ -1,0 +1,79 @@
+urn: "wmbt:drive-state-machine:E001"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "leaked-worktrees-on-failed-multi-issue-launch"
+context_clarifier: "when coach launches multiple issues in a wave and one worktree creation fails — without two-phase commit discipline, partial state persists across runs (orphaned worktrees, half-launched sessions). Spec §4.6 inherits this from atdd orchestrate: Phase A creates all worktrees with rollback-on-any-failure, Phase B launches sessions and writes a decision per success. The state file moves from .atdd/orchestrate-state.json (single-document JSON) to .atdd/runtime/coach/decisions.jsonl (JSON-lines, owned by #J3 / P001) as the durable resume source"
+lens: "functional.availability"
+statement: "minimize likelihood of leaked-worktrees-on-failed-multi-issue-launch when coach launches multiple issues in a wave by absorbing the two-phase-commit discipline from atdd orchestrate (Phase A worktrees with rollback, Phase B launch with per-success decision writes), preserving rollback verbatim"
+acceptances:
+  - identity:
+      urn: "acc:drive-state-machine:E001-INTEGRATION-001-phase-a-rollback"
+      id: "AC-INTEGRATION-001"
+      purpose: "Coach with multiple issues creates all worktrees in Phase A; if any fail, all already-created worktrees roll back via git worktree remove --force before exit"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "_create_worktree and _remove_worktree from src/atdd/coach/commands/orchestrate.py are absorbed into coach.py per spec §4.6"
+        - "Three issues are configured (358, 359, 360); creation of the worktree for 360 is rigged to fail"
+    when:
+      abstract: "Coach is invoked with the three issues"
+    then:
+      abstract:
+        - "Worktrees for 358 and 359 are created"
+        - "When 360's creation fails, _remove_worktree is called for 358 and 359 before coach exits"
+        - "Coach returns a non-zero exit code with an error naming the failed issue"
+        - "No partial state persists: no worktrees remain, no decisions.jsonl entries for the rolled-back creations"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:E001-INTEGRATION-002-phase-b-launch"
+      id: "AC-INTEGRATION-002"
+      purpose: "After all worktrees succeed, Phase B launches sessions and writes a decision per success; failed launches log without rolling back already-launched siblings"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "Phase A completed successfully for issues 358, 359, 360"
+        - "Launch of issue 360 is rigged to fail at multiplexer dispatch"
+    when:
+      abstract: "Phase B runs"
+    then:
+      abstract:
+        - "Sessions for 358 and 359 launch successfully and each writes a decision to decisions.jsonl"
+        - "When 360's launch fails, the failure is logged but 358's and 359's sessions are NOT rolled back"
+        - "Coach records the partial-launch state durably so --resume can finish 360 without restarting 358/359"
+        - "The rationale (a successfully-launched agent is recoverable on --resume; we don't undo it) is honored"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:E001-INTEGRATION-003-resume-source-replaced"
+      id: "AC-INTEGRATION-003"
+      purpose: "decisions.jsonl replaces .atdd/orchestrate-state.json as the durable resume source; coach --resume reconstructs which worktrees exist and which sessions launched, skipping idempotent steps"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "Coach was killed mid-Phase-B with worktrees for 358, 359, 360 created and only 358's session launched"
+        - ".atdd/orchestrate-state.json is NOT written by coach (the file format change is part of the absorption)"
+    when:
+      abstract: "atdd coach --resume <run-id> is invoked"
+    then:
+      abstract:
+        - "Coach reads decisions.jsonl to reconstruct the state"
+        - "Worktrees for 358, 359, 360 are recognized as already created (idempotent _create_worktree no-op)"
+        - "358's session is recognized as already launched (idempotent spawn check)"
+        - "Only 359 and 360 are newly launched"
+        - "src/atdd/coach/commands/orchestrate.py is not yet decommissioned (#P5 owns that); E001 absorbs the machinery without removing it"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/drive_state_machine/M001.yaml
+++ b/plan/drive_state_machine/M001.yaml
@@ -1,0 +1,120 @@
+urn: "wmbt:drive-state-machine:M001"
+step: "monitor"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "missed-agent-runtime-events-from-polling-only-observation"
+context_clarifier: "when coach must replace atdd babysit's lossy polling model with three concurrent event sources (spec §4.4): inotify/fswatch on .atdd/runtime/agents/*/, inotify on each worktree's .git/refs/heads/ + gh pr view polling, and a 30s liveness timer. Events feed a single coach event queue. The contract is bound by event-semantics.md (#C0): each event type declares idempotency (at-least-once vs exactly-once), ordering (per-agent total order, cross-agent partial order, none), and replay behavior on coach --resume. Watcher reattachment, duplicate-event suppression, append-only fsync discipline on decisions.jsonl, and replay-consistency are first-class concerns"
+lens: "functional.availability"
+statement: "minimize likelihood of missed-agent-runtime-events-from-polling-only-observation when coach must observe per-agent state changes through three concurrent watchers (runtime, git, liveness) whose events feed a single coach queue with the idempotency, ordering, and replay contracts from event-semantics.md"
+acceptances:
+  - identity:
+      urn: "acc:drive-state-machine:M001-INTEGRATION-001-runtime-event-latency"
+      id: "AC-INTEGRATION-001"
+      purpose: "A file change in .atdd/runtime/agents/<id>/ triggers a coach event within 1s via the inotify/fswatch watcher"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "The runtime watcher is running on .atdd/runtime/agents/*/"
+        - "An agent under test writes to heartbeat.json, events.jsonl, escalations.jsonl, or corrections.jsonl"
+    when:
+      abstract: "The agent file is modified"
+    then:
+      abstract:
+        - "Coach receives the parsed event within 1s (per-platform: inotify on Linux, fswatch on macOS)"
+        - "The event payload conforms to runtime-event.schema.json (#C0)"
+        - "Events are pushed onto the single coach event queue (not per-watcher queues)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:M001-INTEGRATION-002-git-watcher-commit-observed"
+      id: "AC-INTEGRATION-002"
+      purpose: "A git commit on a worktree branch triggers a commit_observed event via the git refs/heads watcher"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "The git watcher is running on each worktree's .git/refs/heads/"
+        - "gh pr view polling is configured for PR-state observation"
+    when:
+      abstract: "An agent writes a commit on the worktree branch"
+    then:
+      abstract:
+        - "A commit_observed event is emitted with the new commit SHA, branch, and worktree path"
+        - "The event payload includes parsed commit trailers (Agent-Id, Issue, WMBT-Urn, Phase) per spec §6.4 step 1"
+        - "PR-state changes (pr_opened, pr_closed) are emitted via the gh pr view poller"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:M001-INTEGRATION-003-liveness-stuck-detection"
+      id: "AC-INTEGRATION-003"
+      purpose: "An agent with no process heartbeat for >coach.process_silence_seconds triggers a stuck event via the 30s liveness timer"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "The liveness checker runs every 30s"
+        - "An agent stops writing process_heartbeat.json"
+    when:
+      abstract: "coach.process_silence_seconds elapses without a heartbeat update"
+    then:
+      abstract:
+        - "A stuck event is emitted with agent-id, last-heartbeat-timestamp, and elapsed-seconds"
+        - "The event is written to .atdd/runtime/agents/<id>/events.jsonl per the runtime-event contract"
+        - "Liveness emissions are bounded — one stuck event per silence threshold, not one per timer tick (dedup at the consumer per event-semantics.md)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:M001-INTEGRATION-004-watcher-reattachment"
+      id: "AC-INTEGRATION-004"
+      purpose: "Killing the watcher process mid-run and restarting it loses no events from disk-persisted state and emits no duplicates for in-flight transitions, per the event-semantics.md reattachment contract"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "The watcher is running with a known stream of recent events on disk"
+        - "event-semantics.md specifies the reattachment contract for each of the 12 event types"
+    when:
+      abstract: "The watcher process is killed and restarted"
+    then:
+      abstract:
+        - "On restart, the watcher reads disk-persisted state (events.jsonl, decisions.jsonl) and rebuilds its position"
+        - "No events whose handlers have already completed are re-emitted (replay-consistency)"
+        - "No events from before the kill are lost (durability via append-only on-disk state)"
+        - "Events specified as exactly-once never re-fire; events specified as at-least-once trigger correct dedup at the consumer"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:M001-INTEGRATION-005-append-only-no-interleave"
+      id: "AC-INTEGRATION-005"
+      purpose: "Concurrent writes to decisions.jsonl from the watcher and the coach main loop don't interleave partial records; fsync+append discipline preserved"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "The watcher and the coach main loop both write to .atdd/runtime/coach/decisions.jsonl"
+        - "Synthetic event-burst conditions are simulated (rapid file writes triggering multiple watcher emissions)"
+    when:
+      abstract: "Concurrent writes are issued"
+    then:
+      abstract:
+        - "Each record in decisions.jsonl is a complete, parseable JSON line — no partial records"
+        - "Records are written with O_APPEND + fsync; readers see whole records or none"
+        - "Each event arrives at the coach state machine exactly once per its idempotency contract from event-semantics.md"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/drive_state_machine/P001.yaml
+++ b/plan/drive_state_machine/P001.yaml
@@ -1,0 +1,99 @@
+urn: "wmbt:drive-state-machine:P001"
+step: "prepare"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "lossy-coach-decisions-and-judgments-on-restart"
+context_clarifier: "when coach must own the per-issue lifecycle as a durable orchestrator — every state transition must be appended to .atdd/runtime/coach/decisions.jsonl BEFORE the action runs (per spec §4.5), and every atdd judge call must be appended to .atdd/runtime/coach/judgments.jsonl (per spec §6.9). Without this, a coach restart loses the truth of which transitions ran and which judgments were rendered, breaking idempotent --resume (#J6) and the 'mechanical floor' principle (§2). Schemas come from #C0 (coach-decision.schema.json, coach-judgment.schema.json); P001 prepares the writers + write-time validation"
+lens: "functional.availability"
+statement: "minimize likelihood of lossy-coach-decisions-and-judgments-on-restart when coach must append every state transition to decisions.jsonl before the action runs and every judge call to judgments.jsonl, with schema validation at write time, so that restart-and-resume is lossless"
+acceptances:
+  - identity:
+      urn: "acc:drive-state-machine:P001-UNIT-001-decisions-append-only"
+      id: "AC-UNIT-001"
+      purpose: "A coach run writes every state transition to decisions.jsonl in append-only fashion BEFORE the action runs, conformant to coach-decision.schema.json"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "coach-decision.schema.json is committed at src/atdd/coach/schemas/ (from #C0)"
+        - "A coach run that drives an issue from INIT to PLANNED is configured"
+    when:
+      abstract: "Coach executes the INIT→PLANNED transition"
+    then:
+      abstract:
+        - ".atdd/runtime/coach/decisions.jsonl exists and contains a JSON-line record matching coach-decision.schema.json"
+        - "The record was appended BEFORE the action ran (verified by injecting a failure at action-time and observing the decision still recorded)"
+        - "Required fields decision_id, timestamp, coach_run_id, issue_number, decision_type, inputs, outcome are populated per #C0 schema"
+        - "The file is opened with O_APPEND semantics; concurrent writes don't corrupt records"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:P001-UNIT-002-judgments-append-only"
+      id: "AC-UNIT-002"
+      purpose: "A coach run that calls atdd judge writes every call to judgments.jsonl conformant to coach-judgment.schema.json with inputs hashed by default"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "coach-judgment.schema.json is committed at src/atdd/coach/schemas/ (from #C0)"
+        - "atdd judge is invoked from one of the six v1 call sites (per spec §6.9)"
+    when:
+      abstract: "Coach completes a judge call"
+    then:
+      abstract:
+        - ".atdd/runtime/coach/judgments.jsonl gains a JSON-line record matching coach-judgment.schema.json"
+        - "Required fields judgment_id, timestamp, call_site, inputs_hash, response, cached are populated"
+        - "inputs_hash is a content hash; full inputs are written to the gitignored cache, not the durable log"
+        - "call_site value is one of the six enumerated in spec §6.9"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:P001-UNIT-003-schema-validation-at-write"
+      id: "AC-UNIT-003"
+      purpose: "Schema validation runs at write time for both decisions.jsonl and judgments.jsonl — malformed records are rejected before durable persistence"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "coach-decision.schema.json and coach-judgment.schema.json are loaded by the writer"
+        - "An attempt is made to write a record missing a required field"
+    when:
+      abstract: "The writer is invoked with an invalid payload"
+    then:
+      abstract:
+        - "The write is rejected with a schema-validation error before any bytes hit the file"
+        - "The error names the missing/invalid field"
+        - "The file is not partially written"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:P001-UNIT-004-actions-idempotent"
+      id: "AC-UNIT-004"
+      purpose: "All actions whose intent is durably logged remain idempotent — replaying the same decision record produces no double-execution"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A decisions.jsonl with a recorded INIT→PLANNED transition for issue 358"
+        - "Coach is restarted and replays the log"
+    when:
+      abstract: "The replayed transition is re-encountered"
+    then:
+      abstract:
+        - "The action is recognized as already executed (via the durable log) and is skipped"
+        - "No duplicate side-effects are produced (no second commit, no second worktree, no second event emission)"
+        - "Idempotency is the contract that makes #J6 resume feasible"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/drive_state_machine/R001.yaml
+++ b/plan/drive_state_machine/R001.yaml
@@ -1,0 +1,78 @@
+urn: "wmbt:drive-state-machine:R001"
+step: "resolve"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "duplicate-state-transitions-on-coach-resume"
+context_clarifier: "when a coach run is killed mid-execution and restarted via atdd coach --resume <run-id> per spec §4.5: coach must reconstruct the per-issue state-machine positions from .atdd/runtime/coach/decisions.jsonl, skip actions already logged as completed (idempotency from #J3 / P001), and re-attach to the runtime watchers (#J5 / M001) without losing the event stream or re-emitting events whose handlers already completed. The two-phase commit absorbed in #J4 / E001 makes worktree creation idempotent; this WMBT extends that idempotency end-to-end through the state machine"
+lens: "functional.availability"
+statement: "minimize likelihood of duplicate-state-transitions-on-coach-resume when atdd coach --resume reconstructs per-issue state from decisions.jsonl, skips already-logged actions, and re-attaches to watchers without losing or duplicating events"
+acceptances:
+  - identity:
+      urn: "acc:drive-state-machine:R001-INTEGRATION-001-resume-mid-run"
+      id: "AC-INTEGRATION-001"
+      purpose: "Coach killed mid-run resumes correctly with --resume <run-id>, completing without re-executing already-logged transitions"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "decisions.jsonl from #J3 / P001 contains the durable transition log"
+        - "A coach run was killed after issue 358 reached PLANNED but before reaching RED"
+        - "The two-phase-commit absorption from #J4 / E001 is in place (worktree creation idempotent)"
+    when:
+      abstract: "atdd coach --resume <run-id> is invoked"
+    then:
+      abstract:
+        - "Coach reads decisions.jsonl and reconstructs that issue 358 is at PLANNED"
+        - "INIT and INIT→PLANNED transitions are NOT re-executed"
+        - "Coach proceeds from PLANNED toward the next allowed transition per the state-transition table"
+        - "Run completes the issue lifecycle without manual intervention"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:R001-INTEGRATION-002-no-duplicate-transitions"
+      id: "AC-INTEGRATION-002"
+      purpose: "Duplicate state transitions are not written to decisions.jsonl during resume — append-only idempotency holds across the kill-restart boundary"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "A coach run with N transitions logged in decisions.jsonl"
+        - "The run is killed and resumed via --resume"
+    when:
+      abstract: "Coach finishes the run after the resume"
+    then:
+      abstract:
+        - "decisions.jsonl contains each transition exactly once (no duplicates between original and resumed runs)"
+        - "The action-precedes-write invariant from #J3 / P001 holds: any duplicate WOULD be detected at write-time but the resume logic prevents re-execution upstream"
+        - "Coach exits cleanly with the state-machine in COMPLETE for the resumed issue"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"
+  - identity:
+      urn: "acc:drive-state-machine:R001-INTEGRATION-003-watcher-reconstruct"
+      id: "AC-INTEGRATION-003"
+      purpose: "Watcher state reconstructs from on-disk .atdd/runtime/ during resume — events from before the kill are not lost and events whose handlers already completed are not re-emitted"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "Per-agent runtime state is on disk at .atdd/runtime/agents/<id>/ (events.jsonl, heartbeat.json, escalations.jsonl, corrections.jsonl)"
+        - "event-semantics.md from #C0 specifies the replay contract per event type"
+    when:
+      abstract: "Coach resume re-attaches the runtime watcher (#J5 / M001)"
+    then:
+      abstract:
+        - "The watcher rebuilds its position from disk-persisted state"
+        - "Events whose handlers already completed (visible via decisions.jsonl) are NOT re-emitted (replay-consistency)"
+        - "Events that occurred during the kill window but whose handlers had not run are delivered now"
+        - "The single coach event queue receives each event exactly once per its event-semantics.md idempotency contract"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-09"

--- a/plan/drive_state_machine/_drive_state_machine.yaml
+++ b/plan/drive_state_machine/_drive_state_machine.yaml
@@ -1,0 +1,73 @@
+wagon: drive-state-machine
+urn: "wagon:drive-state-machine"
+name: "Drive State Machine"
+description: "atdd coach state machine MVP + atdd agent CLI subcommands + decision/judgment durability + two-phase commit absorbed from orchestrate + runtime/git/liveness watchers + resume from decisions log; the durable orchestrator that owns the per-issue lifecycle (INIT → COMPLETE) instead of trusting agents to self-report phase"
+theme: commons
+
+subject: "agent:coach"
+context: "in-coach-v9-execution, polling-based-orchestrate-replaced, runtime-contracts-frozen"
+action: "drives the per-issue state machine deterministically with durable decisions.jsonl, agent-CLI side-effects, two-phase-commit rollback discipline, event-driven watchers, and resume semantics"
+goal: "own the issue lifecycle as a durable orchestrator that survives restarts and is the single writer of phase truth"
+outcome: "atdd coach + atdd agent CLI surface with decisions.jsonl + judgments.jsonl + two-phase commit + three watchers (runtime/git/liveness) + --resume <run-id> reconstructing without double-execution"
+
+features:
+  - urn: "feature:drive-state-machine:coach-state-machine-and-runtime"
+
+produce:
+  - name: commons:coach:coach-cli-skeleton
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:agent-cli-subcommands
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:decisions-jsonl-writer
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:judgments-jsonl-writer
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:two-phase-commit-runner
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:runtime-event-watcher
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:git-event-watcher
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:liveness-checker
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:resume-runner
+    contract: null
+    telemetry: null
+    to: external
+
+consume:
+  - name: commons:coach:coach-decision-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:coach-judgment-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:runtime-event-schema
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:runtime-layout-doc
+    from: wagon:freeze-runtime-contracts
+  - name: commons:coach:event-semantics-doc
+    from: wagon:freeze-runtime-contracts
+
+wmbt:
+  total: 6
+  D001: "minimize likelihood of ad-hoc-coach-state-machine-without-shared-skeleton"
+  D002: "minimize likelihood of agent-runtime-side-effects-without-rule-ided-cli-surface"
+  P001: "minimize likelihood of lossy-coach-decisions-and-judgments-on-restart"
+  E001: "minimize likelihood of leaked-worktrees-on-failed-multi-issue-launch"
+  M001: "minimize likelihood of missed-agent-runtime-events-from-polling-only-observation"
+  R001: "minimize likelihood of duplicate-state-transitions-on-coach-resume"

--- a/plan/drive_state_machine/features/coach_state_machine_and_runtime.yaml
+++ b/plan/drive_state_machine/features/coach_state_machine_and_runtime.yaml
@@ -1,0 +1,35 @@
+urn: "feature:drive-state-machine:coach-state-machine-and-runtime"
+wagon: "wagon:drive-state-machine"
+description: "atdd coach state machine + atdd agent CLI subcommands + durable decisions/judgments + two-phase commit (worktrees, launch) absorbed from orchestrate + runtime/git/liveness watchers + --resume reconstruction. Owns the per-issue lifecycle (INIT → COMPLETE) deterministically with append-only decisions.jsonl as the resume source of truth, replacing atdd orchestrate's polling-and-trust model."
+sizing:
+  wmbts: 6
+  footprint_score: 18
+  footprint_size: "L"
+wmbts:
+  - "wmbt:drive-state-machine:D001"
+  - "wmbt:drive-state-machine:D002"
+  - "wmbt:drive-state-machine:P001"
+  - "wmbt:drive-state-machine:E001"
+  - "wmbt:drive-state-machine:M001"
+  - "wmbt:drive-state-machine:R001"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 2
+        rationale: "atdd coach <issue-numbers...> entry point and atdd agent <subcommand> entry point — argparse + dispatch only"
+    application:
+      - type: "use_cases"
+        count: 6
+        rationale: "Per-issue state-machine driver, agent-CLI write coordinator, durable-log writer, two-phase-commit runner, watcher event router, resume reconstructor"
+    domain:
+      - type: "value_objects"
+        count: 3
+        rationale: "Phase enum (INIT|PLANNED|RED|GREEN|SMOKE|REFACTOR|COMPLETE|BLOCKED|MERGED), state-transition table, watcher event"
+    integration:
+      - type: "adapters"
+        count: 3
+        rationale: "inotify/fswatch runtime watcher, git refs/heads watcher + gh pr view poller, liveness timer"
+      - type: "absorbed_machinery"
+        count: 4
+        rationale: "compute_waves, _create_worktree, _remove_worktree, two-phase commit loop — absorbed verbatim from src/atdd/coach/commands/orchestrate.py per spec §0.2"


### PR DESCRIPTION
## Summary

Authors the **drive-state-machine** wagon under `plan/drive_state_machine/` for coach v9 (Track J). Mirrors the structural template established by the already-authored `freeze-runtime-contracts` (C0) sibling wagon on the parent branch `feat/coach-v9-bootstrap`.

This PR is **scaffolding only** — no code changes, no issue filing, no train/`_wagons.yaml` mutation. The 9-wagon registry was authored on the bootstrap branch; this PR only fills in the `drive-state-machine` slot.

### What's in this PR

- `plan/drive_state_machine/_drive_state_machine.yaml` — wagon manifest (subject `agent:coach`, theme `commons`, mirrors C0 shape)
- `plan/drive_state_machine/features/coach_state_machine_and_runtime.yaml` — single feature spanning the 6 J-track issues
- 6 WMBTs covering the J track:
  - `D001` — coach state-machine + §5.1 CLI skeleton (J1)
  - `D002` — `atdd agent` CLI subcommands surface (J2)
  - `P001` — durable `decisions.jsonl` + `judgments.jsonl` writers (J3)
  - `E001` — two-phase commit with rollback absorbed from `orchestrate.py` (J4)
  - `M001` — runtime/git/liveness watchers replacing `babysit` polling (J5)
  - `R001` — `--resume <run-id>` reconstruction without double-execution (J6)
- 6 issue body markdowns under `.coach-v9-bootstrap/bodies/J{1..6}.md` — compliant with the template at `.coach-v9-bootstrap/briefing/compliant-issue-template.md`

### Issue filing — not in this PR

Per the parent-branch protocol, **no `gh issue create` or `atdd issue` calls** ran in this branch. Internal-spec-id placeholders (`#J1`, `#J3`, `#C0`, `#K1`, `#L1`, `#M3`, `#N1`, `#P5`) appear verbatim in the body markdowns and will be rewritten to actual GH numbers by the sequential filer pane in topological order per `.coach-v9-bootstrap/briefing/track-wagon-map.md`.

### Validation

`atdd validate planner --quick`: planner validators pass clean. Pre-existing failures (3) are in coach validators (`test_open_issue_compliance`, `test_required_label_set`, `test_rule_id_uniqueness`) and reflect repo state on `main`, not this PR.

## Test plan

- [ ] Reviewer reads `plan/drive_state_machine/_drive_state_machine.yaml` against C0's shape
- [ ] Reviewer skims J1 body for the §5.1 flag list and the explicit non-goals (no scope leak into J5/M3/L1/K1/J4/J3/J6)
- [ ] Reviewer confirms each WMBT's lens is `functional.<authorized>` (effectiveness or availability)
- [ ] Reviewer confirms each acceptance URN matches the `acc:drive-state-machine:<WMBT-step><NNN>-<HARNESS>-<NUM>-<slug>` grammar
- [ ] Filer pane rewrites `#J*`/`#C0`/`#K1`/`#L1`/`#M3`/`#N1`/`#P5` placeholders to real GH numbers when filing wave w1