### PR TITLE
feat(coach): freeze coach v9 runtime + validator contracts (#483)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -363,7 +363,7 @@ sessions:
   feature: null
   train: 0001-self-compliance-validate
 - id: '483'
-  slug: coach-v9-bootstrap
+  slug: coach-v9-c0-runtime-contracts
   file: null
   issue_number: 483
   type: implementation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.12.1"
+version = "3.13.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/schemas/coach-decision.schema.json
+++ b/src/atdd/coach/schemas/coach-decision.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "coach-decision.schema.json",
+  "title": "Coach v9 Decision",
+  "description": "Append-only entry in `.atdd/runtime/coach/decisions.jsonl`. One record per state transition, configuration choice, or escalation taken by the coach. Producer: coach state machine (#J3). Consumers: review reporters (#N2/#O2), audit tooling. Spec: atdd-coach-spec-v9.md §4.5 / §C0.",
+  "type": "object",
+  "required": [
+    "decision_id",
+    "timestamp",
+    "coach_run_id",
+    "issue_number",
+    "decision_type",
+    "inputs",
+    "outcome"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "decision_id": {
+      "type": "string",
+      "description": "Stable identifier for this decision. ULID or UUID is recommended for sortability across the JSONL stream.",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp at which the decision was finalized."
+    },
+    "coach_run_id": {
+      "type": "string",
+      "description": "Identifier of the coach run that emitted the decision. Multiple decisions share a `coach_run_id` for one orchestration session.",
+      "minLength": 1
+    },
+    "issue_number": {
+      "type": "integer",
+      "description": "GitHub issue number this decision relates to.",
+      "minimum": 1
+    },
+    "decision_type": {
+      "type": "string",
+      "description": "Coarse category of the decision. Open enum: extend with care, but consumers should tolerate unknown values for forward-compat.",
+      "examples": [
+        "phase-transition",
+        "configuration",
+        "escalation",
+        "agent-spawn",
+        "agent-respawn",
+        "pr-open",
+        "pr-merge",
+        "abort"
+      ]
+    },
+    "inputs": {
+      "type": "object",
+      "description": "Snapshot of inputs the decision was made on. Shape is decision-type specific; consumers MUST tolerate unknown keys.",
+      "additionalProperties": true
+    },
+    "outcome": {
+      "type": "object",
+      "description": "What the coach actually did as a result. Shape is decision-type specific; consumers MUST tolerate unknown keys.",
+      "additionalProperties": true
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Optional human-readable note. Useful for cases where automated audit struggles to reconstruct the why."
+    },
+    "judgment_id": {
+      "type": "string",
+      "description": "Optional cross-reference to the `coach-judgment` record this decision is anchored on (when the decision required an LLM judgment)."
+    }
+  }
+}

--- a/src/atdd/coach/schemas/coach-judgment.schema.json
+++ b/src/atdd/coach/schemas/coach-judgment.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "coach-judgment.schema.json",
+  "title": "Coach v9 Judgment",
+  "description": "Append-only entry in `.atdd/runtime/coach/judgments.jsonl`. One record per LLM-judgment call the coach issues. Producer: coach state machine (#J3) via the judge wagon. Consumers: cache lookup, review reporters, audit tooling. Spec: atdd-coach-spec-v9.md §4.5 / §6.9 / §C0. The six call_site values mirror the six judgment surfaces enumerated in spec §6.9.",
+  "type": "object",
+  "required": [
+    "judgment_id",
+    "timestamp",
+    "call_site",
+    "inputs_hash",
+    "response",
+    "cached"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "judgment_id": {
+      "type": "string",
+      "description": "Stable identifier for this judgment. ULID or UUID is recommended for sortability across the JSONL stream.",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp at which the judgment was returned (cache-hit timestamps still record the *return* time, not the original)."
+    },
+    "call_site": {
+      "type": "string",
+      "description": "The judgment surface this record came from. Frozen at C0 to the six surfaces named in spec §6.9. New surfaces require an explicit follow-up issue.",
+      "enum": [
+        "phase-advance",
+        "violation-suppression",
+        "correction-injection",
+        "review-disposition",
+        "escalation",
+        "merge-readiness"
+      ]
+    },
+    "inputs_hash": {
+      "type": "string",
+      "description": "Stable hash of the (call_site, normalized-inputs) tuple. Used as the cache key; identical hashes MUST yield identical responses.",
+      "minLength": 1
+    },
+    "response": {
+      "description": "The judgment payload. Shape is call_site specific; consumers MUST tolerate unknown keys for forward-compat.",
+      "type": ["object", "string", "boolean", "number", "array", "null"]
+    },
+    "cached": {
+      "type": "boolean",
+      "description": "True if this entry was satisfied from the judgment cache; false if the LLM was actually invoked."
+    },
+    "model": {
+      "type": "string",
+      "description": "Optional identifier of the model that produced the judgment (when cached=false)."
+    },
+    "latency_ms": {
+      "type": "integer",
+      "description": "Optional wall-clock latency for the judgment call. For cached entries this is the cache lookup latency.",
+      "minimum": 0
+    },
+    "decision_id": {
+      "type": "string",
+      "description": "Optional cross-reference to the `coach-decision` record this judgment fed into."
+    }
+  }
+}

--- a/src/atdd/coach/schemas/correction.schema.json
+++ b/src/atdd/coach/schemas/correction.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "correction.schema.json",
+  "title": "Coach v9 Observer Correction",
+  "description": "Observer correction payload. Producer: observer-correction track (#L1). Consumer: runtime watcher (#J5) which performs the actual injection. Stored append-only in `.atdd/runtime/agents/<id>/corrections.jsonl`. Spec: atdd-coach-spec-v9.md §C0.",
+  "type": "object",
+  "required": [
+    "agent_id",
+    "rule_id",
+    "severity",
+    "disposition",
+    "correction_text",
+    "injection_method"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "agent_id": {
+      "type": "string",
+      "description": "ID of the agent the correction targets.",
+      "minLength": 1
+    },
+    "rule_id": {
+      "type": "string",
+      "description": "Stable rule identifier (`<DOMAIN>-<TOPIC>-<NNN>` per substrate rule-id grammar) the correction is anchored on.",
+      "minLength": 1
+    },
+    "severity": {
+      "type": "integer",
+      "description": "Severity 1..5, aligned with substrate.Violation.severity.",
+      "minimum": 1,
+      "maximum": 5
+    },
+    "disposition": {
+      "type": "string",
+      "description": "Coach v9 disposition that drove the correction. Aligns with the substrate disposition vocabulary.",
+      "enum": [
+        "strict",
+        "suppress-and-clean",
+        "advisory",
+        "documentation-only"
+      ]
+    },
+    "correction_text": {
+      "type": "string",
+      "description": "Human-readable correction copy. Injected verbatim into the agent's input channel by the runtime watcher.",
+      "minLength": 1
+    },
+    "injection_method": {
+      "type": "string",
+      "description": "How the correction is delivered to the agent. Frozen at C0 to the three named methods; expansions require a follow-up issue.",
+      "enum": [
+        "cli-return",
+        "multiplexer-send",
+        "respawn"
+      ]
+    },
+    "issued_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Optional ISO-8601 UTC timestamp at which the observer issued the correction. The watcher records its own observation time when it injects."
+    },
+    "validator_id": {
+      "type": "string",
+      "description": "Optional identifier of the validator whose result triggered the correction."
+    },
+    "violation_location": {
+      "type": "string",
+      "description": "Optional `path:line` (or `path:line:col`) location anchor — useful when the correction references a specific site."
+    }
+  }
+}

--- a/src/atdd/coach/schemas/event-semantics.md
+++ b/src/atdd/coach/schemas/event-semantics.md
@@ -1,0 +1,239 @@
+# Coach v9 Event Semantics
+
+> **Status:** Frozen at C0 (issue #483).
+>
+> **Sibling contracts:**
+> [`runtime-event.schema.json`](./runtime-event.schema.json) ·
+> [`runtime-layout.md`](./runtime-layout.md) ·
+> [`validator-invocation.md`](./validator-invocation.md)
+
+[`runtime-event.schema.json`](./runtime-event.schema.json) freezes the
+**shape** of every runtime event. This document freezes the
+**semantics**: who emits each event, on what state change, what the
+idempotency contract is, what ordering guarantees consumers can rely
+on, and how the event behaves under `coach --resume`.
+
+The 12 event types below are the closed set frozen at C0. They MUST
+match the `event_type` enum in
+[`runtime-event.schema.json`](./runtime-event.schema.json) one-for-one;
+adding a new type requires an explicit follow-up issue.
+
+---
+
+## Glossary
+
+- **At-least-once** — the producer guarantees the event will be
+  written ≥1 times. Consumers MUST dedupe on the natural key.
+- **Exactly-once** — the producer guarantees the event is written
+  exactly once across crash and resume. Consumers do not need to
+  dedupe.
+- **Per-agent total order** — events for one `agent_id` are appended
+  to that agent's `events.jsonl` in monotonic timestamp order; a
+  consumer reading one agent's stream sees a total order.
+- **Cross-agent partial order** — there is no synchronization clock
+  across agents; a consumer joining two agents' streams MUST treat
+  them as concurrent.
+- **None** — no ordering guarantee; a consumer must look at the event
+  payload to reconstruct order.
+- **Replay re-fires** — on `coach --resume`, the event is emitted
+  again from the durable state.
+- **Replay suppressed** — on `coach --resume`, the event is not
+  re-emitted; consumers see only the post-resume stream.
+- **Replay cached** — on `coach --resume`, the producer reads its
+  prior emission from the durable ledger and republishes it as a
+  cached copy.
+
+---
+
+## `agent_spawned`
+
+- **Producer.** Coach state machine (#J3), at the moment the agent
+  subprocess has been launched and its `agents/<id>/heartbeat.json`
+  has been first-written.
+- **Triggering condition.** A `coach orchestrate` decision committed
+  to spawn a new agent and the spawn syscall returned a PID. The
+  event MUST NOT be emitted before the heartbeat file is on disk
+  (consumers assume the agent directory exists when they see the
+  event).
+- **Idempotency.** **Exactly-once** per `agent_id` per coach run.
+  Spawn is gated by the coach's run-scoped agent registry; a re-spawn
+  produces a new `agent_id`, not a second `agent_spawned` for the
+  old one.
+- **Ordering.** Per-agent total order — trivially, since this is the
+  first event in the agent's stream.
+- **Replay.** **Replay cached** — `coach --resume` reads the prior
+  event from `agents/<id>/events.jsonl` and republishes it; consumers
+  do not see a fresh spawn.
+
+## `heartbeat`
+
+- **Producer.** Runtime watcher (#J5), on a periodic timer scoped to
+  one agent.
+- **Triggering condition.** The watcher's heartbeat tick fires AND
+  the agent process is still alive (PID exists, no zombie). Each
+  tick rewrites `heartbeat.json` and appends one event.
+- **Idempotency.** **At-least-once.** A watcher restart can re-emit
+  the most recent heartbeat. Consumers MUST dedupe on
+  `(agent_id, payload.observed_at)` if exact-count matters.
+- **Ordering.** Per-agent total order on the agent's stream.
+- **Replay.** **Replay suppressed.** Heartbeats are not replayed on
+  resume — they describe transient liveness, and a stale
+  pre-resume heartbeat would be actively misleading.
+
+## `commit_observed`
+
+- **Producer.** Git watcher (#M1).
+- **Triggering condition.** A new commit appears on the worktree's
+  HEAD (detected by the git watcher polling `git rev-parse HEAD`
+  against its last-seen value). The event payload carries the new
+  SHA, the parent SHA, and the author.
+- **Idempotency.** **At-least-once.** A watcher crash mid-emit can
+  republish the same SHA; consumers MUST dedupe on `payload.sha`.
+- **Ordering.** Per-agent total order on the worktree's git watcher
+  stream; cross-agent partial order otherwise.
+- **Replay.** **Replay cached** — on resume the watcher reconstructs
+  its observed-SHA history from the prior `events.jsonl` and
+  republishes the cached entries.
+
+## `event_emitted`
+
+- **Producer.** Coach state machine (#J3) — the meta-event the coach
+  uses to record that *itself* fired any of the other 11 event types.
+- **Triggering condition.** Any other event type was just appended.
+  This is the audit-loop event, used to reconstruct what the coach
+  emitted across all streams without scanning every agent.
+- **Idempotency.** **At-least-once.** Pairs with the underlying
+  event; consumers MUST dedupe on
+  `(payload.original_event_id, payload.original_event_type)`.
+- **Ordering.** None across the audit stream — events are inserted in
+  the order the coach ratified each underlying event, but two
+  underlying emissions can interleave.
+- **Replay.** **Replay cached** — the audit stream is reconstructed
+  from the union of underlying agent streams on resume.
+
+## `escalation_emitted`
+
+- **Producer.** Coach state machine (#J3), called by the judge wagon
+  when the `escalation` judgment surface returns a non-null
+  escalation target.
+- **Triggering condition.** A `coach-judgment` record with
+  `call_site: "escalation"` returned a non-null `response.target`.
+  The event payload carries the target and the issue / agent context.
+- **Idempotency.** **Exactly-once** per `(judgment_id)`. The judge
+  wagon is the gating side; re-asking the same hashable inputs hits
+  the cache and does not re-fire.
+- **Ordering.** Cross-agent partial order — escalations across
+  different agents have no synchronization.
+- **Replay.** **Replay suppressed.** Escalations are external
+  side-effects (notifications, human pages); they are not
+  re-emitted on resume to avoid double-paging.
+
+## `pr_opened`
+
+- **Producer.** Coach state machine (#J3), after `atdd pr <N>`
+  reports the PR was created.
+- **Triggering condition.** A successful `atdd pr <N>` invocation
+  returned a PR number. The event payload carries
+  `{pr_number, base, head, sha}`.
+- **Idempotency.** **Exactly-once** per `pr_number`. The coach
+  records the PR number in its run manifest and refuses to re-emit
+  for a known PR.
+- **Ordering.** Cross-agent partial order — PRs from sibling agents
+  carry no synchronization.
+- **Replay.** **Replay cached** — on resume the coach reads the
+  prior PR number from the run manifest and republishes the event.
+
+## `pr_closed`
+
+- **Producer.** Git watcher (#M1) for self-closed PRs; coach state
+  machine (#J3) for coach-driven closures (merge or abort).
+- **Triggering condition.** GitHub webhook or polled state shows the
+  PR transitioned out of `open` (to `merged`, `closed`, or
+  `auto-merge`). Payload includes the terminal state and the SHA.
+- **Idempotency.** **At-least-once.** Polling can observe the
+  transition twice if the webhook also fires; consumers MUST dedupe
+  on `(pr_number, payload.terminal_state)`.
+- **Ordering.** Cross-agent partial order.
+- **Replay.** **Replay cached** for already-closed PRs; **replay
+  suppressed** for PRs that were open at the resume point (those
+  re-enter the live observation path).
+
+## `validation_pending`
+
+- **Producer.** Coach state machine (#J3) at the moment a phase
+  transition starts and validators are about to be invoked.
+- **Triggering condition.** A phase transition (e.g. RED → GREEN)
+  has been ratified and the coach is about to spawn the validator
+  subprocess (per [`validator-invocation.md`](./validator-invocation.md)).
+- **Idempotency.** **Exactly-once** per `(coach_run_id, phase, sha)`
+  — the coach gate guards against duplicate invocations on the same
+  state.
+- **Ordering.** Per-agent total order on the coach stream.
+- **Replay.** **Replay suppressed.** A pending validation that was
+  in flight at resume is not re-marked pending; the coach either
+  re-runs the validation (and emits a fresh `validation_pending`)
+  or treats the previous outcome as authoritative — never both.
+
+## `validation_complete`
+
+- **Producer.** Coach state machine (#J3), after the validator
+  subprocess exited and the violation-collector plugin flushed its
+  records to `validations/<sha>/violations.jsonl`.
+- **Triggering condition.** The validator subprocess exited (with
+  any status — see retry-policy in
+  [`validator-invocation.md`](./validator-invocation.md) §4) AND the
+  risk-scorer (#M3) finished writing `risk-score.json`.
+- **Idempotency.** **Exactly-once** per `(coach_run_id, phase, sha)`.
+  This is the durable signal the auto-phase gate consumes; duplicate
+  emission would corrupt the gate's bookkeeping.
+- **Ordering.** Per-agent total order on the coach stream; pairs
+  monotonically with the matching `validation_pending`.
+- **Replay.** **Replay cached** — on resume the coach reads the
+  prior outcome from `validations/<sha>/risk-score.json` and
+  republishes the cached `validation_complete`.
+
+## `review_complete`
+
+- **Producer.** Review-report writer (#N2) once the
+  `issue-reviews/<issue-N>/aggregate.json` write finishes.
+- **Triggering condition.** A reviewer-agent (#O2) finished
+  consuming the latest `validation_complete` and the writer wrote
+  the aggregated review payload.
+- **Idempotency.** **At-least-once.** A writer crash mid-flush can
+  republish; consumers MUST dedupe on
+  `(payload.issue_number, payload.aggregate_sha)`.
+- **Ordering.** Cross-agent partial order — reviews of different
+  parent issues carry no synchronization.
+- **Replay.** **Replay cached** — on resume the writer reads the
+  prior `aggregate.json` and republishes the event.
+
+## `correction_emitted`
+
+- **Producer.** Observer (#L1) — the watcher's `corrections.jsonl`
+  append of one [`correction.schema.json`](./correction.schema.json)
+  record always pairs with this event.
+- **Triggering condition.** Observer matched an agent-output rule and
+  produced a correction record. The event payload carries the
+  `(agent_id, rule_id, injection_method)` triple.
+- **Idempotency.** **At-least-once** per natural key
+  `(agent_id, rule_id, payload.detected_at)`. The observer's pattern
+  match can re-fire on a second window; consumers MUST dedupe.
+- **Ordering.** Per-agent total order.
+- **Replay.** **Replay suppressed.** Corrections are external
+  side-effects (they were already injected into the live agent);
+  re-firing on resume would double-inject and confuse the agent.
+
+## `process_silence`
+
+- **Producer.** Runtime watcher (#J5), on the silence-detector tick.
+- **Triggering condition.** No new bytes on the agent's
+  `output.log`, no new commit observed, AND no `heartbeat` event for
+  longer than the configured silence window. The event payload
+  carries `silent_for_seconds`.
+- **Idempotency.** **At-least-once.** A silence-detector restart
+  can re-fire if the silence persists; consumers MUST dedupe on
+  `(agent_id, payload.silence_window_started_at)`.
+- **Ordering.** Per-agent total order.
+- **Replay.** **Replay suppressed.** Silence is a transient liveness
+  state; the post-resume detector starts fresh from the resume point
+  and emits a new `process_silence` only if the silence persists.

--- a/src/atdd/coach/schemas/fixtures/coach-decision/full.json
+++ b/src/atdd/coach/schemas/fixtures/coach-decision/full.json
@@ -1,0 +1,18 @@
+{
+  "decision_id": "01HW9P6XJC2E8YB4PQTKR9V3ZN",
+  "timestamp": "2026-05-09T13:46:11.012Z",
+  "coach_run_id": "run-2026-05-09-coach-v9-bootstrap",
+  "issue_number": 483,
+  "decision_type": "escalation",
+  "inputs": {
+    "trigger": "process_silence",
+    "agent_id": "agent-K1-tester",
+    "silent_for_seconds": 1800
+  },
+  "outcome": {
+    "action": "respawn",
+    "previous_pid": 42891
+  },
+  "rationale": "Agent silent past the 30-minute heartbeat threshold; no recent stdout, no recent commits. Respawn rather than escalate to human because the behavior matches a known transient cmux hang.",
+  "judgment_id": "01HW9P6XK1G7H4ZN2A5DYJ8Q3X"
+}

--- a/src/atdd/coach/schemas/fixtures/coach-decision/minimal.json
+++ b/src/atdd/coach/schemas/fixtures/coach-decision/minimal.json
@@ -1,0 +1,15 @@
+{
+  "decision_id": "01HW9P5C8K3D5R8X4M7VJZ4MZA",
+  "timestamp": "2026-05-09T13:45:02.482Z",
+  "coach_run_id": "run-2026-05-09-coach-v9-bootstrap",
+  "issue_number": 483,
+  "decision_type": "phase-transition",
+  "inputs": {
+    "current_phase": "GREEN",
+    "target_phase": "SMOKE"
+  },
+  "outcome": {
+    "transitioned": true,
+    "new_phase": "SMOKE"
+  }
+}

--- a/src/atdd/coach/schemas/fixtures/coach-judgment/full.json
+++ b/src/atdd/coach/schemas/fixtures/coach-judgment/full.json
@@ -1,0 +1,14 @@
+{
+  "judgment_id": "01HW9PA3XK7Q2RB9N6V1MZJ4FY",
+  "timestamp": "2026-05-09T13:50:42.118Z",
+  "call_site": "violation-suppression",
+  "inputs_hash": "sha256:1a79a4d60de6718e8e5b326e338ae533",
+  "response": {
+    "appropriate": true,
+    "until_recommended": "2026-08-15"
+  },
+  "cached": true,
+  "model": "claude-opus-4-7",
+  "latency_ms": 12,
+  "decision_id": "01HW9PA42XK7Q2RB9N6V1MZJ8FY"
+}

--- a/src/atdd/coach/schemas/fixtures/coach-judgment/minimal.json
+++ b/src/atdd/coach/schemas/fixtures/coach-judgment/minimal.json
@@ -1,0 +1,11 @@
+{
+  "judgment_id": "01HW9P6XK1G7H4ZN2A5DYJ8Q3X",
+  "timestamp": "2026-05-09T13:46:10.998Z",
+  "call_site": "escalation",
+  "inputs_hash": "sha256:8b1a9953c4611296a827abf8c47804d7",
+  "response": {
+    "decision": "respawn",
+    "confidence": 0.82
+  },
+  "cached": false
+}

--- a/src/atdd/coach/schemas/fixtures/correction/full.json
+++ b/src/atdd/coach/schemas/fixtures/correction/full.json
@@ -1,0 +1,11 @@
+{
+  "agent_id": "agent-M3-coder",
+  "rule_id": "coder.boundaries.qualified-import",
+  "severity": 4,
+  "disposition": "suppress-and-clean",
+  "correction_text": "src/atdd/coach/utils/repo.py:42 imports across a wagon boundary without a qualified `from atdd.<wagon>.<feature> import` form. Replace the bare import or add an explicit `# atdd:suppress(coder.boundaries.qualified-import) UNTIL=2026-09-01` with a tracked cleanup ticket.",
+  "injection_method": "cli-return",
+  "issued_at": "2026-05-09T13:52:05.221Z",
+  "validator_id": "test_boundaries_qualified_import::test_no_unqualified_cross_wagon_import",
+  "violation_location": "src/atdd/coach/utils/repo.py:42"
+}

--- a/src/atdd/coach/schemas/fixtures/correction/minimal.json
+++ b/src/atdd/coach/schemas/fixtures/correction/minimal.json
@@ -1,0 +1,8 @@
+{
+  "agent_id": "agent-K1-tester",
+  "rule_id": "tester.red.assertion-mode",
+  "severity": 3,
+  "disposition": "strict",
+  "correction_text": "Your last commit added a structural-only assertion in a presentation-layer test. Per tester/red.convention.yaml §assertion_classification, presentation tests must declare Assertion: behavioral and execute the component. Re-run the test in execution mode and assert observable behavior.",
+  "injection_method": "multiplexer-send"
+}

--- a/src/atdd/coach/schemas/fixtures/risk-score/full.json
+++ b/src/atdd/coach/schemas/fixtures/risk-score/full.json
@@ -1,0 +1,24 @@
+{
+  "sum": 27,
+  "by_severity": {
+    "2": 3,
+    "3": 4,
+    "4": 2,
+    "5": 1
+  },
+  "by_archetype": {
+    "repo": 12,
+    "coach": 8,
+    "be": 5,
+    "fe": 2
+  },
+  "by_disposition": {
+    "strict": 13,
+    "suppress-and-clean": 9,
+    "advisory": 5
+  },
+  "stale_suppressions": 1,
+  "phase": "GREEN",
+  "generated_at": "2026-05-09T13:55:10.001Z",
+  "sha": "7631322"
+}

--- a/src/atdd/coach/schemas/fixtures/risk-score/minimal.json
+++ b/src/atdd/coach/schemas/fixtures/risk-score/minimal.json
@@ -1,0 +1,9 @@
+{
+  "sum": 0,
+  "by_severity": {},
+  "by_archetype": {
+    "repo": 0
+  },
+  "by_disposition": {},
+  "stale_suppressions": 0
+}

--- a/src/atdd/coach/schemas/fixtures/runtime-event/full.json
+++ b/src/atdd/coach/schemas/fixtures/runtime-event/full.json
@@ -1,0 +1,11 @@
+{
+  "event_type": "validation_complete",
+  "agent_id": "agent-J3-coach",
+  "timestamp": "2026-05-09T13:45:02.482Z",
+  "payload": {
+    "phase": "GREEN",
+    "sha": "7631322abcd",
+    "violations_total": 0,
+    "duration_ms": 4218
+  }
+}

--- a/src/atdd/coach/schemas/fixtures/runtime-event/minimal.json
+++ b/src/atdd/coach/schemas/fixtures/runtime-event/minimal.json
@@ -1,0 +1,7 @@
+{
+  "event_type": "heartbeat",
+  "timestamp": "2026-05-09T13:42:18Z",
+  "payload": {
+    "load_avg": 0.31
+  }
+}

--- a/src/atdd/coach/schemas/fixtures/validator-result/full.json
+++ b/src/atdd/coach/schemas/fixtures/validator-result/full.json
@@ -1,0 +1,11 @@
+{
+  "validator_id": "test_boundaries_qualified_import::test_no_unqualified_cross_wagon_import",
+  "rule_id": "coder.boundaries.qualified-import",
+  "severity": 4,
+  "disposition": "suppress-and-clean",
+  "location": "src/atdd/coach/utils/repo.py:42",
+  "detail": "Bare `from atdd.coach.utils.repo import find_repo_root` from a wagon-internal module — qualify or suppress.",
+  "suppression_marker": "# atdd:suppress(coder.boundaries.qualified-import) UNTIL=2026-09-01",
+  "fix_hint_ref": "recipe:boundaries#qualified-imports",
+  "outcome": "suppressed"
+}

--- a/src/atdd/coach/schemas/fixtures/validator-result/minimal.json
+++ b/src/atdd/coach/schemas/fixtures/validator-result/minimal.json
@@ -1,0 +1,9 @@
+{
+  "validator_id": "test_no_stale_suppressions::test_no_stale_suppressions",
+  "rule_id": "coach.suppression.no-stale",
+  "severity": 3,
+  "disposition": "strict",
+  "location": "src/atdd/coach/utils/legacy.py:118",
+  "detail": "Suppression marker has UNTIL=2026-04-30, which is in the past. Remove the suppression and fix the underlying violation.",
+  "suppression_marker": null
+}

--- a/src/atdd/coach/schemas/risk-score.schema.json
+++ b/src/atdd/coach/schemas/risk-score.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "risk-score.schema.json",
+  "title": "Coach v9 Risk Score",
+  "description": "Per-phase-exit risk-score document. Producer: coach risk-scorer (#M3). Consumer: PR routing, review reporters (#N2), gate auto-phase. Single-doc JSON, written to `.atdd/runtime/validations/<sha>/risk-score.json` and rewritten on every phase exit (not append-only). Spec: atdd-coach-spec-v9.md §6.8 / §C0.",
+  "type": "object",
+  "required": [
+    "sum",
+    "by_severity",
+    "by_archetype",
+    "by_disposition",
+    "stale_suppressions"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "sum": {
+      "type": "integer",
+      "description": "Total risk = sum of severity * count across all unsuppressed validator-results for this <sha>.",
+      "minimum": 0
+    },
+    "by_severity": {
+      "type": "object",
+      "description": "Risk slice keyed by severity level (1..5). Keys are stringified integers because JSON object keys are strings.",
+      "additionalProperties": false,
+      "propertyNames": {
+        "pattern": "^[1-5]$"
+      },
+      "patternProperties": {
+        "^[1-5]$": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "by_archetype": {
+      "type": "object",
+      "description": "Risk slice keyed by archetype name. MUST include the `repo` slice (per spec §C0); other archetypes (`db`, `be`, `fe`, `coach`, `contracts`, …) appear when they contributed risk for this run.",
+      "required": ["repo"],
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "by_disposition": {
+      "type": "object",
+      "description": "Risk slice keyed by disposition. Values mirror the substrate disposition vocabulary.",
+      "additionalProperties": false,
+      "propertyNames": {
+        "enum": [
+          "strict",
+          "suppress-and-clean",
+          "advisory",
+          "documentation-only"
+        ]
+      },
+      "patternProperties": {
+        "^(strict|suppress-and-clean|advisory|documentation-only)$": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "stale_suppressions": {
+      "type": "integer",
+      "description": "Count of suppression markers whose `UNTIL=<date>` is in the past. Risk-score sum does NOT include these (suppressed results are excluded from sum); the count is exposed separately so the gate can fail on staleness.",
+      "minimum": 0
+    },
+    "phase": {
+      "type": "string",
+      "description": "Optional ATDD phase this risk score was emitted at the exit of.",
+      "enum": ["RED", "GREEN", "SMOKE", "REFACTOR"]
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Optional ISO-8601 UTC timestamp at which the risk-score doc was rewritten."
+    },
+    "sha": {
+      "type": "string",
+      "description": "Optional commit SHA the risk score is anchored on (mirrors the directory anchor `validations/<sha>/`).",
+      "minLength": 7
+    }
+  }
+}

--- a/src/atdd/coach/schemas/runtime-event.schema.json
+++ b/src/atdd/coach/schemas/runtime-event.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "runtime-event.schema.json",
+  "title": "Coach v9 Runtime Event",
+  "description": "Coach v9 runtime watcher event. One JSON document per line in `.atdd/runtime/agents/<id>/events.jsonl`. Producer: #J5 runtime watcher. Consumers: #L1 (observer), #M1 (git watcher), #N* (review reporters). Spec: atdd-coach-spec-v9.md §3.2 / §4.4 / §C0. Temporal contracts (idempotency, ordering, replay) live in event-semantics.md.",
+  "type": "object",
+  "required": ["event_type", "timestamp", "payload"],
+  "additionalProperties": false,
+  "properties": {
+    "event_type": {
+      "type": "string",
+      "description": "One of the 12 event types frozen at C0. The set is closed; new types require an explicit follow-up issue per the C0 scope.",
+      "enum": [
+        "agent_spawned",
+        "heartbeat",
+        "commit_observed",
+        "event_emitted",
+        "escalation_emitted",
+        "pr_opened",
+        "pr_closed",
+        "validation_pending",
+        "validation_complete",
+        "review_complete",
+        "correction_emitted",
+        "process_silence"
+      ]
+    },
+    "agent_id": {
+      "type": "string",
+      "description": "ID of the agent the event concerns. Optional because some events (e.g. process_silence at the coach level) are not bound to a single agent.",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 UTC timestamp at which the event was observed. The watcher writes its observation time, not the underlying source time."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Event-type-specific body. Free-form per event type; downstream consumers MUST tolerate unknown keys for forward-compat.",
+      "additionalProperties": true
+    }
+  }
+}

--- a/src/atdd/coach/schemas/runtime-layout.md
+++ b/src/atdd/coach/schemas/runtime-layout.md
@@ -1,0 +1,270 @@
+# Coach v9 Runtime Layout
+
+> **Status:** Frozen at C0 (issue #483). Every coach v9 track (J1, K1, L1, M1, N1, O1, P1) reads/writes against this contract; new files require an explicit follow-up issue.
+>
+> **Sibling contracts:**
+> [`runtime-event.schema.json`](./runtime-event.schema.json) ·
+> [`coach-decision.schema.json`](./coach-decision.schema.json) ·
+> [`coach-judgment.schema.json`](./coach-judgment.schema.json) ·
+> [`correction.schema.json`](./correction.schema.json) ·
+> [`validator-result.schema.json`](./validator-result.schema.json) ·
+> [`risk-score.schema.json`](./risk-score.schema.json) ·
+> [`event-semantics.md`](./event-semantics.md) ·
+> [`validator-invocation.md`](./validator-invocation.md)
+
+This document specifies the directory and file structure under
+`.atdd/runtime/`. For every file we name:
+
+- **role** — what the file is for, in one sentence;
+- **writer** — the single component allowed to write it;
+- **reader** — the components that consume it;
+- **appendability** — whether the file is **append-only** (one JSON
+  document per line, never rewritten in place) or **rewritten** in full
+  on every update;
+- **serialization shape** — whether the file is a **JSON-line** stream
+  (`*.jsonl`) or a **single-doc** JSON document (`*.json`).
+
+Plain `*.log` files are byte streams, not JSON; we still record their
+role/writer/reader and they are always append-only.
+
+The directory tree is opaque to `git`: `.atdd/runtime/` is gitignored.
+Anything under it is local to a coach run; nothing here is committed.
+
+---
+
+## Top-level tree
+
+```
+.atdd/runtime/
+├── agents/<id>/
+│   ├── heartbeat.json
+│   ├── output.log
+│   ├── events.jsonl
+│   └── corrections.jsonl
+├── coach/
+│   ├── decisions.jsonl
+│   └── judgments.jsonl
+├── validations/<sha>/
+│   ├── violations.jsonl
+│   ├── risk-score.json
+│   ├── suppressed.jsonl
+│   └── stale-suppressions.jsonl
+├── issue-reviews/<issue-N>/
+│   └── aggregate.json
+└── runs/<run-id>/
+    └── manifest.json
+```
+
+The five top-level subtrees — `agents/<id>/`, `coach/`,
+`validations/<sha>/`, `issue-reviews/<issue-N>/`, `runs/<run-id>/` —
+are the C0-frozen partition of runtime state. Every other coach v9
+artifact MUST live under one of them.
+
+### Path index (full paths)
+
+Every file documented below, listed in full-path form so consumers can
+grep this document for an exact match:
+
+- `.atdd/runtime/agents/<id>/heartbeat.json`
+- `.atdd/runtime/agents/<id>/output.log`
+- `.atdd/runtime/agents/<id>/events.jsonl`
+- `.atdd/runtime/agents/<id>/corrections.jsonl`
+- `.atdd/runtime/coach/decisions.jsonl`
+- `.atdd/runtime/coach/judgments.jsonl`
+- `.atdd/runtime/validations/<sha>/violations.jsonl`
+- `.atdd/runtime/validations/<sha>/risk-score.json`
+- `.atdd/runtime/validations/<sha>/suppressed.jsonl`
+- `.atdd/runtime/validations/<sha>/stale-suppressions.jsonl`
+- `.atdd/runtime/issue-reviews/<issue-N>/aggregate.json`
+- `.atdd/runtime/runs/<run-id>/manifest.json`
+
+---
+
+## `agents/<id>/` — per-agent runtime state
+
+Each spawned agent owns a directory keyed by its agent id (a slug like
+`agent-J3-coach-state-machine` or a UUID — coach picks). The watcher
+(#J5) writes; observer (#L1) and review reporters (#N2/#O2) read.
+
+### `agents/<id>/heartbeat.json`
+
+| facet | value |
+|-------|-------|
+| role | Liveness signal: last-known PID, wall-clock, and free-form status payload for one agent. Coach uses it to detect process_silence. |
+| writer | Runtime watcher (#J5) |
+| reader | Runtime watcher (silence detection); review reporters; `atdd babysit` |
+| appendability | **rewritten** in place — most recent state replaces the previous |
+| serialization shape | **single-doc** JSON |
+| schema | (no committed schema — one-key-only `{pid, observed_at, status}`; if grown beyond that, file a follow-up to add one) |
+
+### `agents/<id>/output.log`
+
+| facet | value |
+|-------|-------|
+| role | Captured stdout/stderr stream of the agent process. Used for postmortem and for observer pattern matching. |
+| writer | Runtime watcher (#J5) — tee'd from the agent's pipe |
+| reader | Observer (#L1); human review |
+| appendability | **append-only** byte stream |
+| serialization shape | not JSON — line-buffered text log |
+
+### `agents/<id>/events.jsonl`
+
+| facet | value |
+|-------|-------|
+| role | Per-agent runtime event stream — one event document per line. The 12 event types are frozen at C0. |
+| writer | Runtime watcher (#J5) |
+| reader | Observer (#L1); git watcher (#M1); review reporters; `atdd babysit` |
+| appendability | **append-only** — never rewritten in place |
+| serialization shape | **JSON-line** stream |
+| schema | [`runtime-event.schema.json`](./runtime-event.schema.json) — temporal contracts in [`event-semantics.md`](./event-semantics.md) |
+
+### `agents/<id>/corrections.jsonl`
+
+| facet | value |
+|-------|-------|
+| role | Observer-issued corrections that the watcher injected into the agent. One record per correction. |
+| writer | Runtime watcher (#J5) — after observer (#L1) emits |
+| reader | Observer (re-evaluation); review reporters; audit |
+| appendability | **append-only** |
+| serialization shape | **JSON-line** stream |
+| schema | [`correction.schema.json`](./correction.schema.json) |
+
+---
+
+## `coach/` — process-wide coach state
+
+Coach state that is not bound to any single agent. Writer is always the
+coach state machine (#J3); readers are reporters and the audit pipeline.
+
+### `coach/decisions.jsonl`
+
+| facet | value |
+|-------|-------|
+| role | Append-only ledger of every decision the coach took (state transitions, configuration choices, escalations). Spec §4.5 / §C0. |
+| writer | Coach state machine (#J3) |
+| reader | Review reporters (#N2/#O2); audit tooling |
+| appendability | **append-only** |
+| serialization shape | **JSON-line** stream |
+| schema | [`coach-decision.schema.json`](./coach-decision.schema.json) |
+
+### `coach/judgments.jsonl`
+
+| facet | value |
+|-------|-------|
+| role | Append-only ledger of every LLM-judgment call the coach made (one of the six call sites per spec §6.9). Acts as the durable cache index. |
+| writer | Coach state machine (#J3) via the judge wagon |
+| reader | Cache lookup; review reporters; audit |
+| appendability | **append-only** |
+| serialization shape | **JSON-line** stream |
+| schema | [`coach-judgment.schema.json`](./coach-judgment.schema.json) |
+
+---
+
+## `validations/<sha>/` — per-commit validator artifacts
+
+One subdirectory per commit SHA the coach has validated against. The
+SHA-anchored layout makes risk scores reproducible and lets the
+review-reporter aggregate per-commit history without scanning logs.
+
+### `validations/<sha>/violations.jsonl`
+
+| facet | value |
+|-------|-------|
+| role | Every structured `Violation` raised at this SHA, serialized through the C0 contract. Spec §6.4 / §7.5. |
+| writer | Pytest violation-collector plugin (#M2) |
+| reader | Review-report writer (#N2); reviewer-agents (#O2); risk-scorer |
+| appendability | **append-only** during one validation run; the *file* is rewritten only when the SHA changes (a new SHA gets a new directory). |
+| serialization shape | **JSON-line** stream |
+| schema | [`validator-result.schema.json`](./validator-result.schema.json) |
+
+### `validations/<sha>/risk-score.json`
+
+| facet | value |
+|-------|-------|
+| role | Aggregate risk score for the SHA — `sum`, `by_severity`, `by_archetype` (incl. `repo`), `by_disposition`, `stale_suppressions`. Spec §6.8. |
+| writer | Risk-scorer (#M3) — runs after the violation-collector flushes |
+| reader | PR-routing logic; auto-phase gate; review reporters |
+| appendability | **rewritten** on every phase exit at this SHA |
+| serialization shape | **single-doc** JSON |
+| schema | [`risk-score.schema.json`](./risk-score.schema.json) |
+
+### `validations/<sha>/suppressed.jsonl`
+
+| facet | value |
+|-------|-------|
+| role | Violations that were absorbed by an inline `# atdd:suppress(...)` marker. Useful for "what is suppression masking?" review questions. |
+| writer | Pytest violation-collector plugin (#M2) — same writer as `violations.jsonl` but routed through the disposition gate |
+| reader | Review-report writer; suppression audit |
+| appendability | **append-only** for the SHA |
+| serialization shape | **JSON-line** stream |
+| schema | [`validator-result.schema.json`](./validator-result.schema.json) (records carry a non-null `suppression_marker`) |
+
+### `validations/<sha>/stale-suppressions.jsonl`
+
+| facet | value |
+|-------|-------|
+| role | Suppression markers whose `UNTIL=<date>` is in the past. The coach gate fails on a non-zero count of these. |
+| writer | Suppression scanner (substrate v12) — invoked by coach at validate time |
+| reader | Coach gate; review reporters |
+| appendability | **append-only** for the SHA |
+| serialization shape | **JSON-line** stream |
+| schema | (no committed schema yet — substrate's scanner shape is the source; if frozen later, file a follow-up to add one) |
+
+---
+
+## `issue-reviews/<issue-N>/` — per-parent-issue aggregate
+
+Spec §6.10. One subdirectory per ATDD parent issue, holding the rolled-up
+review payload that the reporter writes to GitHub.
+
+### `issue-reviews/<issue-N>/aggregate.json`
+
+| facet | value |
+|-------|-------|
+| role | Cross-SHA roll-up: latest risk score, list of open violations, link to last review-complete event. Drives the parent-issue review comment. |
+| writer | Review-report writer (#N2) |
+| reader | Reviewer-agents (#O2); auto-phase gate |
+| appendability | **rewritten** every time the writer recomputes the aggregate |
+| serialization shape | **single-doc** JSON |
+| schema | (no committed schema yet — frozen in a downstream issue alongside the writer that will produce it) |
+
+---
+
+## `runs/<run-id>/` — coach-run scoped manifest
+
+One subdirectory per coach orchestration run (a `coach_run_id`). Holds
+the manifest that ties together the agents spawned and the SHAs
+validated within this run, so postmortem can be reconstructed without
+walking the union of `agents/`, `coach/`, and `validations/`.
+
+### `runs/<run-id>/manifest.json`
+
+| facet | value |
+|-------|-------|
+| role | Run-scoped index: list of agent ids, list of validation SHAs, start/end timestamps, exit status. |
+| writer | Coach state machine (#J3) — finalized at run end |
+| reader | Postmortem tooling; review reporters |
+| appendability | **rewritten** at run-end (and incrementally during the run if the implementer chooses) |
+| serialization shape | **single-doc** JSON |
+| schema | (no committed schema yet — frozen alongside the run-orchestrator that produces it) |
+
+---
+
+## Conventions across the layout
+
+1. **Append-only files never seek-and-truncate.** A coach instance may
+   crash; the JSONL writer MUST be safe under crash-recover by reopening
+   in append mode.
+2. **Single-doc files are written atomically.** Implementers MUST write
+   to `<path>.tmp` and `os.rename` into place to avoid partial reads.
+3. **Schemas freeze shape; semantics live in sibling docs.** Temporal
+   contracts (idempotency, ordering, replay) for runtime events live in
+   [`event-semantics.md`](./event-semantics.md). The validator
+   subprocess contract lives in
+   [`validator-invocation.md`](./validator-invocation.md).
+4. **Cross-references use relative paths.** The schemas referenced
+   above (`runtime-event.schema.json`, `coach-decision.schema.json`,
+   `coach-judgment.schema.json`, `correction.schema.json`,
+   `validator-result.schema.json`, `risk-score.schema.json`) are
+   sibling files in `src/atdd/coach/schemas/` and are linked
+   accordingly.

--- a/src/atdd/coach/schemas/validator-invocation.md
+++ b/src/atdd/coach/schemas/validator-invocation.md
@@ -1,0 +1,196 @@
+# Coach v9 Validator Invocation Contract
+
+> **Status:** Frozen at C0 (issue #483).
+>
+> **Sibling contracts:**
+> [`runtime-layout.md`](./runtime-layout.md) ·
+> [`event-semantics.md`](./event-semantics.md) ·
+> [`validator-result.schema.json`](./validator-result.schema.json) ·
+> [`risk-score.schema.json`](./risk-score.schema.json)
+
+This document is the subprocess contract between the coach state
+machine (#J3) and the substrate's pytest plugin. Track M (validator
+dispatch) and Track J (state machine) MUST agree on every clause here;
+deviation is a coordination break, not a tuning knob.
+
+---
+
+## 1. Pytest CLI flag set
+
+The coach invokes `python -m pytest` per phase with the following base
+flag set:
+
+```sh
+python -m pytest \
+    --tb=short \
+    -q \
+    --strict-markers \
+    -p atdd.coach.plugins.violation_collector \
+    -p atdd.coach.plugins.diagnostics \
+    --rootdir=<repo-root> \
+    <selected-validator-paths>
+```
+
+Per-flag rationale:
+
+| Flag | Why |
+|------|-----|
+| `--tb=short` | Tracebacks fit in the JSONL output line; longer forms break log parsers. |
+| `-q` | Coach reads from the violation-collector plugin, not stdout — quiet pytest avoids drowning the log. |
+| `--strict-markers` | Unknown markers are a coordination failure (a track using an unregistered marker), and MUST fail loud. |
+| `-p atdd.coach.plugins.violation_collector` | Forces the violation-collector plugin to load even with autoload disabled (see §2). |
+| `-p atdd.coach.plugins.diagnostics` | Loads the diagnostics plugin (timing, env capture) for the same reason. |
+| `--rootdir=<repo-root>` | Pin the pytest rootdir so the coach is independent of the cwd it was launched from. |
+
+The `<selected-validator-paths>` are computed by the coach's per-phase
+dispatch (see §3); the coach passes explicit paths rather than relying
+on `testpaths` so the dispatch decision is auditable.
+
+---
+
+## 2. Plugin autoload policy
+
+The coach sets:
+
+```sh
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+```
+
+**Rationale.** Autoload makes the validator subprocess implicitly
+inherit any `pytest-*` plugin installed in the consumer environment.
+That is unsafe for the coach because:
+
+1. **Reproducibility.** Two consumer repos with different installed
+   plugin sets would produce different validator results — the coach's
+   risk score would not be portable.
+2. **Plugin conflicts.** A consumer with `pytest-mock` shadows fixtures
+   the substrate plugin owns; with autoload off, the coach loads only
+   what it explicitly opts into via `-p ...` (see §1).
+3. **Failure surface.** An autoloaded plugin that crashes at
+   `pytest_configure` exits the subprocess before the violation
+   collector can flush — a pure plumbing failure that looks like a
+   validator failure to the coach gate.
+
+The trade-off — manually opting in via `-p atdd.coach.plugins.*` for
+every coach-managed plugin — is the price for a deterministic
+validator contract.
+
+---
+
+## 3. Per-phase timeout defaults and override mechanism
+
+Validators run under per-phase timeouts. The defaults are tuned for
+the dispatch-set size at each phase (RED is small; REFACTOR sweeps the
+whole repo and is much larger).
+
+| Phase | Default timeout (seconds) |
+|-------|---------------------------|
+| RED | 60 |
+| GREEN | 180 |
+| SMOKE | 300 |
+| REFACTOR | 600 |
+
+**Override mechanism.** Per-phase defaults can be overridden two ways:
+
+1. **Env var.** `ATDD_VALIDATOR_TIMEOUT_<PHASE>=<seconds>` — e.g.
+   `ATDD_VALIDATOR_TIMEOUT_REFACTOR=900`. Empty / unset means "use the
+   default above". Negative values are rejected and the coach refuses
+   to start the run.
+2. **Config key.** `coach.validator.timeout.<phase>` in
+   `.atdd/config.yaml` (lower-case phase). Resolution order is
+   env-var > config > default, so a CI-only env-var bump cannot be
+   accidentally locked in by a stray config edit.
+
+A timeout firing kills the subprocess group with `SIGTERM`, waits 5
+seconds, then `SIGKILL`s anything still alive. The coach records a
+`validator_timeout` outcome in the run manifest.
+
+---
+
+## 4. Retry policy — subprocess crash vs test failure
+
+These two failure modes carry different signal handling and the coach
+MUST distinguish them at every dispatch site.
+
+### 4.1 Test failure
+
+A "test failure" is a non-zero pytest exit code where the
+violation-collector plugin produced records (i.e. pytest itself ran
+and the failure surface is one or more validators reporting violations).
+
+**Retry policy.** **No retry.** Test failures are coach-visible signal
+and feed directly into the disposition gate. Retrying would mask
+transient determinism bugs (one of the highest-cost failure classes
+this contract was written to surface).
+
+**Detection.** Pytest exit code in `{1, 2, 3, 4}` (test failures,
+collection errors, internal errors, usage errors) AND
+`violations.jsonl` is non-empty.
+
+### 4.2 Subprocess crash
+
+A "subprocess crash" is the validator process dying *outside* the
+test path — segfault (`SIGSEGV`), hard timeout, OOM kill, or an
+exception inside a pytest hook before the violation-collector plugin
+flushed.
+
+**Retry policy.** **One retry**, with full subprocess restart and
+plugin reload. A second crash on the same dispatch unit fails the
+coach run with a `subprocess_crash` outcome rather than a violation
+report.
+
+**Detection.** Any of:
+- Exit was a fatal signal (negative exit code on POSIX, where
+  `os.WIFSIGNALED(status)` is True);
+- Pytest exit code `{5, 6}` (no tests collected, usage errors with no
+  collection) AND `violations.jsonl` is empty;
+- Coach-side timeout (§3) fired before pytest exited.
+
+### 4.3 Why the distinction matters
+
+The two policies use **different signal handling**: test failure is a
+clean exit from pytest with structured records; subprocess crash is
+out-of-band signal-driven termination. Conflating them — retrying on
+test failure or failing-on-first-crash — corrupts the risk score in
+ways that surface only at the integration step. C0 freezes the
+distinction so #J3 and #M3 cannot drift.
+
+---
+
+## 5. Env-var passthrough
+
+The coach passes the following env vars to validator subprocesses,
+verbatim from its own environment (no transformation, no defaulting):
+
+| Var | Why |
+|-----|-----|
+| `PATH` | Locating the python interpreter and any helper binaries. |
+| `HOME` | Some validators read user-level config; required for stable resolution. |
+| `PYTHONPATH` | Honors the consumer repo's `pythonpath` if set. |
+| `PYTEST_DISABLE_PLUGIN_AUTOLOAD` | Forwarded to enforce the §2 policy in the child. |
+| `ATDD_VALIDATOR_TIMEOUT_*` | Honors per-phase overrides (§3). |
+| `ATDD_RUN_ID` | Run-scoped correlation id; lets the violation-collector tag records. |
+| `CI` | Some validators relax behavior outside CI; the env var must reach the child. |
+| `GITHUB_TOKEN` | Forwarded only if the validator's manifest opts in (security: most validators MUST NOT see it). |
+| `LANG`, `LC_ALL` | Locale; YAML/JSON parsers can otherwise interpret bytes inconsistently. |
+
+Every other env var is **dropped**. This is deliberate: the coach
+runs with whatever environment cmux/CI hands it, and we do not want
+arbitrary ambient state to leak into the validator subprocess.
+
+---
+
+## 6. Summary checklist for implementers
+
+Before opening a PR that touches the validator dispatch path, confirm:
+
+- [ ] Pytest CLI flags match §1 verbatim (no implicit additions in
+      the dispatch wrapper).
+- [ ] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` is set on the subprocess
+      env (§2).
+- [ ] Per-phase timeouts match §3 unless an explicit override path is
+      added — and the override path is documented.
+- [ ] Subprocess-crash retry is distinct from test-failure retry
+      (§4); the two are not collapsed into a generic "retry on
+      failure" branch.
+- [ ] Env-var passthrough is whitelisted, not blacklisted (§5).

--- a/src/atdd/coach/schemas/validator-result.schema.json
+++ b/src/atdd/coach/schemas/validator-result.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "validator-result.schema.json",
+  "title": "Coach v9 Validator Result",
+  "description": "One serialized validator result, written by coach's pytest plugin to `.atdd/runtime/validations/<sha>/violations.jsonl`. Producer: pytest violation-collector plugin (#M2). Consumers: review-report writer (#N2) and reviewer-agents (#O2). Aligns with substrate's `Violation` dataclass — every Violation field is preserved (rule_id, severity, location, detail, fix_hint_ref) and the coach extends with validator_id, disposition, and suppression_marker. Spec: atdd-coach-spec-v9.md §6.4 / §7.5 / §C0.",
+  "type": "object",
+  "required": [
+    "validator_id",
+    "rule_id",
+    "severity",
+    "disposition",
+    "location",
+    "detail",
+    "suppression_marker"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "validator_id": {
+      "type": "string",
+      "description": "Identifier of the validator that produced this result. Format: `<module_basename>::<function_name>` matching substrate.RuleMetadata.validator.",
+      "minLength": 1
+    },
+    "rule_id": {
+      "type": "string",
+      "description": "Stable rule identifier matching the substrate grammar `<DOMAIN>-<TOPIC>-<NNN>` (or the namespaced `<archetype>.<convention>.<rule>` form used by RuleMetadata.rule_id). Persisted forever; renames go through superseded_by.",
+      "minLength": 1
+    },
+    "severity": {
+      "type": "integer",
+      "description": "Integer 1..5 — aligns with substrate.Violation.__post_init__ which rejects values outside [1,5].",
+      "minimum": 1,
+      "maximum": 5
+    },
+    "disposition": {
+      "type": "string",
+      "description": "Per-rule CI policy (substrate spec v12 §4.5 / issue #395). Strict fails CI; suppress-and-clean honors inline `# atdd:suppress(<rule_id>)` markers; advisory logs and passes; documentation-only is non-enforced.",
+      "enum": [
+        "strict",
+        "suppress-and-clean",
+        "advisory",
+        "documentation-only"
+      ]
+    },
+    "location": {
+      "type": "string",
+      "description": "`path:line` or `path:line:col` of the offending site, relative to the repo root. Aligns with substrate.Violation.location.",
+      "minLength": 1
+    },
+    "detail": {
+      "type": "string",
+      "description": "One-line human-readable description of *this* violation instance. Aligns with substrate.Violation.detail."
+    },
+    "suppression_marker": {
+      "type": ["string", "null"],
+      "description": "Inline suppression marker text that absorbed this result (e.g. `# atdd:suppress(<rule_id>) UNTIL=2026-12-31`), or null when no marker matched. Required field; null is the explicit 'no marker' sentinel."
+    },
+    "fix_hint_ref": {
+      "type": "string",
+      "description": "Optional pointer to a fix recipe step (e.g. `recipe:adapter#step-1`). Aligns with substrate.Violation.fix_hint_ref."
+    },
+    "outcome": {
+      "type": "string",
+      "description": "Optional terminal outcome of the result after disposition gating.",
+      "enum": [
+        "fail",
+        "suppressed",
+        "advisory-warn",
+        "documentation"
+      ]
+    }
+  }
+}

--- a/src/atdd/coach/validators/test_d001_unit_001_six_schemas_exist.py
+++ b/src/atdd/coach/validators/test_d001_unit_001_six_schemas_exist.py
@@ -1,0 +1,206 @@
+# URN: test:freeze-runtime-contracts:runtime-schema-freeze:D001-UNIT-001-six-schemas-exist
+# Acceptance: acc:freeze-runtime-contracts:D001-UNIT-001-six-schemas-exist
+# WMBT: wmbt:freeze-runtime-contracts:D001
+# Phase: RED
+# Layer: backend.integration
+# Assertion: structural
+
+"""
+D001-UNIT-001 — All six coach v9 runtime schemas exist at
+``src/atdd/coach/schemas/``, parse as JSON Schema draft-2020-12, declare
+the required fields per spec §C0, and (for ``runtime-event``) enumerate
+the 12 event types; ``validator-result`` aligns with substrate's
+``Violation`` dataclass.
+
+Phase RED: fails on a tree where no schemas have been added; phase GREEN
+when all six schemas land.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+import atdd
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+SCHEMAS_DIR = ATDD_PKG_DIR / "coach" / "schemas"
+
+# The six schemas frozen at C0. Order is the order in spec §C0.
+SCHEMA_FILES = (
+    "runtime-event.schema.json",
+    "coach-decision.schema.json",
+    "coach-judgment.schema.json",
+    "correction.schema.json",
+    "validator-result.schema.json",
+    "risk-score.schema.json",
+)
+
+# The 12 runtime-event types frozen by spec §C0 (D004 context_clarifier).
+EVENT_TYPES = (
+    "agent_spawned",
+    "heartbeat",
+    "commit_observed",
+    "event_emitted",
+    "escalation_emitted",
+    "pr_opened",
+    "pr_closed",
+    "validation_pending",
+    "validation_complete",
+    "review_complete",
+    "correction_emitted",
+    "process_silence",
+)
+
+# Per spec §C0 / issue body, the required fields each schema must declare.
+REQUIRED_FIELDS: Dict[str, tuple] = {
+    "runtime-event.schema.json": ("event_type", "timestamp", "payload"),
+    "coach-decision.schema.json": (
+        "decision_id",
+        "timestamp",
+        "coach_run_id",
+        "issue_number",
+        "decision_type",
+        "inputs",
+        "outcome",
+    ),
+    "coach-judgment.schema.json": (
+        "judgment_id",
+        "timestamp",
+        "call_site",
+        "inputs_hash",
+        "response",
+        "cached",
+    ),
+    "correction.schema.json": (
+        "agent_id",
+        "rule_id",
+        "severity",
+        "disposition",
+        "correction_text",
+        "injection_method",
+    ),
+    "validator-result.schema.json": (
+        "validator_id",
+        "rule_id",
+        "severity",
+        "disposition",
+        "location",
+        "detail",
+        "suppression_marker",
+    ),
+    "risk-score.schema.json": (
+        "sum",
+        "by_severity",
+        "by_archetype",
+        "by_disposition",
+        "stale_suppressions",
+    ),
+}
+
+DRAFT_2020_12_URI = "https://json-schema.org/draft/2020-12/schema"
+
+
+def _load(name: str) -> Dict[str, Any]:
+    path = SCHEMAS_DIR / name
+    assert path.exists(), (
+        f"Schema not found: {path}. "
+        f"Acceptance D001-UNIT-001 requires all six schemas at "
+        f"src/atdd/coach/schemas/."
+    )
+    with path.open() as fh:
+        return json.load(fh)
+
+
+@pytest.mark.parametrize("schema_name", SCHEMA_FILES)
+def test_schema_exists(schema_name: str) -> None:
+    """Each of the six schemas is committed at src/atdd/coach/schemas/."""
+    path = SCHEMAS_DIR / schema_name
+    assert path.exists(), (
+        f"Missing schema: {path}. C0 freezes six runtime artifact "
+        f"contracts; this one is required."
+    )
+
+
+@pytest.mark.parametrize("schema_name", SCHEMA_FILES)
+def test_schema_declares_draft_2020_12(schema_name: str) -> None:
+    """Each schema declares ``$schema`` = JSON Schema draft-2020-12."""
+    schema = _load(schema_name)
+    assert schema.get("$schema") == DRAFT_2020_12_URI, (
+        f"{schema_name}: $schema must be {DRAFT_2020_12_URI!r}, "
+        f"got {schema.get('$schema')!r}. The whole schema set is "
+        f"frozen on draft-2020-12 to keep parsers consistent across "
+        f"the six coach v9 tracks."
+    )
+
+
+@pytest.mark.parametrize("schema_name", SCHEMA_FILES)
+def test_schema_parses_as_jsonschema(schema_name: str) -> None:
+    """Each schema is itself well-formed against the draft-2020-12 meta-schema."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = _load(schema_name)
+    # Will raise if the schema body is malformed against the meta-schema.
+    jsonschema.Draft202012Validator.check_schema(schema)
+
+
+@pytest.mark.parametrize("schema_name", SCHEMA_FILES)
+def test_schema_declares_required_fields(schema_name: str) -> None:
+    """Each schema's ``required`` list covers the spec §C0 fields."""
+    schema = _load(schema_name)
+    expected = set(REQUIRED_FIELDS[schema_name])
+    declared = set(schema.get("required") or ())
+    missing = expected - declared
+    assert not missing, (
+        f"{schema_name}: missing required fields {sorted(missing)}. "
+        f"Spec §C0 requires {sorted(expected)}."
+    )
+
+
+def test_runtime_event_enumerates_12_event_types() -> None:
+    """``runtime-event.schema.json`` enumerates the 12 event types from spec §C0."""
+    schema = _load("runtime-event.schema.json")
+    props = schema.get("properties") or {}
+    event_type = props.get("event_type") or {}
+    enum = event_type.get("enum")
+    assert enum is not None, (
+        "runtime-event.schema.json: properties.event_type.enum is missing. "
+        "Spec §C0 freezes 12 event types as an enum so cross-track "
+        "consumers cannot drift."
+    )
+    assert sorted(enum) == sorted(EVENT_TYPES), (
+        f"runtime-event.schema.json: event_type enum {sorted(enum)} "
+        f"does not match the 12 spec §C0 types {sorted(EVENT_TYPES)}."
+    )
+
+
+def test_validator_result_aligns_with_substrate_violation() -> None:
+    """``validator-result.schema.json`` carries every substrate ``Violation`` field.
+
+    Substrate's ``Violation`` dataclass exposes ``rule_id``, ``severity``,
+    ``location``, ``detail``, and ``fix_hint_ref`` (optional). The C0
+    contract adds ``validator_id``, ``disposition``, and ``suppression_marker``
+    on top of those — but must not drop any substrate field, so a
+    serialized ``Violation`` round-trips through the C0 schema.
+    """
+    schema = _load("validator-result.schema.json")
+    props = schema.get("properties") or {}
+    # Required fields on validator-result include the substrate-aligned set.
+    for substrate_field in ("rule_id", "severity", "location", "detail"):
+        assert substrate_field in props, (
+            f"validator-result.schema.json: missing property "
+            f"{substrate_field!r}; the schema must align with "
+            f"substrate's Violation dataclass."
+        )
+    # severity is integer 1..5 to match Violation.__post_init__.
+    sev = props["severity"]
+    assert sev.get("type") == "integer", (
+        "validator-result.schema.json: severity must be integer to "
+        "align with substrate.Violation.severity."
+    )
+    assert sev.get("minimum") == 1 and sev.get("maximum") == 5, (
+        "validator-result.schema.json: severity must constrain to "
+        "[1, 5] to align with substrate.Violation.__post_init__."
+    )

--- a/src/atdd/coach/validators/test_d001_unit_002_fixtures_validate.py
+++ b/src/atdd/coach/validators/test_d001_unit_002_fixtures_validate.py
@@ -1,0 +1,142 @@
+# URN: test:freeze-runtime-contracts:runtime-schema-freeze:D001-UNIT-002-fixtures-validate
+# Acceptance: acc:freeze-runtime-contracts:D001-UNIT-002-fixtures-validate
+# WMBT: wmbt:freeze-runtime-contracts:D001
+# Phase: RED
+# Layer: backend.integration
+# Assertion: behavioral
+
+"""
+D001-UNIT-002 — Each schema has at least one valid example fixture
+co-located at ``src/atdd/coach/schemas/fixtures/<schema-name>/``;
+fixtures collectively cover ``required-only`` and
+``required-plus-optional`` shapes.
+
+Phase RED: fails because no fixtures have been committed yet.
+Phase GREEN: every fixture round-trips through its schema with zero errors.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+import atdd
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+SCHEMAS_DIR = ATDD_PKG_DIR / "coach" / "schemas"
+FIXTURES_DIR = SCHEMAS_DIR / "fixtures"
+
+SCHEMA_BASENAMES = (
+    "runtime-event",
+    "coach-decision",
+    "coach-judgment",
+    "correction",
+    "validator-result",
+    "risk-score",
+)
+
+
+def _schema_path(basename: str) -> Path:
+    return SCHEMAS_DIR / f"{basename}.schema.json"
+
+
+def _fixture_dir(basename: str) -> Path:
+    return FIXTURES_DIR / basename
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    with path.open() as fh:
+        return json.load(fh)
+
+
+def _enumerate_fixtures(basename: str) -> List[Path]:
+    d = _fixture_dir(basename)
+    if not d.exists():
+        return []
+    return sorted(p for p in d.glob("*.json") if p.is_file())
+
+
+@pytest.mark.parametrize("basename", SCHEMA_BASENAMES)
+def test_fixture_directory_exists(basename: str) -> None:
+    """Every schema has a co-located fixtures directory."""
+    d = _fixture_dir(basename)
+    assert d.is_dir(), (
+        f"Missing fixture directory {d}. Acceptance D001-UNIT-002 "
+        f"requires each schema to have at least one example fixture."
+    )
+
+
+@pytest.mark.parametrize("basename", SCHEMA_BASENAMES)
+def test_fixture_directory_has_at_least_one_fixture(basename: str) -> None:
+    """At least one fixture .json per schema."""
+    fixtures = _enumerate_fixtures(basename)
+    assert fixtures, (
+        f"No fixtures under {_fixture_dir(basename)}. C0 acceptance "
+        f"D001-UNIT-002 requires at least one valid example."
+    )
+
+
+def _all_fixture_pairs() -> List[Tuple[str, Path]]:
+    pairs: List[Tuple[str, Path]] = []
+    for basename in SCHEMA_BASENAMES:
+        for f in _enumerate_fixtures(basename):
+            pairs.append((basename, f))
+    return pairs
+
+
+@pytest.mark.parametrize(
+    "basename,fixture",
+    _all_fixture_pairs() or [pytest.param("none", None, marks=pytest.mark.skip(
+        reason="no fixtures present yet — covered by directory tests"
+    ))],
+)
+def test_fixture_validates_against_schema(basename: str, fixture: Path) -> None:
+    """Every committed fixture validates with zero errors against its schema."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = _load_json(_schema_path(basename))
+    instance = _load_json(fixture)
+    validator = jsonschema.Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(instance), key=lambda e: e.path)
+    assert not errors, (
+        f"Fixture {fixture} fails {basename}.schema.json:\n"
+        + "\n".join(f"  - {e.message} at /{'/'.join(map(str, e.path))}" for e in errors)
+    )
+
+
+def test_fixtures_collectively_cover_required_only_and_full_shapes() -> None:
+    """At least one fixture is required-only; at least one is required-plus-optional.
+
+    "Collectively" is read across the union of all fixtures, not
+    per-schema, per the WMBT D001-UNIT-002 ``then`` clause.
+    """
+    seen_minimal = False
+    seen_full = False
+    for basename in SCHEMA_BASENAMES:
+        schema = _load_json(_schema_path(basename))
+        required = set(schema.get("required") or ())
+        properties = set((schema.get("properties") or {}).keys())
+        optional = properties - required
+        for fixture in _enumerate_fixtures(basename):
+            instance = _load_json(fixture)
+            if not isinstance(instance, dict):
+                continue
+            keys = set(instance.keys())
+            # required-only: exactly the required fields
+            if keys == required:
+                seen_minimal = True
+            # required-plus-optional: contains at least one optional field
+            elif required.issubset(keys) and (keys & optional):
+                seen_full = True
+    assert seen_minimal, (
+        "No required-only fixture found across schemas. Add one fixture "
+        "(e.g. fixtures/<name>/minimal.json) that omits all optional "
+        "fields."
+    )
+    assert seen_full, (
+        "No required-plus-optional fixture found across schemas. Add "
+        "one fixture (e.g. fixtures/<name>/full.json) that includes at "
+        "least one optional field."
+    )

--- a/src/atdd/coach/validators/test_d002_unit_001_runtime_layout_doc_committed.py
+++ b/src/atdd/coach/validators/test_d002_unit_001_runtime_layout_doc_committed.py
@@ -1,0 +1,121 @@
+# URN: test:freeze-runtime-contracts:runtime-schema-freeze:D002-UNIT-001-runtime-layout-doc-committed
+# Acceptance: acc:freeze-runtime-contracts:D002-UNIT-001-runtime-layout-doc-committed
+# WMBT: wmbt:freeze-runtime-contracts:D002
+# Phase: RED
+# Layer: backend.integration
+# Assertion: structural
+
+"""
+D002-UNIT-001 — ``src/atdd/coach/schemas/runtime-layout.md`` exists and
+documents every file path under ``.atdd/runtime/`` with role / writer /
+reader / append-only-vs-rewritten / JSON-line-vs-single-doc, and
+references the JSON schemas it complements.
+
+Phase RED: fails because the doc is not yet committed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import atdd
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+LAYOUT_DOC = ATDD_PKG_DIR / "coach" / "schemas" / "runtime-layout.md"
+
+# Paths from spec §3.2 / issue body that must each appear in the doc.
+REQUIRED_PATHS = (
+    ".atdd/runtime/agents/<id>/heartbeat.json",
+    ".atdd/runtime/agents/<id>/output.log",
+    ".atdd/runtime/agents/<id>/events.jsonl",
+    ".atdd/runtime/agents/<id>/corrections.jsonl",
+    ".atdd/runtime/coach/decisions.jsonl",
+    ".atdd/runtime/coach/judgments.jsonl",
+    ".atdd/runtime/validations/<sha>/violations.jsonl",
+    ".atdd/runtime/validations/<sha>/risk-score.json",
+    ".atdd/runtime/validations/<sha>/suppressed.jsonl",
+    ".atdd/runtime/validations/<sha>/stale-suppressions.jsonl",
+)
+
+# Top-level directories the WMBT ``then`` clause names explicitly.
+REQUIRED_DIRECTORIES = (
+    "agents/<id>/",
+    "coach/",
+    "validations/<sha>/",
+    "issue-reviews/<issue-N>/",
+    "runs/<run-id>/",
+)
+
+# Required per-row metadata columns / labels every documented file must carry.
+REQUIRED_METADATA_TOKENS = (
+    "role",
+    "writer",
+    "reader",
+    # append-only vs rewritten
+    "append-only",
+    "rewritten",
+    # JSON-line vs single-doc
+    "JSON-line",
+    "single-doc",
+)
+
+# Schemas the doc must reference by relative path.
+REFERENCED_SCHEMAS = (
+    "runtime-event.schema.json",
+    "coach-decision.schema.json",
+    "coach-judgment.schema.json",
+    "correction.schema.json",
+    "validator-result.schema.json",
+    "risk-score.schema.json",
+)
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    assert LAYOUT_DOC.exists(), (
+        f"Missing {LAYOUT_DOC}. Acceptance D002-UNIT-001 requires "
+        f"runtime-layout.md to be committed at "
+        f"src/atdd/coach/schemas/runtime-layout.md."
+    )
+    return LAYOUT_DOC.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("path", REQUIRED_PATHS)
+def test_runtime_layout_documents_path(path: str, doc_text: str) -> None:
+    assert path in doc_text, (
+        f"runtime-layout.md does not mention {path!r}. Spec §3.2 "
+        f"enumerates this file under .atdd/runtime/."
+    )
+
+
+@pytest.mark.parametrize("directory", REQUIRED_DIRECTORIES)
+def test_runtime_layout_documents_directory(directory: str, doc_text: str) -> None:
+    """``agents/<id>/``, ``coach/``, ``validations/<sha>/``, ``issue-reviews/<issue-N>/``, ``runs/<run-id>/`` appear with child-file contracts."""
+    assert directory in doc_text, (
+        f"runtime-layout.md does not document the {directory!r} subtree. "
+        f"WMBT D002-UNIT-001 requires every top-level subtree to appear "
+        f"with its child-file contracts."
+    )
+
+
+@pytest.mark.parametrize("token", REQUIRED_METADATA_TOKENS)
+def test_runtime_layout_describes_metadata(token: str, doc_text: str) -> None:
+    """Each documented file carries role/writer/reader/appendability/serialization."""
+    assert token in doc_text, (
+        f"runtime-layout.md does not describe {token!r}. WMBT "
+        f"D002-UNIT-001 requires every file's role, writer, reader, "
+        f"append-only-vs-rewritten, and JSON-line-vs-single-doc to be "
+        f"documented."
+    )
+
+
+@pytest.mark.parametrize("schema", REFERENCED_SCHEMAS)
+def test_runtime_layout_references_schemas(schema: str, doc_text: str) -> None:
+    """The doc references the JSON schemas it complements by relative path."""
+    assert schema in doc_text, (
+        f"runtime-layout.md does not reference {schema!r}. WMBT "
+        f"D002-UNIT-001 requires schema cross-references so consumers "
+        f"can find the shape contract for each documented file."
+    )

--- a/src/atdd/coach/validators/test_d003_unit_001_validator_invocation_doc_committed.py
+++ b/src/atdd/coach/validators/test_d003_unit_001_validator_invocation_doc_committed.py
@@ -1,0 +1,110 @@
+# URN: test:freeze-runtime-contracts:runtime-schema-freeze:D003-UNIT-001-validator-invocation-doc-committed
+# Acceptance: acc:freeze-runtime-contracts:D003-UNIT-001-validator-invocation-doc-committed
+# WMBT: wmbt:freeze-runtime-contracts:D003
+# Phase: RED
+# Layer: backend.integration
+# Assertion: structural
+
+"""
+D003-UNIT-001 — ``src/atdd/coach/schemas/validator-invocation.md``
+specifies the full subprocess contract: pytest CLI flags,
+``PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`` policy, per-phase timeout defaults,
+retry-on-subprocess-crash distinguished from retry-on-test-failure, and
+the env vars passed through to validator subprocesses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import atdd
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+DOC = ATDD_PKG_DIR / "coach" / "schemas" / "validator-invocation.md"
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    assert DOC.exists(), (
+        f"Missing {DOC}. Acceptance D003-UNIT-001 requires "
+        f"validator-invocation.md committed at "
+        f"src/atdd/coach/schemas/validator-invocation.md."
+    )
+    return DOC.read_text(encoding="utf-8")
+
+
+def test_doc_specifies_pytest_cli_flags(doc_text: str) -> None:
+    """Pytest CLI flag set used to invoke validators is enumerated."""
+    # Coach invokes validators with these representative flags. The doc
+    # must enumerate enough of them that downstream tracks can quote the
+    # contract verbatim.
+    for flag in ("-p ", "--tb=", "-q", "--strict-markers"):
+        assert flag in doc_text, (
+            f"validator-invocation.md does not mention pytest flag "
+            f"{flag!r}. WMBT D003-UNIT-001 requires the pytest CLI "
+            f"flag set to be enumerated."
+        )
+
+
+def test_doc_states_plugin_autoload_policy(doc_text: str) -> None:
+    """``PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`` policy is stated with rationale."""
+    assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1" in doc_text, (
+        "validator-invocation.md must declare the "
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 policy."
+    )
+    # Rationale: any of these markers indicates the doc explains the
+    # 'why', not just the value.
+    rationale_signals = ("rationale", "Rationale", "because", "to prevent")
+    assert any(s in doc_text for s in rationale_signals), (
+        "validator-invocation.md must explain the rationale for "
+        "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 (why, not just what)."
+    )
+
+
+def test_doc_states_per_phase_timeout_defaults(doc_text: str) -> None:
+    """Per-phase timeout defaults and override mechanism are stated."""
+    assert "timeout" in doc_text.lower(), (
+        "validator-invocation.md must specify per-phase timeout defaults."
+    )
+    # Each ATDD phase that runs validators must appear so per-phase
+    # tunability is unambiguous.
+    for phase in ("RED", "GREEN", "SMOKE", "REFACTOR"):
+        assert phase in doc_text, (
+            f"validator-invocation.md must enumerate phase {phase!r} "
+            f"in its per-phase timeout section."
+        )
+    assert "override" in doc_text.lower(), (
+        "validator-invocation.md must describe the timeout override "
+        "mechanism (env var, config key, or CLI flag)."
+    )
+
+
+def test_doc_distinguishes_subprocess_crash_from_test_failure(doc_text: str) -> None:
+    """Retry-on-subprocess-crash is explicitly distinguished from retry-on-test-failure."""
+    assert "subprocess crash" in doc_text.lower() or "subprocess-crash" in doc_text.lower(), (
+        "validator-invocation.md must mention subprocess-crash retry policy."
+    )
+    assert "test failure" in doc_text.lower() or "test-failure" in doc_text.lower(), (
+        "validator-invocation.md must mention test-failure retry policy."
+    )
+    # The two must be distinguished — "different signal handling" or
+    # similar wording must appear.
+    assert "signal" in doc_text.lower() or "distinct" in doc_text.lower() or "different" in doc_text.lower(), (
+        "validator-invocation.md must distinguish the two retry "
+        "policies (different signal handling)."
+    )
+
+
+def test_doc_enumerates_env_passthrough(doc_text: str) -> None:
+    """Env vars passed through to validator subprocesses are enumerated."""
+    # Section header and at least the universally-passed env vars.
+    assert "env" in doc_text.lower(), (
+        "validator-invocation.md must enumerate env-var passthrough."
+    )
+    for var in ("PATH", "HOME", "PYTEST_DISABLE_PLUGIN_AUTOLOAD"):
+        assert var in doc_text, (
+            f"validator-invocation.md must list {var!r} in its env "
+            f"passthrough enumeration."
+        )

--- a/src/atdd/coach/validators/test_d004_unit_001_event_semantics_doc_complete.py
+++ b/src/atdd/coach/validators/test_d004_unit_001_event_semantics_doc_complete.py
@@ -1,0 +1,139 @@
+# URN: test:freeze-runtime-contracts:runtime-schema-freeze:D004-UNIT-001-event-semantics-doc-complete
+# Acceptance: acc:freeze-runtime-contracts:D004-UNIT-001-event-semantics-doc-complete
+# WMBT: wmbt:freeze-runtime-contracts:D004
+# Phase: RED
+# Layer: backend.integration
+# Assertion: structural
+
+"""
+D004-UNIT-001 — ``src/atdd/coach/schemas/event-semantics.md`` exists and
+specifies, for every one of the 12 event types, Producer + Triggering
+condition + Idempotency contract + Ordering guarantees + Replay behavior.
+
+The doc is cross-checked against ``runtime-event.schema.json``'s
+``event_type`` enum so the two cannot drift.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+import atdd
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+SCHEMAS_DIR = ATDD_PKG_DIR / "coach" / "schemas"
+DOC = SCHEMAS_DIR / "event-semantics.md"
+SCHEMA = SCHEMAS_DIR / "runtime-event.schema.json"
+
+# Frozen by spec §C0; D004 context_clarifier enumerates the same 12.
+EVENT_TYPES = (
+    "agent_spawned",
+    "heartbeat",
+    "commit_observed",
+    "event_emitted",
+    "escalation_emitted",
+    "pr_opened",
+    "pr_closed",
+    "validation_pending",
+    "validation_complete",
+    "review_complete",
+    "correction_emitted",
+    "process_silence",
+)
+
+REQUIRED_SUBSECTION_LABELS = (
+    "Producer",
+    "Triggering",
+    "Idempotency",
+    "Ordering",
+    "Replay",
+)
+
+
+@pytest.fixture(scope="module")
+def doc_text() -> str:
+    assert DOC.exists(), (
+        f"Missing {DOC}. Acceptance D004-UNIT-001 requires "
+        f"event-semantics.md committed at "
+        f"src/atdd/coach/schemas/event-semantics.md."
+    )
+    return DOC.read_text(encoding="utf-8")
+
+
+def _section_for(event: str, doc_text: str) -> str:
+    """Return the section body for ``event``, raising if not found.
+
+    A section starts at a heading line (``#`` or ``##``) that contains
+    the event type name (as a code span or bare token) and ends at the
+    next same-or-higher-level heading line.
+    """
+    # Find a heading line that contains the event name. We accept any
+    # heading depth from H2..H4 as long as it contains the event token.
+    heading_re = re.compile(
+        rf"^(#{{2,4}})\s.*\b{re.escape(event)}\b",
+        re.MULTILINE,
+    )
+    m = heading_re.search(doc_text)
+    if not m:
+        return ""
+    start = m.end()
+    depth = m.group(1)
+    # Next heading at same depth or shallower terminates this section.
+    end_re = re.compile(rf"^#{{1,{len(depth)}}}\s", re.MULTILINE)
+    e = end_re.search(doc_text, pos=start)
+    return doc_text[start: e.start() if e else len(doc_text)]
+
+
+@pytest.mark.parametrize("event", EVENT_TYPES)
+def test_event_has_subsection(event: str, doc_text: str) -> None:
+    """Every one of the 12 event types has its own subsection."""
+    section = _section_for(event, doc_text)
+    assert section, (
+        f"event-semantics.md is missing a subsection for {event!r}. "
+        f"WMBT D004-UNIT-001 requires per-event-type subsections."
+    )
+
+
+@pytest.mark.parametrize("event", EVENT_TYPES)
+def test_event_subsection_specifies_all_five_facets(event: str, doc_text: str) -> None:
+    """Producer / Triggering / Idempotency / Ordering / Replay all appear."""
+    section = _section_for(event, doc_text)
+    if not section:
+        pytest.skip(f"section for {event!r} missing — covered by sibling test")
+    for label in REQUIRED_SUBSECTION_LABELS:
+        assert label in section, (
+            f"event-semantics.md: {event!r} subsection is missing "
+            f"{label!r}. WMBT D004-UNIT-001 requires all five facets "
+            f"(Producer, Triggering, Idempotency, Ordering, Replay) "
+            f"per event type."
+        )
+
+
+def test_doc_matches_schema_enumeration() -> None:
+    """The 12 event types in event-semantics.md match runtime-event.schema.json's enum."""
+    if not SCHEMA.exists():
+        pytest.skip("runtime-event.schema.json missing — covered by D001 tests")
+    if not DOC.exists():
+        pytest.skip("event-semantics.md missing — covered by sibling test")
+    with SCHEMA.open() as fh:
+        schema = json.load(fh)
+    enum = (schema.get("properties", {}).get("event_type") or {}).get("enum") or []
+    text = DOC.read_text(encoding="utf-8")
+    for e in enum:
+        # Each enumerated event type appears at least once in the doc.
+        assert e in text, (
+            f"event-semantics.md does not document event type {e!r} "
+            f"declared by runtime-event.schema.json."
+        )
+    # And conversely, the doc cannot introduce types not in the schema.
+    # We don't enforce a hard equality here because future docs may
+    # describe the schema-changing process — the schema enum is the
+    # source of truth.
+    assert sorted(enum) == sorted(EVENT_TYPES), (
+        f"runtime-event.schema.json enum {sorted(enum)} drifted from "
+        f"the spec §C0 list {sorted(EVENT_TYPES)}."
+    )


### PR DESCRIPTION
Closes #483

## Summary

Coach v9 Track **C0** (contract freeze). Documentation- and schemas-only PR — no behavior changes. Unblocks the six parallel coach v9 tracks (J/K/L/M/N/O/P) by freezing every cross-track artifact contract before any track ships code.

### Six JSON Schemas (draft-2020-12) at `src/atdd/coach/schemas/`

- `runtime-event.schema.json` — events.jsonl entries; **12 frozen `event_type` values** (spec §C0).
- `coach-decision.schema.json` — append-only `decisions.jsonl` records.
- `coach-judgment.schema.json` — append-only `judgments.jsonl` records; **6 frozen `call_site` values** (spec §6.9).
- `correction.schema.json` — observer-correction payloads; **3 frozen `injection_method` values**.
- `validator-result.schema.json` — fields aligned with substrate's `Violation` dataclass (`rule_id`, `severity 1..5`, `location`, `detail`) plus coach extensions (`validator_id`, `disposition`, `suppression_marker`).
- `risk-score.schema.json` — risk-score doc with `by_severity` / `by_archetype` (incl. required `repo` slice) / `by_disposition` / `stale_suppressions`.

Each schema has `minimal.json` (required-only) and `full.json` (required-plus-optional) fixtures at `src/atdd/coach/schemas/fixtures/<name>/`, all validated by the D001-UNIT-002 test.

### Three contract docs at `src/atdd/coach/schemas/`

- `runtime-layout.md` — every file under `.atdd/runtime/` (agents/, coach/, validations/, issue-reviews/, runs/) with role / writer / reader / appendability / serialization shape, plus a flat path index.
- `validator-invocation.md` — pytest CLI flag set, `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` policy with rationale, per-phase timeout defaults, **subprocess-crash vs test-failure retry distinction** (different signal handling), env-var passthrough whitelist.
- `event-semantics.md` — per-event-type subsections (Producer / Triggering / Idempotency / Ordering / Replay) for all 12 event types frozen by `runtime-event.schema.json`.

### Acceptance tests at `src/atdd/coach/validators/`

Five RED-then-GREEN tests covering the five WMBT acceptance criteria:

- `test_d001_unit_001_six_schemas_exist.py` — 26 assertions (existence, draft-2020-12, required fields, 12 event types, substrate alignment).
- `test_d001_unit_002_fixtures_validate.py` — 25 assertions (fixture existence + validation + collective shape coverage).
- `test_d002_unit_001_runtime_layout_doc_committed.py` — 28 assertions (paths, directories, metadata tokens, schema cross-refs).
- `test_d003_unit_001_validator_invocation_doc_committed.py` — 5 assertions (CLI flags, autoload policy, timeouts, retry distinction, env passthrough).
- `test_d004_unit_001_event_semantics_doc_complete.py` — 25 assertions (per-event subsections + facets + cross-check against schema enum).

**109/109 new tests pass.**

### Repo state corrections

- `.atdd/manifest.yaml` — slug for issue #483 corrected from stale `coach-v9-bootstrap` to `coach-v9-c0-runtime-contracts` so the pre-commit hook recognises the worktree.
- Version bump 3.12.1 → **3.13.0** (MINOR — new schemas + new conventions, non-breaking).

## Test plan

- [x] All five WMBT acceptance tests pass when run from worktree source.
- [x] No regressions across `src/atdd/` test suite (3 pre-existing failures in `test_open_issue_compliance.py`, `test_release_versioning.py`, `test_required_label_set.py` are unrelated to this PR — they concern other open issues and the v3.12.1-tag-behind-HEAD condition that this PR's version bump resolves).
- [x] `test_E001_cli_characterization.py::test_status_shows_total_72_validators` — pre-existing characterization-test drift (expected `133 files`, actual `145 files` before this PR). This PR adds 5 validator files, taking actual to `150`. Out of scope to repair.
- [ ] Track owners (J1, K1, L1, M1, N1, O1, P1) to sign off on `runtime-layout.md` and `event-semantics.md` per WMBT D002-UNIT-001 and D004-UNIT-001 review-and-approve clauses.

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |