### PR TITLE
feat: bug(atdd): `atdd sync` silently strips externally-added content from managed files (#581)

### DIFF
--- a/plan/self_compliance_migration/Y001.yaml
+++ b/plan/self_compliance_migration/Y001.yaml
@@ -4,7 +4,7 @@ direction: "minimize"
 dimension: "likelihood"
 object_of_control: "silent-content-loss-during-atdd-sync"
 context_clarifier: "when atdd sync re-renders managed files (CLAUDE.md, AGENTS.md, etc.) and the file contains user-owned content outside the ATDD:BEGIN/END markers, or the managed block would shrink relative to the current file, the sync must never silently remove that content"
-lens: "functional.safety"
+lens: "functional.availability"
 statement: "minimize likelihood of silent-content-loss-during-atdd-sync when atdd sync re-renders managed agent config files that contain user-owned content outside the ATDD:BEGIN/END markers or sections present in the current block but absent from the regenerated template"
 acceptances:
   - identity:

--- a/plan/self_compliance_migration/Y001.yaml
+++ b/plan/self_compliance_migration/Y001.yaml
@@ -1,0 +1,71 @@
+urn: "wmbt:self-compliance-migration:Y001"
+step: "modify"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "silent-content-loss-during-atdd-sync"
+context_clarifier: "when atdd sync re-renders managed files (CLAUDE.md, AGENTS.md, etc.) and the file contains user-owned content outside the ATDD:BEGIN/END markers, or the managed block would shrink relative to the current file, the sync must never silently remove that content"
+lens: "functional.safety"
+statement: "minimize likelihood of silent-content-loss-during-atdd-sync when atdd sync re-renders managed agent config files that contain user-owned content outside the ATDD:BEGIN/END markers or sections present in the current block but absent from the regenerated template"
+acceptances:
+  - identity:
+      urn: "acc:self-compliance-migration:Y001-UNIT-001-user-content-before-block-preserved"
+      id: "AC-UNIT-001"
+      purpose: "Content appearing before the ATDD:BEGIN marker is preserved unchanged after sync"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A managed file in tmp_path with user-authored content BEFORE the ATDD:BEGIN marker"
+        - "The file also contains a valid managed block between ATDD:BEGIN and ATDD:END"
+    when:
+      abstract: "atdd sync renders a new managed block for that file"
+    then:
+      abstract:
+        - "The content before the ATDD:BEGIN marker is byte-for-byte identical after sync"
+    metadata:
+      author: "atdd:bug-581"
+      created: "2026-05-12"
+
+  - identity:
+      urn: "acc:self-compliance-migration:Y001-UNIT-002-user-content-after-block-preserved"
+      id: "AC-UNIT-002"
+      purpose: "Content appearing after the ATDD:END marker is preserved unchanged after sync"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A managed file in tmp_path with user-authored content AFTER the ATDD:END marker"
+        - "The file also contains a valid managed block between ATDD:BEGIN and ATDD:END"
+    when:
+      abstract: "atdd sync renders a new managed block for that file"
+    then:
+      abstract:
+        - "The content after the ATDD:END marker is byte-for-byte identical after sync"
+    metadata:
+      author: "atdd:bug-581"
+      created: "2026-05-12"
+
+  - identity:
+      urn: "acc:self-compliance-migration:Y001-UNIT-003-within-block-deletion-warns"
+      id: "AC-UNIT-003"
+      purpose: "When the newly rendered managed block removes lines that existed in the current file's block, atdd sync prints a warning listing the deleted heading lines before writing"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A managed file whose current block contains section headings (## Foo, ## Bar) that will NOT appear in the newly rendered block"
+    when:
+      abstract: "atdd sync renders a new managed block for that file"
+    then:
+      abstract:
+        - "stdout contains a warning message that names the headings being removed"
+        - "The file is still updated (warning is advisory, not blocking)"
+    metadata:
+      author: "atdd:bug-581"
+      created: "2026-05-12"

--- a/plan/self_compliance_migration/_self_compliance_migration.yaml
+++ b/plan/self_compliance_migration/_self_compliance_migration.yaml
@@ -22,7 +22,7 @@ produce:
 consume: []
 
 wmbt:
-  total: 8
+  total: 9
   C001: "Confirm all existing tests pass (baseline lock)"
   D001: "Define wagon manifests for coach, planner, tester, coder"
   D002: "Define feature YAMLs with WMBTs for each wagon"
@@ -31,3 +31,4 @@ wmbt:
   P001: "Define validate lifecycle train"
   R001: "Wire URN traceability across plan, test, code"
   K001: "Both atdd validate and local pytest pass on the toolkit itself"
+  Y001: "atdd sync preserves user content outside managed block and warns on within-block deletions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.40.0"
+version = "3.40.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/sync.py
+++ b/src/atdd/coach/commands/sync.py
@@ -549,7 +549,36 @@ class AgentConfigSync:
         if self.BLOCK_BEGIN in remaining:
             print("Warning: Multiple managed blocks found, updating first only")
 
+        self._warn_on_block_deletions(block, new_block)
+
         return content[:start_idx] + new_block + content[end_idx:]
+
+    def _warn_on_block_deletions(self, old_block: str, new_block: str) -> None:
+        """Warn when headings present in the current managed block are absent from the new one.
+
+        Guards against silent content loss (bug #581): when a template change
+        removes sections that were previously rendered (e.g. via an overlay or
+        persona template), the operator sees exactly which headings disappear.
+        """
+        old_headings = {
+            line.strip()
+            for line in old_block.splitlines()
+            if line.strip().startswith("#")
+            and not line.strip().startswith(self.BLOCK_BEGIN.strip())
+            and not line.strip().startswith(self.BLOCK_END.strip())
+        }
+        new_headings = {
+            line.strip()
+            for line in new_block.splitlines()
+            if line.strip().startswith("#")
+            and not line.strip().startswith(self.BLOCK_BEGIN.strip())
+            and not line.strip().startswith(self.BLOCK_END.strip())
+        }
+        removed = sorted(old_headings - new_headings)
+        if removed:
+            print("Warning: the following headings will be removed from the managed block:")
+            for heading in removed:
+                print(f"  - {heading}")
 
     def _append_managed_block(self, content: str, new_block: str) -> str:
         """

--- a/src/atdd/coach/commands/tests/test_y001_unit_001_user_content_before_block_preserved.py
+++ b/src/atdd/coach/commands/tests/test_y001_unit_001_user_content_before_block_preserved.py
@@ -1,0 +1,37 @@
+# Acceptance: acc:self-compliance-migration:Y001-UNIT-001-user-content-before-block-preserved
+"""
+RED test: atdd sync must preserve user-owned content that appears BEFORE the
+ATDD:BEGIN marker.
+
+Bug #581: content outside the managed block was silently removed when sync
+re-rendered the managed section.
+"""
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.commands.sync import AgentConfigSync
+
+BEFORE_CONTENT = "## Rule-ID grammar\n\nCanonical rule IDs use `<archetype>.<convention_short_name>.<rule_name>`.\n\n"
+
+
+def test_y001_unit_001_user_content_before_block_preserved(tmp_path: Path) -> None:
+    """Content before ATDD:BEGIN is byte-for-byte identical after sync."""
+    claude_md = tmp_path / "CLAUDE.md"
+    existing_block = (
+        f"{AgentConfigSync.BLOCK_BEGIN}\n"
+        "old managed content\n"
+        f"{AgentConfigSync.BLOCK_END}\n"
+    )
+    claude_md.write_text(BEFORE_CONTENT + existing_block)
+
+    sync = AgentConfigSync(target_dir=tmp_path)
+    rc = sync.sync(agents=["claude"])
+    assert rc == 0
+
+    result = claude_md.read_text()
+    assert result.startswith(BEFORE_CONTENT), (
+        "Content before ATDD:BEGIN was modified or removed by sync.\n"
+        f"Expected prefix:\n{BEFORE_CONTENT!r}\n"
+        f"Actual start:\n{result[:len(BEFORE_CONTENT) + 50]!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_y001_unit_002_user_content_after_block_preserved.py
+++ b/src/atdd/coach/commands/tests/test_y001_unit_002_user_content_after_block_preserved.py
@@ -1,0 +1,37 @@
+# Acceptance: acc:self-compliance-migration:Y001-UNIT-002-user-content-after-block-preserved
+"""
+RED test: atdd sync must preserve user-owned content that appears AFTER the
+ATDD:END marker.
+
+Bug #581: content outside the managed block was silently removed when sync
+re-rendered the managed section.
+"""
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.commands.sync import AgentConfigSync
+
+AFTER_CONTENT = "\n## bind_rule contract\n\nvalidators MUST call `bind_rule` at module-import time.\n"
+
+
+def test_y001_unit_002_user_content_after_block_preserved(tmp_path: Path) -> None:
+    """Content after ATDD:END is byte-for-byte identical after sync."""
+    claude_md = tmp_path / "CLAUDE.md"
+    existing_block = (
+        f"{AgentConfigSync.BLOCK_BEGIN}\n"
+        "old managed content\n"
+        f"{AgentConfigSync.BLOCK_END}"
+    )
+    claude_md.write_text(existing_block + AFTER_CONTENT)
+
+    sync = AgentConfigSync(target_dir=tmp_path)
+    rc = sync.sync(agents=["claude"])
+    assert rc == 0
+
+    result = claude_md.read_text()
+    assert result.endswith(AFTER_CONTENT), (
+        "Content after ATDD:END was modified or removed by sync.\n"
+        f"Expected suffix:\n{AFTER_CONTENT!r}\n"
+        f"Actual end:\n{result[-len(AFTER_CONTENT) - 50:]!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_y001_unit_003_within_block_deletion_warns.py
+++ b/src/atdd/coach/commands/tests/test_y001_unit_003_within_block_deletion_warns.py
@@ -3,9 +3,9 @@
 RED test: atdd sync must print a warning when the newly rendered managed block
 would remove heading lines that existed in the current file's block.
 
-Bug #581: PR #561 added ## Rule-ID grammar and ## bind_rule contract sections
-inside the ATDD:BEGIN/END block; a subsequent atdd sync silently stripped them
-without any warning or diff shown.
+Bug #581: content added inside the ATDD:BEGIN/END block (e.g. via a persona
+template that later changed) was silently stripped on the next atdd sync with
+no diff shown, no warning, no opt-in required.
 """
 from pathlib import Path
 
@@ -13,18 +13,21 @@ import pytest
 
 from atdd.coach.commands.sync import AgentConfigSync
 
+# Headings that will NEVER appear in the real template — so they are guaranteed
+# to be "removed" when sync regenerates the block from the live ATDD.md.
+_PHANTOM_HEADING_1 = "## Phantom-Section-581-Alpha"
+_PHANTOM_HEADING_2 = "## Phantom-Section-581-Beta"
 
-def _build_file_with_extra_sections(block_begin: str, block_end: str, tmp_path: Path) -> Path:
-    """Write a CLAUDE.md whose managed block contains headings not in the template."""
+
+def _build_file_with_phantom_sections(block_begin: str, block_end: str, tmp_path: Path) -> Path:
+    """Write a CLAUDE.md whose managed block contains headings absent from the template."""
     claude_md = tmp_path / "CLAUDE.md"
     content = (
         f"{block_begin}\n"
-        "## Existing Template Section\n\n"
-        "Some template content.\n\n"
-        "## Rule-ID grammar\n\n"
-        "Canonical rule IDs use `<archetype>.<convention_short_name>.<rule_name>`.\n\n"
-        "## bind_rule contract\n\n"
-        "validators MUST call `bind_rule` at module-import time.\n"
+        f"{_PHANTOM_HEADING_1}\n\n"
+        "Content that will not survive the next sync.\n\n"
+        f"{_PHANTOM_HEADING_2}\n\n"
+        "More ephemeral content.\n"
         f"{block_end}\n"
     )
     claude_md.write_text(content)
@@ -35,7 +38,7 @@ def test_y001_unit_003_within_block_deletion_warns(
     tmp_path: Path, capsys: pytest.CaptureFixture
 ) -> None:
     """When sync removes headings from the managed block, stdout must warn about them."""
-    _build_file_with_extra_sections(
+    _build_file_with_phantom_sections(
         AgentConfigSync.BLOCK_BEGIN,
         AgentConfigSync.BLOCK_END,
         tmp_path,
@@ -46,11 +49,11 @@ def test_y001_unit_003_within_block_deletion_warns(
     assert rc == 0  # warning is advisory, sync still writes
 
     out = capsys.readouterr().out
-    assert "## Rule-ID grammar" in out or "Rule-ID grammar" in out, (
-        "Expected a warning mentioning '## Rule-ID grammar' being removed from the "
-        f"managed block, but stdout was:\n{out}"
+    assert _PHANTOM_HEADING_1 in out, (
+        f"Expected a warning mentioning {_PHANTOM_HEADING_1!r} being removed, "
+        f"but stdout was:\n{out}"
     )
-    assert "## bind_rule contract" in out or "bind_rule contract" in out, (
-        "Expected a warning mentioning '## bind_rule contract' being removed from the "
-        f"managed block, but stdout was:\n{out}"
+    assert _PHANTOM_HEADING_2 in out, (
+        f"Expected a warning mentioning {_PHANTOM_HEADING_2!r} being removed, "
+        f"but stdout was:\n{out}"
     )

--- a/src/atdd/coach/commands/tests/test_y001_unit_003_within_block_deletion_warns.py
+++ b/src/atdd/coach/commands/tests/test_y001_unit_003_within_block_deletion_warns.py
@@ -1,0 +1,56 @@
+# Acceptance: acc:self-compliance-migration:Y001-UNIT-003-within-block-deletion-warns
+"""
+RED test: atdd sync must print a warning when the newly rendered managed block
+would remove heading lines that existed in the current file's block.
+
+Bug #581: PR #561 added ## Rule-ID grammar and ## bind_rule contract sections
+inside the ATDD:BEGIN/END block; a subsequent atdd sync silently stripped them
+without any warning or diff shown.
+"""
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.commands.sync import AgentConfigSync
+
+
+def _build_file_with_extra_sections(block_begin: str, block_end: str, tmp_path: Path) -> Path:
+    """Write a CLAUDE.md whose managed block contains headings not in the template."""
+    claude_md = tmp_path / "CLAUDE.md"
+    content = (
+        f"{block_begin}\n"
+        "## Existing Template Section\n\n"
+        "Some template content.\n\n"
+        "## Rule-ID grammar\n\n"
+        "Canonical rule IDs use `<archetype>.<convention_short_name>.<rule_name>`.\n\n"
+        "## bind_rule contract\n\n"
+        "validators MUST call `bind_rule` at module-import time.\n"
+        f"{block_end}\n"
+    )
+    claude_md.write_text(content)
+    return claude_md
+
+
+def test_y001_unit_003_within_block_deletion_warns(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """When sync removes headings from the managed block, stdout must warn about them."""
+    _build_file_with_extra_sections(
+        AgentConfigSync.BLOCK_BEGIN,
+        AgentConfigSync.BLOCK_END,
+        tmp_path,
+    )
+
+    sync = AgentConfigSync(target_dir=tmp_path)
+    rc = sync.sync(agents=["claude"])
+    assert rc == 0  # warning is advisory, sync still writes
+
+    out = capsys.readouterr().out
+    assert "## Rule-ID grammar" in out or "Rule-ID grammar" in out, (
+        "Expected a warning mentioning '## Rule-ID grammar' being removed from the "
+        f"managed block, but stdout was:\n{out}"
+    )
+    assert "## bind_rule contract" in out or "bind_rule contract" in out, (
+        "Expected a warning mentioning '## bind_rule contract' being removed from the "
+        f"managed block, but stdout was:\n{out}"
+    )


### PR DESCRIPTION
Closes #581

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #581 |
| Labels | atdd-issue, atdd:INIT |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.