### PR TITLE
fix(coach): cmux send + acceptEdits/allowedTools in spawn (#646 spawn bugs, 3.46.1 → 3.46.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.46.1"
+version = "3.46.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/spawn.py
+++ b/src/atdd/coach/commands/spawn.py
@@ -67,8 +67,20 @@ def _claude_code_adapter(prompt_path: Path) -> str:
     """Spec §5.2: shell out to ``claude`` with the rendered launch prompt
     inlined via ``$(cat <prompt>)``. The shell expands the substitution
     inside the multiplexer surface so claude receives the full prompt as
-    one argv element."""
-    return f'claude --dangerously-skip-permissions "$(cat {prompt_path})"'
+    one argv element.
+
+    Permission policy: ``--permission-mode acceptEdits --allowedTools
+    "Bash Edit Write Read TodoWrite Glob Grep WebFetch"`` is the sanctioned
+    alternative to the forbidden ``bypassPermissions`` (per repo memory
+    rule). Tool-level allowlist gives autonomous flow without skipping
+    the permission system entirely.
+    """
+    allowed_tools = "Bash Edit Write Read TodoWrite Glob Grep WebFetch"
+    return (
+        f'claude --permission-mode acceptEdits '
+        f'--allowedTools "{allowed_tools}" '
+        f'"$(cat {prompt_path})"'
+    )
 
 
 # Open extension point — codex / gemini / glm follow-up issues register

--- a/src/atdd/coach/commands/tests/test_e001_unit_002_claude_code_adapter_invoked.py
+++ b/src/atdd/coach/commands/tests/test_e001_unit_002_claude_code_adapter_invoked.py
@@ -80,7 +80,11 @@ def test_claude_code_adapter_returns_expected_shell_invocation(tmp_path):
     prompt_path.write_text("body")
     cmd = spawn.ADAPTER_REGISTRY["claude-code"](prompt_path)
     # The exact shell invocation, per spec §5.2 and acceptance E001-UNIT-002.
-    assert cmd == f'claude --dangerously-skip-permissions "$(cat {prompt_path})"'
+    assert cmd == (
+        f'claude --permission-mode acceptEdits '
+        f'--allowedTools "Bash Edit Write Read TodoWrite Glob Grep WebFetch" '
+        f'"$(cat {prompt_path})"'
+    )
 
 
 def test_spawn_dispatches_adapter_off_llm_flag(tmp_path, monkeypatch):
@@ -112,7 +116,8 @@ def test_spawn_dispatches_adapter_off_llm_flag(tmp_path, monkeypatch):
     )
 
     expected = (
-        f'claude --dangerously-skip-permissions '
+        f'claude --permission-mode acceptEdits '
+        f'--allowedTools "Bash Edit Write Read TodoWrite Glob Grep WebFetch" '
         f'"$(cat {worktree / ".launch_prompt.txt"})"'
     )
     assert fake_mx.last_command == expected

--- a/src/atdd/coach/commands/tests/test_multiplexer.py
+++ b/src/atdd/coach/commands/tests/test_multiplexer.py
@@ -419,7 +419,7 @@ def test_cmux_new_surface_creates_pane_then_surface_then_seeds():
     assert calls[1][:2] == ["cmux", "new-surface"]
     assert "pane:42" in calls[1]
     # Call 2 — cmux rpc surface.send_text seeding cwd + command together
-    assert calls[2][:3] == ["cmux", "rpc", "surface.send_text"]
+    assert calls[2][:3] == ["cmux", "send", "--surface"]
     seeded = next(arg for arg in calls[2] if "echo y" in arg)
     assert seeded == "cd /x && echo y\n"
     assert "surface:99" in calls[2]
@@ -471,7 +471,7 @@ def test_cmux_read_screen_dispatches_by_ref_prefix():
     assert "--workspace" in calls[0]
     assert "workspace:5" in calls[0]
 
-    assert calls[1][:3] == ["cmux", "rpc", "surface.read_text"]
+    assert calls[1][:3] == ["cmux", "read-screen", "--surface"]
     assert "surface:31" in calls[1]
 
 
@@ -490,7 +490,7 @@ def test_cmux_send_dispatches_by_ref_prefix():
 
     assert calls[0][:3] == ["cmux", "send", "--workspace"]
     assert "hello" in calls[0]
-    assert calls[1][:3] == ["cmux", "rpc", "surface.send_text"]
+    assert calls[1][:3] == ["cmux", "send", "--surface"]
     assert "surface:31" in calls[1]
     assert "hi" in calls[1]
 

--- a/src/atdd/coach/commands/two_phase_commit.py
+++ b/src/atdd/coach/commands/two_phase_commit.py
@@ -247,7 +247,8 @@ def phase_b_launch_sessions(
         slug = branch_to_slug(issue.branch) or f"issue-{num}"
         canonical_name = compute_canonical_name(repo_short, num, slug)
         launch_cmd = (
-            "claude --dangerously-skip-permissions "
+            "claude --permission-mode acceptEdits "
+            "--allowedTools \"Bash Edit Write Read TodoWrite Glob Grep WebFetch\" "
             f"\"$(cat {script_path})\""
         )
 

--- a/src/atdd/coach/utils/multiplexer.py
+++ b/src/atdd/coach/utils/multiplexer.py
@@ -207,7 +207,7 @@ class CmuxBackend(MultiplexerBackend):
                 seed_parts.append(command)
             seed_text = " && ".join(seed_parts) + "\n"
             _run(
-                ["cmux", "rpc", "surface.send_text", "--surface", surface_ref, seed_text],
+                ["cmux", "send", "--surface", surface_ref, seed_text],
                 capture=False,
             )
 
@@ -215,12 +215,12 @@ class CmuxBackend(MultiplexerBackend):
 
     def read_screen(self, ref: MultiplexerRef, lines: int = 50) -> str:
         if _is_surface_ref(ref):
-            result = _run(["cmux", "rpc", "surface.read_text", "--surface", ref])
-            out = result.stdout or ""
-            if lines and lines > 0:
-                tail = out.splitlines()[-lines:]
-                return "\n".join(tail) + ("\n" if out.endswith("\n") else "")
-            return out
+            result = _run([
+                "cmux", "read-screen",
+                "--surface", ref,
+                "--lines", str(lines),
+            ])
+            return result.stdout or ""
         result = _run([
             "cmux", "read-screen",
             "--workspace", ref,
@@ -231,7 +231,7 @@ class CmuxBackend(MultiplexerBackend):
     def send(self, ref: MultiplexerRef, text: str) -> None:
         if _is_surface_ref(ref):
             _run(
-                ["cmux", "rpc", "surface.send_text", "--surface", ref, text],
+                ["cmux", "send", "--surface", ref, text],
                 capture=False,
             )
             return

--- a/src/atdd/coach/utils/tests/test_multiplexer.py
+++ b/src/atdd/coach/utils/tests/test_multiplexer.py
@@ -156,9 +156,8 @@ class TestCmuxNewSurface:
 
         assert ref == "surface:4"
         seed_call = calls[-1]
-        assert seed_call[:4] == ["cmux", "rpc", "surface.send_text", "--surface"]
-        assert seed_call[4] == "surface:4"
-        assert seed_call[5] == "cd /tmp/wt && claude --dangerously-skip-permissions\n"
+        assert seed_call[:4] == ["cmux", "send", "--surface", "surface:4"]
+        assert seed_call[4] == "cd /tmp/wt && claude --dangerously-skip-permissions\n"
 
     def test_raises_when_pane_ref_cannot_be_extracted(self):
         backend = CmuxBackend()


### PR DESCRIPTION
Closes #645

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #645 |
| Labels | atdd-issue, atdd:COMPLETE, archetype:coach |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.