### PR TITLE
feat(coach): resume from decisions log (#511)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -472,3 +472,14 @@ sessions:
   wagon: drive-state-machine
   feature: feature:drive-state-machine:coach-state-machine-and-runtime
   train: 0002-coach-drives-lifecycle
+- id: '511'
+  slug: coach-v9-j6-resume-from-decisions-log
+  file: null
+  issue_number: 511
+  type: feat
+  status: RED
+  created: '2026-05-09'
+  archived: null
+  wagon: drive-state-machine
+  feature: feature:drive-state-machine:coach-state-machine-and-runtime
+  train: 0002-coach-drives-lifecycle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.19.0"
+version = "3.20.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/coach.py
+++ b/src/atdd/coach/commands/coach.py
@@ -35,6 +35,7 @@ import argparse
 import sys
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import Optional
 
 # Per spec §0.2 absorption discipline: reuse, do not redefine.
@@ -359,7 +360,24 @@ def run(
                 print(f"  Wave {i}: {nums}")
 
     if cfg.resume is not None:
-        print(f"  --resume={cfg.resume!r} parsed; reconstruction owned by #J6")
+        from atdd.coach.commands.durability import DecisionWriter
+        from atdd.coach.commands.resume import ResumeRunner
+
+        runtime_dir = Path(".atdd") / "runtime"
+        writer = DecisionWriter(runtime_dir=runtime_dir)
+        runner = ResumeRunner(
+            runtime_dir=runtime_dir,
+            run_id=cfg.resume,
+            decision_writer=writer,
+        )
+        reconstructed = runner.reconstruct()
+        print(f"  --resume={cfg.resume!r}: reconstructed {len(reconstructed)} issue(s)")
+        for issue, phase in sorted(reconstructed.items()):
+            print(f"    #{issue}: {phase}")
+        if not cfg.dry_run:
+            final = runner.drive_to_complete(cfg.issue_numbers)
+            for issue, phase in sorted(final.items()):
+                print(f"    #{issue} → {phase}")
 
     return 0
 

--- a/src/atdd/coach/commands/resume.py
+++ b/src/atdd/coach/commands/resume.py
@@ -1,0 +1,281 @@
+"""`atdd coach --resume <run-id>` runner — issue #511 / J6.
+
+Closes the durability loop. Reads `.atdd/runtime/coach/decisions.jsonl`,
+filters by `coach_run_id`, reconstructs the per-issue state-machine
+position (the most recent reached phase per issue), then drives the
+state machine forward to COMPLETE while consuming the idempotency
+contract from #498 / P001 so already-logged transitions never
+double-execute.
+
+The resume runner is the consumer of three producers:
+
+- ``decisions.jsonl`` (#498 / P001) — the durable transition log,
+  source of truth for "what already happened".
+- Idempotent worktree creation (#502 / E001) — re-running Phase A on
+  resume is a no-op for already-recorded creations.
+- Reattachable runtime watcher (#510 / M001) — events whose handlers
+  already completed (visible via ``decisions.jsonl``) are NOT
+  re-emitted; events that occurred during the kill window are
+  delivered now.
+
+Per spec §4.5: "On `--resume <run-id>`, coach reconstructs
+state-machine positions from the log. Actions are idempotent."
+
+Public surface:
+
+- ``read_decisions(runtime_dir, run_id)`` — load and filter the log.
+- ``reconstruct_state(runtime_dir, run_id)`` — most-recent phase per
+  issue, scoped to the run.
+- ``ResumeRunner`` — drives the lifecycle from a reconstructed state,
+  reattaches watchers, refuses to re-run already-logged transitions.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Optional
+
+from atdd.coach.commands.coach import (
+    PLANNED_PATH,
+    Phase,
+    can_transition,
+)
+from atdd.coach.commands.durability import DecisionWriter, transactional_decision
+from atdd.coach.commands.event_queue import (
+    CoachEventQueue,
+    NATURAL_KEY,
+    natural_key,
+)
+from atdd.coach.commands.runtime_watcher import RuntimeWatcher
+
+
+TransitionAction = Callable[[int, str, str], dict]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _phase_transition_decision_id(run_id: str, issue: int, src: str, dst: str) -> str:
+    return f"{run_id}:#{issue}:{src}->{dst}"
+
+
+def read_decisions(runtime_dir: Path, run_id: str) -> list[dict]:
+    """Return decision records for ``run_id``, in file (append) order."""
+    path = Path(runtime_dir) / "coach" / "decisions.jsonl"
+    if not path.exists():
+        return []
+    records: list[dict] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if rec.get("coach_run_id") == run_id:
+                records.append(rec)
+    return records
+
+
+def reconstruct_state(runtime_dir: Path, run_id: str) -> dict[int, str]:
+    """Return ``{issue_number: phase_name}`` for the resumed run.
+
+    The phase is the most recent ``target_phase`` per issue across all
+    ``phase-transition`` decisions for the run. Issues mentioned only
+    in non-transition decisions (``worktree-create``, ``agent-spawn``)
+    have no reconstructed phase entry — the state-machine position is
+    defined exclusively by ``phase-transition`` records per spec §4.5.
+    """
+    state: dict[int, str] = {}
+    for rec in read_decisions(runtime_dir, run_id):
+        if rec.get("decision_type") != "phase-transition":
+            continue
+        issue = rec.get("issue_number")
+        target = (rec.get("inputs") or {}).get("target_phase")
+        if issue is None or target is None:
+            continue
+        state[issue] = target
+    return state
+
+
+def _phase_index(phase_name: str) -> int:
+    """Return the index of ``phase_name`` in the canonical PLANNED_PATH.
+
+    Returns ``-1`` if the phase is not on the planned-path
+    (e.g. ``BLOCKED``); in that case the resume runner cannot make
+    forward progress without external intervention.
+    """
+    for i, p in enumerate(PLANNED_PATH):
+        if p.value == phase_name:
+            return i
+    return -1
+
+
+@dataclass
+class ResumeRunner:
+    """Drives a coach run forward from a reconstructed state.
+
+    The runner is constructed with a ``decision_writer`` (the same
+    append-only writer used by the original run; #498 / P001) and an
+    optional ``transition_action`` callable that performs the side
+    effect for one transition. The runner relies on the writer's
+    decision-id idempotency to skip already-logged transitions — so a
+    transition's action is only invoked when no record for it exists in
+    the durable log yet.
+    """
+
+    runtime_dir: Path
+    run_id: str
+    decision_writer: DecisionWriter
+    transition_action: Optional[TransitionAction] = None
+    _watcher: Optional[RuntimeWatcher] = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.runtime_dir = Path(self.runtime_dir)
+
+    # ------------------------------------------------------------------
+    # State reconstruction
+    # ------------------------------------------------------------------
+
+    def reconstruct(self) -> dict[int, str]:
+        return reconstruct_state(self.runtime_dir, self.run_id)
+
+    # ------------------------------------------------------------------
+    # Watcher reattachment
+    # ------------------------------------------------------------------
+
+    def attach_watchers(self) -> tuple[CoachEventQueue, RuntimeWatcher]:
+        """Reattach the runtime watcher and replay pending events.
+
+        Marks every event already represented in ``decisions.jsonl`` as
+        handled BEFORE replay, so events whose handlers completed are
+        not re-emitted. Events that occurred during the kill window
+        but whose handlers had not run are delivered now via the
+        watcher's ``replay_from_disk()`` machinery.
+
+        Returns the queue and the started watcher; callers are
+        responsible for ``watcher.stop()``.
+        """
+        queue = CoachEventQueue(runtime_dir=self.runtime_dir)
+        watcher = RuntimeWatcher(runtime_dir=self.runtime_dir, queue=queue)
+        self._mark_handled_from_decisions(watcher)
+        watcher.replay_from_disk()
+        watcher.persist_checkpoint()
+        watcher.start()
+        self._watcher = watcher
+        return queue, watcher
+
+    def _mark_handled_from_decisions(self, watcher: RuntimeWatcher) -> None:
+        """Tell the watcher to suppress events whose handlers already
+        completed.
+
+        The mapping from decision → event natural-key is governed by
+        the decision's ``inputs`` payload. Decisions emitted by handlers
+        for a given ``event_type`` use input keys that mirror that
+        type's natural-key tuple from ``event_queue.NATURAL_KEY``.
+        """
+        for rec in read_decisions(self.runtime_dir, self.run_id):
+            event = self._decision_to_event(rec)
+            if event is None:
+                continue
+            watcher.mark_handled(event)
+
+    @staticmethod
+    def _decision_to_event(rec: dict) -> Optional[dict]:
+        """Best-effort recovery of an event-shaped dict from a decision
+        record so the watcher's natural-key index can recognize it.
+
+        Returns ``None`` when the decision does not correspond to a
+        handled event (e.g. ``worktree-create``, ``agent-spawn`` write
+        their own events but those are emitted directly by coach, not
+        handled-by-coach).
+        """
+        dtype = rec.get("decision_type") or ""
+        inputs = rec.get("inputs") or {}
+        if dtype.startswith("commit-"):
+            event_type = "commit_observed"
+        elif dtype in NATURAL_KEY:
+            event_type = dtype
+        else:
+            return None
+        # Build a synthetic event using the inputs payload. We lift the
+        # natural-key fields back into the event shape: top-level keys
+        # land at the top level, ``payload.X`` keys land in payload.
+        ev: dict = {"event_type": event_type, "payload": {}}
+        keys = NATURAL_KEY.get(event_type, ())
+        for key in keys:
+            if key.startswith("payload."):
+                pkey = key.split(".", 1)[1]
+                if pkey in inputs:
+                    ev["payload"][pkey] = inputs[pkey]
+            else:
+                if key in inputs:
+                    ev[key] = inputs[key]
+        return ev
+
+    # ------------------------------------------------------------------
+    # Driving forward
+    # ------------------------------------------------------------------
+
+    def drive_to_complete(self, issue_numbers: list[int]) -> dict[int, str]:
+        """Walk each issue from its reconstructed phase to COMPLETE.
+
+        For every transition along ``PLANNED_PATH``, we consult the
+        durable log via ``transactional_decision``: if a record for the
+        transition already exists the action is skipped (this is the
+        consumer side of P001's idempotency contract); otherwise the
+        action is invoked and a new record is appended.
+
+        Returns the final phase per issue.
+        """
+        reconstructed = self.reconstruct()
+        final: dict[int, str] = {}
+
+        for issue in issue_numbers:
+            phase_name = reconstructed.get(issue, Phase.INIT.value)
+            idx = _phase_index(phase_name)
+            if idx < 0:
+                # BLOCKED or unknown; the resume runner cannot make
+                # forward progress without operator action. Leave the
+                # phase as-is and continue with siblings.
+                final[issue] = phase_name
+                continue
+
+            current = phase_name
+            while current != Phase.COMPLETE.value:
+                idx = _phase_index(current)
+                if idx < 0 or idx + 1 >= len(PLANNED_PATH):
+                    break
+                next_phase = PLANNED_PATH[idx + 1]
+                # Stop walking past COMPLETE — MERGED is owned by the
+                # PR-merge handler, not the per-issue resume runner.
+                if next_phase == Phase.MERGED:
+                    break
+                if not can_transition(Phase(current), next_phase):
+                    break
+
+                self._step_transition(issue, current, next_phase.value)
+                current = next_phase.value
+
+            final[issue] = current
+
+        return final
+
+    def _step_transition(self, issue: int, src: str, dst: str) -> None:
+        record = {
+            "decision_id": _phase_transition_decision_id(self.run_id, issue, src, dst),
+            "timestamp": _now(),
+            "coach_run_id": self.run_id,
+            "issue_number": issue,
+            "decision_type": "phase-transition",
+            "inputs": {"current_phase": src, "target_phase": dst},
+            "outcome": {"transitioned": True, "new_phase": dst},
+        }
+        with transactional_decision(self.decision_writer, record) as run_action:
+            if run_action and self.transition_action is not None:
+                self.transition_action(issue, src, dst)

--- a/src/atdd/coach/commands/tests/test_R001_integration_001_resume_mid_run.py
+++ b/src/atdd/coach/commands/tests/test_R001_integration_001_resume_mid_run.py
@@ -1,0 +1,123 @@
+# URN: test:drive-state-machine:coach-state-machine-and-runtime:R001-INTEGRATION-001-resume-mid-run
+# Acceptance: acc:drive-state-machine:R001-INTEGRATION-001-resume-mid-run
+# WMBT: wmbt:drive-state-machine:R001
+# Phase: RED
+# Layer: integration
+"""R001-INTEGRATION-001 — `atdd coach --resume <run-id>` reconstructs
+per-issue state from `decisions.jsonl` and proceeds without
+re-executing already-logged transitions.
+
+Given a coach run killed after issue 358 reached PLANNED but before
+RED, when `--resume <run-id>` is invoked, then coach reads the durable
+log, recognizes #358 as PLANNED, skips the INIT → PLANNED transition
+(idempotency from #498 / P001), and drives toward the next allowed
+transition per the §4.1 state-transition table.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _seed_decision(writer, *, run_id: str, issue: int, src: str, dst: str, ts: str) -> None:
+    writer.append({
+        "decision_id": f"{run_id}:#{issue}:{src}->{dst}",
+        "timestamp": ts,
+        "coach_run_id": run_id,
+        "issue_number": issue,
+        "decision_type": "phase-transition",
+        "inputs": {"current_phase": src, "target_phase": dst},
+        "outcome": {"transitioned": True, "new_phase": dst},
+    })
+
+
+def test_resume_reconstructs_phase_from_decisions_jsonl(tmp_path):
+    """The most-recent reached phase per issue is reconstructed from
+    decisions.jsonl filtered by coach_run_id."""
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import reconstruct_state
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    run_id = "run-r001-1"
+    _seed_decision(writer, run_id=run_id, issue=358, src="INIT", dst="PLANNED",
+                   ts="2026-05-09T13:00:00Z")
+    # Decoy from a different run-id must be ignored.
+    _seed_decision(writer, run_id="other-run", issue=358, src="PLANNED", dst="RED",
+                   ts="2026-05-09T13:30:00Z")
+
+    state = reconstruct_state(runtime_dir=tmp_path, run_id=run_id)
+    assert state == {358: "PLANNED"}, (
+        f"reconstruct_state must filter by coach_run_id and pick the most "
+        f"recent target_phase per issue; got {state}"
+    )
+
+
+def test_resume_skips_already_logged_transitions(tmp_path):
+    """When the resume runner walks the planned path, transitions whose
+    decision_id already exists in the durable log are recognized as done
+    (the consumer side of P001's idempotency contract) — the
+    corresponding action handler is NOT re-invoked."""
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    run_id = "run-r001-2"
+    # Pre-seed: INIT → PLANNED already happened.
+    _seed_decision(writer, run_id=run_id, issue=358, src="INIT", dst="PLANNED",
+                   ts="2026-05-09T13:00:00Z")
+
+    invoked: list[tuple[int, str, str]] = []
+
+    def action(issue: int, src: str, dst: str) -> dict:
+        invoked.append((issue, src, dst))
+        return {"transitioned": True, "new_phase": dst}
+
+    runner = ResumeRunner(
+        runtime_dir=tmp_path,
+        run_id=run_id,
+        decision_writer=writer,
+        transition_action=action,
+    )
+    runner.drive_to_complete(issue_numbers=[358])
+
+    # The INIT → PLANNED handler must NOT have been invoked (it was
+    # already logged). PLANNED → RED → ... → COMPLETE handlers run.
+    assert (358, "INIT", "PLANNED") not in invoked, (
+        "already-logged transition was re-executed during resume"
+    )
+    # Forward progress: subsequent transitions were driven.
+    assert (358, "PLANNED", "RED") in invoked, (
+        f"resume runner must drive forward from reconstructed phase; "
+        f"invoked={invoked}"
+    )
+
+
+def test_resume_run_completes_killed_issue(tmp_path):
+    """End-to-end: a coach run killed at PLANNED reaches COMPLETE for
+    the resumed issue without manual intervention."""
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    run_id = "run-r001-3"
+    _seed_decision(writer, run_id=run_id, issue=358, src="INIT", dst="PLANNED",
+                   ts="2026-05-09T13:00:00Z")
+
+    def action(issue: int, src: str, dst: str) -> dict:
+        return {"transitioned": True, "new_phase": dst}
+
+    runner = ResumeRunner(
+        runtime_dir=tmp_path,
+        run_id=run_id,
+        decision_writer=writer,
+        transition_action=action,
+    )
+    final_phases = runner.drive_to_complete(issue_numbers=[358])
+
+    assert final_phases.get(358) == "COMPLETE", (
+        f"resumed issue must reach COMPLETE; got {final_phases}"
+    )

--- a/src/atdd/coach/commands/tests/test_R001_integration_002_no_duplicate_transitions.py
+++ b/src/atdd/coach/commands/tests/test_R001_integration_002_no_duplicate_transitions.py
@@ -1,0 +1,111 @@
+# URN: test:drive-state-machine:coach-state-machine-and-runtime:R001-INTEGRATION-002-no-duplicate-transitions
+# Acceptance: acc:drive-state-machine:R001-INTEGRATION-002-no-duplicate-transitions
+# WMBT: wmbt:drive-state-machine:R001
+# Phase: RED
+# Layer: integration
+"""R001-INTEGRATION-002 — Resume does not write duplicate transitions
+to ``decisions.jsonl``.
+
+The action-precedes-write invariant from #498 / P001 holds; the resume
+logic prevents re-execution upstream so duplicates never reach the
+writer. The log contains each transition exactly once across the
+original and resumed runs.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _seed_decision(writer, *, run_id: str, issue: int, src: str, dst: str, ts: str) -> None:
+    writer.append({
+        "decision_id": f"{run_id}:#{issue}:{src}->{dst}",
+        "timestamp": ts,
+        "coach_run_id": run_id,
+        "issue_number": issue,
+        "decision_type": "phase-transition",
+        "inputs": {"current_phase": src, "target_phase": dst},
+        "outcome": {"transitioned": True, "new_phase": dst},
+    })
+
+
+def test_no_duplicate_decisions_after_resume(tmp_path):
+    """Pre-seeded transitions are not duplicated by the resumed run.
+
+    Original run logs INIT → PLANNED. Resume drives the issue forward to
+    COMPLETE. The final log contains each transition exactly once.
+    """
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    run_id = "run-r001-dup"
+    _seed_decision(writer, run_id=run_id, issue=358, src="INIT", dst="PLANNED",
+                   ts="2026-05-09T13:00:00Z")
+
+    def action(issue: int, src: str, dst: str) -> dict:
+        return {"transitioned": True, "new_phase": dst}
+
+    runner = ResumeRunner(
+        runtime_dir=tmp_path,
+        run_id=run_id,
+        decision_writer=writer,
+        transition_action=action,
+    )
+    runner.drive_to_complete(issue_numbers=[358])
+
+    records = _read_jsonl(writer.path)
+    decision_ids = [r["decision_id"] for r in records]
+    assert len(decision_ids) == len(set(decision_ids)), (
+        f"decisions.jsonl contains duplicate decision_ids after resume; "
+        f"got {decision_ids}"
+    )
+
+    init_planned = [r for r in records
+                    if r["inputs"].get("current_phase") == "INIT"
+                    and r["inputs"].get("target_phase") == "PLANNED"]
+    assert len(init_planned) == 1, (
+        f"INIT → PLANNED was logged {len(init_planned)} times; resume "
+        f"re-executed an already-logged transition"
+    )
+
+
+def test_resume_reaches_complete_for_resumed_issue(tmp_path):
+    """The resumed issue reaches the COMPLETE phase exactly once in
+    the durable log."""
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    run_id = "run-r001-complete"
+    _seed_decision(writer, run_id=run_id, issue=358, src="INIT", dst="PLANNED",
+                   ts="2026-05-09T13:00:00Z")
+    _seed_decision(writer, run_id=run_id, issue=358, src="PLANNED", dst="RED",
+                   ts="2026-05-09T13:30:00Z")
+
+    def action(issue: int, src: str, dst: str) -> dict:
+        return {"transitioned": True, "new_phase": dst}
+
+    runner = ResumeRunner(
+        runtime_dir=tmp_path,
+        run_id=run_id,
+        decision_writer=writer,
+        transition_action=action,
+    )
+    runner.drive_to_complete(issue_numbers=[358])
+
+    records = _read_jsonl(writer.path)
+    completes = [r for r in records
+                 if r["inputs"].get("target_phase") == "COMPLETE"]
+    assert len(completes) == 1, (
+        f"COMPLETE transition was logged {len(completes)} times; "
+        f"resume must produce exactly one COMPLETE entry"
+    )

--- a/src/atdd/coach/commands/tests/test_R001_integration_003_watcher_reconstruct.py
+++ b/src/atdd/coach/commands/tests/test_R001_integration_003_watcher_reconstruct.py
@@ -1,0 +1,200 @@
+# URN: test:drive-state-machine:coach-state-machine-and-runtime:R001-INTEGRATION-003-watcher-reconstruct
+# Acceptance: acc:drive-state-machine:R001-INTEGRATION-003-watcher-reconstruct
+# WMBT: wmbt:drive-state-machine:R001
+# Phase: RED
+# Layer: integration
+"""R001-INTEGRATION-003 — Resume reattaches the runtime watcher and
+preserves the event-semantics replay contract.
+
+Per `event-semantics.md` (#483):
+- events whose handlers already completed (visible via
+  `decisions.jsonl`) are NOT re-emitted on resume;
+- events that occurred during the kill window but whose handlers had
+  not run are delivered now;
+- the single coach event queue receives each event exactly once.
+
+The resume runner is responsible for hydrating the watcher's "handled"
+set from the durable decision log before calling
+``replay_from_disk()``, then emitting the queued events to whatever
+consumer the runner is driving.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _agent_dir(runtime_dir: Path, agent_id: str) -> Path:
+    d = runtime_dir / "agents" / agent_id
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _seed_events(agent_dir: Path, events: list[dict]) -> None:
+    path = agent_dir / "events.jsonl"
+    with path.open("a") as fh:
+        for ev in events:
+            fh.write(json.dumps(ev) + "\n")
+
+
+def _seed_decision(writer, *, run_id: str, decision_id: str,
+                   issue: int, dtype: str, inputs: dict, outcome: dict,
+                   ts: str = "2026-05-09T13:00:00Z") -> None:
+    writer.append({
+        "decision_id": decision_id,
+        "timestamp": ts,
+        "coach_run_id": run_id,
+        "issue_number": issue,
+        "decision_type": dtype,
+        "inputs": inputs,
+        "outcome": outcome,
+    })
+
+
+def test_watcher_reattaches_with_queue_and_event_stream(tmp_path):
+    """ResumeRunner.attach_watchers() returns a started RuntimeWatcher
+    bound to a CoachEventQueue and replays from on-disk state."""
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    runtime = tmp_path
+    agent_dir = _agent_dir(runtime, "agent-r001")
+    _seed_events(agent_dir, [
+        {
+            "event_type": "commit_observed",
+            "agent_id": "agent-r001",
+            "timestamp": "2026-05-09T14:00:00Z",
+            "payload": {"sha": "deadbeef", "branch": "feat/foo",
+                        "worktree_path": "/x"},
+        },
+    ])
+
+    writer = DecisionWriter(runtime_dir=runtime)
+
+    runner = ResumeRunner(
+        runtime_dir=runtime,
+        run_id="run-r001-watch-1",
+        decision_writer=writer,
+    )
+    queue, watcher = runner.attach_watchers()
+    try:
+        events = queue.drain()
+        commit_events = [e for e in events if e["event_type"] == "commit_observed"]
+        assert len(commit_events) == 1, (
+            f"reattachment must replay unhandled cached events; got "
+            f"{len(commit_events)}"
+        )
+        assert commit_events[0]["payload"]["sha"] == "deadbeef"
+    finally:
+        watcher.stop()
+
+
+def test_handled_events_not_re_emitted(tmp_path):
+    """Events whose handlers already completed (visible in
+    decisions.jsonl) are NOT re-emitted on resume.
+
+    The resume runner inspects decision records and marks the matching
+    natural-key entries on the watcher BEFORE replay_from_disk(). The
+    queue therefore does not see the handled event.
+    """
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    runtime = tmp_path
+    agent_dir = _agent_dir(runtime, "agent-r001-handled")
+    _seed_events(agent_dir, [
+        {
+            "event_type": "commit_observed",
+            "agent_id": "agent-r001-handled",
+            "timestamp": "2026-05-09T14:00:00Z",
+            "payload": {"sha": "handled-sha", "branch": "feat/handled",
+                        "worktree_path": "/x"},
+        },
+        {
+            "event_type": "commit_observed",
+            "agent_id": "agent-r001-handled",
+            "timestamp": "2026-05-09T14:05:00Z",
+            "payload": {"sha": "pending-sha", "branch": "feat/pending",
+                        "worktree_path": "/x"},
+        },
+    ])
+
+    writer = DecisionWriter(runtime_dir=runtime)
+    run_id = "run-r001-watch-2"
+    # The handler for `handled-sha` already completed and produced a
+    # decision; the runner must consult this and suppress the replay
+    # of that event.
+    _seed_decision(writer, run_id=run_id,
+                   decision_id=f"{run_id}:agent-r001-handled:commit-handled-sha",
+                   issue=358, dtype="commit-observed",
+                   inputs={"sha": "handled-sha",
+                           "agent_id": "agent-r001-handled"},
+                   outcome={"handled": True, "sha": "handled-sha"})
+
+    runner = ResumeRunner(
+        runtime_dir=runtime,
+        run_id=run_id,
+        decision_writer=writer,
+    )
+    queue, watcher = runner.attach_watchers()
+    try:
+        commit_events = [e for e in queue.drain()
+                         if e["event_type"] == "commit_observed"]
+        shas = [e["payload"]["sha"] for e in commit_events]
+        assert "handled-sha" not in shas, (
+            f"already-handled event was re-emitted on resume; got {shas}"
+        )
+        assert "pending-sha" in shas, (
+            f"unhandled cached event must be delivered on resume; got {shas}"
+        )
+    finally:
+        watcher.stop()
+
+
+def test_each_event_arrives_exactly_once(tmp_path):
+    """The single coach event queue receives each event exactly once
+    per its natural-key contract — duplicate replay emissions collapse
+    to one consumer-visible event."""
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    runtime = tmp_path
+    agent_dir = _agent_dir(runtime, "agent-r001-dedup")
+    _seed_events(agent_dir, [
+        {
+            "event_type": "commit_observed",
+            "agent_id": "agent-r001-dedup",
+            "timestamp": "2026-05-09T14:00:00Z",
+            "payload": {"sha": "abc", "branch": "feat/x",
+                        "worktree_path": "/x"},
+        },
+        # Duplicate emission with same natural-key (payload.sha).
+        {
+            "event_type": "commit_observed",
+            "agent_id": "agent-r001-dedup",
+            "timestamp": "2026-05-09T14:01:00Z",
+            "payload": {"sha": "abc", "branch": "feat/x",
+                        "worktree_path": "/x"},
+        },
+    ])
+
+    writer = DecisionWriter(runtime_dir=runtime)
+    runner = ResumeRunner(
+        runtime_dir=runtime,
+        run_id="run-r001-watch-3",
+        decision_writer=writer,
+    )
+    queue, watcher = runner.attach_watchers()
+    try:
+        commit_events = [e for e in queue.drain()
+                         if e["event_type"] == "commit_observed"]
+        assert len(commit_events) == 1, (
+            f"natural-key dedup must collapse duplicate emissions; "
+            f"got {len(commit_events)}"
+        )
+    finally:
+        watcher.stop()

--- a/src/atdd/coach/commands/tests/test_R001_smoke_001_resume_real_runtime.py
+++ b/src/atdd/coach/commands/tests/test_R001_smoke_001_resume_real_runtime.py
@@ -1,0 +1,138 @@
+# URN: test:drive-state-machine:coach-state-machine-and-runtime:R001-SMOKE-001-resume-real-runtime
+# Acceptance: acc:drive-state-machine:R001-INTEGRATION-001-resume-mid-run
+# WMBT: wmbt:drive-state-machine:R001
+# Phase: SMOKE
+# Layer: assembly
+# Smoke: true
+# Purpose: exercise the J6 resume runner against the real runtime layout
+"""R001 SMOKE — exercise ``ResumeRunner`` against the real runtime
+layout and the committed C0 schemas.
+
+What this verifies that the integration tests do not:
+- The runner reads ``decisions.jsonl`` written by the *real* J3
+  ``DecisionWriter`` against the *committed* C0 schemas (no fixtures).
+- The kill-and-resume cycle is end-to-end durable on the real
+  filesystem: a first run logs INIT → PLANNED, the writer is closed,
+  a fresh ``ResumeRunner`` is constructed, and forward progress
+  reaches COMPLETE without re-executing any logged transition.
+- Watcher reattachment uses the real ``runtime/agents/<id>/`` layout
+  per ``runtime-layout.md`` and the natural-key dedup in the real
+  ``CoachEventQueue``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_smoke_kill_and_resume_end_to_end_on_real_fs(tmp_path):
+    """End-to-end kill-and-resume on the real filesystem."""
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    runtime = tmp_path / ".atdd" / "runtime"
+
+    # ----- "Original" run: INIT → PLANNED then process killed.
+    writer = DecisionWriter(runtime_dir=runtime)
+    run_id = "smoke-run-r001"
+    writer.append({
+        "decision_id": f"{run_id}:#358:INIT->PLANNED",
+        "timestamp": "2026-05-09T13:00:00Z",
+        "coach_run_id": run_id,
+        "issue_number": 358,
+        "decision_type": "phase-transition",
+        "inputs": {"current_phase": "INIT", "target_phase": "PLANNED"},
+        "outcome": {"transitioned": True, "new_phase": "PLANNED"},
+    })
+    # Drop the writer instance to mimic process death.
+    del writer
+
+    # ----- Resumed run: fresh writer + runner, no in-memory continuity.
+    writer2 = DecisionWriter(runtime_dir=runtime)
+    actions: list[tuple[int, str, str]] = []
+
+    def action(issue: int, src: str, dst: str) -> dict:
+        actions.append((issue, src, dst))
+        return {"transitioned": True, "new_phase": dst}
+
+    runner = ResumeRunner(
+        runtime_dir=runtime,
+        run_id=run_id,
+        decision_writer=writer2,
+        transition_action=action,
+    )
+    final = runner.drive_to_complete([358])
+
+    assert final[358] == "COMPLETE"
+    # No re-execution of the already-logged INIT → PLANNED.
+    assert (358, "INIT", "PLANNED") not in actions
+    # Forward progress was driven through every PLANNED-path step.
+    expected_path = [
+        (358, "PLANNED", "RED"),
+        (358, "RED", "GREEN"),
+        (358, "GREEN", "SMOKE"),
+        (358, "SMOKE", "REFACTOR"),
+        (358, "REFACTOR", "COMPLETE"),
+    ]
+    assert actions == expected_path, (
+        f"resume must drive PLANNED → COMPLETE step by step; got {actions}"
+    )
+
+    records = _read_jsonl(runtime / "coach" / "decisions.jsonl")
+    decision_ids = [r["decision_id"] for r in records]
+    assert len(decision_ids) == len(set(decision_ids)), (
+        "no duplicate decision_ids on the real fs after resume"
+    )
+
+
+def test_smoke_watcher_reattach_against_real_runtime_layout(tmp_path):
+    """Watcher reattaches against the real ``agents/<id>/`` layout."""
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    runtime = tmp_path / ".atdd" / "runtime"
+    agent_dir = runtime / "agents" / "smoke-agent"
+    agent_dir.mkdir(parents=True, exist_ok=True)
+
+    events_path = agent_dir / "events.jsonl"
+    with events_path.open("w") as fh:
+        fh.write(json.dumps({
+            "event_type": "commit_observed",
+            "agent_id": "smoke-agent",
+            "timestamp": "2026-05-09T14:00:00Z",
+            "payload": {"sha": "smoke-sha", "branch": "feat/smoke",
+                        "worktree_path": "/x"},
+        }) + "\n")
+
+    writer = DecisionWriter(runtime_dir=runtime)
+    runner = ResumeRunner(
+        runtime_dir=runtime,
+        run_id="smoke-watcher-r001",
+        decision_writer=writer,
+    )
+    queue, watcher = runner.attach_watchers()
+    try:
+        events = queue.drain()
+        commit_events = [e for e in events if e["event_type"] == "commit_observed"]
+        assert len(commit_events) == 1
+        assert commit_events[0]["payload"]["sha"] == "smoke-sha"
+
+        # The runtime watcher's checkpoint file lives at
+        # runtime/coach/watcher-checkpoint.json per
+        # runtime-watcher.persist_checkpoint(). Verify it is on disk
+        # after attach_watchers() so a subsequent restart picks it up.
+        checkpoint = runtime / "coach" / "watcher-checkpoint.json"
+        assert checkpoint.exists(), (
+            "attach_watchers() must persist the watcher checkpoint to "
+            "the real runtime/coach/ tree"
+        )
+    finally:
+        watcher.stop()


### PR DESCRIPTION
Closes #511.

J6 closes the durability loop. Implements `atdd coach --resume <run-id>` per spec §4.5: reads `decisions.jsonl`, reconstructs the per-issue state-machine position from logged transitions, skips already-logged actions via P001's idempotency contract, and reattaches the runtime watcher without losing the event stream.

## Summary

- New module `src/atdd/coach/commands/resume.py`:
  - `read_decisions(runtime_dir, run_id)` — load and filter `decisions.jsonl` by `coach_run_id`.
  - `reconstruct_state(runtime_dir, run_id)` — most-recent target_phase per issue across `phase-transition` records.
  - `ResumeRunner.drive_to_complete()` — walks `PLANNED_PATH` from the reconstructed phase, consulting `transactional_decision` so already-logged transitions skip the action and never produce a duplicate log entry.
  - `ResumeRunner.attach_watchers()` — hydrates the runtime watcher's handled-set from `decisions.jsonl` before `replay_from_disk()` so events whose handlers completed are not re-emitted; events from the kill window are delivered.
- `coach.run()` invokes `ResumeRunner` when `--resume` is set: prints reconstructed state and drives forward unless `--dry-run`.

## Test plan

- [x] AC-INTEGRATION-001 — resume mid-run reconstructs phase from `decisions.jsonl`, skips already-logged transitions, drives forward to COMPLETE.
- [x] AC-INTEGRATION-002 — no duplicate transitions in `decisions.jsonl` across the kill-restart boundary.
- [x] AC-INTEGRATION-003 — watcher reattaches with replay-suppressed handled events and exactly-once event delivery.
- [x] R001 SMOKE — end-to-end kill-and-resume on the real fs; watcher checkpoint persisted to real `runtime/coach/`.
- [x] All 681 pre-existing coach command tests still pass.

## Release Gate

- [x] Version bump: 3.19.0 → 3.20.0 (MINOR — `feat/`).