### PR TITLE
chore(atdd): Observer Scan Worktree Skips Own Runtime (#706)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,10 @@ coverage.xml
 .atdd/diagnostics/
 .atdd/orchestration-log.jsonl
 .atdd/worker-state-*.json
+# Per-agent runtime (observer corrections/cli-return, persona events) — pure
+# ephemera; never committed. Without this the observer's runaway corrections
+# (#706) surface as untracked noise in the persona's `git status`.
+.atdd/runtime/agents/
 .scratch/
 
 # Forbidden-command classifier runtime state (issue #668)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.53.0"
+version = "3.53.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/observer.py
+++ b/src/atdd/coach/commands/observer.py
@@ -796,6 +796,22 @@ class Observer:
         self._worktree_baseline_taken = False
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
+        # Roots excluded from worktree scanning (#706). The observer writes
+        # its own corrections.jsonl / cli-return.jsonl into runtime_dir,
+        # which lives INSIDE the scanned worktree — scanning it makes every
+        # correction-write a detected change, which fires out-of-scope-edit,
+        # which writes another correction: an unbounded self-feedback loop.
+        # Exclude the observer's own runtime tree (resolved relative to the
+        # worktree when given as a relative path).
+        self._scan_skip_roots: list[Path] = []
+        if self.worktree is not None:
+            rt = self.runtime_dir
+            if not rt.is_absolute():
+                rt = self.worktree / rt
+            try:
+                self._scan_skip_roots.append(rt.resolve())
+            except OSError:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-31
+                pass
 
     # --- rule loading -----------------------------------------------------
 
@@ -831,12 +847,29 @@ class Observer:
         lines = chunk.splitlines()
         return [ln for ln in lines if ln]
 
+    # Directory components whose subtrees carry no agent work — pruned from
+    # every worktree scan (#706): VCS internals and Python bytecode caches.
+    _SCAN_SKIP_PARTS = frozenset({".git", "__pycache__"})
+
+    def _is_excluded_from_scan(self, path: Path) -> bool:
+        """True when *path* is the observer's own runtime output or VCS/cache
+        noise — excluding it breaks the self-feedback loop (#706)."""
+        if any(part in self._SCAN_SKIP_PARTS for part in path.parts):
+            return True
+        try:
+            resolved = path.resolve()
+        except OSError:
+            resolved = path
+        return any(
+            resolved.is_relative_to(root) for root in self._scan_skip_roots
+        )
+
     def _scan_worktree(self) -> list[str]:
         if self.worktree is None or not self.worktree.exists():
             return []
         current: dict[str, float] = {}
         for p in self.worktree.rglob("*"):
-            if p.is_file():
+            if p.is_file() and not self._is_excluded_from_scan(p):
                 try:
                     rel = str(p.relative_to(self.worktree))
                 except ValueError:

--- a/src/atdd/coach/commands/tests/test_observer_scan_worktree_excludes_runtime.py
+++ b/src/atdd/coach/commands/tests/test_observer_scan_worktree_excludes_runtime.py
@@ -1,0 +1,104 @@
+# URN: test:observe-and-correct:observer-runtime-and-rules:OBSSCAN-001-scan-excludes-own-runtime
+# Acceptance: acc:observe-and-correct:OBSSCAN-001-runtime-excluded
+# WMBT: wmbt:observe-and-correct:M001
+# Phase: RED
+# Layer: integration
+"""Regression tests for #706 — `Observer._scan_worktree` must exclude the
+observer's own runtime output.
+
+The observer writes `corrections.jsonl` / `cli-return.jsonl` into
+`<runtime_dir>/agents/<id>/`, which lives inside the scanned worktree. Before
+#706 `_scan_worktree` had no exclusions, so every correction-write was detected
+as a change, fired `out-of-scope-edit`, wrote another correction — an unbounded
+self-feedback loop (observed: 694/694 self-referential corrections on a single
+coach 690 dispatch).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.commands import observer
+
+pytestmark = [pytest.mark.platform]
+
+
+def _observer(worktree: Path, runtime_dir: Path) -> observer.Observer:
+    return observer.Observer(
+        agent_id="planner-999-abc-observer",
+        runtime_dir=runtime_dir,
+        rules_dir=None,
+        worktree=worktree,
+    )
+
+
+def test_scan_excludes_observer_runtime_output(tmp_path: Path):
+    """A file written under runtime_dir does NOT surface as a worktree
+    change — this is the loop-breaking fix."""
+    worktree = tmp_path / "wt"
+    (worktree / "src").mkdir(parents=True)
+    runtime_dir = worktree / ".atdd" / "runtime"
+    (runtime_dir / "agents" / "planner-999-abc-observer").mkdir(parents=True)
+
+    obs = _observer(worktree, runtime_dir)
+
+    # Baseline scan.
+    assert obs._scan_worktree() == []
+
+    # The observer writes a correction into its own runtime dir ...
+    (runtime_dir / "agents" / "planner-999-abc-observer" / "corrections.jsonl").write_text(
+        '{"rule_id": "x"}\n', encoding="utf-8"
+    )
+    # ... and the persona touches a real source file.
+    (worktree / "src" / "feature.py").write_text("x = 1\n", encoding="utf-8")
+
+    changed = obs._scan_worktree()
+
+    assert "src/feature.py" in changed, "a real source change must be detected"
+    assert not any(".atdd/runtime" in c for c in changed), (
+        f"observer runtime output must NOT be scanned (#706 loop): {changed}"
+    )
+
+
+def test_scan_excludes_git_and_pycache(tmp_path: Path):
+    worktree = tmp_path / "wt"
+    (worktree / "src").mkdir(parents=True)
+    (worktree / ".git").mkdir()
+    (worktree / "src" / "__pycache__").mkdir()
+    runtime_dir = worktree / ".atdd" / "runtime"
+    runtime_dir.mkdir(parents=True)
+
+    obs = _observer(worktree, runtime_dir)
+    assert obs._scan_worktree() == []
+
+    (worktree / ".git" / "index").write_text("gitstuff\n", encoding="utf-8")
+    (worktree / "src" / "__pycache__" / "m.pyc").write_text("bytecode\n", encoding="utf-8")
+    (worktree / "src" / "real.py").write_text("y = 2\n", encoding="utf-8")
+
+    changed = obs._scan_worktree()
+    assert "src/real.py" in changed
+    assert not any(".git" in c for c in changed)
+    assert not any("__pycache__" in c for c in changed)
+
+
+def test_scan_does_not_over_prune(tmp_path: Path):
+    """The exclusion must not swallow legitimate .atdd/ edits outside
+    runtime/ — e.g. plan/ files or .atdd/manifest.yaml."""
+    worktree = tmp_path / "wt"
+    (worktree / "plan").mkdir(parents=True)
+    (worktree / ".atdd").mkdir()
+    runtime_dir = worktree / ".atdd" / "runtime"
+    runtime_dir.mkdir(parents=True)
+
+    obs = _observer(worktree, runtime_dir)
+    assert obs._scan_worktree() == []
+
+    (worktree / "plan" / "wagon.yaml").write_text("a: 1\n", encoding="utf-8")
+    (worktree / ".atdd" / "manifest.yaml").write_text("m: 1\n", encoding="utf-8")
+
+    changed = obs._scan_worktree()
+    assert "plan/wagon.yaml" in changed
+    assert ".atdd/manifest.yaml" in changed, (
+        "edits to .atdd/ OUTSIDE runtime/ must still be observed"
+    )

--- a/src/atdd/coach/commands/tests/test_observer_scan_worktree_excludes_runtime.py
+++ b/src/atdd/coach/commands/tests/test_observer_scan_worktree_excludes_runtime.py
@@ -1,8 +1,6 @@
-# URN: test:observe-and-correct:observer-runtime-and-rules:OBSSCAN-001-scan-excludes-own-runtime
-# Acceptance: acc:observe-and-correct:OBSSCAN-001-runtime-excluded
-# WMBT: wmbt:observe-and-correct:M001
-# Phase: RED
-# Layer: integration
+# URN: component:observe-and-correct:observer-runtime-and-rules:test_observer_scan_worktree_excludes_runtime:backend:tests
+# Runtime: python
+# Purpose: Regression tests for #706 — Observer._scan_worktree excludes its own runtime output.
 """Regression tests for #706 — `Observer._scan_worktree` must exclude the
 observer's own runtime output.
 


### PR DESCRIPTION
Closes #706

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #706 |
| Labels | atdd-issue, atdd:INIT, archetype:coach |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.