### PR TITLE
fix(packaging): include atdd.coach.prompts in wheel (3.46.0 → 3.46.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.46.0"
+version = "3.46.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"
@@ -56,6 +56,7 @@ exclude = ["atdd.*.validators.fixtures*"]
 "atdd.coach.templates.harness" = ["*.mjs"]
 "atdd.coach.templates.workflows" = ["*.yml"]
 "atdd.coach.schemas" = ["*.json"]
+"atdd.coach.prompts" = ["**/*.yaml"]
 "atdd.coach.conventions" = ["*.yaml"]
 "atdd.coach.overlays" = ["*.md"]
 "atdd.planner.conventions" = ["*.yaml"]


### PR DESCRIPTION
## Summary

#646 (which closed #645) wired `coach.run()` cold-start to spawn personas from `src/atdd/coach/prompts/persona/<role>/<phase>.prompt.yaml`. But `pyproject.toml::[tool.setuptools.package-data]` was not updated to include those prompt files in the wheel. The 3.46.0 release ships without the prompts dir; every cold-start spawn fails with:

```
❌ spawn handler: Missing persona prompt: /opt/homebrew/lib/python3.14/site-packages/atdd/coach/prompts/persona/planner/planned.prompt.yaml
```

## Fix

One line in `pyproject.toml`:

```diff
[tool.setuptools.package-data]
 "atdd.coach.templates" = ["*.md"]
 "atdd.coach.templates.hooks" = ["pre-commit"]
 "atdd.coach.templates.harness" = ["*.mjs"]
 "atdd.coach.templates.workflows" = ["*.yml"]
 "atdd.coach.schemas" = ["*.json"]
+"atdd.coach.prompts" = ["**/*.yaml"]
```

Bumps version 3.46.0 → 3.46.1 (PATCH — packaging fix, no behavior change).

## Test plan

After this lands + publishes to PyPI:

1. `pip install --upgrade atdd` to 3.46.1
2. `python -c "from importlib.resources import files; print(list(files('atdd.coach.prompts').rglob('*.yaml')))"` should list ~14 prompts
3. `atdd coach <N>` cold-start successfully spawns the planner (no "Missing persona prompt" error)