### PR TITLE
feat(coach): decision and judgment durability (jsonl logs) (#498)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -417,3 +417,14 @@ sessions:
   wagon: drive-state-machine
   feature: feature:drive-state-machine:coach-state-machine-and-runtime
   train: 0002-coach-drives-lifecycle
+- id: '498'
+  slug: coach-v9-j3-decision-judgment-durability
+  file: null
+  issue_number: 498
+  type: feat
+  status: RED
+  created: '2026-05-09'
+  archived: null
+  wagon: drive-state-machine
+  feature: feature:drive-state-machine:coach-state-machine-and-runtime
+  train: 0002-coach-drives-lifecycle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.15.0"
+version = "3.16.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/durability.py
+++ b/src/atdd/coach/commands/durability.py
@@ -1,0 +1,187 @@
+"""Durable JSONL writers for coach state — `decisions.jsonl` and `judgments.jsonl`.
+
+Spec references:
+- §3.2 (runtime folder layout)
+- §4.5 (decision durability — every transition appended *before* the action runs)
+- §6.9 (`atdd judge` and `judgments.jsonl` — six call sites, inputs hashed by default)
+- §C0 (`coach-decision.schema.json`, `coach-judgment.schema.json`)
+- `runtime-layout.md` ("Append-only files never seek-and-truncate")
+
+Public surface:
+- ``DecisionWriter`` — append-only writer for `coach/decisions.jsonl`.
+- ``JudgmentWriter`` — append-only writer for `coach/judgments.jsonl`,
+  routes full inputs to a separate cache directory.
+- ``transactional_decision`` — context manager enforcing the
+  decision-precedes-action invariant and idempotent replay.
+- ``hash_inputs`` — content-stable, order-independent hash for judgment inputs.
+- ``SchemaValidationError`` — raised at write time when a record fails schema.
+
+Design notes:
+- Append-only is implemented via ``os.open`` with ``O_APPEND | O_CREAT |
+  O_WRONLY``; each record is written as a single ``os.write`` call (one
+  JSON line, terminating ``\n``). On POSIX this is atomic for writes
+  ≤ ``PIPE_BUF`` (≥ 4096 on Linux/macOS), which covers normal coach records.
+- ``fsync`` is called after each record to make the durable log resilient
+  to crash; this is the load-bearing property for #J6 resume.
+- Schema validation runs *before* any bytes hit the file. Invalid records
+  raise ``SchemaValidationError`` naming the offending field and never
+  open the file for write.
+- Idempotency is implemented via a forward scan of the log for the
+  ``decision_id``. For J3's expected log sizes (a few thousand records
+  per coach run) this is acceptable; #J6 may layer a faster index.
+"""
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterator, Optional
+
+from jsonschema import Draft202012Validator
+
+import atdd
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+SCHEMAS_DIR = ATDD_PKG_DIR / "coach" / "schemas"
+
+
+class DurabilityError(Exception):
+    """Base class for durability-writer errors."""
+
+
+class SchemaValidationError(DurabilityError):
+    """A record failed schema validation. The message names the offending field."""
+
+
+def _load_validator(schema_filename: str) -> Draft202012Validator:
+    schema_path = SCHEMAS_DIR / schema_filename
+    schema = json.loads(schema_path.read_text())
+    return Draft202012Validator(schema)
+
+
+def _format_error(errors: list, schema_id: str) -> str:
+    parts: list[str] = []
+    for err in errors:
+        path = ".".join(str(p) for p in err.absolute_path) or "<root>"
+        if err.validator == "required":
+            missing = err.message.split("'")[1] if "'" in err.message else err.message
+            parts.append(f"missing required field {missing!r}")
+        else:
+            parts.append(f"{path}: {err.message}")
+    return f"{schema_id} validation failed: {'; '.join(parts)}"
+
+
+def _append_jsonl(path: Path, record: dict) -> None:
+    """Append one JSON line to ``path`` with O_APPEND + fsync semantics."""
+    line = json.dumps(record, separators=(",", ":"), ensure_ascii=False) + "\n"
+    data = line.encode("utf-8")
+    fd = os.open(str(path), os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o644)
+    try:
+        os.write(fd, data)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def hash_inputs(inputs: Any) -> str:
+    """Order-independent SHA-256 hash of judgment inputs.
+
+    Returns a string of the form ``sha256:<hex>``. Two payloads with the
+    same content but different key orderings produce the same hash.
+    """
+    canonical = json.dumps(inputs, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+class DecisionWriter:
+    """Append-only writer for ``<runtime_dir>/coach/decisions.jsonl``.
+
+    Schema-validates every record against ``coach-decision.schema.json``
+    before writing.
+    """
+
+    def __init__(self, runtime_dir: Path) -> None:
+        self.runtime_dir = Path(runtime_dir)
+        self.path = self.runtime_dir / "coach" / "decisions.jsonl"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._validator = _load_validator("coach-decision.schema.json")
+
+    def append(self, record: dict) -> None:
+        errors = sorted(self._validator.iter_errors(record), key=lambda e: list(e.absolute_path))
+        if errors:
+            raise SchemaValidationError(_format_error(errors, "coach-decision"))
+        _append_jsonl(self.path, record)
+
+    def has_decision(self, decision_id: str) -> bool:
+        if not self.path.exists():
+            return False
+        with self.path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("decision_id") == decision_id:
+                    return True
+        return False
+
+
+class JudgmentWriter:
+    """Append-only writer for ``<runtime_dir>/coach/judgments.jsonl``.
+
+    Schema-validates every record against ``coach-judgment.schema.json``
+    before writing. Optionally persists full inputs to a sibling cache
+    directory keyed by ``inputs_hash``; the durable log itself only
+    carries the hash, per spec §6.9.
+    """
+
+    def __init__(self, runtime_dir: Path) -> None:
+        self.runtime_dir = Path(runtime_dir)
+        self.path = self.runtime_dir / "coach" / "judgments.jsonl"
+        self.cache_dir = self.runtime_dir / "coach" / "judgment-inputs"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self._validator = _load_validator("coach-judgment.schema.json")
+
+    def append(self, record: dict, *, full_inputs: Optional[Any] = None) -> None:
+        errors = sorted(self._validator.iter_errors(record), key=lambda e: list(e.absolute_path))
+        if errors:
+            raise SchemaValidationError(_format_error(errors, "coach-judgment"))
+        if full_inputs is not None:
+            self._cache_full_inputs(record["inputs_hash"], full_inputs)
+        _append_jsonl(self.path, record)
+
+    def _cache_full_inputs(self, inputs_hash: str, full_inputs: Any) -> None:
+        safe_name = inputs_hash.replace(":", "_").replace("/", "_") + ".json"
+        target = self.cache_dir / safe_name
+        tmp = target.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(full_inputs, separators=(",", ":"), ensure_ascii=False),
+            encoding="utf-8",
+        )
+        os.replace(tmp, target)
+
+
+@contextlib.contextmanager
+def transactional_decision(
+    writer: DecisionWriter, record: dict
+) -> Iterator[bool]:
+    """Decision-precedes-action context manager.
+
+    On entry: if ``record["decision_id"]`` already exists in the durable
+    log, yield ``False`` so the caller skips the action (idempotent
+    replay). Otherwise, append the decision *before* yielding ``True``;
+    if the body raises, the decision is still durably recorded (#J6
+    resume contract).
+    """
+    if writer.has_decision(record["decision_id"]):
+        yield False
+        return
+    writer.append(record)
+    yield True

--- a/src/atdd/coach/commands/tests/test_p001_unit_001_decisions_append_only.py
+++ b/src/atdd/coach/commands/tests/test_p001_unit_001_decisions_append_only.py
@@ -1,0 +1,190 @@
+# URN: test:drive-state-machine:coach-state-machine-and-runtime:P001-UNIT-001-decisions-append-only
+# Acceptance: acc:drive-state-machine:P001-UNIT-001-decisions-append-only
+# WMBT: wmbt:drive-state-machine:P001
+# Phase: RED
+# Layer: application
+"""P001-UNIT-001 — every state transition is appended to
+``decisions.jsonl`` BEFORE the action runs.
+
+Per spec §4.5: "every state transition appended to ``decisions.jsonl``
+*before* the action runs." This is the load-bearing invariant for #J6
+resume — if the durable log is the source of truth and the decision is
+recorded before the action, then idempotent actions absorb replay.
+
+Records conform to ``coach-decision.schema.json`` from #483.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_decisions_log_path_under_runtime_coach(tmp_path):
+    from atdd.coach.commands.durability import DecisionWriter
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    expected = tmp_path / "coach" / "decisions.jsonl"
+    assert writer.path == expected
+    assert writer.path.parent.is_dir()
+
+
+def test_append_writes_one_jsonl_record_per_call(tmp_path):
+    from atdd.coach.commands.durability import DecisionWriter
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    record = {
+        "decision_id": "01HW9P5C8K3D5R8X4M7VJZ4MZA",
+        "timestamp": "2026-05-09T13:45:02.482Z",
+        "coach_run_id": "run-test",
+        "issue_number": 498,
+        "decision_type": "phase-transition",
+        "inputs": {"current_phase": "INIT", "target_phase": "PLANNED"},
+        "outcome": {"transitioned": True, "new_phase": "PLANNED"},
+    }
+    writer.append(record)
+    writer.append({**record, "decision_id": "01HW9P5C8K3D5R8X4M7VJZ4MZB"})
+
+    records = _read_jsonl(writer.path)
+    assert len(records) == 2
+    assert records[0]["decision_id"] == "01HW9P5C8K3D5R8X4M7VJZ4MZA"
+    assert records[1]["decision_id"] == "01HW9P5C8K3D5R8X4M7VJZ4MZB"
+
+
+def test_append_does_not_seek_and_truncate(tmp_path):
+    """Append-only invariant: a new writer opening over an existing file
+    must not erase prior content."""
+    from atdd.coach.commands.durability import DecisionWriter
+
+    writer1 = DecisionWriter(runtime_dir=tmp_path)
+    writer1.append(
+        {
+            "decision_id": "first",
+            "timestamp": "2026-05-09T13:45:00Z",
+            "coach_run_id": "r",
+            "issue_number": 498,
+            "decision_type": "phase-transition",
+            "inputs": {},
+            "outcome": {},
+        }
+    )
+
+    writer2 = DecisionWriter(runtime_dir=tmp_path)
+    writer2.append(
+        {
+            "decision_id": "second",
+            "timestamp": "2026-05-09T13:45:01Z",
+            "coach_run_id": "r",
+            "issue_number": 498,
+            "decision_type": "phase-transition",
+            "inputs": {},
+            "outcome": {},
+        }
+    )
+
+    records = _read_jsonl(writer1.path)
+    assert [r["decision_id"] for r in records] == ["first", "second"]
+
+
+def test_decision_recorded_before_action_runs_under_failure(tmp_path):
+    """Decision-precedes-action invariant: if the action raises, the
+    decision is still durably recorded. Verified by injecting a failure
+    at action-time and observing the decision in the log."""
+    from atdd.coach.commands.durability import DecisionWriter, transactional_decision
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    record = {
+        "decision_id": "tx-1",
+        "timestamp": "2026-05-09T13:45:02Z",
+        "coach_run_id": "r",
+        "issue_number": 498,
+        "decision_type": "phase-transition",
+        "inputs": {},
+        "outcome": {},
+    }
+
+    class ActionFailed(RuntimeError):
+        pass
+
+    with pytest.raises(ActionFailed):
+        with transactional_decision(writer, record) as run_action:
+            assert run_action is True
+            raise ActionFailed("simulated mid-action crash")
+
+    records = _read_jsonl(writer.path)
+    assert len(records) == 1
+    assert records[0]["decision_id"] == "tx-1"
+
+
+def test_required_fields_per_c0_schema(tmp_path):
+    """Required fields per coach-decision.schema.json: decision_id,
+    timestamp, coach_run_id, issue_number, decision_type, inputs,
+    outcome."""
+    from atdd.coach.commands.durability import DecisionWriter
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    full = {
+        "decision_id": "d1",
+        "timestamp": "2026-05-09T13:45:02Z",
+        "coach_run_id": "r",
+        "issue_number": 498,
+        "decision_type": "phase-transition",
+        "inputs": {"k": "v"},
+        "outcome": {"ok": True},
+    }
+    writer.append(full)
+
+    [rec] = _read_jsonl(writer.path)
+    for field in (
+        "decision_id",
+        "timestamp",
+        "coach_run_id",
+        "issue_number",
+        "decision_type",
+        "inputs",
+        "outcome",
+    ):
+        assert field in rec, f"missing required field: {field}"
+
+
+def test_concurrent_appends_do_not_corrupt_records(tmp_path):
+    """O_APPEND semantics: concurrent writes from different threads
+    don't interleave partial records."""
+    import threading
+    from atdd.coach.commands.durability import DecisionWriter
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    n_threads = 8
+    n_per_thread = 25
+
+    def worker(tid: int) -> None:
+        for i in range(n_per_thread):
+            writer.append(
+                {
+                    "decision_id": f"t{tid}-{i}",
+                    "timestamp": "2026-05-09T13:45:02Z",
+                    "coach_run_id": "r",
+                    "issue_number": 498,
+                    "decision_type": "phase-transition",
+                    "inputs": {"thread": tid, "i": i},
+                    "outcome": {},
+                }
+            )
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    records = _read_jsonl(writer.path)
+    assert len(records) == n_threads * n_per_thread
+    ids = {r["decision_id"] for r in records}
+    assert len(ids) == n_threads * n_per_thread

--- a/src/atdd/coach/commands/tests/test_p001_unit_002_judgments_append_only.py
+++ b/src/atdd/coach/commands/tests/test_p001_unit_002_judgments_append_only.py
@@ -1,0 +1,172 @@
+# URN: test:drive-state-machine:coach-state-machine-and-runtime:P001-UNIT-002-judgments-append-only
+# Acceptance: acc:drive-state-machine:P001-UNIT-002-judgments-append-only
+# WMBT: wmbt:drive-state-machine:P001
+# Phase: RED
+# Layer: application
+"""P001-UNIT-002 — every ``atdd judge`` call writes a record to
+``judgments.jsonl`` with ``inputs_hash`` discipline.
+
+Per spec §6.9: "every judgment writes to ``judgments.jsonl``" with
+"Inputs hashed by default; full inputs in gitignored cache." The
+durable log carries ``inputs_hash``; full inputs go to a gitignored
+cache directory under ``.atdd/runtime/`` (which is itself gitignored).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_judgments_log_path_under_runtime_coach(tmp_path):
+    from atdd.coach.commands.durability import JudgmentWriter
+
+    writer = JudgmentWriter(runtime_dir=tmp_path)
+    expected = tmp_path / "coach" / "judgments.jsonl"
+    assert writer.path == expected
+    assert writer.path.parent.is_dir()
+
+
+def test_append_writes_jsonl_record(tmp_path):
+    from atdd.coach.commands.durability import JudgmentWriter
+
+    writer = JudgmentWriter(runtime_dir=tmp_path)
+    record = {
+        "judgment_id": "j1",
+        "timestamp": "2026-05-09T13:45:02Z",
+        "call_site": "phase-advance",
+        "inputs_hash": "sha256:abc123",
+        "response": {"ok": True},
+        "cached": False,
+    }
+    writer.append(record)
+
+    records = _read_jsonl(writer.path)
+    assert len(records) == 1
+    assert records[0]["judgment_id"] == "j1"
+
+
+def test_required_fields_per_c0_schema(tmp_path):
+    """Required: judgment_id, timestamp, call_site, inputs_hash,
+    response, cached."""
+    from atdd.coach.commands.durability import JudgmentWriter
+
+    writer = JudgmentWriter(runtime_dir=tmp_path)
+    record = {
+        "judgment_id": "j1",
+        "timestamp": "2026-05-09T13:45:02Z",
+        "call_site": "phase-advance",
+        "inputs_hash": "sha256:abc",
+        "response": True,
+        "cached": False,
+    }
+    writer.append(record)
+
+    [rec] = _read_jsonl(writer.path)
+    for field in (
+        "judgment_id",
+        "timestamp",
+        "call_site",
+        "inputs_hash",
+        "response",
+        "cached",
+    ):
+        assert field in rec, f"missing required field: {field}"
+
+
+def test_call_site_constrained_to_six_v1_surfaces(tmp_path):
+    """Per spec §6.9: six call sites — phase-advance,
+    violation-suppression, correction-injection, review-disposition,
+    escalation, merge-readiness."""
+    from atdd.coach.commands.durability import (
+        JudgmentWriter,
+        SchemaValidationError,
+    )
+
+    writer = JudgmentWriter(runtime_dir=tmp_path)
+
+    valid_sites = {
+        "phase-advance",
+        "violation-suppression",
+        "correction-injection",
+        "review-disposition",
+        "escalation",
+        "merge-readiness",
+    }
+    for i, site in enumerate(valid_sites):
+        writer.append(
+            {
+                "judgment_id": f"j-{i}",
+                "timestamp": "2026-05-09T13:45:02Z",
+                "call_site": site,
+                "inputs_hash": "sha256:x",
+                "response": True,
+                "cached": False,
+            }
+        )
+
+    with pytest.raises(SchemaValidationError):
+        writer.append(
+            {
+                "judgment_id": "j-bad",
+                "timestamp": "2026-05-09T13:45:02Z",
+                "call_site": "not-a-real-site",
+                "inputs_hash": "sha256:x",
+                "response": True,
+                "cached": False,
+            }
+        )
+
+
+def test_full_inputs_persisted_to_gitignored_cache_not_log(tmp_path):
+    """``inputs_hash`` is a content hash; full inputs go to a cache
+    directory; the durable log never carries the raw inputs."""
+    from atdd.coach.commands.durability import JudgmentWriter, hash_inputs
+
+    writer = JudgmentWriter(runtime_dir=tmp_path)
+    full_inputs = {
+        "prompt": "is INIT→PLANNED safe given these violations: ...",
+        "context": {"violations": [{"id": "v1"}, {"id": "v2"}]},
+    }
+    h = hash_inputs(full_inputs)
+    assert h.startswith("sha256:")
+
+    writer.append(
+        {
+            "judgment_id": "j1",
+            "timestamp": "2026-05-09T13:45:02Z",
+            "call_site": "phase-advance",
+            "inputs_hash": h,
+            "response": True,
+            "cached": False,
+        },
+        full_inputs=full_inputs,
+    )
+
+    [rec] = _read_jsonl(writer.path)
+    assert rec["inputs_hash"] == h
+    assert "prompt" not in rec
+    assert "context" not in rec
+
+    cache_files = list(writer.cache_dir.iterdir())
+    assert len(cache_files) == 1
+    cached = json.loads(cache_files[0].read_text())
+    assert cached == full_inputs
+
+
+def test_inputs_hash_stable_across_calls():
+    from atdd.coach.commands.durability import hash_inputs
+
+    a = hash_inputs({"a": 1, "b": 2})
+    b = hash_inputs({"b": 2, "a": 1})
+    assert a == b, "hash must be order-independent"
+
+    c = hash_inputs({"a": 1, "b": 3})
+    assert a != c

--- a/src/atdd/coach/commands/tests/test_p001_unit_003_schema_validation_at_write.py
+++ b/src/atdd/coach/commands/tests/test_p001_unit_003_schema_validation_at_write.py
@@ -1,0 +1,110 @@
+# URN: test:drive-state-machine:coach-state-machine-and-runtime:P001-UNIT-003-schema-validation-at-write
+# Acceptance: acc:drive-state-machine:P001-UNIT-003-schema-validation-at-write
+# WMBT: wmbt:drive-state-machine:P001
+# Phase: RED
+# Layer: application
+"""P001-UNIT-003 — schema validation runs at write time; malformed
+records are rejected before any bytes hit the file.
+
+The error names the missing/invalid field; the file is not partially
+written.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def test_decision_write_rejects_missing_required_field(tmp_path):
+    from atdd.coach.commands.durability import (
+        DecisionWriter,
+        SchemaValidationError,
+    )
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    invalid = {
+        "decision_id": "d1",
+        "timestamp": "2026-05-09T13:45:02Z",
+        # missing coach_run_id
+        "issue_number": 498,
+        "decision_type": "phase-transition",
+        "inputs": {},
+        "outcome": {},
+    }
+    with pytest.raises(SchemaValidationError) as exc_info:
+        writer.append(invalid)
+    assert "coach_run_id" in str(exc_info.value)
+    assert not writer.path.exists() or writer.path.read_text() == ""
+
+
+def test_decision_write_rejects_wrong_type(tmp_path):
+    from atdd.coach.commands.durability import (
+        DecisionWriter,
+        SchemaValidationError,
+    )
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    invalid = {
+        "decision_id": "d1",
+        "timestamp": "2026-05-09T13:45:02Z",
+        "coach_run_id": "r",
+        "issue_number": "not-an-int",
+        "decision_type": "phase-transition",
+        "inputs": {},
+        "outcome": {},
+    }
+    with pytest.raises(SchemaValidationError) as exc_info:
+        writer.append(invalid)
+    assert "issue_number" in str(exc_info.value)
+
+
+def test_judgment_write_rejects_missing_required_field(tmp_path):
+    from atdd.coach.commands.durability import (
+        JudgmentWriter,
+        SchemaValidationError,
+    )
+
+    writer = JudgmentWriter(runtime_dir=tmp_path)
+    invalid = {
+        "judgment_id": "j1",
+        "timestamp": "2026-05-09T13:45:02Z",
+        # missing call_site
+        "inputs_hash": "sha256:x",
+        "response": True,
+        "cached": False,
+    }
+    with pytest.raises(SchemaValidationError) as exc_info:
+        writer.append(invalid)
+    assert "call_site" in str(exc_info.value)
+    assert not writer.path.exists() or writer.path.read_text() == ""
+
+
+def test_file_not_partially_written_after_rejection(tmp_path):
+    """If a record is invalid, the file must not contain any partial
+    bytes from that record."""
+    from atdd.coach.commands.durability import (
+        DecisionWriter,
+        SchemaValidationError,
+    )
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    valid = {
+        "decision_id": "d1",
+        "timestamp": "2026-05-09T13:45:02Z",
+        "coach_run_id": "r",
+        "issue_number": 498,
+        "decision_type": "phase-transition",
+        "inputs": {},
+        "outcome": {},
+    }
+    writer.append(valid)
+    contents_before = writer.path.read_text()
+
+    with pytest.raises(SchemaValidationError):
+        writer.append({"decision_id": "bad"})  # missing many required fields
+
+    contents_after = writer.path.read_text()
+    assert contents_after == contents_before, (
+        "rejected record must not leave bytes in the file"
+    )

--- a/src/atdd/coach/commands/tests/test_p001_unit_004_actions_idempotent.py
+++ b/src/atdd/coach/commands/tests/test_p001_unit_004_actions_idempotent.py
@@ -1,0 +1,98 @@
+# URN: test:drive-state-machine:coach-state-machine-and-runtime:P001-UNIT-004-actions-idempotent
+# Acceptance: acc:drive-state-machine:P001-UNIT-004-actions-idempotent
+# WMBT: wmbt:drive-state-machine:P001
+# Phase: RED
+# Layer: application
+"""P001-UNIT-004 — replaying a recorded transition skips the action.
+
+Idempotency is the contract that makes #J6 resume feasible: replaying a
+durable decision must NOT cause double-execution. The
+``transactional_decision`` context manager checks the durable log for an
+existing ``decision_id``; if found, the action body is skipped (the
+context yields ``False``) and no new record is appended.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _make_record(decision_id: str = "init-planned-498") -> dict:
+    return {
+        "decision_id": decision_id,
+        "timestamp": "2026-05-09T13:45:02Z",
+        "coach_run_id": "r",
+        "issue_number": 358,
+        "decision_type": "phase-transition",
+        "inputs": {"current_phase": "INIT", "target_phase": "PLANNED"},
+        "outcome": {"transitioned": True, "new_phase": "PLANNED"},
+    }
+
+
+def test_has_decision_returns_false_on_empty_log(tmp_path):
+    from atdd.coach.commands.durability import DecisionWriter
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    assert writer.has_decision("any-id") is False
+
+
+def test_has_decision_returns_true_after_append(tmp_path):
+    from atdd.coach.commands.durability import DecisionWriter
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    record = _make_record("d1")
+    writer.append(record)
+    assert writer.has_decision("d1") is True
+    assert writer.has_decision("d2") is False
+
+
+def test_replay_skips_action_and_does_not_double_log(tmp_path):
+    """Replaying a recorded INIT→PLANNED transition for an issue causes
+    the action to be recognized as already executed and skipped — no
+    duplicate side-effects."""
+    from atdd.coach.commands.durability import DecisionWriter, transactional_decision
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    record = _make_record("init-planned-358")
+
+    side_effects: list[str] = []
+
+    with transactional_decision(writer, record) as run_action:
+        assert run_action is True
+        side_effects.append("commit")
+
+    assert side_effects == ["commit"]
+    assert len(_read_jsonl(writer.path)) == 1
+
+    writer2 = DecisionWriter(runtime_dir=tmp_path)
+    with transactional_decision(writer2, record) as run_action:
+        assert run_action is False
+        if run_action:  # pragma: no cover — guarded by run_action
+            side_effects.append("commit-2")
+
+    assert side_effects == ["commit"], "no duplicate side effect"
+    assert len(_read_jsonl(writer2.path)) == 1, "no duplicate log entry"
+
+
+def test_replay_with_different_decision_id_runs_action(tmp_path):
+    """Sanity: a different decision_id is treated as new work."""
+    from atdd.coach.commands.durability import DecisionWriter, transactional_decision
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    writer.append(_make_record("first"))
+
+    side_effects: list[str] = []
+    with transactional_decision(writer, _make_record("second")) as run_action:
+        assert run_action is True
+        side_effects.append("ran")
+
+    assert side_effects == ["ran"]
+    assert len(_read_jsonl(writer.path)) == 2

--- a/src/atdd/coach/commands/tests/test_p001_unit_005_durability_smoke.py
+++ b/src/atdd/coach/commands/tests/test_p001_unit_005_durability_smoke.py
@@ -1,0 +1,177 @@
+# URN: test:drive-state-machine:coach-state-machine-and-runtime:P001-UNIT-005-durability-smoke
+# Acceptance: acc:drive-state-machine:P001-UNIT-001-decisions-append-only
+# WMBT: wmbt:drive-state-machine:P001
+# Phase: SMOKE
+# Layer: assembly
+# Smoke: true
+# Purpose: verify J3 writers against real schema files + real fs + real OS-level concurrency
+"""P001 SMOKE — exercise the J3 writers against real infrastructure.
+
+What this verifies that the unit tests do not:
+- The writers load and validate against the *committed* C0 schema
+  files at ``src/atdd/coach/schemas/`` (no fixtures, no test doubles).
+- Multi-process concurrent appends preserve no-interleave guarantees
+  under POSIX ``O_APPEND`` semantics on the real filesystem.
+- ``fsync`` durability survives an abrupt close-and-reopen cycle: the
+  log is replayable record-by-record after every append.
+- Replay across a freshly-instantiated writer (simulating coach
+  restart) skips already-recorded decisions.
+"""
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _worker_append(runtime_dir: str, worker_id: int, n: int) -> None:
+    """Top-level so it pickles for `mp.spawn`/`fork`."""
+    from atdd.coach.commands.durability import DecisionWriter
+
+    writer = DecisionWriter(runtime_dir=Path(runtime_dir))
+    for i in range(n):
+        writer.append(
+            {
+                "decision_id": f"w{worker_id}-{i}",
+                "timestamp": "2026-05-09T13:45:02Z",
+                "coach_run_id": "smoke-run",
+                "issue_number": 498,
+                "decision_type": "phase-transition",
+                "inputs": {"worker": worker_id, "i": i, "filler": "x" * 64},
+                "outcome": {"ok": True},
+            }
+        )
+
+
+def test_smoke_real_schemas_load_at_writer_init(tmp_path):
+    """Both writers must load the committed schemas without error."""
+    from atdd.coach.commands.durability import (
+        DecisionWriter,
+        JudgmentWriter,
+        SCHEMAS_DIR,
+    )
+
+    assert (SCHEMAS_DIR / "coach-decision.schema.json").is_file()
+    assert (SCHEMAS_DIR / "coach-judgment.schema.json").is_file()
+
+    DecisionWriter(runtime_dir=tmp_path)
+    JudgmentWriter(runtime_dir=tmp_path)
+
+
+def test_smoke_multiprocess_append_no_interleave(tmp_path):
+    """Concurrent appends from real OS processes don't interleave."""
+    n_workers = 4
+    n_per_worker = 50
+
+    ctx = mp.get_context("fork")
+    procs = [
+        ctx.Process(target=_worker_append, args=(str(tmp_path), w, n_per_worker))
+        for w in range(n_workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=30)
+        assert p.exitcode == 0, f"worker {p.pid} exited {p.exitcode}"
+
+    log = tmp_path / "coach" / "decisions.jsonl"
+    records = _read_jsonl(log)
+    assert len(records) == n_workers * n_per_worker
+
+    ids = {r["decision_id"] for r in records}
+    assert len(ids) == n_workers * n_per_worker, "duplicate or lost ids"
+
+    raw = log.read_text()
+    for line in raw.splitlines():
+        if line:
+            json.loads(line)
+
+
+def test_smoke_resume_skips_recorded_decisions(tmp_path):
+    """Crash-recovery analog: a fresh writer over the same runtime_dir
+    treats existing decisions as already-executed."""
+    from atdd.coach.commands.durability import DecisionWriter, transactional_decision
+
+    rec_a = {
+        "decision_id": "smoke-a",
+        "timestamp": "2026-05-09T13:45:02Z",
+        "coach_run_id": "r1",
+        "issue_number": 498,
+        "decision_type": "phase-transition",
+        "inputs": {"phase": "INIT"},
+        "outcome": {"phase": "PLANNED"},
+    }
+
+    side_effects: list[str] = []
+    writer1 = DecisionWriter(runtime_dir=tmp_path)
+    with transactional_decision(writer1, rec_a) as run_action:
+        if run_action:
+            side_effects.append("first-run")
+
+    writer2 = DecisionWriter(runtime_dir=tmp_path)
+    with transactional_decision(writer2, rec_a) as run_action:
+        if run_action:
+            side_effects.append("second-run")
+
+    assert side_effects == ["first-run"]
+
+    rec_b = {**rec_a, "decision_id": "smoke-b"}
+    with transactional_decision(writer2, rec_b) as run_action:
+        if run_action:
+            side_effects.append("third-run")
+    assert side_effects == ["first-run", "third-run"]
+
+    records = _read_jsonl(writer1.path)
+    assert [r["decision_id"] for r in records] == ["smoke-a", "smoke-b"]
+
+
+def test_smoke_judgment_full_inputs_cache_round_trip(tmp_path):
+    """Full inputs cached on disk reload identically; durable log keeps
+    only the hash."""
+    from atdd.coach.commands.durability import (
+        JudgmentWriter,
+        hash_inputs,
+    )
+
+    writer = JudgmentWriter(runtime_dir=tmp_path)
+    full_inputs = {
+        "prompt": "Should we advance from RED to GREEN?",
+        "context": {"violations": [], "tests_passing": True},
+        "model_hint": "claude-opus-4-7",
+    }
+    h = hash_inputs(full_inputs)
+
+    writer.append(
+        {
+            "judgment_id": "smoke-judgment-1",
+            "timestamp": "2026-05-09T13:45:02Z",
+            "call_site": "phase-advance",
+            "inputs_hash": h,
+            "response": {"advance": True, "confidence": 0.95},
+            "cached": False,
+            "model": "claude-opus-4-7",
+            "latency_ms": 1234,
+        },
+        full_inputs=full_inputs,
+    )
+
+    [log_record] = _read_jsonl(writer.path)
+    assert log_record["inputs_hash"] == h
+    for forbidden in ("prompt", "context", "model_hint"):
+        assert forbidden not in log_record, (
+            f"{forbidden!r} leaked into durable log; should be cache-only"
+        )
+
+    cache_files = list(writer.cache_dir.glob("*.json"))
+    assert len(cache_files) == 1
+    cached = json.loads(cache_files[0].read_text(encoding="utf-8"))
+    assert cached == full_inputs
+    assert cache_files[0].name == h.replace(":", "_") + ".json"


### PR DESCRIPTION
Closes #498

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #498 |
| Type | feat |
| Slug | coach-v9-j3-decision-judgment-durability |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd-issue, atdd:INIT, archetype:coach, track-j, wave-w1, wagon:drive-state-machine, train:0002-coach-drives-lifecycle |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.