### PR TITLE
feat(coach): `atdd rules` discovery: disposition, archetype (#494)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -384,6 +384,17 @@ sessions:
   wagon: discover-and-decommission
   feature: feature:discover-and-decommission:rules-discovery
   train: 0002-coach-drives-lifecycle
+- id: '494'
+  slug: coach-v9-p2-rules-disposition-archetype-suppressions
+  file: null
+  issue_number: 494
+  type: implementation
+  status: RED
+  created: '2026-05-09'
+  archived: null
+  wagon: discover-and-decommission
+  feature: feature:discover-and-decommission:rules-discovery
+  train: 0002-coach-drives-lifecycle
 - id: '495'
   slug: coach-v9-p4-coach-config-loader
   file: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.14.0"
+version = "3.15.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -1523,6 +1523,65 @@ Phase descriptions:
         help="Output format (default: text)",
     )
 
+    # ----- atdd rules disposition / archetype / suppressions (issue #494) -----
+    rules_disposition_parser = rules_subparsers.add_parser(
+        "disposition",
+        help="List rules by disposition (strict / suppress-and-clean / advisory / documentation-only)",
+    )
+    rules_disposition_parser.add_argument(
+        "value",
+        type=str,
+        help="Disposition value to filter by",
+    )
+    rules_disposition_parser.add_argument(
+        "--format", "-f",
+        type=str,
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    rules_archetype_parser = rules_subparsers.add_parser(
+        "archetype",
+        help="List rules by archetype (coder / coach / tester / planner / repo)",
+    )
+    rules_archetype_parser.add_argument(
+        "value",
+        type=str,
+        help="Archetype to filter by",
+    )
+    rules_archetype_parser.add_argument(
+        "--format", "-f",
+        type=str,
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    rules_suppressions_parser = rules_subparsers.add_parser(
+        "suppressions",
+        help="List active atdd:suppress(...) markers",
+    )
+    rules_suppressions_parser.add_argument(
+        "--stale-only",
+        action="store_true",
+        help="Filter to markers whose UNTIL date has passed today",
+    )
+    rules_suppressions_parser.add_argument(
+        "--rule",
+        type=str,
+        default=None,
+        metavar="RULE_ID",
+        help="Filter to markers for the given rule-id",
+    )
+    rules_suppressions_parser.add_argument(
+        "--format", "-f",
+        type=str,
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
     # ----- Legacy flag-based arguments (deprecated, kept for backwards compatibility) -----
 
     # Repository root override (not deprecated - still useful)
@@ -2165,7 +2224,7 @@ Phase descriptions:
         )
         return 1
 
-    # atdd rules {show,where,grep}
+    # atdd rules {show,where,grep,disposition,archetype,suppressions}
     elif args.command == "rules":
         from atdd.coach.commands.rules import RulesCommand
 
@@ -2176,6 +2235,19 @@ Phase descriptions:
             return rules_cmd.where(args.rule_id, format=args.format)
         if args.rules_command == "grep":
             return rules_cmd.grep(args.pattern, format=args.format)
+        if args.rules_command == "disposition":
+            return rules_cmd.disposition(args.value, format=args.format)
+        if args.rules_command == "archetype":
+            return rules_cmd.archetype(args.value, format=args.format)
+        if args.rules_command == "suppressions":
+            # Default scan root: the resolved repo root, or CWD as fallback.
+            scan_root = Path(args.repo) if args.repo else Path.cwd()
+            return rules_cmd.suppressions(
+                roots=[scan_root],
+                stale_only=args.stale_only,
+                rule_id=args.rule,
+                format=args.format,
+            )
         rules_parser.print_help()
         return 0
 

--- a/src/atdd/coach/commands/rules.py
+++ b/src/atdd/coach/commands/rules.py
@@ -6,18 +6,30 @@
 
 Substrate spec v12 §9.2 — surface the merged rule registry to humans.
 
-Three ``atdd rules`` subcommands (issue #493 / spec §5.7):
+Six ``atdd rules`` subcommands (spec §5.7):
 
 * ``atdd rules show <rule-id>`` — print the bound ``RuleMetadata`` (toolkit
   or repo). Legacy aliases resolve to canonical and surface BOTH forms
   so callers learn the canonical name while still seeing what they typed.
+  *(Issue #493.)*
 * ``atdd rules where <rule-id>`` — print the validator
   ``<module>::<function>`` callsite(s) and the inferred archetype-relative
   module path, plus the rule's source path and (for repo rules) the
-  ``acceptance_urn`` discriminator.
+  ``acceptance_urn`` discriminator. *(Issue #493.)*
 * ``atdd rules grep <pattern>`` — case-insensitive substring search over
   rule-id, description, and aliases. Each line shows
-  ``<rule-id>  sev=<n>  <disposition>  — <description>``.
+  ``<rule-id>  sev=<n>  <disposition>  — <description>``. *(Issue #493.)*
+* ``atdd rules disposition <strict|suppress-and-clean|advisory|documentation-only>``
+  — list every rule with the given disposition. Repo rules are uniformly
+  ``strict`` per substrate v12 §2; non-strict dispositions return toolkit
+  rules only. *(Issue #494.)*
+* ``atdd rules archetype <coder|coach|tester|planner|repo>`` — list every
+  rule under the given archetype, sorted by rule-id for stable diffing.
+  *(Issue #494.)*
+* ``atdd rules suppressions [--stale-only] [--rule <id>]`` — list every
+  active suppression marker as ``file_path:line  rule-id  UNTIL=<date>``.
+  Markers referencing ``repo.*`` rules surface as warnings (substrate-
+  unsuppressible per substrate v12 §2). *(Issue #494.)*
 
 Three ``atdd repo`` listing peers (Track-A landing surface; Issue #414
 renamed the legacy CLI namespace to ``atdd repo`` wholesale):
@@ -50,6 +62,27 @@ from atdd.coach.utils.rule_validator_resolver import (
     infer_module_path,
     parse_validator_field,
 )
+from atdd.coach.utils.suppression_scanner import (
+    SuppressionMarker,
+    find_stale_suppressions,
+    find_suppressions,
+)
+
+
+# Per spec §5.7 — the disposition vocabulary is governed by
+# ``acceptance-violation.convention.yaml``. The CLI surface enumerates the
+# four valid values so an invalid input is reported with the full set.
+_VALID_DISPOSITIONS: tuple = (
+    "strict",
+    "suppress-and-clean",
+    "advisory",
+    "documentation-only",
+)
+
+# Per substrate v12 §2 the substrate-derived archetype is ``repo``; the
+# four toolkit archetypes are listed alongside so an invalid input is
+# reported with the full set.
+_VALID_ARCHETYPES: tuple = ("coder", "coach", "tester", "planner", "repo")
 
 
 def _meta_to_dict(meta: RuleMetadata) -> dict:
@@ -321,6 +354,216 @@ class RulesCommand:
         print()
         print(f"Total: {len(matches)} rule(s) matched.")
         return 0
+
+    def disposition(self, value: str, format: str = "text") -> int:
+        """List every rule whose disposition equals *value*.
+
+        Issue #494 acc:L002-UNIT-001 / spec §5.7. The disposition
+        vocabulary is governed by ``acceptance-violation.convention.yaml``;
+        an invalid input exits non-zero and surfaces the full set of valid
+        options on stderr. Repo rules are uniformly ``strict`` per
+        substrate v12 §2 (walker-set), so ``disposition strict`` returns
+        repo + toolkit strict rules and the three other dispositions
+        return only toolkit rules.
+
+        Each line carries rule-id, archetype, severity, and a one-line
+        description so the listing is self-explanatory at a glance.
+        """
+        if value not in _VALID_DISPOSITIONS:
+            options = ", ".join(_VALID_DISPOSITIONS)
+            print(
+                f"Error: unknown disposition {value!r}. Valid options: {options}",
+                file=sys.stderr,
+            )
+            return 1
+
+        matches: List[RuleMetadata] = [
+            meta for meta in iter_rules() if meta.disposition == value
+        ]
+
+        if format == "json":
+            print(json.dumps([_meta_to_dict(m) for m in matches], indent=2))
+            return 0
+
+        if not matches:
+            print(f"No rules with disposition={value!r}.")
+            return 0
+        for meta in matches:
+            print(_format_rule_line(meta))
+        print()
+        print(
+            f"Total: {len(matches)} rule(s) with disposition={value!r}."
+        )
+        return 0
+
+    def archetype(self, value: str, format: str = "text") -> int:
+        """List every rule under archetype *value*, sorted by rule-id.
+
+        Issue #494 acc:L002-UNIT-002 / spec §5.7. ``archetype repo`` lists
+        every substrate-derived rule (WMBT-acceptance, train-acceptance,
+        security-derived) per substrate v12. The four toolkit archetypes
+        return their respective toolkit rules. An unknown archetype exits
+        non-zero and surfaces the five valid options on stderr.
+
+        Output sorted ascending by rule-id within an archetype so a
+        regenerated listing diffs cleanly against the previous run.
+        """
+        if value not in _VALID_ARCHETYPES:
+            options = ", ".join(_VALID_ARCHETYPES)
+            print(
+                f"Error: unknown archetype {value!r}. Valid options: {options}",
+                file=sys.stderr,
+            )
+            return 1
+
+        matches: List[RuleMetadata] = sorted(
+            (m for m in iter_rules() if _archetype_of(m.rule_id) == value),
+            key=lambda m: m.rule_id,
+        )
+
+        if format == "json":
+            print(json.dumps([_meta_to_dict(m) for m in matches], indent=2))
+            return 0
+
+        if not matches:
+            print(f"No rules under archetype={value!r}.")
+            return 0
+        for meta in matches:
+            print(_format_rule_line(meta))
+        print()
+        print(
+            f"Total: {len(matches)} rule(s) under archetype={value!r}."
+        )
+        return 0
+
+    def suppressions(
+        self,
+        roots: Optional[List[Path]] = None,
+        stale_only: bool = False,
+        rule_id: Optional[str] = None,
+        format: str = "text",
+    ) -> int:
+        """List active ``atdd:suppress(...)`` markers across the repo.
+
+        Issue #494 acc:L002-UNIT-003 / spec §5.7. Delegates to
+        ``find_suppressions`` and ``find_stale_suppressions`` per the
+        existing scanner contract.
+
+        Args:
+            roots: Directories to scan. Defaults to the current working
+                directory — the CLI dispatcher passes the repo root.
+            stale_only: When True, restricts output to markers whose
+                ``UNTIL=`` date has passed today.
+            rule_id: When set, restricts output to markers for that rule.
+            format: ``text`` (default) or ``json``.
+
+        Returns: ``0`` on success including empty results — the scanner is a
+        discovery surface, not a gate. Markers referencing ``repo.*`` rules
+        are surfaced as warnings on stderr because substrate v12 §2 makes
+        repo rules unsuppressible regardless of the marker's presence.
+        """
+        scan_roots: List[Path] = list(roots) if roots else [Path.cwd()]
+
+        if stale_only:
+            markers = find_stale_suppressions(scan_roots)
+        else:
+            markers = find_suppressions(scan_roots)
+
+        if rule_id is not None:
+            markers = [m for m in markers if m.rule_id == rule_id]
+
+        # Stable order: file path then line. The scanner walks rglob which
+        # is filesystem-order so we sort here.
+        markers = sorted(markers, key=lambda m: (str(m.file_path), m.line))
+
+        repo_markers = [m for m in markers if m.rule_id.startswith("repo.")]
+
+        if format == "json":
+            payload = [
+                {
+                    "file_path": str(m.file_path),
+                    "line": m.line,
+                    "rule_id": m.rule_id,
+                    "until": m.until.isoformat() if m.until else None,
+                    "is_stale": m.is_stale,
+                    "is_repo_rule": m.rule_id.startswith("repo."),
+                }
+                for m in markers
+            ]
+            print(json.dumps(payload, indent=2))
+            # Repo-rule warnings still go to stderr in JSON mode so a
+            # caller piping stdout to jq still sees the alert.
+            for m in repo_markers:
+                _warn_repo_rule_marker(m)
+            return 0
+
+        if not markers:
+            print("No suppression markers found.")
+            return 0
+        for m in markers:
+            print(_format_suppression_line(m))
+        print()
+        suffix = " (stale only)" if stale_only else ""
+        print(f"Total: {len(markers)} marker(s){suffix}.")
+        for m in repo_markers:
+            _warn_repo_rule_marker(m)
+        return 0
+
+
+def _format_rule_line(meta: RuleMetadata) -> str:
+    """Render one rule line for ``disposition`` / ``archetype`` listings.
+
+    Format: ``<rule-id>  [<archetype>]  sev=<n>  <disposition>  — <description>``
+    Carries the four context fields required by acc:L002-UNIT-001 (rule-id,
+    archetype, severity, description) plus disposition for cross-reference
+    use when ``archetype`` is the calling surface.
+    """
+    archetype = _archetype_of(meta.rule_id)
+    disposition = meta.disposition or "-"
+    description = meta.description or ""
+    return (
+        f"{meta.rule_id}  [{archetype}]  sev={meta.severity}  "
+        f"{disposition}  — {description}"
+    )
+
+
+def _format_suppression_line(marker: SuppressionMarker) -> str:
+    """Render one suppression marker line for the list output.
+
+    Format: ``<file_path>:<line>  <rule-id>  UNTIL=<date>``. Markers
+    without an ``UNTIL=`` segment render ``UNTIL=-`` so the column stays
+    aligned even when a marker omits the date. A trailing ``[STALE]``
+    or ``[REPO-RULE]`` tag flags the two non-default cases the operator
+    most often cares about.
+    """
+    until = marker.until.isoformat() if marker.until else "-"
+    tags: List[str] = []
+    if marker.is_stale:
+        tags.append("[STALE]")
+    if marker.rule_id.startswith("repo."):
+        tags.append("[REPO-RULE]")
+    suffix = ("  " + " ".join(tags)) if tags else ""
+    return (
+        f"{marker.file_path}:{marker.line}  {marker.rule_id}  "
+        f"UNTIL={until}{suffix}"
+    )
+
+
+def _warn_repo_rule_marker(marker: SuppressionMarker) -> None:
+    """Emit a stderr warning for a marker referencing a ``repo.*`` rule.
+
+    Substrate v12 §2 makes repo rules unsuppressible — the gate ignores
+    the marker silently. Surfacing the warning here is the CLI's job:
+    operators write the marker expecting absorption; without this line
+    the misapplication is invisible until the next CI run.
+    """
+    print(
+        f"Warning: {marker.file_path}:{marker.line} suppresses "
+        f"{marker.rule_id!r}, but repo.* rules are unsuppressible "
+        f"per substrate v12 §2. The marker is silently ignored by the "
+        f"gate.",
+        file=sys.stderr,
+    )
 
 
 def _filter_repo_rules(rules: Iterable[RuleMetadata]) -> List[RuleMetadata]:

--- a/src/atdd/coach/commands/tests/test_rules_cli.py
+++ b/src/atdd/coach/commands/tests/test_rules_cli.py
@@ -899,6 +899,13 @@ def test_rules_archetype_json_format(
 # atdd rules suppressions [--stale-only] [--rule <id>]
 #   acc:discover-and-decommission:L002-UNIT-003
 # ---------------------------------------------------------------------------
+# Build the suppression marker token at runtime so this *source* file does
+# not itself trigger the suppression scanner / stale-suppression validator
+# when CI walks the repo. The written tmp_path files reconstruct the full
+# literal so the scanner under test still sees a real marker.
+_SUPPRESS_TOKEN = "atdd:" + "suppress"
+
+
 def _seed_suppression_files(tmp_path: Path) -> None:
     """Plant a mix of active, stale, and repo-rule markers under *tmp_path*.
 
@@ -909,19 +916,19 @@ def _seed_suppression_files(tmp_path: Path) -> None:
       repo.py   — marker referencing a repo.* rule (substrate-unsuppressible)
     """
     (tmp_path / "a.py").write_text(
-        "x = 1  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2099-01-01\n",
+        f"x = 1  # {_SUPPRESS_TOKEN}(coder.logging.coach-silent-swallow) UNTIL=2099-01-01\n",
         encoding="utf-8",
     )
     (tmp_path / "b.py").write_text(
-        "y = 2  # atdd:suppress(coder.logging.no-print-calls-in)\n",
+        f"y = 2  # {_SUPPRESS_TOKEN}(coder.logging.no-print-calls-in)\n",
         encoding="utf-8",
     )
     (tmp_path / "stale.py").write_text(
-        "z = 3  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2020-01-01\n",
+        f"z = 3  # {_SUPPRESS_TOKEN}(coder.logging.coach-silent-swallow) UNTIL=2020-01-01\n",
         encoding="utf-8",
     )
     (tmp_path / "repo.py").write_text(
-        "w = 4  # atdd:suppress(repo.foo-wagon.D001-acc-http-007) UNTIL=2099-01-01\n",
+        f"w = 4  # {_SUPPRESS_TOKEN}(repo.foo-wagon.D001-acc-http-007) UNTIL=2099-01-01\n",
         encoding="utf-8",
     )
 

--- a/src/atdd/coach/commands/tests/test_rules_cli.py
+++ b/src/atdd/coach/commands/tests/test_rules_cli.py
@@ -618,3 +618,428 @@ def test_iter_rules_emits_each_canonical_rule_once(seeded_registry: Path):
     }
     # No duplicates anywhere.
     assert len(set(rule_ids)) == len(rule_ids)
+
+
+# =============================================================================
+# Issue #494 — atdd rules disposition / archetype / suppressions
+# =============================================================================
+# These three subcommands extend the discovery surface from #493 with the
+# enumerate-by-attribute view (per spec §5.7). The fixture registry already
+# carries three repo.* rules (all walker-set to ``strict``) plus the full
+# toolkit-convention registry, so the assertions key off the fixture rules
+# while still tolerating the toolkit's own catalog growing over time.
+
+# ---------------------------------------------------------------------------
+# atdd rules disposition <strict|suppress-and-clean|advisory|documentation-only>
+#   acc:discover-and-decommission:L002-UNIT-001
+# ---------------------------------------------------------------------------
+def test_rules_disposition_strict_lists_repo_and_toolkit_rules(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``disposition strict`` surfaces every strict rule across both registries.
+
+    Repo rules are uniformly strict per substrate v12 §2 (walker-set), so
+    every fixture repo rule must appear; toolkit strict rules also appear
+    because the merged registry is one stream.
+    """
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().disposition("strict")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # All three fixture repo rules — uniformly strict per §2.
+    assert "repo.govern-lifecycle.D010-acc-unit-001" in out
+    assert "repo.foo-wagon.D001-acc-http-007" in out
+    assert "repo.0001-self-compliance-validate.acc-idempotent-on-retry" in out
+
+
+def test_rules_disposition_strict_line_carries_id_archetype_severity_description(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Each output line shows rule-id + archetype + severity + description.
+
+    Per acc:L002-UNIT-001: each line shows enough context to be
+    self-explanatory at a glance — rule-id, archetype, severity, and
+    the one-line description.
+    """
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().disposition("strict")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # The fixture repo rule's line carries the four required fields.
+    matching = [
+        line for line in out.splitlines()
+        if "repo.govern-lifecycle.D010-acc-unit-001" in line
+    ]
+    assert matching, "fixture repo rule missing from disposition strict output"
+    line = matching[0]
+    # Archetype tag.
+    assert "repo" in line
+    # Severity (walker constant: 4).
+    assert "sev=4" in line
+    # Description (purpose) substring.
+    assert "theme_map" in line
+
+
+def test_rules_disposition_suppress_and_clean_returns_toolkit_only(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``disposition suppress-and-clean`` lists toolkit rules only.
+
+    Per substrate v12 §2 repo rules are uniformly strict; non-strict
+    dispositions must NOT include any ``repo.*`` rule.
+    """
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().disposition("suppress-and-clean")
+    # Either zero (when toolkit has at least one) or non-zero (empty); but
+    # the load-bearing assertion is the registry purity.
+    out = capsys.readouterr().out
+    assert "repo." not in out, "repo.* rules must not appear under non-strict dispositions"
+
+
+def test_rules_disposition_advisory_returns_toolkit_only(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Same purity invariant as suppress-and-clean for advisory."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    RulesCommand().disposition("advisory")
+    out = capsys.readouterr().out
+    assert "repo." not in out
+
+
+def test_rules_disposition_documentation_only_returns_toolkit_only(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Same purity invariant for documentation-only."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    RulesCommand().disposition("documentation-only")
+    out = capsys.readouterr().out
+    assert "repo." not in out
+
+
+def test_rules_disposition_invalid_value_returns_nonzero_with_options(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """An unknown disposition exits 1 and surfaces the four valid options."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().disposition("nonsense")
+    assert rc == 1
+    err = capsys.readouterr().err
+    # Lists each valid option so the operator sees the vocabulary.
+    assert "strict" in err
+    assert "suppress-and-clean" in err
+    assert "advisory" in err
+    assert "documentation-only" in err
+
+
+def test_rules_disposition_json_format(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``--format json`` emits a list of rule metadata dicts."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().disposition("strict", format="json")
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload, list)
+    rule_ids = {entry["rule_id"] for entry in payload}
+    assert "repo.govern-lifecycle.D010-acc-unit-001" in rule_ids
+    # Every entry has disposition='strict'.
+    assert all(entry["disposition"] == "strict" for entry in payload)
+
+
+# ---------------------------------------------------------------------------
+# atdd rules archetype <coder|coach|tester|planner|repo>
+#   acc:discover-and-decommission:L002-UNIT-002
+# ---------------------------------------------------------------------------
+def test_rules_archetype_repo_lists_every_substrate_rule(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``archetype repo`` lists every substrate-derived rule (per substrate v12)."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().archetype("repo")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # All three fixture repo rules.
+    assert "repo.govern-lifecycle.D010-acc-unit-001" in out
+    assert "repo.foo-wagon.D001-acc-http-007" in out
+    assert "repo.0001-self-compliance-validate.acc-idempotent-on-retry" in out
+    # No toolkit rule (e.g., coach.*) leaks in.
+    assert "coach.orchestration.canonical-session-name" not in out
+
+
+def test_rules_archetype_repo_output_sorted_by_rule_id(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Output is sorted by rule-id within an archetype (stable diffing)."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().archetype("repo")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Find positions of the three fixture rule-ids; they must be ordered
+    # ascending by string.
+    ids = [
+        "repo.0001-self-compliance-validate.acc-idempotent-on-retry",
+        "repo.foo-wagon.D001-acc-http-007",
+        "repo.govern-lifecycle.D010-acc-unit-001",
+    ]
+    positions = [out.index(rid) for rid in ids]
+    assert positions == sorted(positions), (
+        f"archetype repo output not sorted: positions={positions}"
+    )
+
+
+def test_rules_archetype_coach_excludes_repo_rules(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``archetype coach`` returns coach toolkit rules only — no repo leakage."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().archetype("coach")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # No repo.* rule in coach archetype.
+    assert "repo." not in out
+    # A known coach toolkit rule appears.
+    assert "coach.orchestration.canonical-session-name" in out
+
+
+def test_rules_archetype_coder_returns_only_coder_rules(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``archetype coder`` returns only rules whose id starts with ``coder.``."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().archetype("coder")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # A real coder rule we know exists.
+    assert "coder.logging.coach-silent-swallow" in out
+    # Other archetypes don't leak.
+    assert "coach." not in out.replace("coach-silent-swallow", "")
+    assert "tester." not in out
+    assert "planner." not in out
+
+
+def test_rules_archetype_tester_excludes_other_archetypes(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``archetype tester`` returns only tester rules."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().archetype("tester")
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Other archetypes absent from each line.
+    for line in out.splitlines():
+        if "—" in line:  # rule lines carry an em-dash separator
+            # Lines under archetype=tester start with tester. rule-id.
+            stripped = line.lstrip()
+            if stripped and not stripped.startswith("Total:"):
+                assert stripped.startswith("tester."), f"non-tester rule in archetype tester: {line!r}"
+
+
+def test_rules_archetype_planner_excludes_other_archetypes(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``archetype planner`` returns only planner rules."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().archetype("planner")
+    assert rc == 0
+    out = capsys.readouterr().out
+    for line in out.splitlines():
+        if "—" in line and not line.lstrip().startswith("Total:"):
+            stripped = line.lstrip()
+            if stripped:
+                assert stripped.startswith("planner."), (
+                    f"non-planner rule in archetype planner: {line!r}"
+                )
+
+
+def test_rules_archetype_unknown_value_returns_nonzero_with_options(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """An unknown archetype exits 1 and surfaces the five valid options."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().archetype("frontend")
+    assert rc == 1
+    err = capsys.readouterr().err
+    for option in ("coder", "coach", "tester", "planner", "repo"):
+        assert option in err, f"missing valid archetype {option!r} in error message"
+
+
+def test_rules_archetype_json_format(
+    seeded_registry: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``--format json`` emits a list of rule metadata dicts for the archetype."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().archetype("repo", format="json")
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert isinstance(payload, list)
+    assert len(payload) == 3
+    assert {entry["rule_id"] for entry in payload} == {
+        "repo.govern-lifecycle.D010-acc-unit-001",
+        "repo.foo-wagon.D001-acc-http-007",
+        "repo.0001-self-compliance-validate.acc-idempotent-on-retry",
+    }
+
+
+# ---------------------------------------------------------------------------
+# atdd rules suppressions [--stale-only] [--rule <id>]
+#   acc:discover-and-decommission:L002-UNIT-003
+# ---------------------------------------------------------------------------
+def _seed_suppression_files(tmp_path: Path) -> None:
+    """Plant a mix of active, stale, and repo-rule markers under *tmp_path*.
+
+    Layout:
+      a.py      — active marker (UNTIL future)
+      b.py      — bare marker (no UNTIL — never stale)
+      stale.py  — stale marker (UNTIL past)
+      repo.py   — marker referencing a repo.* rule (substrate-unsuppressible)
+    """
+    (tmp_path / "a.py").write_text(
+        "x = 1  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2099-01-01\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "b.py").write_text(
+        "y = 2  # atdd:suppress(coder.logging.no-print-calls-in)\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "stale.py").write_text(
+        "z = 3  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2020-01-01\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "repo.py").write_text(
+        "w = 4  # atdd:suppress(repo.foo-wagon.D001-acc-http-007) UNTIL=2099-01-01\n",
+        encoding="utf-8",
+    )
+
+
+def test_rules_suppressions_lists_all_active_markers(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``atdd rules suppressions`` lists every active marker (file, line, rule, UNTIL)."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    _seed_suppression_files(tmp_path)
+    rc = RulesCommand().suppressions(roots=[tmp_path])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # All four files surface.
+    assert "a.py" in out
+    assert "b.py" in out
+    assert "stale.py" in out
+    assert "repo.py" in out
+    # Each line shows rule-id + line number.
+    assert "coder.logging.coach-silent-swallow" in out
+    assert "coder.logging.no-print-calls-in" in out
+    assert "repo.foo-wagon.D001-acc-http-007" in out
+    # UNTIL date for the dated marker is rendered.
+    assert "2099-01-01" in out
+
+
+def test_rules_suppressions_stale_only_filters_to_past_until(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``--stale-only`` filters to markers whose UNTIL date has passed."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    _seed_suppression_files(tmp_path)
+    rc = RulesCommand().suppressions(roots=[tmp_path], stale_only=True)
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Only the stale marker survives.
+    assert "stale.py" in out
+    assert "2020-01-01" in out
+    # Active and bare markers are filtered out.
+    assert "a.py" not in out
+    assert "b.py" not in out
+
+
+def test_rules_suppressions_rule_filter_narrows_to_one_rule(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``--rule <id>`` filters to markers for the given rule-id only."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    _seed_suppression_files(tmp_path)
+    rc = RulesCommand().suppressions(
+        roots=[tmp_path],
+        rule_id="coder.logging.no-print-calls-in",
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Only b.py (the matching marker) appears.
+    assert "b.py" in out
+    assert "coder.logging.no-print-calls-in" in out
+    # Other markers do not.
+    assert "a.py" not in out
+    assert "stale.py" not in out
+    assert "repo.py" not in out
+
+
+def test_rules_suppressions_warns_on_repo_rule_marker(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Markers referencing ``repo.*`` rules surface as warnings.
+
+    Per substrate v12 §2 repo rules are uniformly strict and unsuppressible
+    — the marker is silently ignored by the gate, so the CLI is the only
+    place an operator can see the misapplication.
+    """
+    from atdd.coach.commands.rules import RulesCommand
+
+    _seed_suppression_files(tmp_path)
+    RulesCommand().suppressions(roots=[tmp_path])
+    captured = capsys.readouterr()
+    # The warning surfaces the offending rule-id and a clear "unsuppressible"
+    # phrase. Stderr is the right channel — operators piping stdout into a
+    # report still get the alert.
+    combined = captured.out + captured.err
+    assert "repo.foo-wagon.D001-acc-http-007" in combined
+    assert any(
+        token in combined.lower()
+        for token in ("warning", "unsuppressible", "ignored")
+    ), "repo-rule marker did not surface as a warning"
+
+
+def test_rules_suppressions_empty_repo_exits_zero(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """Empty result (no markers) still exits zero — distinct from grep."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    rc = RulesCommand().suppressions(roots=[tmp_path])
+    assert rc == 0
+
+
+def test_rules_suppressions_json_format(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """``--format json`` emits a structured list of marker dicts."""
+    from atdd.coach.commands.rules import RulesCommand
+
+    _seed_suppression_files(tmp_path)
+    rc = RulesCommand().suppressions(roots=[tmp_path], format="json")
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert isinstance(payload, list)
+    # Each entry has the four required fields per spec §5.7.
+    for entry in payload:
+        assert set(entry).issuperset({"file_path", "line", "rule_id", "until"})
+    # All four markers appear.
+    assert len(payload) == 4
+    rule_ids = {entry["rule_id"] for entry in payload}
+    assert "repo.foo-wagon.D001-acc-http-007" in rule_ids


### PR DESCRIPTION
Closes #494

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #494 |
| Type | implementation |
| Slug | coach-v9-p2-rules-disposition-archetype-suppressions |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd-issue, atdd:INIT, archetype:coach, wave-w0, track-p, wagon:discover-and-decommission, train:0002-coach-drives-lifecycle |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.