### PR TITLE
feat(atdd): Enforce live-smoke tests honor their declared boundary (#704)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.52.2"
+version = "3.53.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/tests/test_m001_smoke_001_basic_observer_rules_load_end_to_end.py
+++ b/src/atdd/coach/commands/tests/test_m001_smoke_001_basic_observer_rules_load_end_to_end.py
@@ -103,7 +103,7 @@ def test_loaded_rules_evaluate_and_dispatch_corrections(tmp_path: Path):
             wmbt_target_paths=("src/",),
         )
 
-    obs.collect_input = _synthetic  # type: ignore[assignment]
+    obs.collect_input = _synthetic  # type: ignore[assignment]  # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=2026-08-15  this test is mislabelled SMOKE (bound to a UNIT acceptance); #704 follow-up relabels it
 
     corrections = obs.scan_once()
     fired_ids = {c.rule_id for c in corrections}

--- a/src/atdd/tester/conventions/smoke.convention.yaml
+++ b/src/atdd/tester/conventions/smoke.convention.yaml
@@ -409,3 +409,42 @@ presentation_smoke_rules:
       disposition: documentation-only
       description: "Every web/src/*/presentation/*.tsx must have a sibling smoke test under e2e/*smoke*.spec.ts"
       introduced_in: "1.67.0"
+
+# =============================================================================
+# Collaborator-substitution rule (issue #704, Tier 1)
+# =============================================================================
+# A SMOKE test must exercise the real subject. A test that substitutes one of
+# the subject's collaborators — via monkeypatch.setattr, or by assigning a
+# locally-defined function/lambda over an object attribute — is a unit test
+# wearing a SMOKE label: it passes CI while exercising nothing real. The lived
+# incident is the observer's `obs.collect_input = _synthetic` substitution,
+# which let an unwired observer ship GREEN.
+#
+# A static validator CANNOT certify that a test exercises real infrastructure
+# (a runtime-behaviour property, undecidable from source — Rice's theorem).
+# This rule does only the decidable NEGATIVE check (catch substitution); the
+# positive side is the #704 Tier 2 runtime gate. Scope is Python-only; TS
+# smoke tests (consumer-repo frontend e2e) are a #704 follow-up.
+#
+# Nested under a sibling key — the top-level `rules:` slot holds the legacy
+# must/must_not prose block.
+collaborator_substitution_rules:
+  rules:
+    - id: "tester.smoke.no-collaborator-substitution"
+      severity: 4
+      disposition: suppress-and-clean
+      validator: "test_smoke_no_collaborator_substitution::test_smoke_tests_do_not_substitute_collaborators"
+      description: "A SMOKE-phase test must not substitute a production collaborator (monkeypatch.setattr, or assigning a locally-defined function/lambda over an object attribute) — that turns it into a unit test passing CI while exercising nothing real."
+      fix_hint: |
+        The flagged SMOKE test replaces a collaborator instead of driving the
+        real code path. Choose ONE:
+          - If it was never a smoke test: relabel it — change `# Phase:` and the
+            filename away from SMOKE (it is a unit/integration test, or
+            hermetic_integration per #690).
+          - If it should be smoke: remove the substitution and exercise the real
+            boundary (real subprocess / file / socket / DB).
+        Environment setup is allowed — monkeypatch.setenv / .delenv / .chdir /
+        .syspath_prepend do NOT trigger this rule.
+        Temporary escape: add an inline marker on the offending line:
+          # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=<YYYY-MM-DD>
+      introduced_in: "3.53.0"

--- a/src/atdd/tester/validators/test_smoke_no_collaborator_substitution.py
+++ b/src/atdd/tester/validators/test_smoke_no_collaborator_substitution.py
@@ -1,0 +1,212 @@
+# URN: component:observe-and-correct:enforcement-substrate:test_smoke_no_collaborator_substitution:backend:tests
+# Runtime: python
+# Purpose: Flag SMOKE-phase tests that substitute a production collaborator (#704 Tier 1).
+
+"""SMOKE collaborator-substitution validator (#704, Tier 1).
+
+A test labelled ``# Phase: SMOKE`` must exercise the real subject. A test
+that substitutes one of the subject's collaborators — by ``monkeypatch.setattr``
+or by assigning a locally-defined function/lambda over an object attribute —
+is a unit test wearing a SMOKE label: it passes CI while exercising nothing
+real. The lived incident is the observer's ``collect_input`` substitution
+(``obs.collect_input = _synthetic``), which let an unwired observer ship GREEN.
+
+Hard constraint: a static validator CANNOT certify that a test exercises real
+infrastructure (that is a runtime-behaviour property, undecidable from source —
+Rice's theorem). This validator therefore does only the *decidable negative*
+check — catch collaborator substitution. The positive side (does it touch real
+infra) is the Tier 2 runtime gate, out of scope here.
+
+Detection is two AST patterns, both decidable:
+  1. ``monkeypatch.setattr(...)`` — collaborator stubbing. ``monkeypatch``
+     environment methods (``setenv`` / ``delenv`` / ``chdir`` /
+     ``syspath_prepend``) are legitimate smoke setup and are NOT flagged.
+  2. assignment of a locally-``def``'d function or ``lambda`` over an object
+     attribute (``obj.method = local_fn``). Data assignments
+     (``self.path = tmp_path``) are not flagged — the RHS must resolve to a
+     function/lambda defined in the same test module.
+
+Scope (Tier 1): **Python only.** Backend smoke tests (``test_*.py`` carrying
+``# Phase: SMOKE``) are covered wherever they live — ``src/**`` or a consumer
+repo's ``e2e/be/**``. A consumer repo's *frontend* e2e smoke tests are
+TypeScript (``*smoke*.spec.ts``); Tier 1 does NOT scan them — TS substitution
+detection needs non-``ast`` machinery (``test_smoke_coverage.py`` already
+catches TS *mock-imports* for e2e smoke). TypeScript smoke-fidelity is a #704
+follow-up, not silently in scope.
+
+Known limitations (all mitigated by the ``suppress-and-clean`` escape hatch;
+the first two closed precisely by #704 Tier 2's acceptance-``boundary_kind``
+trace):
+  - a fake injected from an *imported* helper is not caught (RHS not local);
+  - wiring a real handler into real infra under test
+    (``real_server.on_request = my_handler``) matches pattern 2 and is a
+    false positive — suppress it with an inline marker;
+  - TypeScript smoke tests are out of Tier 1 scope (see Scope above).
+
+Failures route through ``assert_disposition_satisfied`` under
+``tester.smoke.no-collaborator-substitution`` (``suppress-and-clean``).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+
+from atdd.coach.utils.repo import find_repo_root
+from atdd.coach.utils.rule_binding import bind_rule
+from atdd.coach.validators._violation import Violation
+from atdd.coach.utils.disposition_gate import assert_disposition_satisfied
+
+
+pytestmark = [pytest.mark.tester]
+
+
+_RULE = bind_rule("tester.smoke.no-collaborator-substitution")
+_VALIDATOR_ID = (
+    "test_smoke_no_collaborator_substitution::"
+    "test_smoke_tests_do_not_substitute_collaborators"
+)
+_SEVERITY = 4
+
+# monkeypatch methods that set up the *environment* (legitimate in a smoke
+# test) rather than substituting a collaborator.
+_MONKEYPATCH_ENV_METHODS = frozenset(
+    {"setenv", "delenv", "chdir", "syspath_prepend"}
+)
+
+# Directory names pruned from the repo scan.
+_SKIP_DIRS = frozenset(
+    {".git", "__pycache__", "node_modules", ".venv", "venv", ".atdd", ".mypy_cache"}
+)
+
+_PHASE_SMOKE_MARKER = "# Phase: SMOKE"
+
+
+# ---------------------------------------------------------------------------
+# Detection (pure — unit-tested directly against source strings)
+# ---------------------------------------------------------------------------
+
+
+def detect_substitutions(source: str) -> List[tuple[int, str]]:
+    """Return ``(lineno, detail)`` for each collaborator-substitution site.
+
+    Pure function over a Python source string. A syntax error yields a single
+    synthetic finding so an unparseable smoke test is surfaced, not silently
+    skipped.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return [(getattr(exc, "lineno", 1) or 1, f"unparseable test file: {exc}")]
+
+    # Names bound to a locally-defined function or lambda in this module.
+    local_callables: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            local_callables.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and isinstance(node.value, ast.Lambda):
+                    local_callables.add(tgt.id)
+
+    findings: List[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        # Pattern 1: monkeypatch.<method>(...)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            fn = node.func
+            if isinstance(fn.value, ast.Name) and fn.value.id == "monkeypatch":
+                if fn.attr == "setattr":
+                    findings.append(
+                        (node.lineno, "monkeypatch.setattr(...) substitutes a collaborator")
+                    )
+                # other monkeypatch.* (env methods) are intentionally ignored
+
+        # Pattern 2: obj.attr = <local def/lambda>
+        if isinstance(node, ast.Assign):
+            value = node.value
+            rhs_is_local_fn = (
+                isinstance(value, ast.Lambda)
+                or (isinstance(value, ast.Name) and value.id in local_callables)
+            )
+            if rhs_is_local_fn:
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Attribute):
+                        try:
+                            target_repr = ast.unparse(tgt)
+                        except Exception:  # pragma: no cover - defensive
+                            target_repr = f"<attr>.{tgt.attr}"
+                        rhs = (
+                            "<lambda>"
+                            if isinstance(value, ast.Lambda)
+                            else value.id  # type: ignore[union-attr]
+                        )
+                        findings.append(
+                            (
+                                node.lineno,
+                                f"{target_repr} = {rhs} substitutes a collaborator "
+                                f"(local function/lambda assigned over an attribute)",
+                            )
+                        )
+
+    findings.sort(key=lambda f: f[0])
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Repo scan
+# ---------------------------------------------------------------------------
+
+
+def _iter_smoke_test_files(repo_root: Path):
+    """Yield ``test_*.py`` files that carry the ``# Phase: SMOKE`` header."""
+    for path in repo_root.rglob("test_*.py"):
+        if any(part in _SKIP_DIRS for part in path.parts):
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if _PHASE_SMOKE_MARKER in text:
+            yield path, text
+
+
+def collect_violations(repo_root: Optional[Path] = None) -> List[Violation]:
+    """Scan every ``# Phase: SMOKE`` test for collaborator substitution."""
+    root = Path(repo_root).resolve() if repo_root is not None else find_repo_root()
+    violations: List[Violation] = []
+    for path, text in _iter_smoke_test_files(root):
+        try:
+            rel = str(path.relative_to(root))
+        except ValueError:
+            rel = str(path)
+        for lineno, detail in detect_substitutions(text):
+            violations.append(
+                Violation(
+                    rule_id="tester.smoke.no-collaborator-substitution",
+                    severity=_SEVERITY,
+                    location=f"{rel}:{lineno}",
+                    detail=detail,
+                )
+            )
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Validator (orchestration)
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_tests_do_not_substitute_collaborators():
+    """SMOKE tests must not substitute a production collaborator.
+
+    Convention: smoke.convention.yaml > collaborator_substitution_rules
+    Rule: tester.smoke.no-collaborator-substitution (suppress-and-clean)
+    """
+    violations = collect_violations()
+    assert_disposition_satisfied(
+        validator_id=_VALIDATOR_ID,
+        violations=violations,
+    )

--- a/src/atdd/tester/validators/tests/test_smoke_no_collaborator_substitution_helpers.py
+++ b/src/atdd/tester/validators/tests/test_smoke_no_collaborator_substitution_helpers.py
@@ -1,0 +1,157 @@
+# URN: component:observe-and-correct:enforcement-substrate:test_smoke_no_collaborator_substitution_helpers:backend:tests
+# Runtime: python
+# Purpose: Unit tests for the #704 Tier 1 collaborator-substitution detector.
+
+"""Tests for ``test_smoke_no_collaborator_substitution`` (#704 Tier 1).
+
+The detector is a pure function over a Python source string. These tests
+exercise it directly and exercise ``collect_violations`` against a synthetic
+``tmp_path`` tree — never against the live repo, so the validator's own
+fixtures cannot be self-flagged.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atdd.tester.validators.test_smoke_no_collaborator_substitution import (
+    collect_violations,
+    detect_substitutions,
+)
+
+pytestmark = [pytest.mark.tester]
+
+
+# ---------------------------------------------------------------------------
+# detect_substitutions — positive cases (must flag)
+# ---------------------------------------------------------------------------
+
+
+def test_flags_monkeypatch_setattr():
+    src = (
+        "def test_x(monkeypatch):\n"
+        "    monkeypatch.setattr(mod, 'fn', lambda: None)\n"
+    )
+    hits = detect_substitutions(src)
+    assert len(hits) >= 1
+    assert any("monkeypatch.setattr" in d for _, d in hits)
+
+
+def test_flags_local_def_assigned_over_attribute():
+    """The lived observer incident: obj.method = <local def>."""
+    src = (
+        "def _synthetic():\n"
+        "    return 1\n"
+        "def test_x():\n"
+        "    obs.collect_input = _synthetic\n"
+    )
+    hits = detect_substitutions(src)
+    assert len(hits) == 1
+    lineno, detail = hits[0]
+    assert lineno == 4
+    assert "obs.collect_input = _synthetic" in detail
+
+
+def test_flags_lambda_assigned_over_attribute():
+    src = "def test_x():\n    server.handler = lambda r: None\n"
+    hits = detect_substitutions(src)
+    assert len(hits) == 1
+    assert "<lambda>" in hits[0][1]
+
+
+# ---------------------------------------------------------------------------
+# detect_substitutions — negative cases (must NOT flag)
+# ---------------------------------------------------------------------------
+
+
+def test_does_not_flag_monkeypatch_env_methods():
+    """Environment setup is legitimate in a smoke test."""
+    src = (
+        "def test_x(monkeypatch, tmp_path):\n"
+        "    monkeypatch.setenv('K', 'v')\n"
+        "    monkeypatch.chdir(tmp_path)\n"
+        "    monkeypatch.delenv('Q', raising=False)\n"
+        "    monkeypatch.syspath_prepend('/x')\n"
+    )
+    assert detect_substitutions(src) == []
+
+
+def test_does_not_flag_data_attribute_assignment():
+    """obj.attr = <data> is not collaborator substitution."""
+    src = (
+        "def test_x(tmp_path):\n"
+        "    self.path = tmp_path\n"
+        "    cfg.retries = 3\n"
+        "    obj.name = 'hello'\n"
+    )
+    assert detect_substitutions(src) == []
+
+
+def test_does_not_flag_attribute_assigned_an_imported_name():
+    """Stated Tier 1 limitation: an imported helper as RHS is NOT caught
+    (the RHS does not resolve to a locally-defined function)."""
+    src = (
+        "from helpers import real_handler\n"
+        "def test_x():\n"
+        "    server.handler = real_handler\n"
+    )
+    assert detect_substitutions(src) == []
+
+
+def test_syntax_error_surfaces_as_a_finding():
+    """An unparseable smoke test is surfaced, not silently skipped."""
+    hits = detect_substitutions("def test_x(:\n    pass\n")
+    assert len(hits) == 1
+    assert "unparseable" in hits[0][1]
+
+
+# ---------------------------------------------------------------------------
+# collect_violations — repo-scan integration against a tmp_path tree
+# ---------------------------------------------------------------------------
+
+
+def _write(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_collect_violations_scans_only_phase_smoke_files(tmp_path: Path):
+    # A SMOKE test that substitutes a collaborator -> flagged.
+    _write(
+        tmp_path / "src" / "x" / "tests" / "test_a_smoke.py",
+        "# Phase: SMOKE\n"
+        "def _fake():\n    return 0\n"
+        "def test_a():\n    obj.boundary = _fake\n",
+    )
+    # A non-SMOKE test with the same substitution -> NOT flagged (not in scope).
+    _write(
+        tmp_path / "src" / "x" / "tests" / "test_b_unit.py",
+        "# Phase: GREEN\n"
+        "def _fake():\n    return 0\n"
+        "def test_b():\n    obj.boundary = _fake\n",
+    )
+    # A SMOKE test that is clean -> NOT flagged.
+    _write(
+        tmp_path / "src" / "x" / "tests" / "test_c_smoke.py",
+        "# Phase: SMOKE\n"
+        "def test_c(monkeypatch, tmp_path):\n    monkeypatch.chdir(tmp_path)\n",
+    )
+
+    violations = collect_violations(repo_root=tmp_path)
+
+    assert len(violations) == 1
+    v = violations[0]
+    assert v.rule_id == "tester.smoke.no-collaborator-substitution"
+    assert v.severity == 4
+    assert v.location.startswith("src/x/tests/test_a_smoke.py:")
+    assert v.location.endswith(":5")
+
+
+def test_collect_violations_skips_pycache_and_vcs(tmp_path: Path):
+    _write(
+        tmp_path / "__pycache__" / "test_z_smoke.py",
+        "# Phase: SMOKE\ndef _f():\n    return 0\ndef test_z():\n    o.b = _f\n",
+    )
+    assert collect_violations(repo_root=tmp_path) == []

--- a/tests/integration/test_coach_end_to_end_smoke.py
+++ b/tests/integration/test_coach_end_to_end_smoke.py
@@ -112,25 +112,25 @@ def test_real_drive_writes_decisions_jsonl_to_real_path(
     runtime_dir.mkdir(parents=True)
 
     # Stub only genuine external service boundaries (no MagicMock):
-    monkeypatch.setattr(
+    monkeypatch.setattr(  # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=2026-08-15
         spawn_handler,
         "_call_spawn",
         lambda ctx, persona, phase, llm, prompt, wt, agent_id, rr: {"surface_ref": "stub"},
     )
-    monkeypatch.setattr(
+    monkeypatch.setattr(  # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=2026-08-15
         spawn_handler, "_load_persona_prompt", lambda p, ph, **kw: "stub-prompt"
     )
     wt = tmp_path / "worktree"
     wt.mkdir()
-    monkeypatch.setattr(spawn_handler, "_resolve_worktree", lambda ctx: wt)
-    monkeypatch.setattr(spawn_handler, "_RUNTIME_ROOT", runtime_dir)
-    monkeypatch.setattr(
+    monkeypatch.setattr(spawn_handler, "_resolve_worktree", lambda ctx: wt)  # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=2026-08-15
+    monkeypatch.setattr(spawn_handler, "_RUNTIME_ROOT", runtime_dir)  # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=2026-08-15
+    monkeypatch.setattr(  # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=2026-08-15
         tpc_handler, "_create_pr", lambda issue_number: True
     )
-    monkeypatch.setattr(
+    monkeypatch.setattr(  # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=2026-08-15
         tpc_handler, "_merge_pr", lambda: (True, "")
     )
-    monkeypatch.setattr(
+    monkeypatch.setattr(  # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=2026-08-15
         tpc_handler, "_find_worktree_for_issue", lambda n: None
     )
 
@@ -212,7 +212,7 @@ def test_real_watcher_event_loop_with_real_queue(
         def persist_checkpoint(self) -> None:
             pass
 
-    monkeypatch.setattr(
+    monkeypatch.setattr(  # atdd:suppress(tester.smoke.no-collaborator-substitution) UNTIL=2026-08-15
         "atdd.coach.handlers.watcher.RuntimeWatcher", _StubRuntimeWatcher
     )
 


### PR DESCRIPTION
Tier 1 of #704. This PR intentionally does not carry an auto-close keyword — #704 stays open for Tier 2.

## Summary — #704 Tier 1

A SMOKE-labelled test could pass CI while testing nothing real. This ships
Tier 1 of #704: a decidable negative static check, no #690 dependency.

- New rule `tester.smoke.no-collaborator-substitution` (`suppress-and-clean`)
  in `smoke.convention.yaml`, extending the existing `tester.smoke.*`
  namespace (#690-compliant — not a new namespace).
- New validator `test_smoke_no_collaborator_substitution.py` — scans every
  `# Phase: SMOKE` test repo-wide, AST-flags `monkeypatch.setattr(...)` and
  assignment of a local def/lambda over an object attribute. `monkeypatch`
  env methods (`setenv`/`delenv`/`chdir`/`syspath_prepend`) are allowed.
- Scope: Python-only. TS smoke tests (consumer FE e2e) are a stated Tier 1
  limitation, tracked as a #704 follow-up.

## RED-first outcome

The validator surfaced 2 violators; both carry time-boxed
`# atdd:suppress(...) UNTIL=2026-08-15` markers pending #704 follow-up:
- the observer test — mislabelled SMOKE, bound to a UNIT acceptance;
- `test_coach_end_to_end_smoke.py` — `hermetic_integration` mislabelled
  SMOKE (stubs documented external-service boundaries; `pytestmark
  integration`). Honest reclassification routes through #690.

## Not in this PR (Tier 2, tracked on #704)

- the `# Acceptance` to `execution_kind`/`boundary_kind` trace (depends #690);
- the runtime gate (run `live_smoke` with infra absent, expect failure);
- the relabel of the two suppressed tests;
- TypeScript smoke-fidelity.

## Test plan

- [x] 9 validator unit tests (`test_smoke_no_collaborator_substitution_helpers.py`)
- [x] `atdd validate tester` — 173 passed
- [x] new validator GREEN against the repo (both violators suppressed)
- [x] `atdd repo validate` — pass

Generated with Claude Code