### PR TITLE
feat(coach): wire J5 runtime watcher to drive `atdd coach` state transitions reactively (#587)

### DIFF
--- a/plan/integration_hardening/E001.yaml
+++ b/plan/integration_hardening/E001.yaml
@@ -77,9 +77,9 @@ acceptances:
       id: "AC-INTEGRATION-004"
       purpose: "Concurrent watcher events serialize deterministically"
       phase: "GREEN"
-    signal:
-      metric: "watcher.event_ordering.deterministic"
-      threshold: "= true"
+    harness:
+      type: "integration"
+      category: "backend"
     given:
       abstract:
         - "Multiple watcher event sources fire concurrently (git-refs + filesystem)"
@@ -96,9 +96,9 @@ acceptances:
       id: "AC-SMOKE-001"
       purpose: "Watcher works against real filesystem and git refs"
       phase: "SMOKE"
-    signal:
-      metric: "watcher.commit_observed.count"
-      threshold: ">= 1"
+    harness:
+      type: "smoke"
+      category: "backend"
     given:
       abstract:
         - "atdd coach is running against a real git worktree with filesystem watchers active"

--- a/plan/integration_hardening/E001.yaml
+++ b/plan/integration_hardening/E001.yaml
@@ -71,6 +71,26 @@ acceptances:
       author: "atdd:self-compliance"
       created: "2026-05-11"
 
+
+  - identity:
+      urn: "acc:integration-hardening:E001-INTEGRATION-004-event-serialization"
+      id: "AC-INTEGRATION-004"
+      purpose: "Concurrent watcher events serialize deterministically"
+      phase: "GREEN"
+    signal:
+      metric: "watcher.event_ordering.deterministic"
+      threshold: "= true"
+    given:
+      abstract:
+        - "Multiple watcher event sources fire concurrently (git-refs + filesystem)"
+    when:
+      abstract: "The state machine processes them"
+    then:
+      abstract:
+        - "Transition ordering is deterministic per timestamp"
+    metadata:
+      author: "atdd:integration-hardening"
+      created: "2026-05-11"
   - identity:
       urn: "acc:integration-hardening:E001-SMOKE-001-watcher-real-infrastructure"
       id: "AC-SMOKE-001"

--- a/src/atdd/coach/commands/coach.py
+++ b/src/atdd/coach/commands/coach.py
@@ -96,6 +96,7 @@ class Config:
     allow_stale_suppressions: bool = False
     resume: Optional[str] = None
     dry_run: bool = False
+    stale_warn_minutes: Optional[int] = None
 
 
 @dataclass
@@ -220,6 +221,14 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--dry-run", action="store_true", dest="dry_run",
     )
+    parser.add_argument(
+        "--stale-warn",
+        type=int,
+        default=None,
+        dest="stale_warn_minutes",
+        metavar="MINUTES",
+        help="Emit INFO escalation after MINUTES of no watcher events.",
+    )
     return parser
 
 
@@ -243,6 +252,7 @@ def parse_cli(argv: list[str]) -> Config:
         allow_stale_suppressions=ns.allow_stale_suppressions,
         resume=ns.resume,
         dry_run=ns.dry_run,
+        stale_warn_minutes=ns.stale_warn_minutes,
     )
 
 

--- a/src/atdd/coach/handlers/tests/test_j5_integration_001_watcher_drives_state.py
+++ b/src/atdd/coach/handlers/tests/test_j5_integration_001_watcher_drives_state.py
@@ -1,0 +1,153 @@
+# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-INTEGRATION-001-watcher-drives-state
+# Acceptance: acc:integration-hardening:J5-INTEGRATION-001-watcher-drives-state
+# WMBT: wmbt:drive-state-machine:M001
+# Phase: RED
+# Layer: integration
+"""J5-INTEGRATION-001 — a git commit on a worktree branch drives a state
+transition in the per-issue StateMachine via the watcher event loop.
+
+The state advance is NOT driven by polling; the WatcherEventLoop consumes
+a `commit_observed` event (injected via test double) and advances the
+state machine. Per spec §4.5 a decision record is appended to decisions.jsonl
+before the transition executes.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _make_commit_event(sha: str, issue_number: int, from_phase: str) -> dict:
+    """Build a commit_observed event with Issue + Phase trailers."""
+    return {
+        "event_type": "commit_observed",
+        "agent_id": None,
+        "timestamp": "2026-05-11T12:00:00.000000Z",
+        "payload": {
+            "sha": sha,
+            "parent_sha": None,
+            "branch": "feat/test",
+            "worktree_path": "/tmp/wt",
+            "author": "test <test@example.com>",
+            "trailers": {
+                "Issue": str(issue_number),
+                "Phase": from_phase,
+            },
+        },
+    }
+
+
+def test_commit_observed_advances_state_machine(tmp_path):
+    """A commit_observed event with Phase: RED + Issue: N drives RED→GREEN
+    on the StateMachine for issue N."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import (
+        Phase,
+        StateMachine,
+        initialize_state_machine,
+    )
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+    sm.phase = Phase.RED
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+
+    event = _make_commit_event(sha="abc123", issue_number=587, from_phase="RED")
+    queue.put(event)
+
+    loop.process_one_event(timeout=1.0)
+
+    assert sm.phase is Phase.GREEN
+    assert Phase.RED in sm.history
+
+
+def test_decision_is_written_before_transition(tmp_path):
+    """Per spec §4.5: decisions.jsonl receives a record for the phase-transition
+    *before* the StateMachine advances (durability first)."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import Phase, initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+    sm.phase = Phase.RED
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+
+    event = _make_commit_event(sha="def456", issue_number=587, from_phase="RED")
+    queue.put(event)
+    loop.process_one_event(timeout=1.0)
+
+    decisions_path = runtime_dir / "coach" / "decisions.jsonl"
+    assert decisions_path.exists(), "decisions.jsonl must exist after a transition"
+    lines = [l for l in decisions_path.read_text().splitlines() if l.strip()]
+    assert len(lines) >= 1
+    record = json.loads(lines[-1])
+    assert record["decision_type"] == "phase-transition"
+    assert record["issue_number"] == 587
+    assert record["outcome"]["from_phase"] == "RED"
+    assert record["outcome"]["to_phase"] == "GREEN"
+
+
+def test_event_for_different_issue_does_not_advance(tmp_path):
+    """A commit_observed event carrying Issue: 999 does NOT advance state
+    for issue 587."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import Phase, initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+    sm.phase = Phase.RED
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+
+    event = _make_commit_event(sha="xyz789", issue_number=999, from_phase="RED")
+    queue.put(event)
+    result = loop.process_one_event(timeout=0.1)
+
+    assert sm.phase is Phase.RED
+    assert result is None or result == "ignored"
+
+
+def test_watcher_event_loop_exposes_handle_stub():
+    """The module-level handle() function is present (required handler interface)."""
+    from atdd.coach.handlers.watcher import handle
+    from atdd.coach.handlers.state_machine import (
+        CoachContext,
+        HandlerResult,
+        Phase,
+        Transition,
+    )
+
+    ctx = CoachContext(issue_number=587)
+    t = Transition(Phase.RED, Phase.GREEN)
+    result = handle(ctx, t)
+    assert result in (HandlerResult.NOOP, HandlerResult.HANDLED)

--- a/src/atdd/coach/handlers/tests/test_j5_integration_001_watcher_drives_state.py
+++ b/src/atdd/coach/handlers/tests/test_j5_integration_001_watcher_drives_state.py
@@ -1,5 +1,5 @@
-# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-INTEGRATION-001-watcher-drives-state
-# Acceptance: acc:integration-hardening:J5-INTEGRATION-001-watcher-drives-state
+# URN: test:integration-hardening:coach-state-machine-and-runtime:E001-INTEGRATION-001-watcher-drives-state
+# Acceptance: acc:integration-hardening:E001-INTEGRATION-001-watcher-drives-state
 # WMBT: wmbt:drive-state-machine:M001
 # Phase: RED
 # Layer: integration

--- a/src/atdd/coach/handlers/tests/test_j5_integration_002_stale_warn_fires.py
+++ b/src/atdd/coach/handlers/tests/test_j5_integration_002_stale_warn_fires.py
@@ -1,0 +1,144 @@
+# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-INTEGRATION-002-stale-warn-fires
+# Acceptance: acc:integration-hardening:J5-INTEGRATION-002-stale-warn-fires
+# WMBT: wmbt:drive-state-machine:M001
+# Phase: RED
+# Layer: integration
+"""J5-INTEGRATION-002 — `atdd coach --stale-warn 1` emits an INFO escalation
+after the configured number of minutes without events.
+
+Uses an injected clock so tests run without real wall-clock delays.
+The escalation appears on `--escalation-channel`; in unit scope the
+channel is a list that the WatcherEventLoop appends to.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def test_stale_warn_emits_escalation_after_timeout(tmp_path):
+    """After stale_warn_minutes of silence, WatcherEventLoop emits a
+    process_silence-style escalation on the configured channel."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+
+    escalations: list[dict] = []
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=1,
+        escalation_channel="test-channel",
+        _escalation_sink=escalations,
+    )
+
+    loop.check_stale(elapsed_minutes=1.5)
+
+    assert len(escalations) == 1
+    esc = escalations[0]
+    assert esc.get("level") in ("INFO", "WARN", "WARNING")
+    assert esc.get("channel") == "test-channel"
+
+
+def test_stale_warn_does_not_fire_before_threshold(tmp_path):
+    """No escalation is emitted if elapsed time is below stale_warn_minutes."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+
+    escalations: list[dict] = []
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=5,
+        escalation_channel="test-channel",
+        _escalation_sink=escalations,
+    )
+
+    loop.check_stale(elapsed_minutes=0.5)
+
+    assert len(escalations) == 0
+
+
+def test_stale_warn_none_never_fires(tmp_path):
+    """When stale_warn_minutes is None, no escalation is emitted regardless
+    of elapsed time."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+
+    escalations: list[dict] = []
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel="test-channel",
+        _escalation_sink=escalations,
+    )
+
+    loop.check_stale(elapsed_minutes=999)
+
+    assert len(escalations) == 0
+
+
+def test_stale_warn_bounded_one_per_window(tmp_path):
+    """Exactly one escalation per silence window — not one per check_stale call."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+
+    escalations: list[dict] = []
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=1,
+        escalation_channel="test-channel",
+        _escalation_sink=escalations,
+    )
+
+    loop.check_stale(elapsed_minutes=2.0)
+    loop.check_stale(elapsed_minutes=3.0)
+    loop.check_stale(elapsed_minutes=4.0)
+
+    assert len(escalations) == 1, "Must emit at most one escalation per silence window"
+
+
+def test_parse_cli_includes_stale_warn_flag():
+    """parse_cli() accepts --stale-warn and maps to stale_warn_minutes on Config."""
+    from atdd.coach.commands.coach import parse_cli
+
+    cfg = parse_cli(["587", "--stale-warn", "3"])
+    assert cfg.stale_warn_minutes == 3
+
+
+def test_parse_cli_stale_warn_defaults_to_none():
+    """--stale-warn is optional; default is None (never fires)."""
+    from atdd.coach.commands.coach import parse_cli
+
+    cfg = parse_cli(["587"])
+    assert cfg.stale_warn_minutes is None

--- a/src/atdd/coach/handlers/tests/test_j5_integration_002_stale_warn_fires.py
+++ b/src/atdd/coach/handlers/tests/test_j5_integration_002_stale_warn_fires.py
@@ -1,5 +1,5 @@
-# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-INTEGRATION-002-stale-warn-fires
-# Acceptance: acc:integration-hardening:J5-INTEGRATION-002-stale-warn-fires
+# URN: test:integration-hardening:coach-state-machine-and-runtime:E001-INTEGRATION-002-stale-warn-fires
+# Acceptance: acc:integration-hardening:E001-INTEGRATION-002-stale-warn-fires
 # WMBT: wmbt:drive-state-machine:M001
 # Phase: RED
 # Layer: integration

--- a/src/atdd/coach/handlers/tests/test_j5_integration_003_liveness_cleanup.py
+++ b/src/atdd/coach/handlers/tests/test_j5_integration_003_liveness_cleanup.py
@@ -1,5 +1,5 @@
-# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-INTEGRATION-003-liveness-cleanup
-# Acceptance: acc:integration-hardening:J5-INTEGRATION-003-liveness-cleanup
+# URN: test:integration-hardening:coach-state-machine-and-runtime:E001-INTEGRATION-003-liveness-cleanup
+# Acceptance: acc:integration-hardening:E001-INTEGRATION-003-liveness-cleanup
 # WMBT: wmbt:drive-state-machine:M001
 # Phase: RED
 # Layer: integration

--- a/src/atdd/coach/handlers/tests/test_j5_integration_003_liveness_cleanup.py
+++ b/src/atdd/coach/handlers/tests/test_j5_integration_003_liveness_cleanup.py
@@ -43,7 +43,8 @@ def test_shutdown_stops_runtime_watcher(tmp_path):
 
     loop.shutdown()
 
-    assert not loop.runtime_watcher._thread.is_alive()
+    # RuntimeWatcher.stop() joins and sets _thread = None
+    assert loop.runtime_watcher._thread is None
 
 
 def test_shutdown_persists_watcher_checkpoint(tmp_path):

--- a/src/atdd/coach/handlers/tests/test_j5_integration_003_liveness_cleanup.py
+++ b/src/atdd/coach/handlers/tests/test_j5_integration_003_liveness_cleanup.py
@@ -1,0 +1,138 @@
+# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-INTEGRATION-003-liveness-cleanup
+# Acceptance: acc:integration-hardening:J5-INTEGRATION-003-liveness-cleanup
+# WMBT: wmbt:drive-state-machine:M001
+# Phase: RED
+# Layer: integration
+"""J5-INTEGRATION-003 — `atdd coach` exits cleanly on SIGTERM; the watcher
+subprocess is terminated; partial state is preserved in decisions.jsonl.
+
+Uses WatcherEventLoop.shutdown() (the SIGTERM handler's body) to verify
+that the stop sequence persists checkpoint + flushes partial state.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def test_shutdown_stops_runtime_watcher(tmp_path):
+    """WatcherEventLoop.shutdown() stops the RuntimeWatcher background thread."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.commands.runtime_watcher import RuntimeWatcher
+    from atdd.coach.handlers.state_machine import initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+    loop.start_background_watchers()
+    assert loop.runtime_watcher._thread is not None
+    assert loop.runtime_watcher._thread.is_alive()
+
+    loop.shutdown()
+
+    assert not loop.runtime_watcher._thread.is_alive()
+
+
+def test_shutdown_persists_watcher_checkpoint(tmp_path):
+    """shutdown() calls RuntimeWatcher.persist_checkpoint() so reattachment
+    is lossless on the next coach --resume."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+    loop.start_background_watchers()
+    loop.shutdown()
+
+    checkpoint = runtime_dir / "coach" / "watcher-checkpoint.json"
+    assert checkpoint.exists(), "watcher-checkpoint.json must exist after shutdown"
+
+
+def test_shutdown_writes_partial_state_to_decisions(tmp_path):
+    """After a state advance followed by shutdown(), decisions.jsonl is non-empty
+    (partial state is preserved even if coach exits mid-run)."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import Phase, initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+    sm.phase = Phase.RED
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+
+    event = {
+        "event_type": "commit_observed",
+        "agent_id": None,
+        "timestamp": "2026-05-11T12:00:00.000000Z",
+        "payload": {
+            "sha": "cafe1234",
+            "parent_sha": None,
+            "branch": "feat/test",
+            "worktree_path": "/tmp/wt",
+            "author": "test <test@example.com>",
+            "trailers": {"Issue": "587", "Phase": "RED"},
+        },
+    }
+    queue.put(event)
+    loop.process_one_event(timeout=1.0)
+
+    loop.shutdown()
+
+    decisions_path = runtime_dir / "coach" / "decisions.jsonl"
+    assert decisions_path.exists()
+    content = decisions_path.read_text()
+    lines = [l for l in content.splitlines() if l.strip()]
+    assert len(lines) >= 1
+
+
+def test_shutdown_idempotent(tmp_path):
+    """Calling shutdown() twice does not raise."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+    loop.start_background_watchers()
+    loop.shutdown()
+    loop.shutdown()  # must not raise

--- a/src/atdd/coach/handlers/tests/test_j5_integration_004_event_serialization.py
+++ b/src/atdd/coach/handlers/tests/test_j5_integration_004_event_serialization.py
@@ -1,0 +1,139 @@
+# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-INTEGRATION-004-event-serialization
+# Acceptance: acc:integration-hardening:J5-INTEGRATION-004-event-serialization
+# WMBT: wmbt:drive-state-machine:M001
+# Phase: RED
+# Layer: integration
+"""J5-INTEGRATION-004 — simultaneous git-refs + filesystem events on the same
+issue produce deterministic transition ordering per timestamp.
+
+The WatcherEventLoop serializes all events on a single ordered queue;
+when two events arrive for the same issue they are processed in timestamp
+order (oldest first), so transitions are applied in a deterministic
+sequence regardless of which watcher fires first.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _make_event(event_type: str, sha: str, issue: int, phase: str, ts: str) -> dict:
+    return {
+        "event_type": event_type,
+        "agent_id": None,
+        "timestamp": ts,
+        "payload": {
+            "sha": sha,
+            "parent_sha": None,
+            "branch": "feat/test",
+            "worktree_path": "/tmp/wt",
+            "author": "test <test@example.com>",
+            "trailers": {"Issue": str(issue), "Phase": phase},
+        },
+    }
+
+
+def test_two_events_applied_in_timestamp_order(tmp_path):
+    """When two commit_observed events arrive for the same issue,
+    process_pending_events applies them in timestamp order."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import Phase, initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+    sm.phase = Phase.RED
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+
+    older = _make_event(
+        "commit_observed", "sha1", 587, "RED", "2026-05-11T10:00:00.000000Z"
+    )
+    newer = _make_event(
+        "commit_observed", "sha2", 587, "GREEN", "2026-05-11T11:00:00.000000Z"
+    )
+    queue.put(newer)
+    queue.put(older)
+
+    loop.process_pending_events(max_events=2)
+
+    # RED→GREEN applied first (older=RED), then GREEN→SMOKE (newer=GREEN)
+    assert sm.phase is Phase.SMOKE
+    assert Phase.RED in sm.history
+    assert Phase.GREEN in sm.history
+
+
+def test_simultaneous_events_different_issues_independent(tmp_path):
+    """Events for different issues are independent; each machine advances
+    only when its own Issue trailer matches."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import Phase, initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm_a = initialize_state_machine(issue_number=100)
+    sm_b = initialize_state_machine(issue_number=200)
+    sm_a.phase = Phase.RED
+    sm_b.phase = Phase.RED
+
+    loop = WatcherEventLoop(
+        machines=[sm_a, sm_b],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+
+    ev_a = _make_event(
+        "commit_observed", "sha100", 100, "RED", "2026-05-11T10:00:00.000000Z"
+    )
+    ev_b = _make_event(
+        "commit_observed", "sha200", 200, "RED", "2026-05-11T10:00:01.000000Z"
+    )
+    queue.put(ev_a)
+    queue.put(ev_b)
+
+    loop.process_pending_events(max_events=2)
+
+    assert sm_a.phase is Phase.GREEN
+    assert sm_b.phase is Phase.GREEN
+
+
+def test_unknown_event_type_is_ignored_without_crash(tmp_path):
+    """An unknown event_type is silently ignored; the state machine is unchanged."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import Phase, initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+    sm.phase = Phase.RED
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+
+    unknown = {
+        "event_type": "alien_invasion",
+        "agent_id": None,
+        "timestamp": "2026-05-11T10:00:00.000000Z",
+        "payload": {},
+    }
+    queue.put(unknown)
+    loop.process_one_event(timeout=0.5)
+
+    assert sm.phase is Phase.RED

--- a/src/atdd/coach/handlers/tests/test_j5_integration_004_event_serialization.py
+++ b/src/atdd/coach/handlers/tests/test_j5_integration_004_event_serialization.py
@@ -1,5 +1,5 @@
-# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-INTEGRATION-004-event-serialization
-# Acceptance: acc:integration-hardening:J5-INTEGRATION-004-event-serialization
+# URN: test:integration-hardening:coach-state-machine-and-runtime:E001-INTEGRATION-004-event-serialization
+# Acceptance: acc:integration-hardening:E001-INTEGRATION-004-event-serialization
 # WMBT: wmbt:drive-state-machine:M001
 # Phase: RED
 # Layer: integration

--- a/src/atdd/coach/handlers/tests/test_j5_smoke_001_watcher_real_infrastructure.py
+++ b/src/atdd/coach/handlers/tests/test_j5_smoke_001_watcher_real_infrastructure.py
@@ -1,5 +1,5 @@
-# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-SMOKE-001-watcher-real-infrastructure
-# Acceptance: acc:integration-hardening:J5-SMOKE-001-watcher-real-infrastructure
+# URN: test:integration-hardening:coach-state-machine-and-runtime:E001-SMOKE-001-watcher-real-infrastructure
+# Acceptance: acc:integration-hardening:E001-SMOKE-001-watcher-real-infrastructure
 # WMBT: wmbt:drive-state-machine:M001
 # Phase: SMOKE
 # Layer: smoke

--- a/src/atdd/coach/handlers/tests/test_j5_smoke_001_watcher_real_infrastructure.py
+++ b/src/atdd/coach/handlers/tests/test_j5_smoke_001_watcher_real_infrastructure.py
@@ -1,0 +1,144 @@
+# URN: test:integration-hardening:coach-state-machine-and-runtime:J5-SMOKE-001-watcher-real-infrastructure
+# Acceptance: acc:integration-hardening:J5-SMOKE-001-watcher-real-infrastructure
+# WMBT: wmbt:drive-state-machine:M001
+# Phase: SMOKE
+# Layer: smoke
+"""J5-SMOKE-001 — WatcherEventLoop drives a state transition via a real git
+commit on a temporary git worktree (no mocks).
+
+This verifies that the GitWatcher + WatcherEventLoop integration works
+against actual subprocess calls and real filesystem state.
+"""
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _bootstrap_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-b", "main"], path)
+    _git(["config", "user.email", "j5-smoke@atdd.local"], path)
+    _git(["config", "user.name", "j5-smoke"], path)
+    (path / "README.md").write_text("seed\n")
+    _git(["add", "."], path)
+    _git(["commit", "-m", "initial"], path)
+
+
+def test_git_commit_drives_state_via_watcher_event_loop(tmp_path):
+    """End-to-end: a real git commit with Issue+Phase trailers is observed
+    by GitWatcher, queued, and consumed by WatcherEventLoop to advance
+    the StateMachine from RED to GREEN."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.commands.git_watcher import GitWatcher
+    from atdd.coach.handlers.state_machine import Phase, initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    repo = tmp_path / "wt"
+    _bootstrap_repo(repo)
+
+    runtime_dir = tmp_path / "runtime"
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+
+    sm = initialize_state_machine(issue_number=587)
+    sm.phase = Phase.RED
+
+    git_watcher = GitWatcher(worktree_paths=[repo], queue=queue)
+    git_watcher.scan_once()  # establish baseline
+    queue.drain()
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+
+    (repo / "work.py").write_text("x = 1\n")
+    _git(["add", "work.py"], repo)
+    _git(
+        [
+            "commit",
+            "-m",
+            (
+                "feat(coach): complete RED phase\n\n"
+                "Issue: 587\n"
+                "Phase: RED\n"
+            ),
+        ],
+        repo,
+    )
+
+    git_watcher.scan_once()
+
+    result = loop.process_one_event(timeout=1.0)
+    assert result == "applied", f"expected 'applied', got {result!r}"
+    assert sm.phase is Phase.GREEN
+    assert Phase.RED in sm.history
+
+
+def test_runtime_watcher_drives_state_via_events_jsonl(tmp_path):
+    """RuntimeWatcher observing a real events.jsonl append drives a state
+    transition via WatcherEventLoop within the 1s latency budget."""
+    from atdd.coach.commands.event_queue import CoachEventQueue
+    from atdd.coach.handlers.state_machine import Phase, initialize_state_machine
+    from atdd.coach.handlers.watcher import WatcherEventLoop
+
+    runtime_dir = tmp_path / "runtime"
+    agent_dir = runtime_dir / "agents" / "agent-587"
+    agent_dir.mkdir(parents=True)
+
+    queue = CoachEventQueue(runtime_dir=runtime_dir)
+    sm = initialize_state_machine(issue_number=587)
+    sm.phase = Phase.RED
+
+    loop = WatcherEventLoop(
+        machines=[sm],
+        runtime_dir=runtime_dir,
+        queue=queue,
+        stale_warn_minutes=None,
+        escalation_channel=None,
+    )
+    loop.start_background_watchers()
+
+    try:
+        import json
+        (agent_dir / "events.jsonl").write_text(
+            json.dumps({
+                "event_type": "commit_observed",
+                "agent_id": "agent-587",
+                "timestamp": "2026-05-11T12:00:00.000000Z",
+                "payload": {
+                    "sha": "deadbeef",
+                    "parent_sha": None,
+                    "branch": "feat/587",
+                    "worktree_path": str(tmp_path / "wt"),
+                    "author": "agent <agent@atdd>",
+                    "trailers": {"Issue": "587", "Phase": "RED"},
+                },
+            }) + "\n"
+        )
+        deadline = time.monotonic() + 2.0
+        applied = False
+        while time.monotonic() < deadline:
+            result = loop.process_one_event(timeout=0.2)
+            if result == "applied":
+                applied = True
+                break
+    finally:
+        loop.shutdown()
+
+    assert applied, "RuntimeWatcher did not surface a commit_observed event within 2s"
+    assert sm.phase is Phase.GREEN

--- a/src/atdd/coach/handlers/watcher.py
+++ b/src/atdd/coach/handlers/watcher.py
@@ -1,8 +1,283 @@
-"""Watcher handler stub — J5 wiring lives here (issue #587 will fill)."""
+"""Watcher handler — J5 wiring (issue #587).
+
+Translates ``CoachEventQueue`` events into proposed phase transitions and
+drives each per-issue ``StateMachine`` reactively.  Architecture per spec
+review comment (issue #587):
+
+- ``RuntimeWatcher`` runs in a background thread, feeds the shared queue.
+- ``GitWatcher`` and ``LivenessChecker`` are called as synchronous tasks
+  from the asyncio-style event-processing layer.
+- All state-machine mutations happen on the single caller thread (the
+  ``WatcherEventLoop`` methods), so no locks are needed for the machines.
+- SIGTERM → ``shutdown()`` → stops background thread + persists checkpoint.
+"""
 from __future__ import annotations
 
-from atdd.coach.handlers.state_machine import CoachContext, HandlerResult, Transition
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from atdd.coach.commands.event_queue import CoachEventQueue
+from atdd.coach.commands.runtime_watcher import RuntimeWatcher
+from atdd.coach.handlers.state_machine import (
+    CoachContext,
+    HandlerResult,
+    Phase,
+    StateMachine,
+    Transition,
+    can_transition,
+)
+
+
+# ---------------------------------------------------------------------------
+# Required module-level stub (per handler interface contract)
+# ---------------------------------------------------------------------------
 
 
 def handle(ctx: CoachContext, transition: Transition) -> HandlerResult:
+    """Per-transition hook — NOOP; watcher drives via WatcherEventLoop."""
     return HandlerResult.NOOP
+
+
+# ---------------------------------------------------------------------------
+# Event-to-transition mapping
+# ---------------------------------------------------------------------------
+
+_PHASE_TRAILER_MAP: dict[str, Phase] = {
+    "INIT": Phase.INIT,
+    "PLANNED": Phase.PLANNED,
+    "RED": Phase.RED,
+    "GREEN": Phase.GREEN,
+    "SMOKE": Phase.SMOKE,
+    "REFACTOR": Phase.REFACTOR,
+    "COMPLETE": Phase.COMPLETE,
+}
+
+_ADVANCE_FROM: dict[Phase, Phase] = {
+    # A commit_observed with Phase: X trailer means the agent just completed
+    # phase X → advance past it to the next phase.
+    Phase.RED: Phase.GREEN,
+    Phase.GREEN: Phase.SMOKE,
+    Phase.SMOKE: Phase.REFACTOR,
+    Phase.REFACTOR: Phase.COMPLETE,
+}
+
+
+def _proposed_transition(sm: StateMachine, event: dict) -> Optional[Transition]:
+    """Map a raw queue event to a (src, dst) Transition for ``sm``, or None."""
+    et = event.get("event_type")
+    if et != "commit_observed":
+        return None
+    payload = event.get("payload") or {}
+    trailers = payload.get("trailers") or {}
+    issue_str = trailers.get("Issue")
+    if issue_str is None or str(sm.issue_number) != str(issue_str):
+        return None
+    phase_str = trailers.get("Phase")
+    if not phase_str:
+        return None
+    completed = _PHASE_TRAILER_MAP.get(phase_str)
+    if completed is None or completed != sm.phase:
+        return None
+    dst = _ADVANCE_FROM.get(completed)
+    if dst is None:
+        return None
+    if not can_transition(sm.phase, dst):
+        return None
+    return Transition(sm.phase, dst)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+# ---------------------------------------------------------------------------
+# WatcherEventLoop
+# ---------------------------------------------------------------------------
+
+
+class WatcherEventLoop:
+    """Reactive driver that attaches J5 watchers to the per-issue state machines.
+
+    Parameters
+    ----------
+    machines:
+        List of ``StateMachine`` objects to manage.
+    runtime_dir:
+        Root of the ``.atdd/runtime/`` tree.
+    queue:
+        Shared ``CoachEventQueue`` that all watchers feed.
+    stale_warn_minutes:
+        If set, emit an escalation after this many minutes without events.
+    escalation_channel:
+        String name of the channel to escalate to (e.g. ``"slack:#coach"``).
+    _escalation_sink:
+        Optional list; if provided, escalation dicts are appended here
+        instead of going to stderr (used in tests).
+    """
+
+    def __init__(
+        self,
+        *,
+        machines: list[StateMachine],
+        runtime_dir: Path,
+        queue: CoachEventQueue,
+        stale_warn_minutes: Optional[int],
+        escalation_channel: Optional[str],
+        _escalation_sink: Optional[list] = None,
+        coach_run_id: Optional[str] = None,
+    ) -> None:
+        self.machines = machines
+        self.runtime_dir = Path(runtime_dir)
+        self.queue = queue
+        self.stale_warn_minutes = stale_warn_minutes
+        self.escalation_channel = escalation_channel
+        self._escalation_sink = _escalation_sink
+        self.coach_run_id = coach_run_id or str(uuid.uuid4())
+        self._stale_warned = False
+
+        self.runtime_watcher = RuntimeWatcher(
+            runtime_dir=self.runtime_dir,
+            queue=self.queue,
+        )
+        self._decision_writer = self._make_decision_writer()
+        self._shutdown_called = False
+
+    def _make_decision_writer(self):  # type: ignore[no-untyped-def]
+        try:
+            from atdd.coach.commands.durability import DecisionWriter
+            return DecisionWriter(runtime_dir=self.runtime_dir)
+        except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+            return None
+
+    # --- background watchers ------------------------------------------------
+
+    def start_background_watchers(self) -> None:
+        """Start the RuntimeWatcher background thread."""
+        self.runtime_watcher.start()
+
+    # --- event processing ---------------------------------------------------
+
+    def process_one_event(self, *, timeout: float = 1.0) -> Optional[str]:
+        """Consume one event from the queue and apply the resulting transition.
+
+        Returns ``"applied"`` if a transition fired, ``"ignored"`` otherwise,
+        or ``None`` if the queue was empty within ``timeout``.
+        """
+        event = self.queue.get(timeout=timeout)
+        if event is None:
+            return None
+        return self._dispatch(event)
+
+    def process_pending_events(self, *, max_events: int = 1000) -> int:
+        """Drain up to ``max_events`` from the queue in timestamp order.
+
+        Returns the number of transitions applied.
+        """
+        pending: list[dict] = []
+        ev = self.queue.get(timeout=0.0)
+        while ev is not None:
+            pending.append(ev)
+            ev = self.queue.get(timeout=0.0)
+
+        pending.sort(key=lambda e: e.get("timestamp") or "")
+        applied = 0
+        for event in pending[:max_events]:
+            if self._dispatch(event) == "applied":
+                applied += 1
+        return applied
+
+    def _dispatch(self, event: dict) -> str:
+        for sm in self.machines:
+            t = _proposed_transition(sm, event)
+            if t is not None:
+                self._apply_transition(sm, t, event)
+                return "applied"
+        return "ignored"
+
+    def _apply_transition(
+        self, sm: StateMachine, t: Transition, source_event: dict
+    ) -> None:
+        """Write decision record then mutate the state machine."""
+        decision_id = str(uuid.uuid4())
+        record: dict[str, Any] = {
+            "decision_id": decision_id,
+            "timestamp": _now_iso(),
+            "coach_run_id": self.coach_run_id,
+            "issue_number": sm.issue_number,
+            "decision_type": "phase-transition",
+            "inputs": {
+                "event_type": source_event.get("event_type"),
+                "sha": (source_event.get("payload") or {}).get("sha"),
+                "from_phase": t.src.value,
+            },
+            "outcome": {
+                "from_phase": t.src.value,
+                "to_phase": t.dst.value,
+            },
+        }
+        if self._decision_writer is not None:
+            try:
+                self._decision_writer.append(record)
+            except Exception as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+                print(f"[watcher] decision write failed: {exc}", file=sys.stderr)
+
+        sm.history.append(sm.phase)
+        sm.phase = t.dst
+
+    # --- stale-warn ---------------------------------------------------------
+
+    def check_stale(self, *, elapsed_minutes: float) -> None:
+        """Emit a stale escalation if ``elapsed_minutes`` exceeds the threshold.
+
+        Bounded: exactly one escalation per silence window (``_stale_warned``
+        resets when an event arrives via ``reset_stale_timer()``).
+        """
+        if self.stale_warn_minutes is None:
+            return
+        if self._stale_warned:
+            return
+        if elapsed_minutes < self.stale_warn_minutes:
+            return
+        self._stale_warned = True
+        self._emit_escalation(elapsed_minutes)
+
+    def reset_stale_timer(self) -> None:
+        """Reset the stale window after a live event is received."""
+        self._stale_warned = False
+
+    def _emit_escalation(self, elapsed_minutes: float) -> None:
+        payload = {
+            "level": "INFO",
+            "channel": self.escalation_channel,
+            "message": (
+                f"[coach] no events for {elapsed_minutes:.1f} min "
+                f"(stale-warn={self.stale_warn_minutes})"
+            ),
+            "timestamp": _now_iso(),
+        }
+        if self._escalation_sink is not None:
+            self._escalation_sink.append(payload)
+        else:
+            print(
+                f"[coach:stale-warn] {payload['message']}",
+                file=sys.stderr,
+            )
+
+    # --- shutdown -----------------------------------------------------------
+
+    def shutdown(self) -> None:
+        """Clean shutdown: stop background thread + persist checkpoint.
+
+        Idempotent — safe to call multiple times.
+        """
+        if self._shutdown_called:
+            return
+        self._shutdown_called = True
+        self.runtime_watcher.stop()
+        try:
+            self.runtime_watcher.persist_checkpoint()
+        except Exception as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+            print(f"[watcher] checkpoint persist failed: {exc}", file=sys.stderr)

--- a/src/atdd/coach/handlers/watcher.py
+++ b/src/atdd/coach/handlers/watcher.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from atdd.coach.commands.durability import DecisionWriter
 from atdd.coach.commands.event_queue import CoachEventQueue
 from atdd.coach.commands.runtime_watcher import RuntimeWatcher
 from atdd.coach.handlers.state_machine import (
@@ -145,9 +146,8 @@ class WatcherEventLoop:
         self._decision_writer = self._make_decision_writer()
         self._shutdown_called = False
 
-    def _make_decision_writer(self):  # type: ignore[no-untyped-def]
+    def _make_decision_writer(self) -> Optional[DecisionWriter]:
         try:
-            from atdd.coach.commands.durability import DecisionWriter
             return DecisionWriter(runtime_dir=self.runtime_dir)
         except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
             return None


### PR DESCRIPTION
Closes #587

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #587 |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.