### PR TITLE
docs(atdd): add worktree_config convention (--worktree flag) to prevent shared-config bleed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.41.0"
+version = "3.42.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/templates/ATDD.md
+++ b/src/atdd/coach/templates/ATDD.md
@@ -277,6 +277,37 @@ git:
     prefixes: ["feat/", "fix/", "refactor/", "chore/", "docs/", "devops/"]
     example: "git worktree add ../feat-traceability-gates -b feat/traceability-gates"
 
+  # ─── PER-WORKTREE GIT CONFIG (PREVENT BLEED-TO-MAIN CONTAMINATION) ─────
+  # Inside a git worktree, `git config <key>` (no scope flag) writes to the
+  # SHARED `.git/config`, which every worktree reads. Setting certain keys
+  # — most dangerously `core.bare` — bleeds to main and other worktrees,
+  # causing the Wave 12 contamination class (PRs #625/#627 shipped 220k-
+  # line deletions; #629 Layer 1 pre-push hook now blocks the push, but
+  # the local mess remains and breaks the worktree's view of files).
+  #
+  # Repo opt-in is already enabled on main:
+  #   extensions.worktreeConfig = true
+  #
+  # RULE: any time you set a git config inside a worktree for testing or
+  # debugging, use the --worktree flag so it stays in that worktree only:
+  #
+  #   git config --worktree core.bare true     # OK — per-worktree
+  #   git config core.bare true                # NEVER — writes to shared
+  #
+  # Better still: don't set core.bare on real worktrees at all — exercise
+  # hook behavior in tmp_path repos. See
+  # `src/atdd/coach/templates/hooks/tests/test_C002_unit_pre_push_bare_mode.py`
+  # for the correct isolation pattern (every git call uses
+  # `git -C str(tmp_path) ...`).
+  # ───────────────────────────────────────────────────────────────────────
+  worktree_config:
+    rule: "Use --worktree flag for per-worktree git config; never run bare git config in a worktree"
+    danger_keys: ["core.bare", "core.worktree", "core.hooksPath"]
+    repo_extension: "extensions.worktreeConfig = true (already set on this repo's .git/config)"
+    test_pattern: "src/atdd/coach/templates/hooks/tests/test_C002_unit_pre_push_bare_mode.py uses git -C str(tmp_path) — never touches the worktree's .git"
+    recovery: "If core.bare=true leaks to main: `git -C <main-worktree> config --unset core.bare` then verify with `git status` that the worktree sees its full file set again"
+    incident_2026_05_12: "An agent debugging the #583 prepush-validator hook ran `git config core.bare true` directly inside its worktree; that wrote to the SHARED .git/config and contaminated main + sibling worktrees. The #629 Layer 1 hook caught the push (Wave 12 PRs #625/#627 also stopped at push), but the local mess cycled for hours before the root cause (worktrees share .git/config by default) was understood. extensions.worktreeConfig was enabled afterwards."
+
   # ─── PARALLEL WORK VIA WORKTREE + CMUX ────────────────────────────────
   # Machine-readable rules for parallel agent sessions (waves, babysitter,
   # prompt approval policy, violation patterns, merge cascade, telemetry)


### PR DESCRIPTION
## Summary

Adds a `worktree_config:` YAML section under `git:` in `src/atdd/coach/templates/ATDD.md` documenting:

- By default, `git config <key>` inside a worktree writes to the SHARED `.git/config`
- For per-worktree state, use `git config --worktree <key>` (requires `extensions.worktreeConfig = true`, already set on this repo)
- Dangerous keys that bleed across worktrees: `core.bare`, `core.worktree`, `core.hooksPath`
- Test hooks via `tmp_path` repos, not by modifying worktree config

## Why

**Wave 12 contamination root cause discovered 2026-05-12.** Two PRs (#625, #627) pushed 220k-line deletions because their worktrees had `core.bare=true` set. The Layer 1 pre-push hook (#629 / PR #630) blocked the push, but the local mess cycled for hours before we understood the cause: an agent debugging the #583 prepush-validator ran `git config core.bare true` directly inside its worktree, which wrote to the SHARED `.git/config` and contaminated main + sibling worktrees.

`extensions.worktreeConfig` was enabled on the repo after; this PR documents the convention.

## Scope

- src/atdd/coach/templates/ATDD.md: +31 lines (new `worktree_config:` block under `git:`)
- pyproject.toml: 3.41.0 → 3.42.0 (MINOR — new convention)
- LLM files (CLAUDE.md/AGENTS.md/GEMINI.md/GLM.md) NOT regenerated in this PR; they will sync on the next `atdd sync` after this version installs.

## References

- Wave 12 incident — PRs #625 + #627 (closed) and PR #630 (Layer 1 pre-push hook)
- #629 — parent issue with the 4-layer prevention plan; Layer 4 (meta-validator on test code) would catch polluting *tests* but not agent shell behavior; this convention complements it.