### PR TITLE
feat(coach): validator selection per phase (toolkit + substrate v12) (#519)

### DIFF
--- a/src/atdd/coach/runtime/tests/test_d001_unit_001_green_phase_selects_all_green_repo_rules.py
+++ b/src/atdd/coach/runtime/tests/test_d001_unit_001_green_phase_selects_all_green_repo_rules.py
@@ -1,0 +1,181 @@
+# URN: test:dispatch-validators:green-phase-selects-all-green-repo-rules
+# Acceptance: acc:dispatch-validators:D001-UNIT-001-green-phase-selects-all-green-repo-rules
+# WMBT: wmbt:dispatch-validators:D001
+# Phase: GREEN
+# Layer: domain
+
+"""AC-UNIT-001: GREEN phase selects all GREEN repo rules + toolkit GREEN mapping.
+
+Per spec §6.5: at GREEN, the selected set is:
+  - Repo slice: every repo.* rule whose bind_rule(rule_id).phase == GREEN
+  - Toolkit slice: atdd.coder.validators.* (coder.* archetype rules)
+No repo rules with phase != GREEN are included.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.runtime.validator_selection import ValidatorSet, build_validator_set
+from atdd.coach.utils.coach_config import CoachConfig, ValidatorsConfig
+from atdd.coach.utils.rule_binding import RuleMetadata
+
+
+_DUMMY_PATH = Path("/dev/null")
+
+
+def _make_repo_rule(rule_id: str, phase: str, source_kind: str = "wmbt") -> RuleMetadata:
+    """Create a repo RuleMetadata for testing."""
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=4,
+        description=f"test rule {rule_id}",
+        recipe=None,
+        introduced_in=None,
+        source_path=_DUMMY_PATH,
+        disposition="strict",
+        phase=phase,
+        acceptance_urn=f"acc:test-wagon:D001-UNIT-001-slug" if source_kind == "wmbt" else None,
+        train_urn=f"train:test-train" if source_kind == "train" else None,
+        security_urn=f"security:test-wagon:test-feature:001" if source_kind == "security" else None,
+    )
+
+
+def _make_toolkit_rule(rule_id: str, archetype: str) -> RuleMetadata:
+    """Create a toolkit RuleMetadata for testing."""
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=3,
+        description=f"test toolkit rule {rule_id}",
+        recipe=None,
+        introduced_in=None,
+        source_path=_DUMMY_PATH,
+        disposition="strict",
+    )
+
+
+class TestGreenPhaseRepoRuleSelection:
+    """AC-UNIT-001: GREEN selects all repo rules with phase=GREEN."""
+
+    def test_green_repo_rules_from_all_source_kinds(self):
+        """Repo rules with phase=GREEN from WMBT, train, and security are all included."""
+        registry = [
+            _make_repo_rule("repo.test-wagon.D001-acc-unit-001", "GREEN", "wmbt"),
+            _make_repo_rule("repo.test-train.acc-green-check", "GREEN", "train"),
+            _make_repo_rule("repo.test-wagon.test-feature-security-001", "GREEN", "security"),
+            # Non-GREEN repo rules — must be excluded
+            _make_repo_rule("repo.test-wagon.D001-acc-unit-002", "RED", "wmbt"),
+            _make_repo_rule("repo.test-wagon.D001-acc-unit-003", "SMOKE", "wmbt"),
+            _make_repo_rule("repo.test-wagon.D001-acc-unit-004", "PLANNED", "wmbt"),
+            # Toolkit rules — should not appear in repo_slice
+            _make_toolkit_rule("coder.dead-code.reachability", "coder"),
+        ]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        repo_ids = {r.rule_id for r in result.repo_slice}
+        assert "repo.test-wagon.D001-acc-unit-001" in repo_ids
+        assert "repo.test-train.acc-green-check" in repo_ids
+        assert "repo.test-wagon.test-feature-security-001" in repo_ids
+
+    def test_non_green_repo_rules_excluded(self):
+        """Repo rules with phase != GREEN must not appear in repo_slice."""
+        registry = [
+            _make_repo_rule("repo.test-wagon.D001-acc-unit-010", "RED", "wmbt"),
+            _make_repo_rule("repo.test-wagon.D001-acc-unit-011", "SMOKE", "wmbt"),
+            _make_repo_rule("repo.test-wagon.D001-acc-unit-012", "PLANNED", "wmbt"),
+            _make_repo_rule("repo.test-wagon.D001-acc-unit-013", "REFACTOR", "wmbt"),
+        ]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        assert len(result.repo_slice) == 0
+
+    def test_repo_rules_without_phase_excluded(self):
+        """Repo rules with phase=None must not appear in repo_slice."""
+        registry = [
+            RuleMetadata(
+                rule_id="repo.test-wagon.D001-acc-unit-020",
+                severity=4,
+                description="no-phase rule",
+                recipe=None,
+                introduced_in=None,
+                source_path=_DUMMY_PATH,
+                disposition="strict",
+                phase=None,
+            ),
+        ]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        assert len(result.repo_slice) == 0
+
+
+class TestGreenPhaseToolkitSelection:
+    """AC-UNIT-001: GREEN includes the toolkit GREEN mapping (coder.*)."""
+
+    def test_coder_rules_in_toolkit_slice(self):
+        """Rules with coder.* archetype are in the GREEN toolkit slice."""
+        registry = [
+            _make_toolkit_rule("coder.dead-code.reachability", "coder"),
+            _make_toolkit_rule("coder.dto.testing-pattern", "coder"),
+            _make_toolkit_rule("coder.error-response.compliance", "coder"),
+            _make_toolkit_rule("coder.frontend.composition-root", "coder"),
+            _make_toolkit_rule("coder.presentation.ratchet", "coder"),
+            # Non-coder rules — should be excluded from GREEN toolkit
+            _make_toolkit_rule("planner.wagon.structure", "planner"),
+            _make_toolkit_rule("tester.red.convention", "tester"),
+        ]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert "coder.dead-code.reachability" in toolkit_ids
+        assert "coder.dto.testing-pattern" in toolkit_ids
+        assert "coder.error-response.compliance" in toolkit_ids
+        assert "coder.frontend.composition-root" in toolkit_ids
+        assert "coder.presentation.ratchet" in toolkit_ids
+
+    def test_non_coder_rules_excluded_from_green_toolkit(self):
+        """Rules from other archetypes are excluded from GREEN toolkit slice."""
+        registry = [
+            _make_toolkit_rule("planner.wagon.structure", "planner"),
+            _make_toolkit_rule("tester.red.convention", "tester"),
+            _make_toolkit_rule("coach.rule-id-uniqueness", "coach"),
+        ]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert "planner.wagon.structure" not in toolkit_ids
+        assert "tester.red.convention" not in toolkit_ids
+        assert "coach.rule-id-uniqueness" not in toolkit_ids
+
+    def test_repo_rules_not_in_toolkit_slice(self):
+        """Repo rules never appear in the toolkit slice."""
+        registry = [
+            _make_repo_rule("repo.test-wagon.D001-acc-unit-001", "GREEN", "wmbt"),
+            _make_toolkit_rule("coder.dead-code.reachability", "coder"),
+        ]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert all(not rid.startswith("repo.") for rid in toolkit_ids)
+
+
+class TestGreenPhaseUnion:
+    """AC-UNIT-001: Selected set is the union of toolkit + repo slices."""
+
+    def test_union_contains_both_slices(self):
+        """all_rules property returns toolkit ∪ repo."""
+        coder_rule = _make_toolkit_rule("coder.dead-code.reachability", "coder")
+        repo_rule = _make_repo_rule("repo.test-wagon.D001-acc-unit-001", "GREEN", "wmbt")
+        registry = [coder_rule, repo_rule]
+
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        all_ids = {r.rule_id for r in result.all_rules}
+        assert "coder.dead-code.reachability" in all_ids
+        assert "repo.test-wagon.D001-acc-unit-001" in all_ids

--- a/src/atdd/coach/runtime/tests/test_d001_unit_002_planned_runs_substrate_enforcement.py
+++ b/src/atdd/coach/runtime/tests/test_d001_unit_002_planned_runs_substrate_enforcement.py
@@ -1,0 +1,188 @@
+# URN: test:dispatch-validators:planned-runs-substrate-enforcement
+# Acceptance: acc:dispatch-validators:D001-UNIT-002-planned-runs-substrate-enforcement
+# WMBT: wmbt:dispatch-validators:D001
+# Phase: GREEN
+# Layer: domain
+
+"""AC-UNIT-002: PLANNED phase runs substrate enforcement validators.
+
+Per spec §6.5 PLANNED row:
+  - Toolkit slice: atdd.planner.validators.* + atdd.tester.validators.acceptance-violation.*
+  - Substrate enforcement includes all five rules from
+    acceptance-violation.convention.yaml:
+      1. acceptance-must-be-measurable
+      2. acceptance-must-declare-phase
+      3. disposition-must-not-be-declared
+      4. validator-binding-must-be-bidirectional
+      5. metric-implementation-must-exist
+"""
+
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.runtime.validator_selection import ValidatorSet, build_validator_set
+from atdd.coach.utils.coach_config import CoachConfig, ValidatorsConfig
+from atdd.coach.utils.rule_binding import RuleMetadata
+
+
+_DUMMY_PATH = Path("/dev/null")
+
+# The five substrate enforcement rule IDs from acceptance-violation.convention.yaml
+SUBSTRATE_ENFORCEMENT_IDS = [
+    "tester.acceptance-violation.acceptance-must-be-measurable",
+    "tester.acceptance-violation.acceptance-must-declare-phase",
+    "tester.acceptance-violation.disposition-must-not-be-declared",
+    "tester.acceptance-violation.validator-binding-must-be-bidirectional",
+    "tester.acceptance-violation.metric-implementation-must-exist",
+]
+
+
+def _make_toolkit_rule(rule_id: str) -> RuleMetadata:
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=3,
+        description=f"test {rule_id}",
+        recipe=None,
+        introduced_in=None,
+        source_path=_DUMMY_PATH,
+        disposition="strict",
+    )
+
+
+class TestPlannedSubstrateEnforcement:
+    """AC-UNIT-002: PLANNED includes all five substrate enforcement rules."""
+
+    def test_all_five_substrate_enforcement_rules_present(self):
+        """All five acceptance-violation.* rules are in PLANNED toolkit slice."""
+        registry = [_make_toolkit_rule(rid) for rid in SUBSTRATE_ENFORCEMENT_IDS]
+        # Add some non-matching rules
+        registry.extend([
+            _make_toolkit_rule("tester.red.convention"),
+            _make_toolkit_rule("coder.dead-code.reachability"),
+        ])
+
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("PLANNED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        for expected_id in SUBSTRATE_ENFORCEMENT_IDS:
+            assert expected_id in toolkit_ids, (
+                f"Substrate enforcement rule {expected_id!r} missing from PLANNED toolkit slice"
+            )
+
+    def test_acceptance_must_be_measurable(self):
+        """acceptance-must-be-measurable is present."""
+        registry = [_make_toolkit_rule("tester.acceptance-violation.acceptance-must-be-measurable")]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("PLANNED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert "tester.acceptance-violation.acceptance-must-be-measurable" in toolkit_ids
+
+    def test_acceptance_must_declare_phase(self):
+        """acceptance-must-declare-phase is present."""
+        registry = [_make_toolkit_rule("tester.acceptance-violation.acceptance-must-declare-phase")]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("PLANNED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert "tester.acceptance-violation.acceptance-must-declare-phase" in toolkit_ids
+
+    def test_disposition_must_not_be_declared(self):
+        """disposition-must-not-be-declared is present."""
+        registry = [_make_toolkit_rule("tester.acceptance-violation.disposition-must-not-be-declared")]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("PLANNED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert "tester.acceptance-violation.disposition-must-not-be-declared" in toolkit_ids
+
+    def test_validator_binding_must_be_bidirectional(self):
+        """validator-binding-must-be-bidirectional is present."""
+        registry = [_make_toolkit_rule("tester.acceptance-violation.validator-binding-must-be-bidirectional")]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("PLANNED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert "tester.acceptance-violation.validator-binding-must-be-bidirectional" in toolkit_ids
+
+    def test_metric_implementation_must_exist(self):
+        """metric-implementation-must-exist is present."""
+        registry = [_make_toolkit_rule("tester.acceptance-violation.metric-implementation-must-exist")]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("PLANNED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert "tester.acceptance-violation.metric-implementation-must-exist" in toolkit_ids
+
+
+class TestPlannedPlannerValidators:
+    """AC-UNIT-002: PLANNED includes atdd.planner.validators.*."""
+
+    def test_planner_rules_in_toolkit_slice(self):
+        """Rules with planner.* archetype are in the PLANNED toolkit slice."""
+        registry = [
+            _make_toolkit_rule("planner.wagon.structure"),
+            _make_toolkit_rule("planner.acceptance.criteria"),
+            _make_toolkit_rule("planner.wmbt.consistency"),
+            # Non-planner, non-acceptance-violation rules — excluded
+            _make_toolkit_rule("coder.dead-code.reachability"),
+            _make_toolkit_rule("tester.red.convention"),
+        ]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("PLANNED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert "planner.wagon.structure" in toolkit_ids
+        assert "planner.acceptance.criteria" in toolkit_ids
+        assert "planner.wmbt.consistency" in toolkit_ids
+
+    def test_non_planner_non_substrate_rules_excluded(self):
+        """Rules from other archetypes (not planner or acceptance-violation) are excluded."""
+        registry = [
+            _make_toolkit_rule("coder.dead-code.reachability"),
+            _make_toolkit_rule("tester.red.convention"),
+            _make_toolkit_rule("coach.rule-id-uniqueness"),
+        ]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("PLANNED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert len(toolkit_ids) == 0
+
+
+class TestPlannedToolkitMappingMatchesSection65:
+    """AC-UNIT-002: PLANNED toolkit mapping matches the §6.5 table union."""
+
+    def test_full_planned_toolkit_slice(self):
+        """PLANNED = planner.* + tester.acceptance-violation.* — no other archetypes."""
+        registry = [
+            # planner rules
+            _make_toolkit_rule("planner.wagon.structure"),
+            _make_toolkit_rule("planner.acceptance.criteria"),
+            # substrate enforcement rules
+            _make_toolkit_rule("tester.acceptance-violation.acceptance-must-be-measurable"),
+            _make_toolkit_rule("tester.acceptance-violation.acceptance-must-declare-phase"),
+            _make_toolkit_rule("tester.acceptance-violation.disposition-must-not-be-declared"),
+            _make_toolkit_rule("tester.acceptance-violation.validator-binding-must-be-bidirectional"),
+            _make_toolkit_rule("tester.acceptance-violation.metric-implementation-must-exist"),
+            # Excluded rules from other archetypes
+            _make_toolkit_rule("coder.dead-code.reachability"),
+            _make_toolkit_rule("tester.red.convention"),
+            _make_toolkit_rule("coach.rule-id-uniqueness"),
+        ]
+        config = CoachConfig(validators=ValidatorsConfig(selection="default"))
+        result = build_validator_set("PLANNED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        expected_ids = {
+            "planner.wagon.structure",
+            "planner.acceptance.criteria",
+            "tester.acceptance-violation.acceptance-must-be-measurable",
+            "tester.acceptance-violation.acceptance-must-declare-phase",
+            "tester.acceptance-violation.disposition-must-not-be-declared",
+            "tester.acceptance-violation.validator-binding-must-be-bidirectional",
+            "tester.acceptance-violation.metric-implementation-must-exist",
+        }
+        assert toolkit_ids == expected_ids

--- a/src/atdd/coach/runtime/tests/test_d001_unit_003_config_override_substitutes_selection.py
+++ b/src/atdd/coach/runtime/tests/test_d001_unit_003_config_override_substitutes_selection.py
@@ -1,0 +1,180 @@
+# URN: test:dispatch-validators:config-override-substitutes-selection
+# Acceptance: acc:dispatch-validators:D001-UNIT-003-config-override-substitutes-selection
+# WMBT: wmbt:dispatch-validators:D001
+# Phase: GREEN
+# Layer: domain
+
+"""AC-UNIT-003: Config override substitutes the toolkit slice per phase.
+
+Per spec §6.5 override semantics:
+  - Override sets the toolkit slice for the named phase (exhaustive — defaults
+    are NOT additionally unioned in for that phase).
+  - Override does NOT change the repo-rule slice (still computed from
+    bind_rule(rule_id).phase per substrate v12).
+  - Phases not present in the override fall back to the §6.5 default mapping.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.runtime.validator_selection import ValidatorSet, build_validator_set
+from atdd.coach.utils.coach_config import CoachConfig, ValidatorsConfig
+from atdd.coach.utils.rule_binding import RuleMetadata
+
+
+_DUMMY_PATH = Path("/dev/null")
+
+
+def _make_toolkit_rule(rule_id: str) -> RuleMetadata:
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=3,
+        description=f"test {rule_id}",
+        recipe=None,
+        introduced_in=None,
+        source_path=_DUMMY_PATH,
+        disposition="strict",
+    )
+
+
+def _make_repo_rule(rule_id: str, phase: str) -> RuleMetadata:
+    return RuleMetadata(
+        rule_id=rule_id,
+        severity=4,
+        description=f"test repo {rule_id}",
+        recipe=None,
+        introduced_in=None,
+        source_path=_DUMMY_PATH,
+        disposition="strict",
+        phase=phase,
+    )
+
+
+class TestConfigOverrideToolkitSlice:
+    """AC-UNIT-003: Override substitutes the toolkit slice exhaustively."""
+
+    def test_override_replaces_default_toolkit_slice(self):
+        """When override is set for GREEN, toolkit slice equals override list only."""
+        registry = [
+            _make_toolkit_rule("coder.dead-code.reachability"),
+            _make_toolkit_rule("coder.dto.testing-pattern"),
+            _make_toolkit_rule("coder.error-response.compliance"),
+            _make_toolkit_rule("planner.wagon.structure"),
+            _make_repo_rule("repo.test.D001-acc-unit-001", "GREEN"),
+        ]
+        # Override GREEN to only include dead-code — dto and error-response excluded
+        config = CoachConfig(
+            validators=ValidatorsConfig(
+                selection={"GREEN": ["coder.dead-code.reachability"]}
+            )
+        )
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert toolkit_ids == {"coder.dead-code.reachability"}
+        assert "coder.dto.testing-pattern" not in toolkit_ids
+        assert "coder.error-response.compliance" not in toolkit_ids
+
+    def test_defaults_not_unioned_into_overridden_phase(self):
+        """Defaults are NOT additionally unioned in for the overridden phase."""
+        registry = [
+            _make_toolkit_rule("coder.dead-code.reachability"),
+            _make_toolkit_rule("coder.dto.testing-pattern"),
+        ]
+        # Override GREEN to only include dead-code
+        config = CoachConfig(
+            validators=ValidatorsConfig(
+                selection={"GREEN": ["coder.dead-code.reachability"]}
+            )
+        )
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        # dto.testing-pattern is in the default GREEN mapping but NOT in override
+        assert "coder.dto.testing-pattern" not in toolkit_ids
+
+
+class TestConfigOverrideRepoSliceUnaffected:
+    """AC-UNIT-003: Repo-rule slice is unaffected by override."""
+
+    def test_repo_slice_still_computed_from_phase(self):
+        """Repo slice still derives from bind_rule(rule_id).phase, not override."""
+        registry = [
+            _make_toolkit_rule("coder.dead-code.reachability"),
+            _make_repo_rule("repo.test.D001-acc-unit-001", "GREEN"),
+            _make_repo_rule("repo.test.D001-acc-unit-002", "RED"),
+        ]
+        config = CoachConfig(
+            validators=ValidatorsConfig(
+                selection={"GREEN": ["coder.dead-code.reachability"]}
+            )
+        )
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        repo_ids = {r.rule_id for r in result.repo_slice}
+        assert "repo.test.D001-acc-unit-001" in repo_ids
+        assert "repo.test.D001-acc-unit-002" not in repo_ids
+
+    def test_override_does_not_filter_repo_rules(self):
+        """Override only affects toolkit slice; repo rules are independent."""
+        green_repo = _make_repo_rule("repo.test.D001-acc-unit-001", "GREEN")
+        registry = [
+            _make_toolkit_rule("planner.wagon.structure"),  # not in GREEN default or override
+            green_repo,
+        ]
+        # Override GREEN to empty list — toolkit slice is empty, but repo is unaffected
+        config = CoachConfig(
+            validators=ValidatorsConfig(
+                selection={"GREEN": []}
+            )
+        )
+        result = build_validator_set("GREEN", config, registry=registry)
+
+        assert len(result.toolkit_slice) == 0
+        assert len(result.repo_slice) == 1
+        assert result.repo_slice[0].rule_id == "repo.test.D001-acc-unit-001"
+
+
+class TestConfigOverrideFallbackForUnspecifiedPhases:
+    """AC-UNIT-003: Phases not in override fall back to §6.5 defaults."""
+
+    def test_unspecified_phase_uses_default_mapping(self):
+        """RED phase uses §6.5 defaults when only GREEN is overridden."""
+        registry = [
+            _make_toolkit_rule("tester.red.convention"),
+            _make_toolkit_rule("tester.filename.naming"),
+            _make_toolkit_rule("coder.dead-code.reachability"),
+        ]
+        # Override GREEN only — RED should use defaults (tester.*)
+        config = CoachConfig(
+            validators=ValidatorsConfig(
+                selection={"GREEN": ["coder.dead-code.reachability"]}
+            )
+        )
+        result = build_validator_set("RED", config, registry=registry)
+
+        toolkit_ids = {r.rule_id for r in result.toolkit_slice}
+        assert "tester.red.convention" in toolkit_ids
+        assert "tester.filename.naming" in toolkit_ids
+        # coder rules are NOT in RED default mapping
+        assert "coder.dead-code.reachability" not in toolkit_ids
+
+    def test_string_default_uses_section65_mapping(self):
+        """selection='default' (string) uses §6.5 mapping for all phases."""
+        registry = [
+            _make_toolkit_rule("coder.dead-code.reachability"),
+            _make_toolkit_rule("planner.wagon.structure"),
+        ]
+        config = CoachConfig(
+            validators=ValidatorsConfig(selection="default")
+        )
+        green_result = build_validator_set("GREEN", config, registry=registry)
+        planned_result = build_validator_set("PLANNED", config, registry=registry)
+
+        green_ids = {r.rule_id for r in green_result.toolkit_slice}
+        planned_ids = {r.rule_id for r in planned_result.toolkit_slice}
+
+        assert "coder.dead-code.reachability" in green_ids
+        assert "planner.wagon.structure" in planned_ids
+        assert "coder.dead-code.reachability" not in planned_ids

--- a/src/atdd/coach/runtime/validator_selection.py
+++ b/src/atdd/coach/runtime/validator_selection.py
@@ -30,9 +30,8 @@ Override:
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Optional, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Tuple
 
 from atdd.coach.utils.coach_config import CoachConfig
 from atdd.coach.utils.rule_binding import RuleMetadata, iter_rules

--- a/src/atdd/coach/runtime/validator_selection.py
+++ b/src/atdd/coach/runtime/validator_selection.py
@@ -7,18 +7,44 @@
 Public API:
   - build_validator_set(phase, config, registry) -> ValidatorSet
   - ValidatorSet (immutable)
+
+The selected set is ``toolkit_slice ∪ repo_slice``:
+
+Toolkit slice (§6.5 mapping table):
+  - PLANNED: planner.* + tester.acceptance-violation.* (substrate enforcement)
+  - RED: tester.* + coach.rule-id-uniqueness
+  - GREEN: coder.*
+  - SMOKE: tester.* (smoke-filtered downstream)
+  - REFACTOR: coder.* with disposition=strict (regression sweep)
+
+Repo-rule slice (substrate v12 §8.1):
+  - Every repo.* rule whose RuleMetadata.phase matches the current coach phase.
+  - At REFACTOR, additionally sweeps all strict-disposition repo rules
+    regardless of phase.
+
+Override:
+  - ``config.validators.selection`` can be a dict mapping phase names to
+    explicit rule-id lists, overriding the toolkit slice for that phase.
+  - Repo-rule slice is never overridden (substrate v12 §2 unsuppressibility).
 """
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 from atdd.coach.utils.coach_config import CoachConfig
-from atdd.coach.utils.rule_binding import RuleMetadata
+from atdd.coach.utils.rule_binding import RuleMetadata, iter_rules
 
 
 VALID_PHASES = ("PLANNED", "RED", "GREEN", "SMOKE", "REFACTOR")
+
+# Extra toolkit rule IDs included at specific phases (not archetype-filtered).
+_RED_EXTRA_IDS = frozenset({"coach.rule-id-uniqueness"})
+
+# Namespace prefix for substrate enforcement at PLANNED.
+_PLANNED_SUBSTRATE_PREFIX = "tester.acceptance-violation."
 
 
 @dataclass(frozen=True)
@@ -33,6 +59,91 @@ class ValidatorSet:
         return self.toolkit_slice + self.repo_slice
 
 
+class PhaseSelectionError(ValueError):
+    """Raised for unknown coach phases or invalid selection arguments."""
+
+
+def _normalize_phase(phase: str) -> str:
+    if not isinstance(phase, str) or not phase.strip():
+        raise PhaseSelectionError(
+            f"phase must be a non-empty string, got {phase!r}"
+        )
+    canonical = phase.strip().upper()
+    if canonical not in VALID_PHASES:
+        raise PhaseSelectionError(
+            f"unknown phase {phase!r}; expected one of {VALID_PHASES}"
+        )
+    return canonical
+
+
+def _is_toolkit_rule(rule: RuleMetadata) -> bool:
+    return not rule.rule_id.startswith("repo.")
+
+
+def _toolkit_matches_phase(rule: RuleMetadata, phase: str) -> bool:
+    """Return True if *rule* is a toolkit rule that belongs in *phase*'s §6.5 mapping."""
+    rid = rule.rule_id
+    archetype = rid.split(".", 1)[0]
+
+    if phase == "PLANNED":
+        return archetype == "planner" or rid.startswith(_PLANNED_SUBSTRATE_PREFIX)
+    elif phase == "RED":
+        return archetype == "tester" or rid in _RED_EXTRA_IDS
+    elif phase == "GREEN":
+        return archetype == "coder"
+    elif phase == "SMOKE":
+        return archetype == "tester"
+    elif phase == "REFACTOR":
+        return archetype == "coder" and rule.disposition == "strict"
+    return False
+
+
+def _select_toolkit_slice(
+    phase: str,
+    registry: List[RuleMetadata],
+    override: Optional[Dict[str, List[str]]],
+) -> List[RuleMetadata]:
+    """Build the toolkit slice for *phase*, applying config override if present."""
+    if isinstance(override, dict) and phase in override:
+        override_ids = set(override[phase])
+        return sorted(
+            [r for r in registry if _is_toolkit_rule(r) and r.rule_id in override_ids],
+            key=lambda r: r.rule_id,
+        )
+
+    return sorted(
+        [r for r in registry if _is_toolkit_rule(r) and _toolkit_matches_phase(r, phase)],
+        key=lambda r: r.rule_id,
+    )
+
+
+def _select_repo_slice(phase: str, registry: List[RuleMetadata]) -> List[RuleMetadata]:
+    """Build the repo-rule slice per substrate v12 §8.1."""
+    selected: List[RuleMetadata] = []
+    seen: set = set()
+
+    def _add(rule: RuleMetadata) -> None:
+        if rule.rule_id not in seen:
+            seen.add(rule.rule_id)
+            selected.append(rule)
+
+    # Phase-matched repo rules
+    for rule in registry:
+        if not rule.rule_id.startswith("repo."):
+            continue
+        if rule.phase and rule.phase.upper() == phase:
+            _add(rule)
+
+    # REFACTOR regression sweep: all strict-disposition repo rules
+    if phase == "REFACTOR":
+        for rule in registry:
+            if rule.rule_id.startswith("repo.") and rule.disposition == "strict":
+                _add(rule)
+
+    selected.sort(key=lambda r: r.rule_id)
+    return selected
+
+
 def build_validator_set(
     phase: str,
     config: CoachConfig,
@@ -40,6 +151,34 @@ def build_validator_set(
 ) -> ValidatorSet:
     """Build the validator set for the given coach phase.
 
-    Stub — will be implemented in GREEN phase.
+    Args:
+        phase: Coach phase (PLANNED, RED, GREEN, SMOKE, REFACTOR).
+        config: Coach configuration with validator selection settings.
+        registry: Optional iterable of RuleMetadata. Defaults to iter_rules().
+
+    Returns:
+        ValidatorSet with toolkit_slice and repo_slice.
+
+    Raises:
+        PhaseSelectionError: when phase is unknown.
     """
-    raise NotImplementedError("validator_selection.build_validator_set not yet implemented")
+    phase_upper = _normalize_phase(phase)
+    rules = list(registry) if registry is not None else list(iter_rules())
+
+    selection = config.validators.selection
+    override: Optional[Dict[str, List[str]]] = None
+    if isinstance(selection, dict):
+        override = selection
+
+    toolkit_slice = tuple(_select_toolkit_slice(phase_upper, rules, override))
+    repo_slice = tuple(_select_repo_slice(phase_upper, rules))
+
+    return ValidatorSet(toolkit_slice=toolkit_slice, repo_slice=repo_slice)
+
+
+__all__ = [
+    "PhaseSelectionError",
+    "VALID_PHASES",
+    "ValidatorSet",
+    "build_validator_set",
+]

--- a/src/atdd/coach/runtime/validator_selection.py
+++ b/src/atdd/coach/runtime/validator_selection.py
@@ -1,0 +1,45 @@
+# URN: component:govern-lifecycle:enforcement-substrate:validator_selection:backend:domain
+# Runtime: python
+# Purpose: Per-phase validator selection per spec §6.5 (toolkit slice) and substrate v12 §8.1 (repo-rule slice).
+
+"""Per-phase validator selection (spec §6.5, substrate v12 §8.1).
+
+Public API:
+  - build_validator_set(phase, config, registry) -> ValidatorSet
+  - ValidatorSet (immutable)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple, Union
+
+from atdd.coach.utils.coach_config import CoachConfig
+from atdd.coach.utils.rule_binding import RuleMetadata
+
+
+VALID_PHASES = ("PLANNED", "RED", "GREEN", "SMOKE", "REFACTOR")
+
+
+@dataclass(frozen=True)
+class ValidatorSet:
+    """Phase-selected validator set: toolkit slice ∪ repo-rule slice."""
+
+    toolkit_slice: Tuple[RuleMetadata, ...]
+    repo_slice: Tuple[RuleMetadata, ...]
+
+    @property
+    def all_rules(self) -> Tuple[RuleMetadata, ...]:
+        return self.toolkit_slice + self.repo_slice
+
+
+def build_validator_set(
+    phase: str,
+    config: CoachConfig,
+    registry: Optional[Iterable[RuleMetadata]] = None,
+) -> ValidatorSet:
+    """Build the validator set for the given coach phase.
+
+    Stub — will be implemented in GREEN phase.
+    """
+    raise NotImplementedError("validator_selection.build_validator_set not yet implemented")

--- a/src/atdd/coach/utils/coach_config.py
+++ b/src/atdd/coach/utils/coach_config.py
@@ -62,7 +62,7 @@ class ReviewConfig:
 class ValidatorsConfig:
     enabled: bool = True
     grace_window_seconds: int = 30
-    selection: str = "default"
+    selection: Union[str, Dict[str, List[str]]] = "default"
     pytest_args: List[str] = field(
         default_factory=lambda: ["-x", "--tb=short"]
     )
@@ -365,7 +365,26 @@ def _parse_validators(raw: Any) -> ValidatorsConfig:
             mapping["grace_window_seconds"], "validators.grace_window_seconds"
         )
     if "selection" in mapping:
-        overrides["selection"] = _str(mapping["selection"], "validators.selection")
+        sel = mapping["selection"]
+        if isinstance(sel, dict):
+            parsed: Dict[str, List[str]] = {}
+            for phase_key, rule_list in sel.items():
+                if not isinstance(phase_key, str):
+                    raise _err(
+                        "validators.selection",
+                        f"phase key must be a string, got {_type_name(phase_key)}",
+                    )
+                parsed[phase_key] = _list_of_str(
+                    rule_list, f"validators.selection.{phase_key}"
+                )
+            overrides["selection"] = parsed
+        elif isinstance(sel, str):
+            overrides["selection"] = _str(sel, "validators.selection")
+        else:
+            raise _err(
+                "validators.selection",
+                f"expected string or mapping, got {_type_name(sel)}",
+            )
     if "pytest_args" in mapping:
         overrides["pytest_args"] = _list_of_str(
             mapping["pytest_args"], "validators.pytest_args"


### PR DESCRIPTION
Closes #519

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #519 |
| Labels | atdd-issue, atdd:INIT, archetype:coach, track-m, wave-w2, archetype:tester, substrate-integration, wagon:dispatch-validators, train:0002-coach-drives-lifecycle |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.