### PR TITLE
feat(coach): config loader extensions for `coach.*` block (#495)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -373,3 +373,14 @@ sessions:
   wagon: freeze-runtime-contracts
   feature: feature:freeze-runtime-contracts:runtime-schema-freeze
   train: 0002-coach-drives-lifecycle
+- id: '495'
+  slug: coach-v9-p4-coach-config-loader
+  file: null
+  issue_number: 495
+  type: feat
+  status: RED
+  created: '2026-05-09'
+  archived: null
+  wagon: discover-and-decommission
+  feature: feature:discover-and-decommission:convention-sync-and-config-loader
+  train: 0002-coach-drives-lifecycle

--- a/src/atdd/coach/utils/coach_config.py
+++ b/src/atdd/coach/utils/coach_config.py
@@ -22,9 +22,9 @@ Public API:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from atdd.coach.utils.config import load_atdd_config
 
@@ -305,7 +305,7 @@ def _parse_persona_llm(raw: Any) -> PersonaLLM:
         key: _str(mapping[key], f"persona_llm.{key}")
         for key in mapping
     }
-    return PersonaLLM(**{**PersonaLLM().__dict__, **overrides})
+    return replace(PersonaLLM(), **overrides)
 
 
 def _parse_observer(raw: Any) -> ObserverConfig:
@@ -325,7 +325,7 @@ def _parse_observer(raw: Any) -> ObserverConfig:
         )
     if "rules_dir" in mapping:
         overrides["rules_dir"] = _str(mapping["rules_dir"], "observer.rules_dir")
-    return ObserverConfig(**{**ObserverConfig().__dict__, **overrides})
+    return replace(ObserverConfig(), **overrides)
 
 
 def _parse_review(raw: Any) -> ReviewConfig:
@@ -348,7 +348,7 @@ def _parse_review(raw: Any) -> ReviewConfig:
         overrides["same_model_allowed"] = _bool(
             mapping["same_model_allowed"], "review.same_model_allowed"
         )
-    return ReviewConfig(**{**ReviewConfig().__dict__, **overrides})
+    return replace(ReviewConfig(), **overrides)
 
 
 def _parse_validators(raw: Any) -> ValidatorsConfig:
@@ -370,7 +370,7 @@ def _parse_validators(raw: Any) -> ValidatorsConfig:
         overrides["pytest_args"] = _list_of_str(
             mapping["pytest_args"], "validators.pytest_args"
         )
-    return ValidatorsConfig(**{**ValidatorsConfig().__dict__, **overrides})
+    return replace(ValidatorsConfig(), **overrides)
 
 
 def _parse_suppressions(raw: Any) -> SuppressionsConfig:
@@ -390,7 +390,7 @@ def _parse_suppressions(raw: Any) -> SuppressionsConfig:
         overrides["grace_days"] = _non_negative_int(
             mapping["grace_days"], "suppressions.grace_days"
         )
-    return SuppressionsConfig(**{**SuppressionsConfig().__dict__, **overrides})
+    return replace(SuppressionsConfig(), **overrides)
 
 
 def _parse_risk_thresholds(raw: Any) -> RiskThresholds:
@@ -403,7 +403,7 @@ def _parse_risk_thresholds(raw: Any) -> RiskThresholds:
         overrides[phase] = _optional_non_negative_int(
             mapping[phase], f"risk_thresholds.{phase}"
         )
-    return RiskThresholds(**{**RiskThresholds().__dict__, **overrides})
+    return replace(RiskThresholds(), **overrides)
 
 
 def _parse_judge(raw: Any) -> JudgeConfig:
@@ -421,7 +421,7 @@ def _parse_judge(raw: Any) -> JudgeConfig:
         overrides["log_full_inputs"] = _bool(
             mapping["log_full_inputs"], "judge.log_full_inputs"
         )
-    return JudgeConfig(**{**JudgeConfig().__dict__, **overrides})
+    return replace(JudgeConfig(), **overrides)
 
 
 def _parse_issue_review(raw: Any) -> IssueReviewConfig:
@@ -453,7 +453,7 @@ def _parse_issue_review(raw: Any) -> IssueReviewConfig:
         overrides["stale_after_days"] = _non_negative_int(
             mapping["stale_after_days"], "issue_review.stale_after_days"
         )
-    return IssueReviewConfig(**{**IssueReviewConfig().__dict__, **overrides})
+    return replace(IssueReviewConfig(), **overrides)
 
 
 def _parse_escalation(raw: Any) -> EscalationConfig:
@@ -479,7 +479,7 @@ def _parse_escalation(raw: Any) -> EscalationConfig:
         overrides["github_label"] = _str(
             mapping["github_label"], "escalation.github_label"
         )
-    return EscalationConfig(**{**EscalationConfig().__dict__, **overrides})
+    return replace(EscalationConfig(), **overrides)
 
 
 def _parse_retries(raw: Any) -> RetriesConfig:
@@ -497,7 +497,7 @@ def _parse_retries(raw: Any) -> RetriesConfig:
         overrides["per_agent"] = _non_negative_int(
             mapping["per_agent"], "retries.per_agent"
         )
-    return RetriesConfig(**{**RetriesConfig().__dict__, **overrides})
+    return replace(RetriesConfig(), **overrides)
 
 
 # ---------------------------------------------------------------------------

--- a/src/atdd/coach/utils/coach_config.py
+++ b/src/atdd/coach/utils/coach_config.py
@@ -1,0 +1,592 @@
+"""
+Coach v9 configuration loader (`coach.*` block per spec §10).
+
+Coach reads `.atdd/config.yaml::coach` once at startup. This module
+materializes that block as an immutable `CoachConfig` value object and
+refuses any deviation from the closed schema (unknown keys, wrong types,
+out-of-range numbers, unknown enum values) with loud errors that cite
+spec §10.
+
+Why closed-schema:
+  Coach config is closed-schema (every valid key is named in spec §10).
+  A typo like `risk_threshhold.green` (note doubled-h) must surface at
+  load time, not silently inherit the default and surface as wrong-phase
+  behavior hours later in a coach run driving multiple parallel issues.
+
+Public API:
+  - load_coach_config(repo_root) -> CoachConfig
+  - load_coach_config_from_dict(raw) -> CoachConfig
+  - CoachConfig (immutable)
+  - CoachConfigError
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from atdd.coach.utils.config import load_atdd_config
+
+
+SPEC_REF = "spec §10"
+
+
+class CoachConfigError(ValueError):
+    """Raised when `.atdd/config.yaml::coach` violates the spec §10 schema."""
+
+
+# ---------------------------------------------------------------------------
+# Nested value objects
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ObserverConfig:
+    activity_silence_seconds: int = 90
+    process_silence_seconds: int = 30
+    rules_dir: str = ".atdd/observer/rules"
+
+
+@dataclass(frozen=True)
+class ReviewConfig:
+    enabled: bool = True
+    phases: List[str] = field(
+        default_factory=lambda: ["planned", "red", "green", "smoke"]
+    )
+    same_model_warning: bool = True
+    same_model_allowed: bool = False
+
+
+@dataclass(frozen=True)
+class ValidatorsConfig:
+    enabled: bool = True
+    grace_window_seconds: int = 30
+    selection: str = "default"
+    pytest_args: List[str] = field(
+        default_factory=lambda: ["-x", "--tb=short"]
+    )
+
+
+@dataclass(frozen=True)
+class SuppressionsConfig:
+    honor: bool = True
+    block_on_stale: bool = True
+    grace_days: int = 7
+
+
+@dataclass(frozen=True)
+class RiskThresholds:
+    planned: Optional[int] = None
+    red: Optional[int] = None
+    green: Optional[int] = 10
+    smoke: Optional[int] = 15
+    refactor: Optional[int] = 5
+    complete: Optional[int] = 0
+
+
+@dataclass(frozen=True)
+class JudgeConfig:
+    enabled: bool = True
+    fail_open: bool = False
+    log_full_inputs: bool = False
+
+
+@dataclass(frozen=True)
+class IssueReviewConfig:
+    passes: int = 3
+    llms: List[str] = field(
+        default_factory=lambda: ["claude-haiku", "gpt-5-mini", "gemini-flash"]
+    )
+    dimensions: List[str] = field(
+        default_factory=lambda: [
+            "systemic", "ambiguities", "gap", "regression", "comprehensiveness",
+        ]
+    )
+    require_for_coach: str = "warn"
+    stale_after_days: int = 14
+
+
+@dataclass(frozen=True)
+class EscalationConfig:
+    channel: str = "file"
+    slack_webhook: Optional[str] = None
+    github_label: str = "coach-escalation"
+
+
+@dataclass(frozen=True)
+class RetriesConfig:
+    per_state_machine: int = 3
+    per_agent: int = 2
+
+
+@dataclass(frozen=True)
+class PersonaLLM:
+    """Persona-to-LLM map. Mapping protocol so consumers can do `cfg.persona_llm["reviewer"]`."""
+    planner: str = "claude-code"
+    tester: str = "claude-code"
+    coder: str = "claude-code"
+    reviewer: str = "gpt-5"
+
+    def __getitem__(self, persona: str) -> str:
+        if persona not in PERSONA_KEYS:
+            raise KeyError(persona)
+        return getattr(self, persona)
+
+    def __contains__(self, persona: object) -> bool:
+        return persona in PERSONA_KEYS
+
+
+PERSONA_KEYS: Tuple[str, ...] = ("planner", "tester", "coder", "reviewer")
+
+
+@dataclass(frozen=True)
+class CoachConfig:
+    default_llm: str = "claude-code"
+    judge_llm: str = "claude-haiku"
+    persona_llm: PersonaLLM = field(default_factory=PersonaLLM)
+    observer: ObserverConfig = field(default_factory=ObserverConfig)
+    review: ReviewConfig = field(default_factory=ReviewConfig)
+    validators: ValidatorsConfig = field(default_factory=ValidatorsConfig)
+    suppressions: SuppressionsConfig = field(default_factory=SuppressionsConfig)
+    risk_thresholds: RiskThresholds = field(default_factory=RiskThresholds)
+    judge: JudgeConfig = field(default_factory=JudgeConfig)
+    issue_review: IssueReviewConfig = field(default_factory=IssueReviewConfig)
+    escalation: EscalationConfig = field(default_factory=EscalationConfig)
+    retries: RetriesConfig = field(default_factory=RetriesConfig)
+    token_alert_threshold: int = 400000
+
+
+# ---------------------------------------------------------------------------
+# Schema (key sets, types, enums, ranges)
+# ---------------------------------------------------------------------------
+
+
+TOP_LEVEL_KEYS: Tuple[str, ...] = (
+    "default_llm",
+    "judge_llm",
+    "persona_llm",
+    "observer",
+    "review",
+    "validators",
+    "suppressions",
+    "risk_thresholds",
+    "judge",
+    "issue_review",
+    "escalation",
+    "retries",
+    "token_alert_threshold",
+)
+
+
+RISK_PHASES: Tuple[str, ...] = (
+    "planned", "red", "green", "smoke", "refactor", "complete",
+)
+REVIEW_PHASE_VALUES: Tuple[str, ...] = (
+    "init", "planned", "red", "green", "smoke", "refactor", "complete",
+)
+ESCALATION_CHANNELS: Tuple[str, ...] = ("file", "slack", "github")
+REQUIRE_FOR_COACH_VALUES: Tuple[str, ...] = ("warn", "block", "off")
+
+
+# ---------------------------------------------------------------------------
+# Validation primitives
+# ---------------------------------------------------------------------------
+
+
+def _err(path: str, detail: str) -> CoachConfigError:
+    return CoachConfigError(
+        f"coach config error at `coach.{path}`: {detail}. See {SPEC_REF}."
+    )
+
+
+def _check_unknown_keys(
+    raw: Mapping[str, Any], allowed: Sequence[str], section: str
+) -> None:
+    unknown = [k for k in raw.keys() if k not in allowed]
+    if unknown:
+        path = f"{section}.{unknown[0]}" if section else unknown[0]
+        raise _err(
+            path,
+            f"unknown key (allowed under `coach.{section}`: {sorted(allowed)})"
+            if section
+            else f"unknown top-level key (allowed: {sorted(allowed)})",
+        )
+
+
+def _require_mapping(value: Any, path: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise _err(path, f"expected mapping, got {_type_name(value)}")
+    return value
+
+
+def _bool(value: Any, path: str) -> bool:
+    # bool is a subclass of int in Python, so this guard order matters.
+    if not isinstance(value, bool):
+        raise _err(path, f"expected bool, got {_type_name(value)}")
+    return value
+
+
+def _int(value: Any, path: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise _err(path, f"expected int, got {_type_name(value)}")
+    return value
+
+
+def _str(value: Any, path: str) -> str:
+    if not isinstance(value, str):
+        raise _err(path, f"expected string, got {_type_name(value)}")
+    return value
+
+
+def _non_negative_int(value: Any, path: str) -> int:
+    n = _int(value, path)
+    if n < 0:
+        raise _err(path, f"expected non-negative int, got {n}")
+    return n
+
+
+def _optional_non_negative_int(value: Any, path: str) -> Optional[int]:
+    if value is None:
+        return None
+    return _non_negative_int(value, path)
+
+
+def _list_of_str(value: Any, path: str) -> List[str]:
+    if not isinstance(value, list):
+        raise _err(path, f"expected list, got {_type_name(value)}")
+    for i, item in enumerate(value):
+        if not isinstance(item, str):
+            raise _err(
+                f"{path}[{i}]",
+                f"expected string element, got {_type_name(item)}",
+            )
+    return list(value)
+
+
+def _enum(value: Any, path: str, allowed: Sequence[str]) -> str:
+    s = _str(value, path)
+    if s not in allowed:
+        raise _err(
+            path,
+            f"unknown value {s!r} (allowed: {list(allowed)})",
+        )
+    return s
+
+
+def _list_of_enum(value: Any, path: str, allowed: Sequence[str]) -> List[str]:
+    items = _list_of_str(value, path)
+    for i, item in enumerate(items):
+        if item not in allowed:
+            raise _err(
+                f"{path}[{i}]",
+                f"unknown value {item!r} (allowed: {list(allowed)})",
+            )
+    return items
+
+
+def _type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    return type(value).__name__
+
+
+# ---------------------------------------------------------------------------
+# Section parsers
+# ---------------------------------------------------------------------------
+
+
+def _parse_persona_llm(raw: Any) -> PersonaLLM:
+    if raw is None:
+        return PersonaLLM()
+    mapping = _require_mapping(raw, "persona_llm")
+    _check_unknown_keys(mapping, PERSONA_KEYS, "persona_llm")
+    overrides = {
+        key: _str(mapping[key], f"persona_llm.{key}")
+        for key in mapping
+    }
+    return PersonaLLM(**{**PersonaLLM().__dict__, **overrides})
+
+
+def _parse_observer(raw: Any) -> ObserverConfig:
+    if raw is None:
+        return ObserverConfig()
+    mapping = _require_mapping(raw, "observer")
+    allowed = ("activity_silence_seconds", "process_silence_seconds", "rules_dir")
+    _check_unknown_keys(mapping, allowed, "observer")
+    overrides: Dict[str, Any] = {}
+    if "activity_silence_seconds" in mapping:
+        overrides["activity_silence_seconds"] = _non_negative_int(
+            mapping["activity_silence_seconds"], "observer.activity_silence_seconds"
+        )
+    if "process_silence_seconds" in mapping:
+        overrides["process_silence_seconds"] = _non_negative_int(
+            mapping["process_silence_seconds"], "observer.process_silence_seconds"
+        )
+    if "rules_dir" in mapping:
+        overrides["rules_dir"] = _str(mapping["rules_dir"], "observer.rules_dir")
+    return ObserverConfig(**{**ObserverConfig().__dict__, **overrides})
+
+
+def _parse_review(raw: Any) -> ReviewConfig:
+    if raw is None:
+        return ReviewConfig()
+    mapping = _require_mapping(raw, "review")
+    allowed = ("enabled", "phases", "same_model_warning", "same_model_allowed")
+    _check_unknown_keys(mapping, allowed, "review")
+    overrides: Dict[str, Any] = {}
+    if "enabled" in mapping:
+        overrides["enabled"] = _bool(mapping["enabled"], "review.enabled")
+    if "phases" in mapping:
+        phases = _list_of_enum(mapping["phases"], "review.phases", REVIEW_PHASE_VALUES)
+        overrides["phases"] = phases
+    if "same_model_warning" in mapping:
+        overrides["same_model_warning"] = _bool(
+            mapping["same_model_warning"], "review.same_model_warning"
+        )
+    if "same_model_allowed" in mapping:
+        overrides["same_model_allowed"] = _bool(
+            mapping["same_model_allowed"], "review.same_model_allowed"
+        )
+    return ReviewConfig(**{**ReviewConfig().__dict__, **overrides})
+
+
+def _parse_validators(raw: Any) -> ValidatorsConfig:
+    if raw is None:
+        return ValidatorsConfig()
+    mapping = _require_mapping(raw, "validators")
+    allowed = ("enabled", "grace_window_seconds", "selection", "pytest_args")
+    _check_unknown_keys(mapping, allowed, "validators")
+    overrides: Dict[str, Any] = {}
+    if "enabled" in mapping:
+        overrides["enabled"] = _bool(mapping["enabled"], "validators.enabled")
+    if "grace_window_seconds" in mapping:
+        overrides["grace_window_seconds"] = _non_negative_int(
+            mapping["grace_window_seconds"], "validators.grace_window_seconds"
+        )
+    if "selection" in mapping:
+        overrides["selection"] = _str(mapping["selection"], "validators.selection")
+    if "pytest_args" in mapping:
+        overrides["pytest_args"] = _list_of_str(
+            mapping["pytest_args"], "validators.pytest_args"
+        )
+    return ValidatorsConfig(**{**ValidatorsConfig().__dict__, **overrides})
+
+
+def _parse_suppressions(raw: Any) -> SuppressionsConfig:
+    if raw is None:
+        return SuppressionsConfig()
+    mapping = _require_mapping(raw, "suppressions")
+    allowed = ("honor", "block_on_stale", "grace_days")
+    _check_unknown_keys(mapping, allowed, "suppressions")
+    overrides: Dict[str, Any] = {}
+    if "honor" in mapping:
+        overrides["honor"] = _bool(mapping["honor"], "suppressions.honor")
+    if "block_on_stale" in mapping:
+        overrides["block_on_stale"] = _bool(
+            mapping["block_on_stale"], "suppressions.block_on_stale"
+        )
+    if "grace_days" in mapping:
+        overrides["grace_days"] = _non_negative_int(
+            mapping["grace_days"], "suppressions.grace_days"
+        )
+    return SuppressionsConfig(**{**SuppressionsConfig().__dict__, **overrides})
+
+
+def _parse_risk_thresholds(raw: Any) -> RiskThresholds:
+    if raw is None:
+        return RiskThresholds()
+    mapping = _require_mapping(raw, "risk_thresholds")
+    _check_unknown_keys(mapping, RISK_PHASES, "risk_thresholds")
+    overrides: Dict[str, Any] = {}
+    for phase in mapping:
+        overrides[phase] = _optional_non_negative_int(
+            mapping[phase], f"risk_thresholds.{phase}"
+        )
+    return RiskThresholds(**{**RiskThresholds().__dict__, **overrides})
+
+
+def _parse_judge(raw: Any) -> JudgeConfig:
+    if raw is None:
+        return JudgeConfig()
+    mapping = _require_mapping(raw, "judge")
+    allowed = ("enabled", "fail_open", "log_full_inputs")
+    _check_unknown_keys(mapping, allowed, "judge")
+    overrides: Dict[str, Any] = {}
+    if "enabled" in mapping:
+        overrides["enabled"] = _bool(mapping["enabled"], "judge.enabled")
+    if "fail_open" in mapping:
+        overrides["fail_open"] = _bool(mapping["fail_open"], "judge.fail_open")
+    if "log_full_inputs" in mapping:
+        overrides["log_full_inputs"] = _bool(
+            mapping["log_full_inputs"], "judge.log_full_inputs"
+        )
+    return JudgeConfig(**{**JudgeConfig().__dict__, **overrides})
+
+
+def _parse_issue_review(raw: Any) -> IssueReviewConfig:
+    if raw is None:
+        return IssueReviewConfig()
+    mapping = _require_mapping(raw, "issue_review")
+    allowed = (
+        "passes", "llms", "dimensions", "require_for_coach", "stale_after_days",
+    )
+    _check_unknown_keys(mapping, allowed, "issue_review")
+    overrides: Dict[str, Any] = {}
+    if "passes" in mapping:
+        overrides["passes"] = _non_negative_int(
+            mapping["passes"], "issue_review.passes"
+        )
+    if "llms" in mapping:
+        overrides["llms"] = _list_of_str(mapping["llms"], "issue_review.llms")
+    if "dimensions" in mapping:
+        overrides["dimensions"] = _list_of_str(
+            mapping["dimensions"], "issue_review.dimensions"
+        )
+    if "require_for_coach" in mapping:
+        overrides["require_for_coach"] = _enum(
+            mapping["require_for_coach"],
+            "issue_review.require_for_coach",
+            REQUIRE_FOR_COACH_VALUES,
+        )
+    if "stale_after_days" in mapping:
+        overrides["stale_after_days"] = _non_negative_int(
+            mapping["stale_after_days"], "issue_review.stale_after_days"
+        )
+    return IssueReviewConfig(**{**IssueReviewConfig().__dict__, **overrides})
+
+
+def _parse_escalation(raw: Any) -> EscalationConfig:
+    if raw is None:
+        return EscalationConfig()
+    mapping = _require_mapping(raw, "escalation")
+    allowed = ("channel", "slack_webhook", "github_label")
+    _check_unknown_keys(mapping, allowed, "escalation")
+    overrides: Dict[str, Any] = {}
+    if "channel" in mapping:
+        overrides["channel"] = _enum(
+            mapping["channel"], "escalation.channel", ESCALATION_CHANNELS
+        )
+    if "slack_webhook" in mapping:
+        webhook = mapping["slack_webhook"]
+        if webhook is not None and not isinstance(webhook, str):
+            raise _err(
+                "escalation.slack_webhook",
+                f"expected string or null, got {_type_name(webhook)}",
+            )
+        overrides["slack_webhook"] = webhook
+    if "github_label" in mapping:
+        overrides["github_label"] = _str(
+            mapping["github_label"], "escalation.github_label"
+        )
+    return EscalationConfig(**{**EscalationConfig().__dict__, **overrides})
+
+
+def _parse_retries(raw: Any) -> RetriesConfig:
+    if raw is None:
+        return RetriesConfig()
+    mapping = _require_mapping(raw, "retries")
+    allowed = ("per_state_machine", "per_agent")
+    _check_unknown_keys(mapping, allowed, "retries")
+    overrides: Dict[str, Any] = {}
+    if "per_state_machine" in mapping:
+        overrides["per_state_machine"] = _non_negative_int(
+            mapping["per_state_machine"], "retries.per_state_machine"
+        )
+    if "per_agent" in mapping:
+        overrides["per_agent"] = _non_negative_int(
+            mapping["per_agent"], "retries.per_agent"
+        )
+    return RetriesConfig(**{**RetriesConfig().__dict__, **overrides})
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load_coach_config_from_dict(raw: Optional[Mapping[str, Any]]) -> CoachConfig:
+    """
+    Parse the `coach.*` block out of a parsed `.atdd/config.yaml` dict.
+
+    Args:
+        raw: Top-level dict from `.atdd/config.yaml`. None / missing
+             `coach` key returns a CoachConfig populated with defaults.
+
+    Returns:
+        Immutable CoachConfig populated per spec §10.
+
+    Raises:
+        CoachConfigError: when the coach block contains unknown keys,
+            wrong types, out-of-range numbers, or unknown enum values.
+            Error messages cite spec §10.
+    """
+    if raw is None:
+        return CoachConfig()
+    if not isinstance(raw, Mapping):
+        return CoachConfig()
+    if "coach" not in raw:
+        return CoachConfig()
+
+    coach_block = raw["coach"]
+    if coach_block is None:
+        return CoachConfig()
+    if not isinstance(coach_block, Mapping):
+        raise CoachConfigError(
+            f"coach config error at `coach`: expected mapping, "
+            f"got {_type_name(coach_block)}. See {SPEC_REF}."
+        )
+
+    _check_unknown_keys(coach_block, TOP_LEVEL_KEYS, "")
+
+    overrides: Dict[str, Any] = {}
+    if "default_llm" in coach_block:
+        overrides["default_llm"] = _str(coach_block["default_llm"], "default_llm")
+    if "judge_llm" in coach_block:
+        overrides["judge_llm"] = _str(coach_block["judge_llm"], "judge_llm")
+    if "persona_llm" in coach_block:
+        overrides["persona_llm"] = _parse_persona_llm(coach_block["persona_llm"])
+    if "observer" in coach_block:
+        overrides["observer"] = _parse_observer(coach_block["observer"])
+    if "review" in coach_block:
+        overrides["review"] = _parse_review(coach_block["review"])
+    if "validators" in coach_block:
+        overrides["validators"] = _parse_validators(coach_block["validators"])
+    if "suppressions" in coach_block:
+        overrides["suppressions"] = _parse_suppressions(coach_block["suppressions"])
+    if "risk_thresholds" in coach_block:
+        overrides["risk_thresholds"] = _parse_risk_thresholds(
+            coach_block["risk_thresholds"]
+        )
+    if "judge" in coach_block:
+        overrides["judge"] = _parse_judge(coach_block["judge"])
+    if "issue_review" in coach_block:
+        overrides["issue_review"] = _parse_issue_review(coach_block["issue_review"])
+    if "escalation" in coach_block:
+        overrides["escalation"] = _parse_escalation(coach_block["escalation"])
+    if "retries" in coach_block:
+        overrides["retries"] = _parse_retries(coach_block["retries"])
+    if "token_alert_threshold" in coach_block:
+        overrides["token_alert_threshold"] = _non_negative_int(
+            coach_block["token_alert_threshold"], "token_alert_threshold"
+        )
+
+    return CoachConfig(**overrides)
+
+
+def load_coach_config(repo_root: Path) -> CoachConfig:
+    """
+    Load and parse the `coach.*` block from `<repo_root>/.atdd/config.yaml`.
+
+    Args:
+        repo_root: Repository root path.
+
+    Returns:
+        Immutable CoachConfig populated per spec §10. If the config file
+        is missing, returns a CoachConfig with all defaults.
+
+    Raises:
+        CoachConfigError: when the coach block violates spec §10.
+    """
+    raw = load_atdd_config(repo_root)
+    return load_coach_config_from_dict(raw)

--- a/src/atdd/coach/utils/tests/test_coach_config.py
+++ b/src/atdd/coach/utils/tests/test_coach_config.py
@@ -1,0 +1,515 @@
+"""
+Unit tests for atdd.coach.utils.coach_config.
+
+URN: urn:atdd:test:coach:utils:coach_config
+WMBT: wmbt:discover-and-decommission:P002
+Acceptances:
+  - acc:discover-and-decommission:P002-UNIT-001-load-atdd-config-parses-coach-block
+  - acc:discover-and-decommission:P002-UNIT-002-invalid-fields-raise-loud-errors
+
+Coach v9 reads `.atdd/config.yaml::coach` once at startup. Spec §10
+documents every field and its default; this parser materializes that
+schema as an immutable `CoachConfig` value object and refuses any
+deviation from the schema (unknown keys, wrong types, out-of-range
+numbers, unknown enum values) with loud errors that cite spec §10.
+
+The strict-unknown-key policy is the inverse of the substrate's
+flexible-by-design YAML loaders. Coach config is closed-schema (every
+valid key is named in spec §10); a typo like `risk_threshhold.green`
+must surface as a config error at load time, not silently inherit the
+default and surface as wrong-phase behavior hours later.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from atdd.coach.utils.coach_config import (
+    CoachConfig,
+    CoachConfigError,
+    load_coach_config,
+    load_coach_config_from_dict,
+)
+
+
+pytestmark = [pytest.mark.platform]
+
+
+# ============================================================================
+# AC-UNIT-001: defaults applied per spec §10
+# ============================================================================
+
+
+class TestEmptyCoachBlockAppliesAllDefaults:
+    """An empty coach: block returns a CoachConfig populated with every
+    spec §10 default. Reference values are quoted from the issue body /
+    spec §10."""
+
+    def test_empty_dict_returns_coach_config(self):
+        cfg = load_coach_config_from_dict({})
+        assert isinstance(cfg, CoachConfig)
+
+    def test_missing_coach_key_returns_coach_config_with_defaults(self):
+        cfg = load_coach_config_from_dict({"version": "1.0"})
+        assert cfg.default_llm == "claude-code"
+
+    def test_explicit_empty_coach_block_returns_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.default_llm == "claude-code"
+
+    def test_default_llm_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.default_llm == "claude-code"
+        assert cfg.judge_llm == "claude-haiku"
+
+    def test_persona_llm_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.persona_llm["planner"] == "claude-code"
+        assert cfg.persona_llm["tester"] == "claude-code"
+        assert cfg.persona_llm["coder"] == "claude-code"
+        assert cfg.persona_llm["reviewer"] == "gpt-5"
+
+    def test_observer_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.observer.activity_silence_seconds == 90
+        assert cfg.observer.process_silence_seconds == 30
+        assert cfg.observer.rules_dir == ".atdd/observer/rules"
+
+    def test_review_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.review.enabled is True
+        assert cfg.review.phases == ["planned", "red", "green", "smoke"]
+        assert cfg.review.same_model_warning is True
+        assert cfg.review.same_model_allowed is False
+
+    def test_validators_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.validators.enabled is True
+        assert cfg.validators.grace_window_seconds == 30
+        assert cfg.validators.selection == "default"
+        assert cfg.validators.pytest_args == ["-x", "--tb=short"]
+
+    def test_suppressions_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.suppressions.honor is True
+        assert cfg.suppressions.block_on_stale is True
+        assert cfg.suppressions.grace_days == 7
+
+    def test_risk_thresholds_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.risk_thresholds.planned is None
+        assert cfg.risk_thresholds.red is None
+        assert cfg.risk_thresholds.green == 10
+        assert cfg.risk_thresholds.smoke == 15
+        assert cfg.risk_thresholds.refactor == 5
+        assert cfg.risk_thresholds.complete == 0
+
+    def test_judge_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.judge.enabled is True
+        assert cfg.judge.fail_open is False
+        assert cfg.judge.log_full_inputs is False
+
+    def test_issue_review_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.issue_review.passes == 3
+        assert cfg.issue_review.llms == ["claude-haiku", "gpt-5-mini", "gemini-flash"]
+        assert cfg.issue_review.dimensions == [
+            "systemic", "ambiguities", "gap", "regression", "comprehensiveness"
+        ]
+        assert cfg.issue_review.require_for_coach == "warn"
+        assert cfg.issue_review.stale_after_days == 14
+
+    def test_escalation_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.escalation.channel == "file"
+        assert cfg.escalation.slack_webhook is None
+        assert cfg.escalation.github_label == "coach-escalation"
+
+    def test_retries_defaults(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.retries.per_state_machine == 3
+        assert cfg.retries.per_agent == 2
+
+    def test_token_alert_threshold_default(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        assert cfg.token_alert_threshold == 400000
+
+
+class TestPartialOverridesMergeWithDefaults:
+    """Overridden fields take effect; unmentioned fields fall back to
+    spec §10 defaults. Tested at every nesting level."""
+
+    def test_top_level_override(self):
+        cfg = load_coach_config_from_dict({
+            "coach": {"default_llm": "claude-haiku"}
+        })
+        assert cfg.default_llm == "claude-haiku"
+        # unspecified fields remain at default
+        assert cfg.judge_llm == "claude-haiku"  # also default value (coincidence)
+        assert cfg.token_alert_threshold == 400000
+
+    def test_persona_llm_partial_override(self):
+        cfg = load_coach_config_from_dict({
+            "coach": {"persona_llm": {"reviewer": "gpt-5-mini"}}
+        })
+        assert cfg.persona_llm["reviewer"] == "gpt-5-mini"
+        # other personas keep defaults
+        assert cfg.persona_llm["planner"] == "claude-code"
+
+    def test_risk_thresholds_partial_override(self):
+        cfg = load_coach_config_from_dict({
+            "coach": {"risk_thresholds": {"green": 25}}
+        })
+        assert cfg.risk_thresholds.green == 25
+        # other thresholds keep defaults
+        assert cfg.risk_thresholds.smoke == 15
+        assert cfg.risk_thresholds.complete == 0
+        assert cfg.risk_thresholds.planned is None
+
+    def test_validators_partial_override(self):
+        cfg = load_coach_config_from_dict({
+            "coach": {"validators": {"pytest_args": ["-v"]}}
+        })
+        assert cfg.validators.pytest_args == ["-v"]
+        assert cfg.validators.grace_window_seconds == 30
+        assert cfg.validators.enabled is True
+
+    def test_observer_partial_override(self):
+        cfg = load_coach_config_from_dict({
+            "coach": {"observer": {"activity_silence_seconds": 120}}
+        })
+        assert cfg.observer.activity_silence_seconds == 120
+        assert cfg.observer.process_silence_seconds == 30
+
+
+class TestNullablesAcceptNull:
+    """Null is allowed where spec §10 lists it: risk_thresholds.planned/red
+    and escalation.slack_webhook."""
+
+    def test_risk_thresholds_planned_accepts_null(self):
+        cfg = load_coach_config_from_dict({
+            "coach": {"risk_thresholds": {"planned": None}}
+        })
+        assert cfg.risk_thresholds.planned is None
+
+    def test_risk_thresholds_red_accepts_null(self):
+        cfg = load_coach_config_from_dict({
+            "coach": {"risk_thresholds": {"red": None}}
+        })
+        assert cfg.risk_thresholds.red is None
+
+    def test_risk_thresholds_green_accepts_null(self):
+        # Spec lists null in risk_thresholds; permitted across all phases.
+        cfg = load_coach_config_from_dict({
+            "coach": {"risk_thresholds": {"green": None}}
+        })
+        assert cfg.risk_thresholds.green is None
+
+    def test_escalation_slack_webhook_accepts_null(self):
+        cfg = load_coach_config_from_dict({
+            "coach": {"escalation": {"slack_webhook": None}}
+        })
+        assert cfg.escalation.slack_webhook is None
+
+
+class TestCoachConfigImmutability:
+    """The CoachConfig value object is immutable — coach reads it once
+    at startup and consumes it everywhere as a single source of truth."""
+
+    def test_cannot_assign_top_level_field(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        with pytest.raises((AttributeError, TypeError)):
+            cfg.default_llm = "claude-haiku"
+
+    def test_cannot_assign_nested_field(self):
+        cfg = load_coach_config_from_dict({"coach": {}})
+        with pytest.raises((AttributeError, TypeError)):
+            cfg.observer.activity_silence_seconds = 999
+
+
+class TestLoadFromYamlFile:
+    """End-to-end: load_coach_config reads .atdd/config.yaml and parses
+    the coach.* block."""
+
+    def test_load_from_repo_root_with_coach_block(self, tmp_path: Path):
+        atdd_dir = tmp_path / ".atdd"
+        atdd_dir.mkdir()
+        (atdd_dir / "config.yaml").write_text(yaml.safe_dump({
+            "version": "1.0",
+            "coach": {"default_llm": "claude-haiku"},
+        }))
+        cfg = load_coach_config(tmp_path)
+        assert cfg.default_llm == "claude-haiku"
+        assert cfg.judge_llm == "claude-haiku"  # default
+
+    def test_load_from_repo_root_without_config_returns_defaults(self, tmp_path: Path):
+        cfg = load_coach_config(tmp_path)
+        assert cfg.default_llm == "claude-code"
+
+
+# ============================================================================
+# AC-UNIT-002: invalid fields raise loud errors
+# ============================================================================
+
+
+class TestUnknownKeysRaiseLoudly:
+    """Unknown top-level keys under coach.* must fail loudly. Typos like
+    `risk_threshhold` (note doubled-h) must not silently inherit defaults."""
+
+    def test_unknown_top_level_key_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"risk_threshhold": {"green": 10}}
+            })
+        msg = str(exc_info.value)
+        assert "risk_threshhold" in msg
+        assert "§10" in msg
+
+    def test_unknown_observer_key_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"observer": {"silence_seconds": 90}}
+            })
+        msg = str(exc_info.value)
+        assert "silence_seconds" in msg
+        assert "observer" in msg
+        assert "§10" in msg
+
+    def test_unknown_review_key_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"review": {"phazes": ["red"]}}
+            })
+        assert "phazes" in str(exc_info.value)
+
+    def test_unknown_risk_thresholds_phase_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"risk_thresholds": {"obsolete": 5}}
+            })
+        assert "obsolete" in str(exc_info.value)
+        assert "risk_thresholds" in str(exc_info.value)
+
+    def test_unknown_persona_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"persona_llm": {"orchestrator": "gpt-5"}}
+            })
+        assert "orchestrator" in str(exc_info.value)
+
+
+class TestInvalidTypesRaiseLoudly:
+    """Wrong types name the offending key and the expected type."""
+
+    def test_default_llm_must_be_string(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({"coach": {"default_llm": 42}})
+        msg = str(exc_info.value)
+        assert "default_llm" in msg
+        assert "string" in msg.lower() or "str" in msg.lower()
+
+    def test_judge_enabled_must_be_bool(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"judge": {"enabled": "yes"}}
+            })
+        msg = str(exc_info.value)
+        assert "judge.enabled" in msg or "enabled" in msg
+        assert "bool" in msg.lower()
+
+    def test_observer_seconds_must_be_int(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"observer": {"activity_silence_seconds": "ninety"}}
+            })
+        msg = str(exc_info.value)
+        assert "activity_silence_seconds" in msg
+        assert "int" in msg.lower()
+
+    def test_review_phases_must_be_list(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"review": {"phases": "red"}}
+            })
+        msg = str(exc_info.value)
+        assert "phases" in msg
+        assert "list" in msg.lower()
+
+    def test_pytest_args_must_be_list_of_strings(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"validators": {"pytest_args": ["-x", 42]}}
+            })
+        msg = str(exc_info.value)
+        assert "pytest_args" in msg
+
+    def test_token_alert_threshold_must_be_int(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"token_alert_threshold": "400k"}
+            })
+        msg = str(exc_info.value)
+        assert "token_alert_threshold" in msg
+
+    def test_risk_threshold_must_be_int_or_null(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"risk_thresholds": {"green": "ten"}}
+            })
+        msg = str(exc_info.value)
+        assert "risk_thresholds.green" in msg or "green" in msg
+
+
+class TestOutOfRangeRaiseLoudly:
+    """Risk thresholds non-negative; seconds non-negative; counts non-negative."""
+
+    def test_risk_threshold_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"risk_thresholds": {"green": -1}}
+            })
+        msg = str(exc_info.value)
+        assert "green" in msg
+        assert "non-negative" in msg.lower() or ">= 0" in msg or "negative" in msg.lower()
+
+    def test_observer_activity_silence_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"observer": {"activity_silence_seconds": -5}}
+            })
+        assert "activity_silence_seconds" in str(exc_info.value)
+
+    def test_observer_process_silence_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"observer": {"process_silence_seconds": -1}}
+            })
+        assert "process_silence_seconds" in str(exc_info.value)
+
+    def test_validators_grace_window_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"validators": {"grace_window_seconds": -10}}
+            })
+        assert "grace_window_seconds" in str(exc_info.value)
+
+    def test_suppressions_grace_days_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"suppressions": {"grace_days": -1}}
+            })
+        assert "grace_days" in str(exc_info.value)
+
+    def test_issue_review_passes_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"issue_review": {"passes": -1}}
+            })
+        assert "passes" in str(exc_info.value)
+
+    def test_issue_review_stale_after_days_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"issue_review": {"stale_after_days": -1}}
+            })
+        assert "stale_after_days" in str(exc_info.value)
+
+    def test_retries_per_state_machine_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"retries": {"per_state_machine": -1}}
+            })
+        assert "per_state_machine" in str(exc_info.value)
+
+    def test_retries_per_agent_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"retries": {"per_agent": -1}}
+            })
+        assert "per_agent" in str(exc_info.value)
+
+    def test_token_alert_threshold_negative_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"token_alert_threshold": -1}
+            })
+        assert "token_alert_threshold" in str(exc_info.value)
+
+
+class TestEnumsRaiseLoudlyOnUnknownValue:
+    """Enums match the documented set; unknown enum values raise."""
+
+    def test_escalation_channel_unknown_value_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"escalation": {"channel": "silack"}}
+            })
+        msg = str(exc_info.value)
+        assert "channel" in msg
+        assert "silack" in msg
+        # Mentions allowed values
+        assert "file" in msg or "slack" in msg or "github" in msg
+
+    def test_issue_review_require_for_coach_unknown_value_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"issue_review": {"require_for_coach": "maybe"}}
+            })
+        msg = str(exc_info.value)
+        assert "require_for_coach" in msg
+        assert "maybe" in msg
+
+    def test_review_phase_unknown_value_raises(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"review": {"phases": ["mauve"]}}
+            })
+        msg = str(exc_info.value)
+        assert "phases" in msg
+        assert "mauve" in msg
+
+
+class TestErrorMessagesReferenceSpec:
+    """Operators hitting a config error must be able to find the canonical
+    schema. Every error message references spec §10."""
+
+    def test_unknown_key_error_cites_spec(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({"coach": {"bogus": 1}})
+        assert "§10" in str(exc_info.value)
+
+    def test_type_error_cites_spec(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({"coach": {"default_llm": 42}})
+        assert "§10" in str(exc_info.value)
+
+    def test_range_error_cites_spec(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"risk_thresholds": {"green": -1}}
+            })
+        assert "§10" in str(exc_info.value)
+
+    def test_enum_error_cites_spec(self):
+        with pytest.raises(CoachConfigError) as exc_info:
+            load_coach_config_from_dict({
+                "coach": {"escalation": {"channel": "silack"}}
+            })
+        assert "§10" in str(exc_info.value)
+
+
+class TestCoachBlockMustBeMapping:
+    """A `coach:` value that isn't a mapping is an obvious operator error
+    and must surface loudly rather than silently using defaults."""
+
+    def test_coach_as_list_raises(self):
+        with pytest.raises(CoachConfigError):
+            load_coach_config_from_dict({"coach": []})
+
+    def test_coach_as_string_raises(self):
+        with pytest.raises(CoachConfigError):
+            load_coach_config_from_dict({"coach": "enabled"})


### PR DESCRIPTION
Closes #495

## Summary

Implements coach v9 P4: extends config loading with a closed-schema parser for the `coach.*` block per spec §10. Materialises the block as an immutable `CoachConfig` value object with documented defaults; rejects unknown keys, wrong types, out-of-range numbers, and unknown enum values with loud errors that cite spec §10.

- New module `src/atdd/coach/utils/coach_config.py` (frozen dataclasses + parser)
- New API: `load_coach_config(repo_root)`, `load_coach_config_from_dict(raw)`, `CoachConfig`, `CoachConfigError`
- 59 co-located unit tests covering both AC-UNIT-001 (defaults) and AC-UNIT-002 (loud errors)
- Coach utils regression suite: 260/260 green
- Real `.atdd/config.yaml` smoke: parses cleanly with all defaults; synthetic typo / negative / valid-override smokes loud-fail with spec-§10 citation

## Inferred enums — please confirm against spec §10

The issue body did not enumerate every allowed value, so two enums were inferred from context. Both are validated by the parser; if spec §10 lists different sets, narrow/widen here:

- `escalation.channel`: `{file, slack, github}` — inferred from sibling fields `slack_webhook` / `github_label` plus default `file`
- `issue_review.require_for_coach`: `{warn, block, off}` — inferred from default `warn`

`review.phases` is constrained to phase names `{init, planned, red, green, smoke, refactor, complete}`; `risk_thresholds` keys are constrained to `{planned, red, green, smoke, refactor, complete}` (matches the documented default keys).

## Test plan

- [x] `pytest src/atdd/coach/utils/tests/test_coach_config.py` — 59/59 green
- [x] `pytest src/atdd/coach/utils/tests/` — 260/260 green
- [x] Live load: `load_coach_config(Path.cwd())` returns defaults from this repo's `.atdd/config.yaml` (which has no `coach:` block)
- [x] Synthetic YAML with a typoed key (`risk_threshhold`) raises `CoachConfigError` mentioning the key + spec §10
- [x] Synthetic YAML with `risk_thresholds.green: -5` raises with "expected non-negative int"

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #495 |
| Type | feat |
| Slug | coach-v9-p4-coach-config-loader |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd-issue, atdd:INIT, archetype:coach, wave-w0, track-p, wagon:discover-and-decommission, train:0002-coach-drives-lifecycle |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.