### PR TITLE
feat(coach): `atdd spawn` skeleton wrapping session_template render (#499)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -439,6 +439,17 @@ sessions:
   wagon: drive-state-machine
   feature: feature:drive-state-machine:coach-state-machine-and-runtime
   train: 0002-coach-drives-lifecycle
+- id: '499'
+  slug: coach-v9-k1-spawn-skeleton
+  file: null
+  issue_number: 499
+  type: feat
+  status: RED
+  created: '2026-05-09'
+  archived: null
+  wagon: spawn-agents
+  feature: feature:spawn-agents:atdd-spawn-skeleton-and-harness
+  train: 0002-coach-drives-lifecycle
 - id: '501'
   slug: coach-v9-o1-atdd-judge-core
   file: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.20.0"
+version = "3.21.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -1076,6 +1076,25 @@ Phase descriptions:
         help="Forwarded to atdd.coach.commands.observer",
     )
 
+    # ----- atdd spawn ... (K1 — #499) -----
+    # Single rule-IDed entry point for every coach v9 persona launch.
+    # Sub-arg surface lives in `atdd.coach.commands.spawn._build_parser`;
+    # we register `spawn` here and forward argv so the surface stays in
+    # one place.
+    spawn_parser = subparsers.add_parser(
+        "spawn",
+        help=(
+            "Coach v9 persona launch: render launch prompt, dispatch "
+            "multiplexer, run per-LLM adapter, emit agent_spawned event."
+        ),
+        add_help=False,
+    )
+    spawn_parser.add_argument(
+        "spawn_argv",
+        nargs=argparse.REMAINDER,
+        help="Forwarded to atdd.coach.commands.spawn",
+    )
+
     # ----- atdd judge --prompt-template ... --schema ... --inputs ... -----
     # O1 (#501): single boundary for ambiguous coach v9 routing decisions.
     # Renders a prompt template, calls a structured-output LLM via the
@@ -2296,6 +2315,11 @@ Phase descriptions:
     elif args.command == "observer":
         from atdd.coach.commands.observer import run as run_observer
         return run_observer(list(getattr(args, "observer_argv", []) or []))
+
+    # atdd spawn ... (K1 — #499)
+    elif args.command == "spawn":
+        from atdd.coach.commands.spawn import run as run_spawn
+        return run_spawn(list(getattr(args, "spawn_argv", []) or []))
 
     # atdd judge ...  (O1 — #501)
     elif args.command == "judge":

--- a/src/atdd/coach/commands/spawn.py
+++ b/src/atdd/coach/commands/spawn.py
@@ -121,7 +121,11 @@ def _create_surface(
         return multiplexer.new_surface(
             cwd=str(worktree), command=command, name=name,
         )
-    except NotImplementedError:
+    except NotImplementedError:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        # Documented fallback per utils/multiplexer.py: tmux/zellij
+        # backends raise NotImplementedError on new_surface; we degrade
+        # to new_workspace so spawn works on every backend the
+        # abstraction supports.
         return multiplexer.new_workspace(
             cwd=str(worktree), command=command, name=name,
         )

--- a/src/atdd/coach/commands/spawn.py
+++ b/src/atdd/coach/commands/spawn.py
@@ -1,0 +1,307 @@
+# URN: component:spawn-agents:atdd-spawn-skeleton-and-harness:spawn:application
+# Runtime: python
+# Purpose: Single rule-IDed entry point that wraps session_template.render, dispatches the multiplexer surface, runs the per-LLM adapter, and emits an agent_spawned runtime event (spec v9 §5.2 / §7.1).
+
+"""`atdd spawn` — coach v9 K1 spawn skeleton (issue #499).
+
+Single rule-IDed launch surface that every coach v9 persona launch
+(planner / tester / coder / reviewer) flows through. K1 ships:
+
+1. The CLI per spec §5.2 with the required flag set
+   (``--persona``, ``--llm``, ``--worktree``, ``--issue``, ``--agent-id``,
+   ``--runtime``, plus optional ``--phase``, ``--target-commit``,
+   ``--prior-attempt``, ``--multiplexer-ref``).
+2. A thin wrapper around ``session_template.render`` that writes
+   ``<worktree>/.launch_prompt.txt``.
+3. Multiplexer dispatch via the existing ``get_multiplexer`` abstraction
+   (cmux / zellij / tmux backends).
+4. A per-``--llm`` adapter registry; K1 ships ``claude-code``. Codex /
+   gemini / glm land in K-track follow-ups by registering on the same
+   registry without editing the CLI surface.
+5. An ``agent_spawned`` runtime event written to
+   ``<runtime>/agents/<agent_id>/events.jsonl`` conforming to
+   ``runtime-event.schema.json`` (frozen at #483).
+
+Out of scope (each owned by an adjacent K-track issue):
+- Substrate spawn-harness blocks ``wmbt_rules`` / ``train_rules`` /
+  ``security_rules`` (#K2).
+- Canonical-naming + layout pass post-launch (#K3).
+- Per-LLM convention file generation: CLAUDE.md / AGENTS.md / GLM.md /
+  GEMINI.md (#K4 + #P3).
+- Codex / gemini / glm adapter implementations (separate K-track).
+- Coach-state-machine integration (#496 + #J4).
+- Worktree creation (#J4 — K1 assumes ``--worktree`` exists).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+# Canonical rule-ID emitted on every spawn (spec §5.2 / §7.1). Observers
+# bind on this anchor to correlate spawn-time decisions with downstream
+# events. K-track follow-ups extend the namespace; the prefix is frozen.
+SPAWN_RULE_ID = "coach.spawn.atdd-spawn-cli"
+
+PERSONAS: tuple[str, ...] = ("planner", "tester", "coder", "reviewer")
+
+
+# ---------------------------------------------------------------------------
+# Adapter registry — open extension point per acceptance E001-UNIT-002
+# ---------------------------------------------------------------------------
+
+
+def _claude_code_adapter(prompt_path: Path) -> str:
+    """Spec §5.2: shell out to ``claude`` with the rendered launch prompt
+    inlined via ``$(cat <prompt>)``. The shell expands the substitution
+    inside the multiplexer surface so claude receives the full prompt as
+    one argv element."""
+    return f'claude --dangerously-skip-permissions "$(cat {prompt_path})"'
+
+
+# Open extension point — codex / gemini / glm follow-up issues register
+# their adapters here without editing this module's CLI surface.
+ADAPTER_REGISTRY: dict[str, Callable[[Path], str]] = {
+    "claude-code": _claude_code_adapter,
+}
+
+
+# ---------------------------------------------------------------------------
+# Multiplexer resolution (split out so tests can inject a fake)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_multiplexer(preferred: Optional[str] = None):
+    """Resolve the multiplexer backend. Tests monkeypatch this to inject
+    a fake; production calls ``get_multiplexer(preferred)``."""
+    from atdd.coach.utils.multiplexer import get_multiplexer
+
+    return get_multiplexer(preferred=preferred)
+
+
+# ---------------------------------------------------------------------------
+# Core spawn flow
+# ---------------------------------------------------------------------------
+
+
+def _render_launch_prompt(issue: int, worktree: Path) -> Path:
+    """Wrap ``session_template`` to render the launch prompt and write
+    it to ``<worktree>/.launch_prompt.txt``. Returns the prompt path."""
+    from atdd.coach.commands import session_template
+
+    fetched = session_template.fetch_issue(issue)
+    body = (fetched or {}).get("body") or ""
+    title = (fetched or {}).get("title") or ""
+    context = session_template.build_context(
+        issue_number=issue,
+        body=body,
+        title=title,
+        worktree_path=str(worktree),
+    )
+    rendered = session_template.render(context)
+    prompt_path = worktree / ".launch_prompt.txt"
+    prompt_path.parent.mkdir(parents=True, exist_ok=True)
+    prompt_path.write_text(rendered)
+    return prompt_path
+
+
+def _create_surface(
+    multiplexer,
+    *,
+    worktree: Path,
+    command: str,
+    name: str,
+) -> str:
+    """Dispatch to the multiplexer. Prefer ``new_surface`` (the cmux
+    workspace+pane+surface model used by orchestrate); fall back to
+    ``new_workspace`` for tmux / zellij backends per the abstraction
+    contract in ``utils/multiplexer.py``."""
+    try:
+        return multiplexer.new_surface(
+            cwd=str(worktree), command=command, name=name,
+        )
+    except NotImplementedError:
+        return multiplexer.new_workspace(
+            cwd=str(worktree), command=command, name=name,
+        )
+
+
+def cmd_spawn(
+    *,
+    persona: str,
+    llm: str,
+    worktree: Path,
+    issue: int,
+    agent_id: str,
+    runtime_root: Path,
+    phase: Optional[str] = None,
+    target_commit: Optional[str] = None,
+    prior_attempt: Optional[str] = None,
+    multiplexer_ref: Optional[str] = None,
+    multiplexer: Any = None,
+) -> dict:
+    """Render the launch prompt, dispatch the multiplexer, run the
+    per-LLM adapter, and emit the ``agent_spawned`` event.
+
+    Returns a dict with keys ``launch_prompt_path``, ``surface_ref``,
+    ``command``, ``rule_id`` for callers that want to log or chain.
+    """
+    if persona not in PERSONAS:
+        raise ValueError(
+            f"persona {persona!r} not in {PERSONAS} — extend PERSONAS to add."
+        )
+    if llm not in ADAPTER_REGISTRY:
+        registered = sorted(ADAPTER_REGISTRY.keys())
+        raise ValueError(
+            f"llm {llm!r} has no registered adapter. "
+            f"Registered: {registered}. Add a new adapter to "
+            f"ADAPTER_REGISTRY in spawn.py without editing the CLI surface."
+        )
+
+    worktree = Path(worktree)
+    runtime_root = Path(runtime_root)
+
+    prompt_path = _render_launch_prompt(issue, worktree)
+    adapter = ADAPTER_REGISTRY[llm]
+    command = adapter(prompt_path)
+
+    backend = multiplexer if multiplexer is not None else _resolve_multiplexer()
+    surface_ref = _create_surface(
+        backend, worktree=worktree, command=command, name=agent_id,
+    )
+
+    # Emit agent_spawned event via the existing agent.cmd_event primitive
+    # so the schema-conforming write path is shared with #J2 (#497).
+    from atdd.coach.commands import agent as agent_mod
+
+    payload: dict[str, Any] = {
+        "persona": persona,
+        "llm": llm,
+        "worktree": str(worktree),
+        "issue": int(issue),
+        "surface_ref": surface_ref,
+        "rule_id": SPAWN_RULE_ID,
+    }
+    if phase is not None:
+        payload["phase"] = phase
+    if target_commit is not None:
+        payload["target_commit"] = target_commit
+    if prior_attempt is not None:
+        payload["prior_attempt"] = prior_attempt
+    if multiplexer_ref is not None:
+        payload["multiplexer_ref"] = multiplexer_ref
+
+    agent_mod.cmd_event(
+        "agent_spawned",
+        agent_id=agent_id,
+        data=payload,
+        runtime_root=runtime_root,
+    )
+
+    return {
+        "launch_prompt_path": prompt_path,
+        "surface_ref": surface_ref,
+        "command": command,
+        "rule_id": SPAWN_RULE_ID,
+    }
+
+
+# ---------------------------------------------------------------------------
+# argparse dispatcher (`atdd spawn ...`)
+# ---------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="atdd spawn",
+        description=(
+            "Coach v9 K1 spawn skeleton. Single rule-IDed entry point "
+            "for every persona launch — wraps session_template.render, "
+            "dispatches the multiplexer, runs the per-LLM adapter, and "
+            "emits an agent_spawned runtime event."
+        ),
+    )
+    parser.add_argument(
+        "--persona", required=True, choices=list(PERSONAS),
+        help="Persona to launch.",
+    )
+    # --llm intentionally accepts arbitrary strings; adapter validation
+    # is deferred to dispatch time so follow-up K-track issues can land
+    # codex / gemini / glm adapters without editing this CLI surface.
+    parser.add_argument(
+        "--llm", required=True,
+        help=(
+            "LLM adapter id (claude-code shipped in K1; codex / gemini / "
+            "glm registered as separate adapters in K-track follow-ups)."
+        ),
+    )
+    parser.add_argument(
+        "--worktree", required=True, type=Path,
+        help="Path to the worktree (assumed to already exist; #J4 owns creation).",
+    )
+    parser.add_argument(
+        "--issue", required=True, type=int,
+        help="GitHub issue number being launched.",
+    )
+    parser.add_argument(
+        "--agent-id", required=True, dest="agent_id",
+        help="Unique agent id; targets .atdd/runtime/agents/<id>/.",
+    )
+    parser.add_argument(
+        "--runtime", required=True, type=Path, dest="runtime_root",
+        help="Path to the runtime root (writes events.jsonl beneath it).",
+    )
+    parser.add_argument("--phase", default=None, help="Optional ATDD phase context.")
+    parser.add_argument(
+        "--target-commit", default=None, dest="target_commit",
+        help="Optional reviewer/replay anchor (spec §6.3).",
+    )
+    parser.add_argument(
+        "--prior-attempt", default=None, dest="prior_attempt",
+        help="Optional prior-attempt agent_id for re-spawn correlation.",
+    )
+    parser.add_argument(
+        "--multiplexer-ref", default=None, dest="multiplexer_ref",
+        help="Optional existing workspace/pane ref (passes through to event payload).",
+    )
+    parser.add_argument(
+        "--multiplexer", default=None,
+        help="Optional multiplexer backend selection (cmux / zellij / tmux).",
+    )
+    return parser
+
+
+def run(argv: list[str]) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = cmd_spawn(
+            persona=args.persona,
+            llm=args.llm,
+            worktree=args.worktree,
+            issue=args.issue,
+            agent_id=args.agent_id,
+            runtime_root=args.runtime_root,
+            phase=args.phase,
+            target_commit=args.target_commit,
+            prior_attempt=args.prior_attempt,
+            multiplexer_ref=args.multiplexer_ref,
+            multiplexer=(
+                _resolve_multiplexer(args.multiplexer)
+                if args.multiplexer
+                else None
+            ),
+        )
+    except ValueError as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        print(f"❌ {exc}", file=sys.stderr)
+        return 2
+    print(
+        f"✓ spawned {args.agent_id} ({args.persona}/{args.llm}) "
+        f"surface={result['surface_ref']} rule_id={result['rule_id']}"
+    )
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    return run(list(sys.argv[1:] if argv is None else argv))

--- a/src/atdd/coach/commands/tests/test_e001_contract_001_agent_spawned_event_conforms.py
+++ b/src/atdd/coach/commands/tests/test_e001_contract_001_agent_spawned_event_conforms.py
@@ -1,0 +1,181 @@
+# URN: test:spawn-agents:atdd-spawn-skeleton-and-harness:E001-CONTRACT-001-agent-spawned-event-conforms
+# Acceptance: acc:spawn-agents:E001-CONTRACT-001-agent-spawned-event-conforms
+# WMBT: wmbt:spawn-agents:E001
+# Phase: RED
+# Layer: contract
+"""E001-CONTRACT-001 — the ``agent_spawned`` event written by ``atdd
+spawn`` MUST round-trip through ``runtime-event.schema.json`` with zero
+validation errors; its producer / triggering condition / idempotency /
+ordering / replay semantics match the ``agent_spawned`` subsection of
+``event-semantics.md`` (frozen at #483).
+
+Issue #499.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import jsonschema
+import pytest
+
+import atdd
+
+pytestmark = [pytest.mark.platform]
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+RUNTIME_EVENT_SCHEMA = (
+    ATDD_PKG_DIR / "coach" / "schemas" / "runtime-event.schema.json"
+)
+EVENT_SEMANTICS_DOC = (
+    ATDD_PKG_DIR / "coach" / "schemas" / "event-semantics.md"
+)
+
+
+SAMPLE_BODY = """## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Branch | `feat/spawn-test` |
+| Train | `0002-coach-drives-lifecycle` |
+| Feature | contract test |
+"""
+
+
+class FakeMultiplexer:
+    name = "fake"
+
+    def new_workspace(self, cwd: str, command: str, name: Optional[str] = None) -> str:
+        return "workspace:1"
+
+    def new_surface(
+        self,
+        workspace_ref: Optional[str] = None,
+        pane_ref: Optional[str] = None,
+        cwd: Optional[str] = None,
+        command: Optional[str] = None,
+        name: Optional[str] = None,
+        direction: Optional[str] = None,
+    ) -> str:
+        return "surface:1"
+
+
+def _spawn(tmp_path: Path, monkeypatch, *, agent_id: str = "coder-358-001"):
+    from atdd.coach.commands import spawn
+    from atdd.coach.commands import session_template
+
+    monkeypatch.setattr(
+        session_template,
+        "fetch_issue",
+        lambda n: {"number": n, "title": "t", "body": SAMPLE_BODY},
+    )
+    worktree = tmp_path / "wt"
+    worktree.mkdir(exist_ok=True)
+    runtime = tmp_path / "rt"
+    spawn.cmd_spawn(
+        persona="coder",
+        llm="claude-code",
+        worktree=worktree,
+        issue=358,
+        agent_id=agent_id,
+        runtime_root=runtime,
+        multiplexer=FakeMultiplexer(),
+    )
+    return runtime / "agents" / agent_id / "events.jsonl"
+
+
+def _read_first_event(events_path: Path) -> dict:
+    lines = [ln for ln in events_path.read_text().splitlines() if ln.strip()]
+    return json.loads(lines[0])
+
+
+# ---------------------------------------------------------------------------
+# Schema conformance
+# ---------------------------------------------------------------------------
+
+
+def test_agent_spawned_event_round_trips_through_runtime_event_schema(tmp_path, monkeypatch):
+    """The emitted event MUST validate against runtime-event.schema.json
+    with zero errors."""
+    events_path = _spawn(tmp_path, monkeypatch)
+    schema = json.loads(RUNTIME_EVENT_SCHEMA.read_text())
+    record = _read_first_event(events_path)
+
+    jsonschema.validate(record, schema)
+    assert record["event_type"] == "agent_spawned"
+    assert "timestamp" in record
+    assert "payload" in record
+
+
+def test_agent_spawned_event_has_no_extra_top_level_keys(tmp_path, monkeypatch):
+    """``runtime-event.schema.json`` is ``additionalProperties: false`` —
+    the producer MUST NOT add unenumerated top-level keys."""
+    events_path = _spawn(tmp_path, monkeypatch)
+    record = _read_first_event(events_path)
+    allowed = {"event_type", "agent_id", "timestamp", "payload"}
+    assert set(record.keys()) <= allowed
+
+
+def test_timestamp_is_iso_8601_utc(tmp_path, monkeypatch):
+    """``timestamp`` is RFC-3339 / ISO-8601 UTC; per the agent.py
+    convention, must end with ``Z``."""
+    events_path = _spawn(tmp_path, monkeypatch)
+    record = _read_first_event(events_path)
+    assert record["timestamp"].endswith("Z")
+
+
+# ---------------------------------------------------------------------------
+# Semantics conformance — event-semantics.md `agent_spawned` subsection
+# ---------------------------------------------------------------------------
+
+
+def test_event_semantics_doc_documents_agent_spawned():
+    """Anchor: the frozen ``event-semantics.md`` must continue to
+    enumerate ``agent_spawned`` as one of the 12 event types and to
+    document its producer / triggering / idempotency / ordering / replay
+    semantics. Without this anchor the `Replay cached` / per-agent total
+    order claims that downstream tests rest on are unverified."""
+    text = EVENT_SEMANTICS_DOC.read_text()
+    section = text.split("## `agent_spawned`", 1)
+    assert len(section) == 2, "event-semantics.md missing `agent_spawned` section"
+    body = section[1].split("## `", 1)[0]
+    for label in ("Producer", "Triggering condition", "Idempotency", "Ordering", "Replay"):
+        assert label in body, f"agent_spawned subsection missing **{label}**"
+
+
+def test_payload_documents_persona_llm_worktree_for_observers(tmp_path, monkeypatch):
+    """Per spec §5.2 + §4.5, the ``agent_spawned`` payload carries the
+    spawn-time decision context (persona, llm, worktree, surface_ref,
+    issue) so the observer rule ``14-canonical-naming-drift`` (#L1) and
+    other downstream consumers can correlate spawn-time decisions with
+    later events without re-reading the issue body."""
+    events_path = _spawn(tmp_path, monkeypatch)
+    record = _read_first_event(events_path)
+    payload = record["payload"]
+    assert payload["persona"] == "coder"
+    assert payload["llm"] == "claude-code"
+    assert payload["issue"] == 358
+    assert payload["surface_ref"]
+    assert payload["worktree"]
+    # The K1 spawn flow must emit at least one rule-ID per spec §7.1 +
+    # acceptance E001 (rule-ID emission). The canonical anchor is
+    # ``coach.spawn.atdd-spawn-cli`` (or equivalent canonical anchor).
+    assert "rule_id" in payload
+    assert payload["rule_id"].startswith("coach.spawn.")
+
+
+def test_idempotency_per_agent_id(tmp_path, monkeypatch):
+    """Per event-semantics.md ``agent_spawned`` is **exactly-once** per
+    ``agent_id`` per coach run. K1's spawn writes each spawn into the
+    per-agent events.jsonl; two separate agent_ids MUST produce two
+    independent events.jsonl files (per-agent total order)."""
+    events_a = _spawn(tmp_path, monkeypatch, agent_id="coder-358-A")
+    events_b = _spawn(tmp_path, monkeypatch, agent_id="coder-358-B")
+    rec_a = _read_first_event(events_a)
+    rec_b = _read_first_event(events_b)
+    assert rec_a["agent_id"] == "coder-358-A"
+    assert rec_b["agent_id"] == "coder-358-B"
+    # Per-agent total order: each stream's first event is the spawn event.
+    assert rec_a["event_type"] == "agent_spawned"
+    assert rec_b["event_type"] == "agent_spawned"

--- a/src/atdd/coach/commands/tests/test_e001_unit_001_spawn_cli_launches_session.py
+++ b/src/atdd/coach/commands/tests/test_e001_unit_001_spawn_cli_launches_session.py
@@ -1,0 +1,279 @@
+# URN: test:spawn-agents:atdd-spawn-skeleton-and-harness:E001-UNIT-001-spawn-cli-launches-session
+# Acceptance: acc:spawn-agents:E001-UNIT-001-spawn-cli-launches-session
+# WMBT: wmbt:spawn-agents:E001
+# Phase: RED
+# Layer: application
+"""E001-UNIT-001 — `atdd spawn` with the full required flag set launches a
+session, writes ``<worktree>/.launch_prompt.txt``, dispatches a multiplexer
+surface (ref returned and logged), and emits an ``agent_spawned`` runtime
+event conforming to ``runtime-event.schema.json``.
+
+Issue #499 — K1 spawn skeleton wrapping ``session_template.py::render``.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import jsonschema
+import pytest
+
+import atdd
+
+pytestmark = [pytest.mark.platform]
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+RUNTIME_EVENT_SCHEMA = (
+    ATDD_PKG_DIR / "coach" / "schemas" / "runtime-event.schema.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeMultiplexer:
+    """Captures new_workspace / new_surface invocations for assertion."""
+
+    name = "fake"
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+        self._surface_counter = 0
+
+    def new_workspace(self, cwd: str, command: str, name: Optional[str] = None) -> str:
+        ref = f"workspace:{len(self.calls) + 1}"
+        self.calls.append(
+            {"op": "new_workspace", "cwd": cwd, "command": command, "name": name, "ref": ref}
+        )
+        return ref
+
+    def new_surface(
+        self,
+        workspace_ref: Optional[str] = None,
+        pane_ref: Optional[str] = None,
+        cwd: Optional[str] = None,
+        command: Optional[str] = None,
+        name: Optional[str] = None,
+        direction: Optional[str] = None,
+    ) -> str:
+        self._surface_counter += 1
+        ref = f"surface:{self._surface_counter}"
+        self.calls.append(
+            {
+                "op": "new_surface",
+                "workspace_ref": workspace_ref,
+                "pane_ref": pane_ref,
+                "cwd": cwd,
+                "command": command,
+                "name": name,
+                "ref": ref,
+            }
+        )
+        return ref
+
+
+SAMPLE_BODY = """## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Branch | `feat/spawn-test` |
+| Train | `0002-coach-drives-lifecycle` |
+| Feature | spawn skeleton sample |
+
+## Scope
+
+### Dependencies
+
+- #1
+"""
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_exposes_spawn_callable():
+    from atdd.coach.commands import spawn
+
+    assert callable(getattr(spawn, "cmd_spawn", None))
+    assert callable(getattr(spawn, "main", None))
+    assert callable(getattr(spawn, "run", None))
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — required flag parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "missing_flag",
+    ["--persona", "--llm", "--worktree", "--issue", "--agent-id", "--runtime"],
+)
+def test_required_flags_parse_without_error(missing_flag, tmp_path):
+    """When all six required flags are provided, the parser MUST accept the
+    invocation. When one is missing, argparse MUST reject it (exit 2)."""
+    from atdd.coach.commands import spawn
+
+    full_argv = [
+        "--persona", "coder",
+        "--llm", "claude-code",
+        "--worktree", str(tmp_path / "wt"),
+        "--issue", "358",
+        "--agent-id", "coder-358-001",
+        "--runtime", str(tmp_path / "rt"),
+    ]
+    parser = spawn._build_parser()
+    parsed = parser.parse_args(full_argv)
+    assert parsed.persona == "coder"
+    assert parsed.llm == "claude-code"
+    assert parsed.issue == 358
+    assert parsed.agent_id == "coder-358-001"
+
+    # Drop one flag at a time → parser must exit with non-zero.
+    pruned = list(full_argv)
+    idx = pruned.index(missing_flag)
+    del pruned[idx : idx + 2]
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(pruned)
+    assert exc.value.code != 0
+
+
+# ---------------------------------------------------------------------------
+# Behavior — launch prompt written, surface created, event emitted
+# ---------------------------------------------------------------------------
+
+
+def test_spawn_writes_launch_prompt_to_worktree(tmp_path, monkeypatch):
+    from atdd.coach.commands import spawn
+    from atdd.coach.commands import session_template
+
+    monkeypatch.setattr(
+        session_template,
+        "fetch_issue",
+        lambda n: {"number": n, "title": "spawn skeleton sample", "body": SAMPLE_BODY},
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    runtime = tmp_path / "rt"
+
+    fake_mx = FakeMultiplexer()
+    result = spawn.cmd_spawn(
+        persona="coder",
+        llm="claude-code",
+        worktree=worktree,
+        issue=358,
+        agent_id="coder-358-001",
+        runtime_root=runtime,
+        multiplexer=fake_mx,
+    )
+
+    prompt_path = worktree / ".launch_prompt.txt"
+    assert prompt_path.is_file()
+    content = prompt_path.read_text()
+    # render(context) substitutes the issue number into the template.
+    assert "358" in content
+    assert result["launch_prompt_path"] == prompt_path
+
+
+def test_spawn_creates_multiplexer_surface_and_returns_ref(tmp_path, monkeypatch):
+    from atdd.coach.commands import spawn
+    from atdd.coach.commands import session_template
+
+    monkeypatch.setattr(
+        session_template,
+        "fetch_issue",
+        lambda n: {"number": n, "title": "t", "body": SAMPLE_BODY},
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    runtime = tmp_path / "rt"
+
+    fake_mx = FakeMultiplexer()
+    result = spawn.cmd_spawn(
+        persona="coder",
+        llm="claude-code",
+        worktree=worktree,
+        issue=358,
+        agent_id="coder-358-001",
+        runtime_root=runtime,
+        multiplexer=fake_mx,
+    )
+    assert any(c["op"] in ("new_workspace", "new_surface") for c in fake_mx.calls)
+    assert result["surface_ref"]
+    assert result["surface_ref"].startswith(("surface:", "workspace:"))
+
+
+def test_spawn_emits_agent_spawned_event_conforming_to_schema(tmp_path, monkeypatch):
+    from atdd.coach.commands import spawn
+    from atdd.coach.commands import session_template
+
+    monkeypatch.setattr(
+        session_template,
+        "fetch_issue",
+        lambda n: {"number": n, "title": "t", "body": SAMPLE_BODY},
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    runtime = tmp_path / "rt"
+
+    fake_mx = FakeMultiplexer()
+    spawn.cmd_spawn(
+        persona="coder",
+        llm="claude-code",
+        worktree=worktree,
+        issue=358,
+        agent_id="coder-358-001",
+        runtime_root=runtime,
+        multiplexer=fake_mx,
+    )
+
+    events_path = runtime / "agents" / "coder-358-001" / "events.jsonl"
+    assert events_path.is_file()
+    lines = [ln for ln in events_path.read_text().splitlines() if ln.strip()]
+    assert len(lines) >= 1
+    record = json.loads(lines[0])
+
+    schema = json.loads(RUNTIME_EVENT_SCHEMA.read_text())
+    jsonschema.validate(record, schema)
+    assert record["event_type"] == "agent_spawned"
+    assert record["agent_id"] == "coder-358-001"
+
+
+def test_spawn_required_flag_set_runs_without_error_via_main(tmp_path, monkeypatch, capsys):
+    """End-to-end: ``atdd.coach.commands.spawn.main([...])`` succeeds when
+    invoked with the required flag set."""
+    from atdd.coach.commands import spawn
+    from atdd.coach.commands import session_template
+
+    monkeypatch.setattr(
+        session_template,
+        "fetch_issue",
+        lambda n: {"number": n, "title": "t", "body": SAMPLE_BODY},
+    )
+
+    fake_mx = FakeMultiplexer()
+    monkeypatch.setattr(spawn, "_resolve_multiplexer", lambda preferred=None: fake_mx)
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    runtime = tmp_path / "rt"
+
+    rc = spawn.main([
+        "--persona", "coder",
+        "--llm", "claude-code",
+        "--worktree", str(worktree),
+        "--issue", "358",
+        "--agent-id", "coder-358-001",
+        "--runtime", str(runtime),
+    ])
+    assert rc == 0
+    # The surface ref must surface to stdout/log so observers can correlate.
+    captured = capsys.readouterr()
+    assert "surface" in (captured.out + captured.err).lower()

--- a/src/atdd/coach/commands/tests/test_e001_unit_002_claude_code_adapter_invoked.py
+++ b/src/atdd/coach/commands/tests/test_e001_unit_002_claude_code_adapter_invoked.py
@@ -1,0 +1,169 @@
+# URN: test:spawn-agents:atdd-spawn-skeleton-and-harness:E001-UNIT-002-claude-code-adapter-invoked
+# Acceptance: acc:spawn-agents:E001-UNIT-002-claude-code-adapter-invoked
+# WMBT: wmbt:spawn-agents:E001
+# Phase: RED
+# Layer: application
+"""E001-UNIT-002 — `--llm claude-code` shells out to
+``claude --dangerously-skip-permissions "$(cat <prompt>)"`` per spec §5.2,
+and adapter selection is dispatched off ``--llm`` so other LLMs register
+as separate adapters in K-track follow-ups without editing ``spawn.py``'s
+CLI surface.
+
+Issue #499.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+SAMPLE_BODY = """## Issue Metadata
+
+| Field | Value |
+|-------|-------|
+| Branch | `feat/spawn-test` |
+| Train | `0002-coach-drives-lifecycle` |
+| Feature | adapter dispatch test |
+"""
+
+
+class FakeMultiplexer:
+    """Captures the command string fed to new_surface so the test can
+    assert against the exact claude-code invocation."""
+
+    name = "fake"
+
+    def __init__(self) -> None:
+        self.last_command: Optional[str] = None
+        self.last_cwd: Optional[str] = None
+
+    def new_workspace(self, cwd: str, command: str, name: Optional[str] = None) -> str:
+        self.last_cwd = cwd
+        self.last_command = command
+        return "workspace:1"
+
+    def new_surface(
+        self,
+        workspace_ref: Optional[str] = None,
+        pane_ref: Optional[str] = None,
+        cwd: Optional[str] = None,
+        command: Optional[str] = None,
+        name: Optional[str] = None,
+        direction: Optional[str] = None,
+    ) -> str:
+        self.last_cwd = cwd
+        self.last_command = command
+        return "surface:1"
+
+
+def test_adapter_registry_exposes_claude_code():
+    """``claude-code`` MUST be a registered adapter; the registry is the
+    open extension point that follow-up K-track issues add codex / gemini
+    / glm to without editing ``spawn.py``'s CLI surface."""
+    from atdd.coach.commands import spawn
+
+    assert isinstance(spawn.ADAPTER_REGISTRY, dict)
+    assert "claude-code" in spawn.ADAPTER_REGISTRY
+    assert callable(spawn.ADAPTER_REGISTRY["claude-code"])
+
+
+def test_claude_code_adapter_returns_expected_shell_invocation(tmp_path):
+    """The claude-code adapter MUST produce the exact spec §5.2 shell
+    invocation against the rendered launch prompt path."""
+    from atdd.coach.commands import spawn
+
+    prompt_path = tmp_path / ".launch_prompt.txt"
+    prompt_path.write_text("body")
+    cmd = spawn.ADAPTER_REGISTRY["claude-code"](prompt_path)
+    # The exact shell invocation, per spec §5.2 and acceptance E001-UNIT-002.
+    assert cmd == f'claude --dangerously-skip-permissions "$(cat {prompt_path})"'
+
+
+def test_spawn_dispatches_adapter_off_llm_flag(tmp_path, monkeypatch):
+    """``cmd_spawn(llm="claude-code", ...)`` MUST resolve and use the
+    claude-code adapter — the multiplexer surface receives the adapter's
+    command string."""
+    from atdd.coach.commands import spawn
+    from atdd.coach.commands import session_template
+
+    monkeypatch.setattr(
+        session_template,
+        "fetch_issue",
+        lambda n: {"number": n, "title": "t", "body": SAMPLE_BODY},
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    runtime = tmp_path / "rt"
+
+    fake_mx = FakeMultiplexer()
+    spawn.cmd_spawn(
+        persona="coder",
+        llm="claude-code",
+        worktree=worktree,
+        issue=358,
+        agent_id="coder-358-001",
+        runtime_root=runtime,
+        multiplexer=fake_mx,
+    )
+
+    expected = (
+        f'claude --dangerously-skip-permissions '
+        f'"$(cat {worktree / ".launch_prompt.txt"})"'
+    )
+    assert fake_mx.last_command == expected
+
+
+def test_unknown_llm_rejected_with_clear_error(tmp_path, monkeypatch):
+    """An ``--llm`` value that has no registered adapter MUST raise a
+    clear error so the operator knows which adapters are wired."""
+    from atdd.coach.commands import spawn
+    from atdd.coach.commands import session_template
+
+    monkeypatch.setattr(
+        session_template,
+        "fetch_issue",
+        lambda n: {"number": n, "title": "t", "body": SAMPLE_BODY},
+    )
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    with pytest.raises(ValueError) as exc:
+        spawn.cmd_spawn(
+            persona="coder",
+            llm="not-a-real-llm",
+            worktree=worktree,
+            issue=358,
+            agent_id="coder-358-001",
+            runtime_root=tmp_path / "rt",
+            multiplexer=FakeMultiplexer(),
+        )
+    msg = str(exc.value)
+    assert "not-a-real-llm" in msg
+    assert "claude-code" in msg  # Show the registered adapters.
+
+
+def test_adapter_extension_point_does_not_require_editing_cli_surface():
+    """A new LLM adapter MUST be registerable on ``ADAPTER_REGISTRY``
+    without editing ``_build_parser()``'s CLI surface — the parser MUST
+    accept arbitrary string values for ``--llm``, with adapter validation
+    deferred to dispatch time."""
+    from atdd.coach.commands import spawn
+
+    parser = spawn._build_parser()
+    # Arbitrary adapter name parses cleanly; it is rejected later only if
+    # not registered. This is the contract that lets follow-up K-track
+    # issues land codex / gemini / glm without touching spawn.py.
+    parsed = parser.parse_args([
+        "--persona", "coder",
+        "--llm", "future-adapter-not-yet-shipped",
+        "--worktree", "/tmp/wt",
+        "--issue", "1",
+        "--agent-id", "x",
+        "--runtime", "/tmp/rt",
+    ])
+    assert parsed.llm == "future-adapter-not-yet-shipped"

--- a/src/atdd/coach/conventions/rule-id.convention.yaml
+++ b/src/atdd/coach/conventions/rule-id.convention.yaml
@@ -550,6 +550,7 @@ migration:
     # Add migrated convention paths here as they land.
     - "src/atdd/coder/conventions/green.convention.yaml"
     - "src/atdd/coach/conventions/orchestration.convention.yaml"
+    - "src/atdd/coach/conventions/spawn.convention.yaml"
     - "src/atdd/coder/conventions/refactor.convention.yaml"
     # Issue #394 Phase 1 — coder conventions whose ratchet validators emit Violations
     - "src/atdd/coder/conventions/boundaries.convention.yaml"

--- a/src/atdd/coach/conventions/spawn.convention.yaml
+++ b/src/atdd/coach/conventions/spawn.convention.yaml
@@ -1,0 +1,36 @@
+version: "1.0"
+name: "Spawn Convention"
+description: |
+  Rules for `atdd spawn` — the coach v9 K1 single rule-IDed entry point
+  that every persona launch (planner / tester / coder / reviewer) flows
+  through. Wraps session_template.render, dispatches the multiplexer,
+  runs the per-LLM adapter, and emits the agent_spawned runtime event
+  (spec v9 §5.2 / §7.1; issue #499).
+
+# =============================================================================
+# Core principle: one entry point owns the launch path. The K-track absorbs
+# the parallel launch paths in atdd orchestrate, atdd coach (v8 prototype),
+# and operator hand-typed claude invocations into one rule-IDed CLI surface.
+# =============================================================================
+
+rules:
+  - id: "coach.spawn.atdd-spawn-cli"
+    aliases: ["COACH-SPAWN-ENTRY-0001"]
+    severity: 3
+    disposition: advisory
+    description: |
+      Every coach v9 persona launch MUST flow through `atdd spawn`. The
+      command renders the launch prompt via session_template.render,
+      writes <worktree>/.launch_prompt.txt, dispatches the multiplexer
+      surface, runs the per-LLM adapter, and emits an agent_spawned
+      runtime event whose payload carries this rule_id so observers can
+      correlate spawn-time decisions with downstream events.
+    introduced_in: "3.20.0"
+    validator: "test_e001_unit_001_spawn_cli_launches_session::test_spawn_emits_agent_spawned_event_conforming_to_schema"
+    fix_hint: |
+      Replace ad-hoc launch shell-out (atdd orchestrate Phase B, the v8
+      atdd coach prototype, or operator-typed `claude` invocations)
+      with a single call to `atdd spawn --persona <p> --llm <l>
+      --worktree <w> --issue <N> --agent-id <id> --runtime <rt>`. The
+      claude-code adapter is shipped in K1; codex / gemini / glm follow
+      as separate K-track issues registering on ADAPTER_REGISTRY.

--- a/src/atdd/coach/conventions/spawn.convention.yaml
+++ b/src/atdd/coach/conventions/spawn.convention.yaml
@@ -25,7 +25,7 @@ rules:
       surface, runs the per-LLM adapter, and emits an agent_spawned
       runtime event whose payload carries this rule_id so observers can
       correlate spawn-time decisions with downstream events.
-    introduced_in: "3.20.0"
+    introduced_in: "3.21.0"
     validator: "test_e001_unit_001_spawn_cli_launches_session::test_spawn_emits_agent_spawned_event_conforming_to_schema"
     fix_hint: |
       Replace ad-hoc launch shell-out (atdd orchestrate Phase B, the v8

--- a/src/atdd/coach/conventions/spawn.convention.yaml
+++ b/src/atdd/coach/conventions/spawn.convention.yaml
@@ -34,3 +34,7 @@ rules:
       --worktree <w> --issue <N> --agent-id <id> --runtime <rt>`. The
       claude-code adapter is shipped in K1; codex / gemini / glm follow
       as separate K-track issues registering on ADAPTER_REGISTRY.
+      e.g. `atdd spawn --persona coder --llm claude-code
+      --worktree ../feat-coach-v9-k1-spawn-skeleton --issue 499
+      --agent-id coder-499-001 --runtime .atdd/runtime`
+      (see src/atdd/coach/commands/spawn.py::cmd_spawn).

--- a/src/atdd/coach/validators/test_e001_unit_001_spawn_cli_launches_session.py
+++ b/src/atdd/coach/validators/test_e001_unit_001_spawn_cli_launches_session.py
@@ -26,11 +26,13 @@ from pathlib import Path
 import pytest
 
 import atdd
+from atdd.coach.utils.rule_binding import bind_rule
 
 pytestmark = [pytest.mark.coach]
 
 ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
 SPAWN_MODULE = ATDD_PKG_DIR / "coach" / "commands" / "spawn.py"
+_RULE = bind_rule("coach.spawn.atdd-spawn-cli")
 
 
 def test_spawn_module_committed() -> None:

--- a/src/atdd/coach/validators/test_e001_unit_001_spawn_cli_launches_session.py
+++ b/src/atdd/coach/validators/test_e001_unit_001_spawn_cli_launches_session.py
@@ -1,0 +1,81 @@
+# URN: test:spawn-agents:atdd-spawn-skeleton-and-harness:E001-UNIT-001-spawn-cli-launches-session-validator
+# Acceptance: acc:spawn-agents:E001-UNIT-001-spawn-cli-launches-session
+# WMBT: wmbt:spawn-agents:E001
+# Phase: RED
+# Layer: backend.integration
+# Assertion: structural
+
+"""E001-UNIT-001 (validator slice) — structural enforcement that the
+``coach.spawn.atdd-spawn-cli`` rule (declared in
+``src/atdd/coach/conventions/spawn.convention.yaml``) is bound to a
+real spawn entry point in the toolkit.
+
+Mirrors the structural-validator pattern of
+``test_d002_unit_001_runtime_layout_doc_committed.py``: assert artifact
+presence, key public symbols, and the adapter registry's K1 anchor
+(``claude-code``). Behavioral coverage of the launch flow lives in
+``src/atdd/coach/commands/tests/test_e001_*`` (the application-layer
+tests; this file is the validator-layer mirror that
+``coach.spawn.atdd-spawn-cli::validator`` resolves to).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import atdd
+
+pytestmark = [pytest.mark.coach]
+
+ATDD_PKG_DIR = Path(atdd.__file__).resolve().parent
+SPAWN_MODULE = ATDD_PKG_DIR / "coach" / "commands" / "spawn.py"
+
+
+def test_spawn_module_committed() -> None:
+    """``src/atdd/coach/commands/spawn.py`` MUST exist — the K1
+    deliverable per spec v9 §5.2."""
+    assert SPAWN_MODULE.exists(), (
+        f"Missing {SPAWN_MODULE}. Acceptance E001-UNIT-001 requires "
+        f"spawn.py to be committed at src/atdd/coach/commands/spawn.py."
+    )
+
+
+def test_spawn_module_exposes_required_callables() -> None:
+    """``cmd_spawn``, ``main``, ``run``, ``_build_parser`` MUST be public
+    on ``atdd.coach.commands.spawn`` — these are the surfaces the K1
+    acceptance tests bind to and the CLI dispatch wires through."""
+    from atdd.coach.commands import spawn
+
+    for name in ("cmd_spawn", "main", "run", "_build_parser"):
+        assert callable(getattr(spawn, name, None)), (
+            f"missing callable atdd.coach.commands.spawn.{name}"
+        )
+
+
+def test_spawn_emits_agent_spawned_event_conforming_to_schema() -> None:
+    """The ``coach.spawn.atdd-spawn-cli`` rule_id MUST be declared as
+    the canonical anchor on the spawn module so observers can correlate
+    spawn-time decisions with downstream events. The event-conformance
+    behavioral coverage lives in
+    ``src/atdd/coach/commands/tests/test_e001_contract_001_agent_spawned_event_conforms.py``."""
+    from atdd.coach.commands import spawn
+
+    assert getattr(spawn, "SPAWN_RULE_ID", None) == "coach.spawn.atdd-spawn-cli", (
+        "spawn.SPAWN_RULE_ID must be 'coach.spawn.atdd-spawn-cli' — the "
+        "canonical anchor declared in spawn.convention.yaml."
+    )
+
+
+def test_spawn_adapter_registry_ships_claude_code() -> None:
+    """K1 ships the ``claude-code`` adapter; codex / gemini / glm land
+    in K-track follow-ups by registering on the same registry without
+    editing the spawn module's CLI surface."""
+    from atdd.coach.commands import spawn
+
+    assert isinstance(spawn.ADAPTER_REGISTRY, dict)
+    assert "claude-code" in spawn.ADAPTER_REGISTRY, (
+        "ADAPTER_REGISTRY must register 'claude-code' as the K1 adapter."
+    )
+    assert callable(spawn.ADAPTER_REGISTRY["claude-code"])


### PR DESCRIPTION
Closes #499

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #499 |
| Type | feat |
| Slug | coach-v9-k1-spawn-skeleton |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd-issue, atdd:INIT, archetype:coach, track-k, wave-w1, wagon:spawn-agents, train:0002-coach-drives-lifecycle |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.