### PR TITLE
chore(release): bump version to 3.51.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.50.0"
+version = "3.51.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Bumps `pyproject.toml` version 3.50.0 → 3.51.0.

`v3.50.0` was already tagged on #681's merge commit (`ae83dd1`). #682 merged with the same version number but cannot share the tag. This PR moves main forward to a new MINOR (3.51.0) which will carry the v3.51.0 tag — #682's substrate ships under v3.51.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)