### PR TITLE
Add local model benchmark notes

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -811,3 +811,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '658'
+  slug: observer-as-tab-not-separate-pane
+  file: null
+  issue_number: 658
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -858,3 +858,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '672'
+  slug: n5-review-gate-broken-on-ci-runners
+  file: null
+  issue_number: 672
+  type: refactor
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -795,3 +795,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '656'
+  slug: coach-uses-repo-graph-for-own-decisions
+  file: null
+  issue_number: 656
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -819,3 +819,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '662'
+  slug: reject-raw-cmux-claude-spawn
+  file: null
+  issue_number: 662
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -834,3 +834,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '666'
+  slug: atdd-issue-chains-to-branch-and-worktree
+  file: null
+  issue_number: 666
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -803,3 +803,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '657'
+  slug: agent-behavior-rules-need-repo-enforcement
+  file: null
+  issue_number: 657
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -826,3 +826,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '665'
+  slug: observer-fires-on-every-entry-point
+  file: null
+  issue_number: 665
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -850,3 +850,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '671'
+  slug: atdd-babysit-help-shows-fake-functional-help
+  file: null
+  issue_number: 671
+  type: refactor
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -735,7 +735,6 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
-<<<<<<< HEAD
 - id: '651'
   slug: prompt-injects-graph
   file: null
@@ -745,14 +744,14 @@ sessions:
   train: 0002-coach-drives-lifecycle
   wagon: integration-hardening
   feature: coach-single-command-driver
-=======
+  created: '2026-05-13'
+  archived: null
 - id: '645'
   slug: coach-cold-start-doesnt-wire-handlers
   file: null
   issue_number: 645
   type: implementation
   status: INIT
->>>>>>> 965498b (chore(coach): register issue #645 in manifest)
   created: '2026-05-13'
   archived: null
 - id: '670'
@@ -767,14 +766,6 @@ sessions:
   slug: coach-observer-cospawn-missing
   file: null
   issue_number: 650
-  type: implementation
-  status: INIT
-  created: '2026-05-13'
-  archived: null
-- id: '651'
-  slug: coach-persona-prompt-injects-repo-graph
-  file: null
-  issue_number: 651
   type: implementation
   status: INIT
   created: '2026-05-13'

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -779,3 +779,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '652'
+  slug: coach-auto-rename-claude-session
+  file: null
+  issue_number: 652
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -735,6 +735,7 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+<<<<<<< HEAD
 - id: '651'
   slug: prompt-injects-graph
   file: null
@@ -744,6 +745,14 @@ sessions:
   train: 0002-coach-drives-lifecycle
   wagon: integration-hardening
   feature: coach-single-command-driver
+=======
+- id: '645'
+  slug: coach-cold-start-doesnt-wire-handlers
+  file: null
+  issue_number: 645
+  type: implementation
+  status: INIT
+>>>>>>> 965498b (chore(coach): register issue #645 in manifest)
   created: '2026-05-13'
   archived: null
 - id: '670'

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -763,3 +763,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '650'
+  slug: coach-observer-cospawn-missing
+  file: null
+  issue_number: 650
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -818,3 +818,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '664'
+  slug: docs-models-md-and-manifest-backfill
+  file: null
+  issue_number: 664
+  type: cleanup
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -771,3 +771,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '651'
+  slug: coach-persona-prompt-injects-repo-graph
+  file: null
+  issue_number: 651
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -866,3 +866,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '674'
+  slug: fix-integration-hardening-wmbt-total-undercount
+  file: null
+  issue_number: 674
+  type: cleanup
+  status: INIT
+  created: '2026-05-14'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -787,3 +787,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '655'
+  slug: coach-spawn-orphan-pane-cleanup
+  file: null
+  issue_number: 655
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -842,3 +842,11 @@ sessions:
   status: INIT
   created: '2026-05-13'
   archived: null
+- id: '668'
+  slug: forbidden-commands-pretooluse-hook
+  file: null
+  issue_number: 668
+  type: implementation
+  status: INIT
+  created: '2026-05-13'
+  archived: null

--- a/MODELS.md
+++ b/MODELS.md
@@ -1,0 +1,92 @@
+# Model Comparison Notes
+
+## Test Device
+
+- MacBook Pro M5
+- 24 GB unified memory
+- 1 TB SSD
+- Ollama local runs inside `cmux` workspace `workspace:23` (`OLLAMA`)
+
+## Models Compared
+
+- `codegeex4`
+- `qwen2.5-coder:14b`
+
+## What Was Tested
+
+- Basic code generation
+- Debugging
+- Refactor without behavior change
+- LRU cache implementation
+- Self-correction after a correction prompt
+
+## Result Summary
+
+### `qwen2.5-coder:14b`
+
+- Better overall coding quality
+- Better constraint following
+- Better self-correction when corrected
+- Slower than `codegeex4`, but more reliable
+
+### `codegeex4`
+
+- Faster first response
+- Weaker task follow-through
+- Drifted more often
+- Mixed older context into later answers
+- Not reliable enough as the main coding assistant
+
+## Score Summary
+
+- `qwen2.5-coder:14b`: about `8.5-9/10`
+- `codegeex4`: about `5.5-6.5/10`
+
+## Clean Benchmark Run - 2026-05-12
+
+Each test was run from a fresh model invocation to avoid chat-history
+pollution. The right-side `cmux` layout used:
+
+- Top: `codegeex4`
+- Bottom: `qwen2.5-coder:14b`
+
+### Test 1: LRU Cache Under 60 Lines
+
+- `codegeex4`: Produced working code quickly, but used a list for recency
+  tracking, which makes promotion and eviction `O(n)`. It also added
+  explanation text despite the "code only" prompt.
+- `qwen2.5-coder:14b`: Produced a cleaner `OrderedDict` implementation with
+  correct promotion on `get` and eviction on `put`. Followed the output
+  constraint better.
+
+Winner: `qwen2.5-coder:14b`
+
+### Test 2: Refactor Without Behavior Change
+
+- `codegeex4`: Kept behavior and stayed concise, but mostly rewrote the
+  original function instead of meaningfully improving testability.
+- `qwen2.5-coder:14b`: Extracted a helper for value cleaning while preserving
+  behavior, making the result easier to test.
+
+Winner: `qwen2.5-coder:14b`
+
+### Test 3: Self-Correction After ATDD-Style Correction
+
+Initial prompt asked for a `collections.Counter` implementation and explanation.
+Correction then required no imports, numbers only, smaller-number tie break, and
+code plus one example only.
+
+- `codegeex4`: Initial answer returned `(number, count)` tuples, which violated
+  the expected return shape. After correction, it fixed the implementation and
+  tie break, but still added explanation text after the code.
+- `qwen2.5-coder:14b`: Initial answer returned numbers correctly. After
+  correction, it removed imports, preserved tie-breaking, and followed the
+  stricter output format more closely.
+
+Winner: `qwen2.5-coder:14b`
+
+## Practical Takeaway
+
+- Use `qwen2.5-coder:14b` as the main coding model on this machine.
+- Use `codegeex4` only when speed matters more than answer quality.
+- For ATDD-style worker loops, `qwen2.5-coder:14b` is the better fit because it recovers better after correction.


### PR DESCRIPTION
## Summary
- add MODELS.md with local Ollama benchmark notes
- document test device, compared models, scoring summary, and clean benchmark results
- capture recommendation for qwen2.5-coder:14b vs codegeex4 for ATDD-style worker loops

## Testing
- Documentation-only change; no tests run.