### PR TITLE
refactor(coach): split `coach.py` into per-handler modules (prerequisite for integration-hardening parallelism) (#591)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.32.0"
+version = "3.33.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/coach.py
+++ b/src/atdd/coach/commands/coach.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import argparse
 import sys
 from dataclasses import dataclass, field
-from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -42,66 +41,33 @@ from typing import Optional
 # P5 (#531): orchestrate.py archived; import from _archived.
 from atdd.coach.commands._archived.orchestrate import build_plan, compute_waves
 
-
-class Phase(str, Enum):
-    """Per-issue lifecycle states (spec §4.1).
-
-    `str` mixin gives a stable string serialization for the eventual
-    decision-log writer (#J3); J1 itself never writes the log.
-    """
-
-    INIT = "INIT"
-    PLANNED = "PLANNED"
-    RED = "RED"
-    GREEN = "GREEN"
-    SMOKE = "SMOKE"
-    REFACTOR = "REFACTOR"
-    COMPLETE = "COMPLETE"
-    BLOCKED = "BLOCKED"
-    MERGED = "MERGED"
-
-    def __str__(self) -> str:
-        return self.value
-
-
-TRANSITION_TABLE: dict[Phase, set[Phase]] = {
-    Phase.INIT:     {Phase.PLANNED, Phase.BLOCKED},
-    Phase.PLANNED:  {Phase.RED, Phase.BLOCKED},
-    Phase.RED:      {Phase.GREEN, Phase.BLOCKED},
-    Phase.GREEN:    {Phase.SMOKE, Phase.BLOCKED},
-    Phase.SMOKE:    {Phase.REFACTOR, Phase.BLOCKED},
-    Phase.REFACTOR: {Phase.COMPLETE, Phase.BLOCKED},
-    Phase.COMPLETE: {Phase.MERGED},
-    Phase.BLOCKED:  {
-        Phase.INIT, Phase.PLANNED, Phase.RED,
-        Phase.GREEN, Phase.SMOKE, Phase.REFACTOR,
-    },
-    Phase.MERGED:   set(),
-}
-
-
-def can_transition(src: Phase, dst: Phase) -> bool:
-    return dst in TRANSITION_TABLE[src]
-
-
-PLANNED_PATH: tuple[Phase, ...] = (
-    Phase.INIT, Phase.PLANNED, Phase.RED, Phase.GREEN,
-    Phase.SMOKE, Phase.REFACTOR, Phase.COMPLETE, Phase.MERGED,
+# State-machine types extracted to handlers package (#591 split).
+# Re-exported here so all existing importers continue to work unchanged.
+from atdd.coach.handlers.state_machine import (
+    Phase,
+    PLANNED_PATH,
+    StateMachine,
+    TRANSITION_TABLE,
+    can_transition,
+    initialize_state_machine,
 )
 
-
-@dataclass
-class StateMachine:
-    """Per-issue state container. J1 ships the structure; transition
-    handlers land in per-state issues across the J/K/L/M tracks."""
-
-    issue_number: int
-    phase: Phase = Phase.INIT
-    history: list[Phase] = field(default_factory=list)
-
-
-def initialize_state_machine(issue_number: int) -> StateMachine:
-    return StateMachine(issue_number=issue_number, phase=Phase.INIT)
+__all__ = [
+    "Phase",
+    "PLANNED_PATH",
+    "StateMachine",
+    "TRANSITION_TABLE",
+    "can_transition",
+    "initialize_state_machine",
+    "Config",
+    "Policy",
+    "parse_cli",
+    "resolve_policy",
+    "build_plan",
+    "compute_waves",
+    "run",
+    "main",
+]
 
 
 # ---------------------------------------------------------------------------

--- a/src/atdd/coach/handlers/__init__.py
+++ b/src/atdd/coach/handlers/__init__.py
@@ -1,0 +1,28 @@
+"""Handler package for coach v9 (issue #591 split).
+
+Re-exports the state-machine symbols so consumers can import from either
+`atdd.coach.handlers` or `atdd.coach.handlers.state_machine`.
+"""
+from atdd.coach.handlers.state_machine import (
+    CoachContext,
+    HandlerResult,
+    Phase,
+    PLANNED_PATH,
+    StateMachine,
+    Transition,
+    TRANSITION_TABLE,
+    can_transition,
+    initialize_state_machine,
+)
+
+__all__ = [
+    "CoachContext",
+    "HandlerResult",
+    "Phase",
+    "PLANNED_PATH",
+    "StateMachine",
+    "Transition",
+    "TRANSITION_TABLE",
+    "can_transition",
+    "initialize_state_machine",
+]

--- a/src/atdd/coach/handlers/decisions.py
+++ b/src/atdd/coach/handlers/decisions.py
@@ -1,0 +1,8 @@
+"""Decisions handler stub — J3 wiring lives here (issue #586 will fill)."""
+from __future__ import annotations
+
+from atdd.coach.handlers.state_machine import CoachContext, HandlerResult, Transition
+
+
+def handle(ctx: CoachContext, transition: Transition) -> HandlerResult:
+    return HandlerResult.NOOP

--- a/src/atdd/coach/handlers/observer.py
+++ b/src/atdd/coach/handlers/observer.py
@@ -1,0 +1,8 @@
+"""Observer handler stub — L1 wiring lives here (issue #589 will fill)."""
+from __future__ import annotations
+
+from atdd.coach.handlers.state_machine import CoachContext, HandlerResult, Transition
+
+
+def handle(ctx: CoachContext, transition: Transition) -> HandlerResult:
+    return HandlerResult.NOOP

--- a/src/atdd/coach/handlers/reviewer.py
+++ b/src/atdd/coach/handlers/reviewer.py
@@ -1,0 +1,8 @@
+"""Reviewer handler stub — N5 wiring lives here (issue #589 will fill)."""
+from __future__ import annotations
+
+from atdd.coach.handlers.state_machine import CoachContext, HandlerResult, Transition
+
+
+def handle(ctx: CoachContext, transition: Transition) -> HandlerResult:
+    return HandlerResult.NOOP

--- a/src/atdd/coach/handlers/spawn.py
+++ b/src/atdd/coach/handlers/spawn.py
@@ -1,0 +1,8 @@
+"""Spawn handler stub — K1 wiring lives here (issue #585 will fill)."""
+from __future__ import annotations
+
+from atdd.coach.handlers.state_machine import CoachContext, HandlerResult, Transition
+
+
+def handle(ctx: CoachContext, transition: Transition) -> HandlerResult:
+    return HandlerResult.NOOP

--- a/src/atdd/coach/handlers/state_machine.py
+++ b/src/atdd/coach/handlers/state_machine.py
@@ -1,0 +1,121 @@
+"""State-machine types extracted from coach.py (issue #591 split).
+
+Defines:
+    HandlerResult  — return type for all per-concern handle() stubs
+    CoachContext   — frozen view of resolved Config passed to handlers
+    Transition     — (src, dst) phase pair passed to handlers
+    Phase          — per-issue lifecycle enum (spec §4.1)
+    TRANSITION_TABLE — legal transitions
+    can_transition — table lookup helper
+    PLANNED_PATH   — canonical state sequence
+    StateMachine   — per-issue state container
+    initialize_state_machine — factory
+
+All logic is unchanged from J1 (issue #496).  Children (#585-#590) fill in
+the stub handle() functions in the sibling modules.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import NamedTuple, Optional
+
+
+class HandlerResult(str, Enum):
+    """Return value for every per-concern handle() stub."""
+
+    NOOP = "NOOP"
+    HANDLED = "HANDLED"
+    ERROR = "ERROR"
+
+
+class Phase(str, Enum):
+    """Per-issue lifecycle states (spec §4.1).
+
+    `str` mixin gives a stable string serialization for the eventual
+    decision-log writer (#J3); J1 itself never writes the log.
+    """
+
+    INIT = "INIT"
+    PLANNED = "PLANNED"
+    RED = "RED"
+    GREEN = "GREEN"
+    SMOKE = "SMOKE"
+    REFACTOR = "REFACTOR"
+    COMPLETE = "COMPLETE"
+    BLOCKED = "BLOCKED"
+    MERGED = "MERGED"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+TRANSITION_TABLE: dict[Phase, set[Phase]] = {
+    Phase.INIT:     {Phase.PLANNED, Phase.BLOCKED},
+    Phase.PLANNED:  {Phase.RED, Phase.BLOCKED},
+    Phase.RED:      {Phase.GREEN, Phase.BLOCKED},
+    Phase.GREEN:    {Phase.SMOKE, Phase.BLOCKED},
+    Phase.SMOKE:    {Phase.REFACTOR, Phase.BLOCKED},
+    Phase.REFACTOR: {Phase.COMPLETE, Phase.BLOCKED},
+    Phase.COMPLETE: {Phase.MERGED},
+    Phase.BLOCKED:  {
+        Phase.INIT, Phase.PLANNED, Phase.RED,
+        Phase.GREEN, Phase.SMOKE, Phase.REFACTOR,
+    },
+    Phase.MERGED:   set(),
+}
+
+
+def can_transition(src: Phase, dst: Phase) -> bool:
+    return dst in TRANSITION_TABLE[src]
+
+
+PLANNED_PATH: tuple[Phase, ...] = (
+    Phase.INIT, Phase.PLANNED, Phase.RED, Phase.GREEN,
+    Phase.SMOKE, Phase.REFACTOR, Phase.COMPLETE, Phase.MERGED,
+)
+
+
+@dataclass
+class StateMachine:
+    """Per-issue state container. J1 ships the structure; transition
+    handlers land in per-state issues across the J/K/L/M tracks."""
+
+    issue_number: int
+    phase: Phase = Phase.INIT
+    history: list[Phase] = field(default_factory=list)
+
+
+def initialize_state_machine(issue_number: int) -> StateMachine:
+    return StateMachine(issue_number=issue_number, phase=Phase.INIT)
+
+
+class Transition(NamedTuple):
+    """(src, dst) pair passed to every per-concern handle() stub."""
+
+    src: Phase
+    dst: Phase
+
+
+@dataclass
+class CoachContext:
+    """Frozen view of resolved CLI config passed to handler stubs.
+
+    Children (#585-#590) will read fields relevant to their concern.
+    J1 / #591 only defines the shape — no logic reads it yet.
+    """
+
+    issue_number: int
+    dry_run: bool = False
+    strict_deps: bool = False
+    multiplexer: Optional[str] = None
+    multiplexer_mode: str = "workspace"
+    llm: Optional[str] = None
+    persona_llm: dict[str, str] = field(default_factory=dict)
+    judge_llm: Optional[str] = None
+    require_issue_review: str = "warn"
+    review_phases: set[str] = field(default_factory=set)
+    skip_review: bool = False
+    risk_threshold_block: Optional[int] = None
+    allow_stale_suppressions: bool = False
+    resume: Optional[str] = None

--- a/src/atdd/coach/handlers/two_phase_commit.py
+++ b/src/atdd/coach/handlers/two_phase_commit.py
@@ -1,0 +1,8 @@
+"""Two-phase-commit handler stub — P2 wiring lives here (issue #590 will fill)."""
+from __future__ import annotations
+
+from atdd.coach.handlers.state_machine import CoachContext, HandlerResult, Transition
+
+
+def handle(ctx: CoachContext, transition: Transition) -> HandlerResult:
+    return HandlerResult.NOOP

--- a/src/atdd/coach/handlers/validator_dispatch.py
+++ b/src/atdd/coach/handlers/validator_dispatch.py
@@ -1,0 +1,8 @@
+"""Validator-dispatch handler stub — M3 wiring lives here (issue #588 will fill)."""
+from __future__ import annotations
+
+from atdd.coach.handlers.state_machine import CoachContext, HandlerResult, Transition
+
+
+def handle(ctx: CoachContext, transition: Transition) -> HandlerResult:
+    return HandlerResult.NOOP

--- a/src/atdd/coach/handlers/watcher.py
+++ b/src/atdd/coach/handlers/watcher.py
@@ -1,0 +1,8 @@
+"""Watcher handler stub — J5 wiring lives here (issue #587 will fill)."""
+from __future__ import annotations
+
+from atdd.coach.handlers.state_machine import CoachContext, HandlerResult, Transition
+
+
+def handle(ctx: CoachContext, transition: Transition) -> HandlerResult:
+    return HandlerResult.NOOP


### PR DESCRIPTION
Closes #591

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #591 |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.