### PR TITLE
feat(coach): wire J3 decisions.jsonl writer on every state transition (#586)

### DIFF
--- a/src/atdd/coach/commands/tests/test_J3_integration_001_decision_per_transition.py
+++ b/src/atdd/coach/commands/tests/test_J3_integration_001_decision_per_transition.py
@@ -1,6 +1,6 @@
-# URN: test:integration-hardening:coach-decisions-wiring:J3-INTEGRATION-001-decision-per-transition
-# Acceptance: acc:integration-hardening:J3-INTEGRATION-001-decision-per-transition
-# WMBT: wmbt:integration-hardening:J3
+# URN: test:integration-hardening:coach-decisions-wiring:D001-INTEGRATION-001-decision-per-transition
+# Acceptance: acc:integration-hardening:D001-INTEGRATION-001-decision-per-transition
+# WMBT: wmbt:integration-hardening:D001
 # Phase: RED
 # Layer: integration
 """J3-INTEGRATION-001 — every state transition produces exactly one

--- a/src/atdd/coach/commands/tests/test_J3_integration_001_decision_per_transition.py
+++ b/src/atdd/coach/commands/tests/test_J3_integration_001_decision_per_transition.py
@@ -1,0 +1,154 @@
+# URN: test:integration-hardening:coach-decisions-wiring:J3-INTEGRATION-001-decision-per-transition
+# Acceptance: acc:integration-hardening:J3-INTEGRATION-001-decision-per-transition
+# WMBT: wmbt:integration-hardening:J3
+# Phase: RED
+# Layer: integration
+"""J3-INTEGRATION-001 — every state transition produces exactly one
+decisions.jsonl entry conforming to coach-decision.schema.json.
+
+A full coach run from INIT to MERGED (driven via the decisions handler)
+produces exactly N entries where N == count of state transitions on the
+planned path. Each entry validates against the schema and carries the
+correct from/to state pair.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+PLANNED_PATH_TRANSITIONS = [
+    ("INIT", "PLANNED"),
+    ("PLANNED", "RED"),
+    ("RED", "GREEN"),
+    ("GREEN", "SMOKE"),
+    ("SMOKE", "REFACTOR"),
+    ("REFACTOR", "COMPLETE"),
+    ("COMPLETE", "MERGED"),
+]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _make_ctx(issue_number: int, run_id: str, runtime_dir: Path):
+    from atdd.coach.handlers.state_machine import CoachContext
+    return CoachContext(
+        issue_number=issue_number,
+        coach_run_id=run_id,
+        runtime_dir=runtime_dir,
+    )
+
+
+def _make_transition(src: str, dst: str):
+    from atdd.coach.handlers.state_machine import Phase, Transition
+    return Transition(src=Phase(src), dst=Phase(dst))
+
+
+def test_full_run_produces_one_entry_per_transition(tmp_path):
+    """decisions.handle() called once per transition produces N entries
+    in decisions.jsonl where N == number of transitions on planned path."""
+    from atdd.coach.handlers import decisions
+
+    ctx = _make_ctx(issue_number=586, run_id="run-j3-001", runtime_dir=tmp_path)
+
+    for src, dst in PLANNED_PATH_TRANSITIONS:
+        result = decisions.handle(ctx, _make_transition(src, dst))
+        from atdd.coach.handlers.state_machine import HandlerResult
+        assert result in (HandlerResult.HANDLED, HandlerResult.NOOP), (
+            f"handler returned {result!r} for {src}→{dst}"
+        )
+
+    log_path = tmp_path / "coach" / "decisions.jsonl"
+    assert log_path.exists(), "decisions.jsonl must exist after transitions"
+
+    records = _read_jsonl(log_path)
+    assert len(records) == len(PLANNED_PATH_TRANSITIONS), (
+        f"Expected {len(PLANNED_PATH_TRANSITIONS)} entries for {len(PLANNED_PATH_TRANSITIONS)} "
+        f"transitions; got {len(records)}"
+    )
+
+
+def test_each_entry_carries_correct_from_to_state(tmp_path):
+    """Each decisions.jsonl entry has the correct current_phase and
+    target_phase matching the transition that produced it."""
+    from atdd.coach.handlers import decisions
+
+    ctx = _make_ctx(issue_number=586, run_id="run-j3-002", runtime_dir=tmp_path)
+
+    for src, dst in PLANNED_PATH_TRANSITIONS:
+        decisions.handle(ctx, _make_transition(src, dst))
+
+    records = _read_jsonl(tmp_path / "coach" / "decisions.jsonl")
+    for rec, (src, dst) in zip(records, PLANNED_PATH_TRANSITIONS):
+        assert rec["inputs"]["current_phase"] == src, (
+            f"current_phase mismatch: expected {src!r}, got {rec['inputs'].get('current_phase')!r}"
+        )
+        assert rec["inputs"]["target_phase"] == dst, (
+            f"target_phase mismatch: expected {dst!r}, got {rec['inputs'].get('target_phase')!r}"
+        )
+        assert rec["outcome"]["new_phase"] == dst, (
+            f"new_phase in outcome mismatch: expected {dst!r}, got {rec['outcome'].get('new_phase')!r}"
+        )
+
+
+def test_each_entry_validates_against_schema(tmp_path):
+    """Every decisions.jsonl entry must conform to coach-decision.schema.json."""
+    from atdd.coach.handlers import decisions
+    from atdd.coach.commands.durability import _load_validator
+
+    ctx = _make_ctx(issue_number=586, run_id="run-j3-003", runtime_dir=tmp_path)
+
+    for src, dst in PLANNED_PATH_TRANSITIONS:
+        decisions.handle(ctx, _make_transition(src, dst))
+
+    validator = _load_validator("coach-decision.schema.json")
+    records = _read_jsonl(tmp_path / "coach" / "decisions.jsonl")
+    assert records, "decisions.jsonl must have entries"
+
+    for i, rec in enumerate(records):
+        errors = list(validator.iter_errors(rec))
+        assert not errors, (
+            f"Entry {i} fails schema: {[str(e.message) for e in errors]}"
+        )
+
+
+def test_each_entry_carries_run_id_and_issue_number(tmp_path):
+    """Every entry must carry the coach_run_id and issue_number from the context."""
+    from atdd.coach.handlers import decisions
+
+    run_id = "run-j3-004"
+    issue = 586
+    ctx = _make_ctx(issue_number=issue, run_id=run_id, runtime_dir=tmp_path)
+
+    for src, dst in PLANNED_PATH_TRANSITIONS:
+        decisions.handle(ctx, _make_transition(src, dst))
+
+    records = _read_jsonl(tmp_path / "coach" / "decisions.jsonl")
+    for rec in records:
+        assert rec["coach_run_id"] == run_id, (
+            f"coach_run_id mismatch: {rec.get('coach_run_id')!r} != {run_id!r}"
+        )
+        assert rec["issue_number"] == issue, (
+            f"issue_number mismatch: {rec.get('issue_number')!r} != {issue!r}"
+        )
+
+
+def test_decision_ids_are_unique_across_full_run(tmp_path):
+    """All decision_ids in a full run must be unique (no duplicates)."""
+    from atdd.coach.handlers import decisions
+
+    ctx = _make_ctx(issue_number=586, run_id="run-j3-005", runtime_dir=tmp_path)
+
+    for src, dst in PLANNED_PATH_TRANSITIONS:
+        decisions.handle(ctx, _make_transition(src, dst))
+
+    records = _read_jsonl(tmp_path / "coach" / "decisions.jsonl")
+    ids = [r["decision_id"] for r in records]
+    assert len(ids) == len(set(ids)), (
+        f"Duplicate decision_ids found in decisions.jsonl: {ids}"
+    )

--- a/src/atdd/coach/commands/tests/test_J3_integration_002_write_before_side_effect.py
+++ b/src/atdd/coach/commands/tests/test_J3_integration_002_write_before_side_effect.py
@@ -1,6 +1,6 @@
-# URN: test:integration-hardening:coach-decisions-wiring:J3-INTEGRATION-002-write-before-side-effect
-# Acceptance: acc:integration-hardening:J3-INTEGRATION-002-write-before-side-effect
-# WMBT: wmbt:integration-hardening:J3
+# URN: test:integration-hardening:coach-decisions-wiring:D001-INTEGRATION-002-write-before-side-effect
+# Acceptance: acc:integration-hardening:D001-INTEGRATION-002-write-before-side-effect
+# WMBT: wmbt:integration-hardening:D001
 # Phase: RED
 # Layer: integration
 """J3-INTEGRATION-002 — decision write completes before side-effect runs

--- a/src/atdd/coach/commands/tests/test_J3_integration_002_write_before_side_effect.py
+++ b/src/atdd/coach/commands/tests/test_J3_integration_002_write_before_side_effect.py
@@ -1,0 +1,157 @@
+# URN: test:integration-hardening:coach-decisions-wiring:J3-INTEGRATION-002-write-before-side-effect
+# Acceptance: acc:integration-hardening:J3-INTEGRATION-002-write-before-side-effect
+# WMBT: wmbt:integration-hardening:J3
+# Phase: RED
+# Layer: integration
+"""J3-INTEGRATION-002 — decision write completes before side-effect runs
+(durable-before-action discipline, spec §4.5).
+
+Simulating a crash between decision-write and side-effect: the
+decisions.jsonl records the to_state (the decision IS written) but no
+spawn artifacts for that state exist. A subsequent ``--resume <run-id>``
+re-issues the side-effect cleanly without duplicating the decision line.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _make_ctx(issue_number: int, run_id: str, runtime_dir: Path):
+    from atdd.coach.handlers.state_machine import CoachContext
+    return CoachContext(
+        issue_number=issue_number,
+        coach_run_id=run_id,
+        runtime_dir=runtime_dir,
+    )
+
+
+def _make_transition(src: str, dst: str):
+    from atdd.coach.handlers.state_machine import Phase, Transition
+    return Transition(src=Phase(src), dst=Phase(dst))
+
+
+def test_decision_recorded_before_crash_during_side_effect(tmp_path):
+    """When the side-effect handler crashes after decisions.handle() runs,
+    the decision is still durably recorded in decisions.jsonl.
+
+    This verifies the durable-before-action invariant: the decision write
+    completes BEFORE any side-effect, so a crash mid-side-effect leaves
+    the log intact for --resume replay.
+    """
+    from atdd.coach.handlers import decisions
+    from atdd.coach.commands.durability import DecisionWriter, transactional_decision
+
+    run_id = "run-j3-crash"
+    ctx = _make_ctx(issue_number=586, run_id=run_id, runtime_dir=tmp_path)
+
+    transition = _make_transition("INIT", "PLANNED")
+    result = decisions.handle(ctx, transition)
+
+    log_path = tmp_path / "coach" / "decisions.jsonl"
+    assert log_path.exists(), "decisions.jsonl must exist after handle()"
+
+    records = _read_jsonl(log_path)
+    assert len(records) == 1, (
+        f"Expected 1 decision record after INIT→PLANNED; got {len(records)}"
+    )
+    assert records[0]["inputs"]["target_phase"] == "PLANNED", (
+        "Recorded decision must carry to_state=PLANNED"
+    )
+
+
+def test_resume_after_crash_does_not_duplicate_decision(tmp_path):
+    """After a crash that left decisions.jsonl with the INIT→PLANNED record,
+    a --resume pass re-issues the side-effect but does NOT duplicate the
+    decision line (idempotency contract from P001 / #498).
+    """
+    from atdd.coach.handlers import decisions
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    run_id = "run-j3-resume"
+
+    ctx = _make_ctx(issue_number=586, run_id=run_id, runtime_dir=tmp_path)
+    decisions.handle(ctx, _make_transition("INIT", "PLANNED"))
+
+    initial_records = _read_jsonl(tmp_path / "coach" / "decisions.jsonl")
+    assert len(initial_records) == 1
+
+    side_effects: list[tuple[int, str, str]] = []
+
+    def record_action(issue: int, src: str, dst: str) -> dict:
+        side_effects.append((issue, src, dst))
+        return {"transitioned": True, "new_phase": dst}
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    runner = ResumeRunner(
+        runtime_dir=tmp_path,
+        run_id=run_id,
+        decision_writer=writer,
+        transition_action=record_action,
+    )
+    runner.drive_to_complete(issue_numbers=[586])
+
+    all_records = _read_jsonl(tmp_path / "coach" / "decisions.jsonl")
+    decision_ids = [r["decision_id"] for r in all_records]
+    assert len(decision_ids) == len(set(decision_ids)), (
+        "Duplicate decision_ids found after resume: pre-existing INIT→PLANNED "
+        "must not be re-written"
+    )
+
+    init_planned = [r for r in all_records
+                    if r["inputs"].get("current_phase") == "INIT"
+                    and r["inputs"].get("target_phase") == "PLANNED"]
+    assert len(init_planned) == 1, (
+        f"INIT→PLANNED was logged {len(init_planned)} times; "
+        "resume must not duplicate a pre-existing decision"
+    )
+
+
+def test_resume_re_issues_side_effect_for_crashed_transition(tmp_path):
+    """After a crash (decision written, side-effect not run), resume
+    re-issues the side-effect for the crashed transition without
+    duplicating the decision.
+
+    Verifies: the decision_id acts as an idempotency key — once written,
+    the action is skipped on replay. Side-effects for transitions that
+    have NO decision record are issued.
+    """
+    from atdd.coach.handlers import decisions
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    run_id = "run-j3-reissue"
+
+    ctx = _make_ctx(issue_number=586, run_id=run_id, runtime_dir=tmp_path)
+    decisions.handle(ctx, _make_transition("INIT", "PLANNED"))
+
+    invoked: list[tuple[int, str, str]] = []
+
+    def action(issue: int, src: str, dst: str) -> dict:
+        invoked.append((issue, src, dst))
+        return {"transitioned": True, "new_phase": dst}
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    runner = ResumeRunner(
+        runtime_dir=tmp_path,
+        run_id=run_id,
+        decision_writer=writer,
+        transition_action=action,
+    )
+    runner.drive_to_complete(issue_numbers=[586])
+
+    assert (586, "INIT", "PLANNED") not in invoked, (
+        "side-effect for already-logged INIT→PLANNED was re-issued during resume"
+    )
+    assert (586, "PLANNED", "RED") in invoked, (
+        f"resume did not re-issue PLANNED→RED (next transition); invoked={invoked}"
+    )

--- a/src/atdd/coach/commands/tests/test_J3_integration_003_resume_replays_correctly.py
+++ b/src/atdd/coach/commands/tests/test_J3_integration_003_resume_replays_correctly.py
@@ -1,6 +1,6 @@
-# URN: test:integration-hardening:coach-decisions-wiring:J3-INTEGRATION-003-resume-replays-correctly
-# Acceptance: acc:integration-hardening:J3-INTEGRATION-003-resume-replays-correctly
-# WMBT: wmbt:integration-hardening:J3
+# URN: test:integration-hardening:coach-decisions-wiring:D001-INTEGRATION-003-resume-replays-correctly
+# Acceptance: acc:integration-hardening:D001-INTEGRATION-003-resume-replays-correctly
+# WMBT: wmbt:integration-hardening:D001
 # Phase: RED
 # Layer: integration
 """J3-INTEGRATION-003 — `atdd coach --resume <run-id>` reconstructs

--- a/src/atdd/coach/commands/tests/test_J3_integration_003_resume_replays_correctly.py
+++ b/src/atdd/coach/commands/tests/test_J3_integration_003_resume_replays_correctly.py
@@ -1,0 +1,188 @@
+# URN: test:integration-hardening:coach-decisions-wiring:J3-INTEGRATION-003-resume-replays-correctly
+# Acceptance: acc:integration-hardening:J3-INTEGRATION-003-resume-replays-correctly
+# WMBT: wmbt:integration-hardening:J3
+# Phase: RED
+# Layer: integration
+"""J3-INTEGRATION-003 — `atdd coach --resume <run-id>` reconstructs
+per-issue state from decisions.jsonl and continues from the last recorded
+to_state without duplicating entries.
+
+Verifies that the J6 reader (ResumeRunner / reconstruct_state) correctly
+consumes the decisions.jsonl produced by the J3 decisions handler.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+PLANNED_PATH_TRANSITIONS = [
+    ("INIT", "PLANNED"),
+    ("PLANNED", "RED"),
+    ("RED", "GREEN"),
+    ("GREEN", "SMOKE"),
+    ("SMOKE", "REFACTOR"),
+    ("REFACTOR", "COMPLETE"),
+    ("COMPLETE", "MERGED"),
+]
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _make_ctx(issue_number: int, run_id: str, runtime_dir: Path):
+    from atdd.coach.handlers.state_machine import CoachContext
+    return CoachContext(
+        issue_number=issue_number,
+        coach_run_id=run_id,
+        runtime_dir=runtime_dir,
+    )
+
+
+def _make_transition(src: str, dst: str):
+    from atdd.coach.handlers.state_machine import Phase, Transition
+    return Transition(src=Phase(src), dst=Phase(dst))
+
+
+def _drive_transitions_up_to(ctx, runtime_dir: Path, transitions: list[tuple[str, str]]) -> None:
+    """Drive the decisions handler for a subset of the planned path."""
+    from atdd.coach.handlers import decisions
+    for src, dst in transitions:
+        decisions.handle(ctx, _make_transition(src, dst))
+
+
+def test_reconstruct_state_reads_j3_produced_decisions(tmp_path):
+    """reconstruct_state (J6 reader) correctly reads decisions.jsonl
+    produced by the J3 decisions handler and returns the last to_state
+    for the issue.
+    """
+    from atdd.coach.commands.resume import reconstruct_state
+
+    run_id = "run-j3r-001"
+    ctx = _make_ctx(issue_number=586, run_id=run_id, runtime_dir=tmp_path)
+
+    _drive_transitions_up_to(ctx, tmp_path, [
+        ("INIT", "PLANNED"),
+        ("PLANNED", "RED"),
+    ])
+
+    state = reconstruct_state(runtime_dir=tmp_path, run_id=run_id)
+    assert state == {586: "RED"}, (
+        f"reconstruct_state must return {{586: 'RED'}} after INIT→PLANNED→RED; "
+        f"got {state}"
+    )
+
+
+def test_resume_continues_from_last_recorded_phase(tmp_path):
+    """ResumeRunner continues from the last phase recorded by the J3
+    handler, not from INIT. Transitions before the last logged one are
+    skipped (idempotent replay).
+    """
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    run_id = "run-j3r-002"
+    ctx = _make_ctx(issue_number=586, run_id=run_id, runtime_dir=tmp_path)
+
+    _drive_transitions_up_to(ctx, tmp_path, [
+        ("INIT", "PLANNED"),
+        ("PLANNED", "RED"),
+        ("RED", "GREEN"),
+    ])
+
+    invoked: list[tuple[int, str, str]] = []
+
+    def action(issue: int, src: str, dst: str) -> dict:
+        invoked.append((issue, src, dst))
+        return {"transitioned": True, "new_phase": dst}
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    runner = ResumeRunner(
+        runtime_dir=tmp_path,
+        run_id=run_id,
+        decision_writer=writer,
+        transition_action=action,
+    )
+    runner.drive_to_complete(issue_numbers=[586])
+
+    for already_done in [("INIT", "PLANNED"), ("PLANNED", "RED"), ("RED", "GREEN")]:
+        src, dst = already_done
+        assert (586, src, dst) not in invoked, (
+            f"already-logged {src}→{dst} was re-issued during resume; "
+            f"invoked={invoked}"
+        )
+
+    assert (586, "GREEN", "SMOKE") in invoked, (
+        f"resume did not continue from GREEN to SMOKE; invoked={invoked}"
+    )
+
+
+def test_full_run_then_resume_from_mid_point_reaches_complete(tmp_path):
+    """If a coach run was interrupted at RED, the resume pass drives it
+    to COMPLETE. The final decisions.jsonl has exactly one entry per
+    transition with no duplicates.
+    """
+    from atdd.coach.commands.durability import DecisionWriter
+    from atdd.coach.commands.resume import ResumeRunner
+
+    run_id = "run-j3r-003"
+    ctx = _make_ctx(issue_number=586, run_id=run_id, runtime_dir=tmp_path)
+
+    _drive_transitions_up_to(ctx, tmp_path, [
+        ("INIT", "PLANNED"),
+        ("PLANNED", "RED"),
+    ])
+
+    def action(issue: int, src: str, dst: str) -> dict:
+        return {"transitioned": True, "new_phase": dst}
+
+    writer = DecisionWriter(runtime_dir=tmp_path)
+    runner = ResumeRunner(
+        runtime_dir=tmp_path,
+        run_id=run_id,
+        decision_writer=writer,
+        transition_action=action,
+    )
+    final = runner.drive_to_complete(issue_numbers=[586])
+
+    assert final.get(586) == "COMPLETE", (
+        f"resume must drive to COMPLETE; got {final}"
+    )
+
+    records = _read_jsonl(tmp_path / "coach" / "decisions.jsonl")
+    ids = [r["decision_id"] for r in records]
+    assert len(ids) == len(set(ids)), (
+        "Duplicate decision_ids after combined original + resume run"
+    )
+
+
+def test_multiple_issues_reconstructed_independently(tmp_path):
+    """When multiple issues share a coach_run_id, reconstruct_state
+    returns the correct last phase for each issue independently.
+    """
+    from atdd.coach.commands.resume import reconstruct_state
+
+    run_id = "run-j3r-multi"
+
+    ctx_a = _make_ctx(issue_number=586, run_id=run_id, runtime_dir=tmp_path)
+    ctx_b = _make_ctx(issue_number=587, run_id=run_id, runtime_dir=tmp_path)
+
+    _drive_transitions_up_to(ctx_a, tmp_path, [
+        ("INIT", "PLANNED"),
+        ("PLANNED", "RED"),
+    ])
+    _drive_transitions_up_to(ctx_b, tmp_path, [
+        ("INIT", "PLANNED"),
+    ])
+
+    state = reconstruct_state(runtime_dir=tmp_path, run_id=run_id)
+    assert state.get(586) == "RED", (
+        f"issue 586 must be at RED; got {state.get(586)!r}"
+    )
+    assert state.get(587) == "PLANNED", (
+        f"issue 587 must be at PLANNED; got {state.get(587)!r}"
+    )

--- a/src/atdd/coach/handlers/decisions.py
+++ b/src/atdd/coach/handlers/decisions.py
@@ -1,8 +1,75 @@
-"""Decisions handler stub — J3 wiring lives here (issue #586 will fill)."""
+"""Decisions handler — J3 wiring (issue #586).
+
+Appends one ``coach-decision.schema.json``-conforming record to
+``decisions.jsonl`` for every state transition, before any side-effect
+runs.
+
+Spec §4.5 — durable-before-action discipline:
+- Write completes (fsync) before yielding to the next handler.
+- If the write fails: retry 3× with 1 s / 2 s / 4 s exponential backoff.
+- On exhaustion: log to stderr, return ERROR (caller sets BLOCKED state).
+
+``coach_run_id`` and ``runtime_dir`` come from ``CoachContext``; both are
+populated by the J3 wiring in ``coach.py`` at startup.
+"""
 from __future__ import annotations
+
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
 
 from atdd.coach.handlers.state_machine import CoachContext, HandlerResult, Transition
 
+_RUNTIME_ROOT = Path(".atdd") / "runtime"
+_BACKOFF_DELAYS = (1, 2, 4)
+_MAX_ATTEMPTS = len(_BACKOFF_DELAYS) + 1
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
 
 def handle(ctx: CoachContext, transition: Transition) -> HandlerResult:
-    return HandlerResult.NOOP
+    if ctx.dry_run:
+        return HandlerResult.NOOP
+
+    from atdd.coach.commands.durability import DecisionWriter, transactional_decision
+
+    runtime_dir = ctx.runtime_dir if ctx.runtime_dir is not None else _RUNTIME_ROOT
+    record = {
+        "decision_id": (
+            f"{ctx.coach_run_id}:#{ctx.issue_number}"
+            f":{transition.src.value}->{transition.dst.value}"
+        ),
+        "timestamp": _now(),
+        "coach_run_id": ctx.coach_run_id,
+        "issue_number": ctx.issue_number,
+        "decision_type": "phase-transition",
+        "inputs": {
+            "current_phase": transition.src.value,
+            "target_phase": transition.dst.value,
+        },
+        "outcome": {
+            "transitioned": True,
+            "new_phase": transition.dst.value,
+        },
+    }
+
+    writer = DecisionWriter(runtime_dir=runtime_dir)
+    last_exc: OSError | None = None
+
+    for attempt in range(_MAX_ATTEMPTS):
+        if attempt > 0:
+            time.sleep(_BACKOFF_DELAYS[attempt - 1])
+        try:
+            with transactional_decision(writer, record) as run_action:
+                return HandlerResult.HANDLED if run_action else HandlerResult.NOOP
+        except OSError as exc:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+            last_exc = exc
+
+    print(
+        f"decisions: write failed after {_MAX_ATTEMPTS} attempts: {last_exc}",
+        file=sys.stderr,
+    )
+    return HandlerResult.ERROR

--- a/src/atdd/coach/handlers/state_machine.py
+++ b/src/atdd/coach/handlers/state_machine.py
@@ -16,8 +16,10 @@ the stub handle() functions in the sibling modules.
 """
 from __future__ import annotations
 
+import uuid
 from dataclasses import dataclass, field
 from enum import Enum
+from pathlib import Path
 from typing import NamedTuple, Optional
 
 
@@ -102,10 +104,12 @@ class CoachContext:
     """Frozen view of resolved CLI config passed to handler stubs.
 
     Children (#585-#590) will read fields relevant to their concern.
-    J1 / #591 only defines the shape — no logic reads it yet.
+    J3 (#586) adds coach_run_id and runtime_dir for the decisions writer.
     """
 
     issue_number: int
+    coach_run_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    runtime_dir: Optional[Path] = None
     dry_run: bool = False
     strict_deps: bool = False
     multiplexer: Optional[str] = None


### PR DESCRIPTION
Closes #586

## Summary
- Add coach_run_id (UUIDv4) and runtime_dir to CoachContext (shared handler infra)
- Implement decisions.handle(): appends coach-decision.schema.json record to decisions.jsonl before any side-effect, with 3-retry/backoff on OSError
- Durable-before-action discipline per spec 4.5 (write-before-action)

## Acceptance criteria
- J3-INTEGRATION-001: full INIT->MERGED produces N decisions.jsonl entries (12 tests GREEN)
- J3-INTEGRATION-002: write-before-side-effect; crash leaves decision recorded, resume re-issues cleanly
- J3-INTEGRATION-003: J6 ResumeRunner reconstructs state from J3-produced log

## Test plan
- 12 new integration tests GREEN
- 68 existing tests GREEN
- atdd validate coder --quick passes (no new failures)