### PR TITLE
feat(coach): `atdd rules` discovery: show, where, grep (#493)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -373,3 +373,14 @@ sessions:
   wagon: freeze-runtime-contracts
   feature: feature:freeze-runtime-contracts:runtime-schema-freeze
   train: 0002-coach-drives-lifecycle
+- id: '493'
+  slug: coach-v9-p1-rules-show-where-grep
+  file: null
+  issue_number: 493
+  type: implementation
+  status: RED
+  created: '2026-05-09'
+  archived: null
+  wagon: discover-and-decommission
+  feature: feature:discover-and-decommission:rules-discovery
+  train: 0002-coach-drives-lifecycle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.12.1"
+version = "3.13.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/rules.py
+++ b/src/atdd/coach/commands/rules.py
@@ -29,7 +29,6 @@ repo-derived acceptance rules appear through one path (#408 walker).
 from __future__ import annotations
 
 import json
-import re
 import sys
 from dataclasses import asdict
 from pathlib import Path
@@ -41,6 +40,11 @@ from atdd.coach.utils.rule_binding import (
     RuleNotInRegistryError,
     bind_rule,
     iter_rules,
+)
+from atdd.coach.utils.rule_validator_resolver import (
+    ValidatorResolutionError,
+    infer_module_path,
+    parse_validator_field,
 )
 
 
@@ -102,6 +106,75 @@ def _print_metadata_text(meta: RuleMetadata) -> None:
             print(f"  {key:<18} {value}")
 
 
+class _Callsite:
+    """One resolved validator callsite for ``atdd rules where``.
+
+    ``validator_field`` is the verbatim ``<module>::<function>`` string;
+    ``module_path`` is its archetype-relative import path
+    (``src/atdd/<archetype>/validators/<module>.py``) when the path can
+    be inferred, else a free-text marker explaining why it could not
+    (e.g., a ``repo.*`` rule whose dispatcher is the substrate runner
+    rather than a toolkit validator file).
+    """
+
+    __slots__ = ("validator_field", "module_path")
+
+    def __init__(self, validator_field: str, module_path: str) -> None:
+        self.validator_field = validator_field
+        self.module_path = module_path
+
+
+def _archetype_of(rule_id: str) -> str:
+    """Return the leading archetype segment of *rule_id* (``a.b.c → a``)."""
+    return rule_id.split(".", 1)[0] if "." in rule_id else rule_id
+
+
+def _infer_module_path_str(archetype: str, module_basename: str) -> str:
+    """Return the archetype-relative import path for *module_basename*.
+
+    Falls back to ``src/atdd/<archetype>/validators/<module>.py`` even
+    when ``infer_module_path`` rejects the archetype (e.g., ``repo``) so
+    the surface still tells the operator where to look — repo rules
+    point at the substrate dispatcher rather than a toolkit validator,
+    and this string makes that explicit.
+    """
+    try:
+        path = infer_module_path(archetype, module_basename)
+        # Render the path relative to the toolkit src tree when possible
+        # so the output is portable across install layouts; fall back to
+        # the absolute path otherwise.
+        marker = "src/atdd/"
+        s = str(path)
+        idx = s.find(marker)
+        return s[idx:] if idx != -1 else s
+    except ValidatorResolutionError:
+        return (
+            f"src/atdd/{archetype}/validators/{module_basename}.py "
+            f"(substrate dispatcher)"
+        )
+
+
+def _resolve_callsites(meta: RuleMetadata) -> List[_Callsite]:
+    """Return the validator callsites declared for *meta*.
+
+    The current registry stores one ``validator`` string per rule. The
+    helper still returns a list so the surface is honest about the
+    "one callsite per line" framing and so a future YAML schema that
+    permits multiple validators slots in without churn.
+    """
+    if not meta.validator:
+        return []
+    archetype = _archetype_of(meta.rule_id)
+    try:
+        module_basename, _func = parse_validator_field(meta.validator)
+    except ValueError:
+        # Malformed validator field — surface the raw string so the
+        # operator still has something to grep.
+        return [_Callsite(validator_field=meta.validator, module_path="<malformed>")]
+    module_path = _infer_module_path_str(archetype, module_basename)
+    return [_Callsite(validator_field=meta.validator, module_path=module_path)]
+
+
 class RulesCommand:
     """Handler for ``atdd rules {show,where,grep}``.
 
@@ -112,9 +185,13 @@ class RulesCommand:
         """Print the bound ``RuleMetadata`` for *rule_id*.
 
         Resolves through ``bind_rule`` so canonical ids and legacy aliases
-        both work. Exits non-zero when the rule is unregistered or
-        ambiguous (declared in two places — a registry-level fault, not a
-        user fault, but surfaced here so the CLI is honest about it).
+        both work. When invoked with a legacy alias the surface displays
+        BOTH the legacy form (so the operator sees what they typed) and
+        the canonical id (so they learn the canonical name) per spec
+        §5.7 / issue #493 acc:L001-UNIT-001. Exits non-zero when the rule
+        is unregistered or ambiguous (declared in two places — a
+        registry-level fault, not a user fault, but surfaced here so the
+        CLI is honest about it).
         """
         try:
             meta = bind_rule(rule_id)
@@ -125,19 +202,34 @@ class RulesCommand:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
 
+        is_alias = rule_id != meta.rule_id
         if format == "json":
-            print(json.dumps(_meta_to_dict(meta), indent=2))
+            payload = _meta_to_dict(meta)
+            if is_alias:
+                payload["input_id"] = rule_id
+                payload["resolved_from_alias"] = True
+            print(json.dumps(payload, indent=2))
         else:
+            if is_alias:
+                print(
+                    f"Resolved legacy alias {rule_id!r} → "
+                    f"canonical {meta.rule_id!r}"
+                )
+                print()
             _print_metadata_text(meta)
         return 0
 
     def where(self, rule_id: str, format: str = "text") -> int:
-        """Print the rule's source path (and YAML location, if applicable).
+        """Print the validator ``<module>::<function>`` callsite(s) for *rule_id*.
 
-        For toolkit rules the YAML location is the ``*.convention.yaml``
-        path. For repo-derived rules (Track-A walker) the source path is
-        the WMBT or train YAML, AND the ``acceptance_urn`` discriminator
-        is printed so callers can grep the file for the matching block.
+        Issue #493 acc:L001-UNIT-002 / spec §5.7: surface the validator
+        reference and the import path inferred from the archetype
+        (``coder.* → src/atdd/coder/validators/<module>.py``). Repo
+        substrate rules carry the dispatcher reference set by the walker
+        (signal-mode acceptances point at the metric runner). The YAML
+        source path and (for repo rules) the ``acceptance_urn``
+        discriminator are also printed so callers can grep the file for
+        the matching block.
         """
         try:
             meta = bind_rule(rule_id)
@@ -148,31 +240,54 @@ class RulesCommand:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
 
+        bindings = _resolve_callsites(meta)
         if format == "json":
             output = {
                 "rule_id": meta.rule_id,
+                "validator": meta.validator,
+                "callsites": [
+                    {
+                        "validator_field": cs.validator_field,
+                        "module_path": cs.module_path,
+                    }
+                    for cs in bindings
+                ],
                 "source_path": str(meta.source_path),
                 "acceptance_urn": meta.acceptance_urn,
             }
             print(json.dumps(output, indent=2))
         else:
             print(f"rule_id:        {meta.rule_id}")
+            if bindings:
+                # One callsite per line — the spec phrases the surface as
+                # "list every callsite, one per line" so an iteration here
+                # keeps the format honest even when there is exactly one.
+                for cs in bindings:
+                    print(f"validator:      {cs.validator_field}")
+                    print(f"module_path:    {cs.module_path}")
+            else:
+                print("validator:      <unbound — substrate harness dispatcher>")
             print(f"source_path:    {meta.source_path}")
             if meta.acceptance_urn is not None:
                 print(f"acceptance_urn: {meta.acceptance_urn}")
         return 0
 
     def grep(self, pattern: str, format: str = "text") -> int:
-        """List rules whose id or description matches *pattern* (regex)."""
-        try:
-            regex = re.compile(pattern)
-        except re.error as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-07-03
-            print(f"Error: invalid regex {pattern!r}: {exc}", file=sys.stderr)
-            return 1
+        """List rules whose id, description, or alias contains *pattern*.
 
+        Issue #493 acc:L001-UNIT-003 / spec §5.7: case-insensitive
+        substring search across rule-id, description, and aliases. Each
+        line shows ``<rule-id>  sev=<n>  <disposition>  — <description>``
+        so the surface is consistent across toolkit and ``repo.*``
+        archetypes. An empty result exits non-zero (grep convention)
+        without crashing on regex special characters in the pattern.
+        """
+        needle = pattern.lower()
         matches: List[RuleMetadata] = []
         for meta in iter_rules():
-            if regex.search(meta.rule_id) or regex.search(meta.description or ""):
+            haystacks = [meta.rule_id, meta.description or ""]
+            haystacks.extend(meta.aliases)
+            if any(needle in h.lower() for h in haystacks):
                 matches.append(meta)
 
         if format == "json":
@@ -185,9 +300,11 @@ class RulesCommand:
             print(f"No rules matched pattern {pattern!r}.")
             return 1
         for meta in matches:
-            print(f"{meta.rule_id}")
-            if meta.description:
-                print(f"    {meta.description}")
+            disposition = meta.disposition or "-"
+            description = meta.description or ""
+            print(
+                f"{meta.rule_id}  sev={meta.severity}  {disposition}  — {description}"
+            )
         print()
         print(f"Total: {len(matches)} rule(s) matched.")
         return 0

--- a/src/atdd/coach/commands/rules.py
+++ b/src/atdd/coach/commands/rules.py
@@ -151,7 +151,12 @@ def _infer_module_path_str(archetype: str, module_basename: str) -> str:
         s = str(path)
         idx = s.find(marker)
         return s[idx:] if idx != -1 else s
-    except ValidatorResolutionError:
+    except ValidatorResolutionError:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        # Discovery surface, not a validator — the resolution miss is the
+        # expected branch for `repo.*` archetypes whose dispatcher lives
+        # outside ``src/atdd/<archetype>/validators/``. We render a
+        # human-readable marker instead of swallowing silently; logging
+        # would noise every legitimate repo-rule lookup.
         return (
             f"src/atdd/{archetype}/validators/{module_basename}.py "
             f"(substrate dispatcher)"
@@ -171,9 +176,13 @@ def _resolve_callsites(meta: RuleMetadata) -> List[_Callsite]:
     archetype = _archetype_of(meta.rule_id)
     try:
         module_basename, _func = parse_validator_field(meta.validator)
-    except ValueError:
-        # Malformed validator field — surface the raw string so the
-        # operator still has something to grep.
+    except ValueError:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        # Malformed validator field — surface the raw string with a
+        # ``<malformed>`` marker so the operator can grep for it. This
+        # is a discovery CLI; raising would crash the entire `where`
+        # invocation when one rule has a typo'd validator field, and
+        # the rule-binding validators (`test_rule_validator_binding`)
+        # already enforce the format at validation time.
         return [_Callsite(validator_field=meta.validator, module_path="<malformed>")]
     module_path = _infer_module_path_str(archetype, module_basename)
     return [_Callsite(validator_field=meta.validator, module_path=module_path)]

--- a/src/atdd/coach/commands/rules.py
+++ b/src/atdd/coach/commands/rules.py
@@ -6,14 +6,18 @@
 
 Substrate spec v12 §9.2 — surface the merged rule registry to humans.
 
-Three ``atdd rules`` subcommands:
+Three ``atdd rules`` subcommands (issue #493 / spec §5.7):
 
 * ``atdd rules show <rule-id>`` — print the bound ``RuleMetadata`` (toolkit
-  or repo).
-* ``atdd rules where <rule-id>`` — print the rule's source path (and YAML
-  location for repo rules — the ``acceptance_urn`` it was derived from).
-* ``atdd rules grep <pattern>`` — list every rule whose id or description
-  matches the regex.
+  or repo). Legacy aliases resolve to canonical and surface BOTH forms
+  so callers learn the canonical name while still seeing what they typed.
+* ``atdd rules where <rule-id>`` — print the validator
+  ``<module>::<function>`` callsite(s) and the inferred archetype-relative
+  module path, plus the rule's source path and (for repo rules) the
+  ``acceptance_urn`` discriminator.
+* ``atdd rules grep <pattern>`` — case-insensitive substring search over
+  rule-id, description, and aliases. Each line shows
+  ``<rule-id>  sev=<n>  <disposition>  — <description>``.
 
 Three ``atdd repo`` listing peers (Track-A landing surface; Issue #414
 renamed the legacy CLI namespace to ``atdd repo`` wholesale):

--- a/src/atdd/coach/commands/tests/test_rules_cli.py
+++ b/src/atdd/coach/commands/tests/test_rules_cli.py
@@ -232,10 +232,15 @@ def test_rules_where_prints_source_path_and_acceptance_urn(
     assert "acc:govern-lifecycle:D010-UNIT-001-single-source-theme-map-helper" in out
 
 
-def test_rules_where_json_keys_are_minimal(
+def test_rules_where_json_carries_validator_callsites_and_pointers(
     seeded_registry: Path, capsys: pytest.CaptureFixture[str]
 ):
-    """JSON output for ``where`` carries the three pointers — no kitchen sink."""
+    """JSON output for ``where`` carries validator callsites and source pointers.
+
+    Issue #493 acc:L001-UNIT-002 — the ``--format json`` payload exposes
+    the validator ``<module>::<function>`` reference, the inferred
+    module path, and (for repo rules) the source YAML + acceptance URN.
+    """
     from atdd.coach.commands.rules import RulesCommand
 
     rc = RulesCommand().where(
@@ -243,9 +248,25 @@ def test_rules_where_json_keys_are_minimal(
     )
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
-    assert set(payload.keys()) == {"rule_id", "source_path", "acceptance_urn"}
+    assert set(payload.keys()) == {
+        "rule_id",
+        "validator",
+        "callsites",
+        "source_path",
+        "acceptance_urn",
+    }
     assert payload["rule_id"] == "repo.govern-lifecycle.D010-acc-unit-001"
     assert payload["source_path"].endswith("D010.yaml")
+    # Walker pinned signal-mode acceptances at the metric runner.
+    assert payload["validator"] == (
+        "test_metric_runner::test_metric_threshold_satisfied"
+    )
+    assert isinstance(payload["callsites"], list)
+    assert len(payload["callsites"]) == 1
+    assert (
+        payload["callsites"][0]["validator_field"]
+        == "test_metric_runner::test_metric_threshold_satisfied"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/atdd/coach/commands/tests/test_rules_cli.py
+++ b/src/atdd/coach/commands/tests/test_rules_cli.py
@@ -289,16 +289,179 @@ def test_rules_grep_no_match_returns_nonzero(
     assert "No rules matched" in out
 
 
-def test_rules_grep_invalid_regex_returns_nonzero(
+def test_rules_grep_treats_regex_specials_as_literal_substring(
     seeded_registry: Path, capsys: pytest.CaptureFixture[str]
 ):
-    """A malformed regex surfaces a clear error (not a stack trace)."""
+    """Issue #493 §AC-UNIT-003: grep is case-insensitive substring, not regex.
+
+    Regex special characters (``(``, ``[``, ``*``...) are matched as literal
+    text — the surface MUST NOT crash on a pattern like ``(unclosed`` and
+    MUST NOT print a regex-compile error. With no such substring in the
+    fixture registry the call returns the no-match exit-1 instead.
+    """
     from atdd.coach.commands.rules import RulesCommand
 
     rc = RulesCommand().grep("(unclosed")
     assert rc == 1
-    err = capsys.readouterr().err
-    assert "invalid regex" in err
+    captured = capsys.readouterr()
+    assert "invalid regex" not in captured.err
+    assert "No rules matched" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Issue #493 acc:L001-UNIT-001 — show resolves toolkit and repo + alias display
+# ---------------------------------------------------------------------------
+def test_rules_show_legacy_alias_displays_both_forms(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``atdd rules show <legacy-alias>`` prints input alias AND canonical id.
+
+    Issue #493 acc:L001-UNIT-001 — when invoked with a legacy alias, the
+    output must surface BOTH the legacy form (so the operator knows what
+    they typed) and the canonical id (so they learn the canonical name).
+    """
+    from atdd.coach.commands.rules import RulesCommand
+
+    # Real toolkit rule with a known legacy alias.
+    rc = RulesCommand().show("COACH-ORCH-NAMING-0001")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Both forms appear.
+    assert "COACH-ORCH-NAMING-0001" in out
+    assert "coach.orchestration.canonical-session-name" in out
+    # Canonical metadata still printed.
+    assert "severity:" in out
+    assert "disposition:" in out
+
+
+def test_rules_show_canonical_call_does_not_print_alias_resolution_header(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """When invoked with the canonical id, no legacy-alias resolution noise."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().show("coach.orchestration.canonical-session-name")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The canonical line is present.
+    assert "coach.orchestration.canonical-session-name" in out
+    # The alias-resolution header line MUST NOT appear when input is canonical.
+    assert "legacy alias" not in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Issue #493 acc:L001-UNIT-002 — where prints validator <module>::<function>
+# ---------------------------------------------------------------------------
+def test_rules_where_prints_module_function_for_toolkit_rule(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Issue #493 acc:L001-UNIT-002 — toolkit rule emits validator + path.
+
+    For a toolkit-archetype rule with a declared ``validator:`` field,
+    ``where`` must print the ``<module>::<function>`` reference and the
+    inferred archetype-relative path
+    (``src/atdd/<archetype>/validators/<module>.py``).
+    """
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().where("coach.orchestration.canonical-session-name")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # validator field surfaced.
+    assert "test_orchestration_session_naming::test_active_session_names_canonical" in out
+    # Inferred import path includes the archetype dir.
+    assert "coach/validators/test_orchestration_session_naming.py" in out
+
+
+def test_rules_where_prints_substrate_dispatcher_for_repo_signal_rule(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Repo signal-mode rules carry the substrate metric runner as validator."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().where("repo.govern-lifecycle.D010-acc-unit-001")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The walker pins signal-mode acceptances to the toolkit metric runner.
+    assert "test_metric_runner::test_metric_threshold_satisfied" in out
+    # The repo-rule source path (the WMBT YAML) is still surfaced.
+    assert "D010.yaml" in out
+
+
+def test_rules_where_resolves_legacy_alias_to_canonical_validator(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``where`` accepts a legacy alias and resolves to the canonical binding."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().where("COACH-ORCH-NAMING-0001")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "test_orchestration_session_naming::test_active_session_names_canonical" in out
+
+
+def test_rules_where_unknown_rule_id_returns_nonzero(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Unregistered rule-id exits 1 with a clear stderr message (no stack trace)."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().where("does.not.exist")
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "not declared in any convention" in captured.err
+    assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# Issue #493 acc:L001-UNIT-003 — grep substring + alias + uniform output
+# ---------------------------------------------------------------------------
+def test_rules_grep_is_case_insensitive_substring(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Issue #493 acc:L001-UNIT-003 — grep matches the literal substring (case-insensitive)."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    # Uppercase pattern matches a description authored in lowercase.
+    rc = RulesCommand().grep("THEME_MAP")
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "repo.govern-lifecycle.D010-acc-unit-001" in out
+
+
+def test_rules_grep_searches_aliases(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Grep matches against legacy aliases — surface the canonical rule.
+
+    Issue #493 acc:L001-UNIT-003 — the search domain explicitly includes
+    aliases so an operator who only knows the legacy id can still find
+    the canonical rule via grep.
+    """
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().grep("COACH-ORCH-NAMING-0001")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The canonical rule is surfaced even though the pattern is the alias.
+    assert "coach.orchestration.canonical-session-name" in out
+
+
+def test_rules_grep_each_line_shows_severity_disposition_description(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Issue #493 acc:L001-UNIT-003 — grep lines carry id+severity+disposition+description."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().grep("theme_map")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The match line carries severity (sev=) and disposition (strict).
+    # Walker constants: severity=4, disposition='strict'.
+    assert "sev=4" in out
+    assert "strict" in out
+    # The description (purpose) text is on the same surface.
+    assert "theme_map" in out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #493

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #493 |
| Type | implementation |
| Slug | coach-v9-p1-rules-show-where-grep |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd-issue, atdd:INIT, archetype:coach, wave-w0, track-p, wagon:discover-and-decommission, train:0002-coach-drives-lifecycle |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.