### PR TITLE
feat(coach): substrate spawn-harness blocks (#503)

### DIFF
--- a/src/atdd/coach/commands/spawn.py
+++ b/src/atdd/coach/commands/spawn.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 from atdd.coach.utils.session_naming import (
     branch_to_slug,
@@ -95,7 +95,7 @@ def _resolve_multiplexer(preferred: Optional[str] = None):
 # ---------------------------------------------------------------------------
 
 
-def _render_launch_prompt(issue: int, worktree: Path) -> Path:
+def _render_launch_prompt(issue: int, worktree: Path, *, phase: Optional[str] = None, rules: Optional[Iterable[Any]] = None) -> Path:
     """Wrap ``session_template`` to render the launch prompt and write
     it to ``<worktree>/.launch_prompt.txt``. Returns the prompt path."""
     from atdd.coach.commands import session_template
@@ -110,10 +110,38 @@ def _render_launch_prompt(issue: int, worktree: Path) -> Path:
         worktree_path=str(worktree),
     )
     rendered = session_template.render(context)
+    if rules is not None and phase is not None:
+        rendered = _append_spawn_rule_blocks(rendered, rules=rules, coach_phase=phase)
     prompt_path = worktree / ".launch_prompt.txt"
     prompt_path.parent.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(rendered)
     return prompt_path
+
+
+def _append_spawn_rule_blocks(
+    rendered: str, *, rules: Iterable[Any], coach_phase: str
+) -> str:
+    import yaml
+
+    from atdd.coach.commands.spawn_harness_blocks import (
+        render_security_rules_block,
+        render_train_rules_block,
+        render_wmbt_rules_block,
+    )
+
+    blocks: dict[str, list[dict[str, Any]]] = {}
+    wmbt_rules = render_wmbt_rules_block(rules, coach_phase=coach_phase)
+    if wmbt_rules:
+        blocks["wmbt_rules"] = wmbt_rules
+    train_rules = render_train_rules_block(rules, coach_phase=coach_phase)
+    if train_rules:
+        blocks["train_rules"] = train_rules
+    security_rules = render_security_rules_block(rules, coach_phase=coach_phase)
+    if security_rules:
+        blocks["security_rules"] = security_rules
+    if not blocks:
+        return rendered
+    return rendered.rstrip() + "\n\n" + yaml.safe_dump(blocks, sort_keys=False)
 
 
 def _create_surface(
@@ -154,6 +182,7 @@ def cmd_spawn(
     prior_attempt: Optional[str] = None,
     multiplexer_ref: Optional[str] = None,
     multiplexer: Any = None,
+    rules: Optional[Iterable[Any]] = None,
 ) -> dict:
     """Render the launch prompt, dispatch the multiplexer, run the
     per-LLM adapter, and emit the ``agent_spawned`` event.
@@ -176,7 +205,7 @@ def cmd_spawn(
     worktree = Path(worktree)
     runtime_root = Path(runtime_root)
 
-    prompt_path = _render_launch_prompt(issue, worktree)
+    prompt_path = _render_launch_prompt(issue, worktree, phase=phase, rules=rules)
     adapter = ADAPTER_REGISTRY[llm]
     command = adapter(prompt_path)
 

--- a/src/atdd/coach/commands/spawn_harness_blocks.py
+++ b/src/atdd/coach/commands/spawn_harness_blocks.py
@@ -43,6 +43,88 @@ from typing import Any, Dict, Iterable, List, Optional
 from atdd.coach.utils.rule_binding import RuleMetadata
 
 
+def _acceptance_kind(rule: RuleMetadata) -> str | None:
+    rule_id = str(getattr(rule, "rule_id", ""))
+    if ".wmbt." in rule_id or ":wmbt:" in rule_id:
+        return "wmbt"
+    if ".train." in rule_id or ":train:" in rule_id:
+        return "train"
+    return None
+
+
+def _phase_filtered_rules(
+    rules: Iterable[RuleMetadata], coach_phase: str | None
+) -> list[RuleMetadata]:
+    return [
+        rule
+        for rule in rules
+        if isinstance(rule, RuleMetadata)
+        and not (coach_phase is not None and rule.phase and rule.phase != coach_phase)
+    ]
+
+
+def _group_by_attr(rules: Iterable[RuleMetadata], attr: str) -> list[tuple[str, list[RuleMetadata]]]:
+    grouped: dict[str, list[RuleMetadata]] = {}
+    for rule in rules:
+        key = getattr(rule, attr, None)
+        if key:
+            grouped.setdefault(str(key), []).append(rule)
+    return sorted(grouped.items(), key=lambda item: item[0])
+
+
+def _rule_expectations(rule: RuleMetadata) -> list[str]:
+    expectations = getattr(rule, "then", None) or getattr(rule, "expectations", None) or []
+    return [str(item) for item in expectations]
+
+
+def _wmbt_rule_entry(rule: RuleMetadata) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "id": rule.rule_id,
+        "acceptance_urn": getattr(rule, "bound_acceptance_urn", None),
+        "purpose": getattr(rule, "description", ""),
+        "expectations": _rule_expectations(rule),
+        "harness_type": getattr(rule, "harness_type", None),
+        "signal_metric": getattr(rule, "signal_metric", None),
+    }
+    return {key: value for key, value in entry.items() if value not in (None, "")}
+
+
+def _train_rule_entry(rule: RuleMetadata) -> dict[str, Any]:
+    return {
+        "id": rule.rule_id,
+        "purpose": getattr(rule, "description", ""),
+        "expectations": _rule_expectations(rule),
+    }
+
+
+def render_wmbt_rules_block(
+    rules: Iterable[RuleMetadata], *, coach_phase: str | None = None
+) -> list[dict[str, Any]]:
+    scoped = [
+        rule
+        for rule in _phase_filtered_rules(rules, coach_phase)
+        if _acceptance_kind(rule) == "wmbt" or getattr(rule, "wmbt_urn", None)
+    ]
+    return [
+        {"wmbt_urn": wmbt_urn, "rules": [_wmbt_rule_entry(rule) for rule in group]}
+        for wmbt_urn, group in _group_by_attr(scoped, "wmbt_urn")
+    ]
+
+
+def render_train_rules_block(
+    rules: Iterable[RuleMetadata], *, coach_phase: str | None = None
+) -> list[dict[str, Any]]:
+    scoped = [
+        rule
+        for rule in _phase_filtered_rules(rules, coach_phase)
+        if _acceptance_kind(rule) == "train" or getattr(rule, "train_urn", None)
+    ]
+    return [
+        {"train_urn": train_urn, "rules": [_train_rule_entry(rule) for rule in group]}
+        for train_urn, group in _group_by_attr(scoped, "train_urn")
+    ]
+
+
 def render_security_rules_block(
     rules: Iterable[RuleMetadata],
     *,
@@ -117,4 +199,4 @@ def render_security_rules_block(
     return out
 
 
-__all__ = ["render_security_rules_block"]
+__all__ = ["render_wmbt_rules_block", "render_train_rules_block", "render_security_rules_block"]

--- a/src/atdd/coach/commands/tests/test_spawn_harness_rules_blocks.py
+++ b/src/atdd/coach/commands/tests/test_spawn_harness_rules_blocks.py
@@ -1,0 +1,124 @@
+# URN: test:spawn-agents:D001:spawn-harness-rules-blocks
+
+import yaml
+
+from atdd.coach.commands.spawn_harness_blocks import (
+    render_train_rules_block,
+    render_wmbt_rules_block,
+)
+from atdd.coach.utils.rule_binding import RuleMetadata
+
+
+def _meta(rule_id: str, **overrides) -> RuleMetadata:
+    values = dict(
+        rule_id=rule_id,
+        description="exercise acceptance rule",
+        phase="GREEN",
+        disposition="strict",
+        severity=2,
+        recipe=None,
+        introduced_in=None,
+        then=("first expectation", "second expectation"),
+        fix_hint="fix it",
+        bound_acceptance_urn="acc:spawn-agents:D001-UNIT-001-wmbt-rules-renderer-shape",
+        source_path=__import__("pathlib").Path("/tmp/D001.yaml"),
+        feature_urn="feature:spawn-agents:atdd-spawn-skeleton-and-harness",
+        wmbt_urn="wmbt:spawn-agents:D001",
+        train_urn="train:0002-coach-drives-lifecycle",
+        harness_type="unit",
+        signal_metric="pytest_pass",
+    )
+    values.update(overrides)
+    return RuleMetadata(**values)
+
+
+def test_wmbt_rules_renderer_shape_parses_as_yaml():
+    rules = [
+        _meta("repo.wmbt.D001.rule-001"),
+        _meta("repo.wmbt.D001.rule-002", bound_acceptance_urn="acc:two"),
+    ]
+
+    block = render_wmbt_rules_block(rules, coach_phase="GREEN")
+
+    assert yaml.safe_load(yaml.safe_dump({"wmbt_rules": block})) == {
+        "wmbt_rules": [
+            {
+                "wmbt_urn": "wmbt:spawn-agents:D001",
+                "rules": [
+                    {
+                        "id": "repo.wmbt.D001.rule-001",
+                        "acceptance_urn": "acc:spawn-agents:D001-UNIT-001-wmbt-rules-renderer-shape",
+                        "purpose": "exercise acceptance rule",
+                        "expectations": ["first expectation", "second expectation"],
+                        "harness_type": "unit",
+                        "signal_metric": "pytest_pass",
+                    },
+                    {
+                        "id": "repo.wmbt.D001.rule-002",
+                        "acceptance_urn": "acc:two",
+                        "purpose": "exercise acceptance rule",
+                        "expectations": ["first expectation", "second expectation"],
+                        "harness_type": "unit",
+                        "signal_metric": "pytest_pass",
+                    },
+                ],
+            }
+        ]
+    }
+
+
+def test_train_rules_renderer_shape_parses_as_yaml():
+    block = render_train_rules_block(
+        [_meta("repo.train.0002.rule-001")], coach_phase="GREEN"
+    )
+
+    assert yaml.safe_load(yaml.safe_dump({"train_rules": block})) == {
+        "train_rules": [
+            {
+                "train_urn": "train:0002-coach-drives-lifecycle",
+                "rules": [
+                    {
+                        "id": "repo.train.0002.rule-001",
+                        "purpose": "exercise acceptance rule",
+                        "expectations": ["first expectation", "second expectation"],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_phase_filter_applies_without_placeholders():
+    green = _meta("repo.wmbt.D001.green", phase="GREEN")
+    smoke = _meta("repo.wmbt.D001.smoke", phase="SMOKE")
+    train_smoke = _meta("repo.train.0002.smoke", phase="SMOKE")
+
+    assert render_wmbt_rules_block([green, smoke], coach_phase="GREEN") == [
+        {
+            "wmbt_urn": "wmbt:spawn-agents:D001",
+            "rules": [
+                {
+                    "id": "repo.wmbt.D001.green",
+                    "acceptance_urn": "acc:spawn-agents:D001-UNIT-001-wmbt-rules-renderer-shape",
+                    "purpose": "exercise acceptance rule",
+                    "expectations": ["first expectation", "second expectation"],
+                    "harness_type": "unit",
+                    "signal_metric": "pytest_pass",
+                }
+            ],
+        }
+    ]
+    assert render_train_rules_block([train_smoke], coach_phase="GREEN") == []
+
+
+def test_mixed_scope_uses_matching_renderer_only():
+    wmbt = _meta("repo.wmbt.D001.only", train_urn=None)
+    train = _meta("repo.train.0002.only", wmbt_urn=None)
+
+    assert [rule["rules"][0]["id"] for rule in render_wmbt_rules_block([wmbt, train], coach_phase="GREEN")] == ["repo.wmbt.D001.only"]
+    assert [rule["rules"][0]["id"] for rule in render_train_rules_block([wmbt, train], coach_phase="GREEN")] == ["repo.train.0002.only"]
+
+
+def test_empty_scope_omits_block_content():
+    assert render_wmbt_rules_block([], coach_phase="GREEN") == []
+    assert render_train_rules_block([], coach_phase="GREEN") == []

--- a/src/atdd/coach/commands/tests/test_spawn_harness_rules_blocks.py
+++ b/src/atdd/coach/commands/tests/test_spawn_harness_rules_blocks.py
@@ -122,3 +122,45 @@ def test_mixed_scope_uses_matching_renderer_only():
 def test_empty_scope_omits_block_content():
     assert render_wmbt_rules_block([], coach_phase="GREEN") == []
     assert render_train_rules_block([], coach_phase="GREEN") == []
+
+
+def test_spawn_prompt_includes_all_three_blocks_in_canonical_order(tmp_path, monkeypatch):
+    from atdd.coach.commands import spawn, session_template
+    from atdd.coach.commands.tests.test_e001_unit_001_spawn_cli_launches_session import FakeMultiplexer
+    from atdd.coach.commands.tests.test_spawn_harness_security_block import _security_meta
+
+    monkeypatch.setattr(
+        session_template,
+        "fetch_issue",
+        lambda n: {"number": n, "title": "t", "body": "body"},
+    )
+
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    runtime = tmp_path / "rt"
+    rules = [
+        _meta("repo.wmbt.D001.green", train_urn=None),
+        _meta("repo.wmbt.D001.smoke", phase="SMOKE", train_urn=None),
+        _meta("repo.train.0002.green", wmbt_urn=None),
+        _security_meta(rule_id="repo.security.green", phase="GREEN"),
+    ]
+
+    spawn.cmd_spawn(
+        persona="coder",
+        llm="claude-code",
+        worktree=worktree,
+        issue=503,
+        agent_id="coder-503-001",
+        runtime_root=runtime,
+        phase="GREEN",
+        multiplexer=FakeMultiplexer(),
+        rules=rules,
+    )
+
+    content = (worktree / ".launch_prompt.txt").read_text()
+    assert content.index("wmbt_rules:") < content.index("train_rules:") < content.index("security_rules:")
+    parsed = yaml.safe_load(content[content.index("wmbt_rules:"):])
+    assert parsed["wmbt_rules"][0]["rules"][0]["id"] == "repo.wmbt.D001.green"
+    assert "repo.wmbt.D001.smoke" not in content
+    assert parsed["train_rules"][0]["rules"][0]["id"] == "repo.train.0002.green"
+    assert parsed["security_rules"][0]["rules"][0]["id"] == "repo.security.green"


### PR DESCRIPTION
Closes #503

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #503 |
| Labels | atdd-issue, atdd:INIT, archetype:coach, track-k, wave-w1, archetype:tester, substrate-integration, wagon:spawn-agents, train:0002-coach-drives-lifecycle |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.