### PR TITLE
fix(atdd): coach cold-start advance pipeline — commit→event→advance chain broken (3 links) (#708)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.53.0"
+version = "3.53.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/coach.py
+++ b/src/atdd/coach/commands/coach.py
@@ -562,6 +562,30 @@ def _process_injected_events(
             break
 
 
+def _watcher_runtime_dir(ctx: "CoachContext", fallback: Path) -> Path:
+    """Runtime dir the coach's ``RuntimeWatcher`` must scan (#708 link 3).
+
+    A dispatched persona runs *inside the issue's worktree* and writes its
+    runtime artifacts (``events.jsonl``, ``done.json``, …) to
+    ``<worktree>/.atdd/runtime`` — NOT the coach process's cwd runtime. If
+    the watcher scans the coach's cwd it never sees a persona event and the
+    coach never advances past the first phase. Resolve the issue's worktree
+    and point the watcher at its ``.atdd/runtime``; fall back to
+    ``fallback`` only when the worktree cannot be resolved.
+    """
+    try:
+        from atdd.coach.handlers.spawn import _resolve_worktree
+
+        worktree = _resolve_worktree(ctx)
+    except Exception as exc:  # noqa: BLE001 — best-effort; logged, then fall back
+        _logger.warning(
+            "coach watcher: worktree resolution failed; using fallback runtime dir",
+            extra={"issue": getattr(ctx, "issue_number", "?"), "error": str(exc)},
+        )
+        return fallback
+    return worktree / ".atdd" / "runtime"
+
+
 def _process_watcher_events(
     ctx: "CoachContext",
     sm: StateMachine,
@@ -578,8 +602,13 @@ def _process_watcher_events(
     from atdd.coach.handlers.state_machine import HandlerResult, Transition
     from atdd.coach.commands.durability import transactional_decision
 
+    # #708 link 3: the watcher must scan the dispatched persona's worktree
+    # runtime, not the coach cwd's. The CoachEventQueue stays on the coach's
+    # own runtime_dir (coach-side durability) — only the watcher's scan root
+    # follows the persona.
+    watch_runtime = _watcher_runtime_dir(ctx, runtime_dir)
     queue = CoachEventQueue(runtime_dir=runtime_dir)
-    watcher = RuntimeWatcher(runtime_dir=runtime_dir, queue=queue)
+    watcher = RuntimeWatcher(runtime_dir=watch_runtime, queue=queue)
     watcher.start()
     events_processed = 0
 

--- a/src/atdd/coach/commands/tests/test_coach_watcher_runtime_dir.py
+++ b/src/atdd/coach/commands/tests/test_coach_watcher_runtime_dir.py
@@ -1,0 +1,60 @@
+# URN: component:coach-drives-lifecycle:coach-cold-start-wiring:test_coach_watcher_runtime_dir:backend:tests
+# Runtime: python
+# Purpose: #708 link 3 — coach RuntimeWatcher scans the persona's worktree runtime, not coach cwd.
+
+"""Regression tests for #708 link 3 — `_watcher_runtime_dir`.
+
+A dispatched persona runs inside the issue's worktree and writes its runtime
+artifacts to `<worktree>/.atdd/runtime`. The coach's `RuntimeWatcher` must
+scan there — not the coach process's cwd runtime — or it never observes a
+persona event and the coach never advances past the first phase.
+
+Scope: this covers link 3 only. Links 1 (commit `Issue`/`Phase` trailers) and
+2 (per-persona git_watcher emitting `commit_observed`) remain on #708.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.commands.coach import _watcher_runtime_dir
+
+pytestmark = [pytest.mark.platform]
+
+
+class _Ctx:
+    """Minimal stand-in — `_watcher_runtime_dir` only needs `issue_number`."""
+
+    def __init__(self, issue_number: int) -> None:
+        self.issue_number = issue_number
+
+
+def test_watcher_runtime_dir_points_at_worktree(monkeypatch, tmp_path):
+    """The watcher runtime dir resolves to <worktree>/.atdd/runtime."""
+    worktree = tmp_path / "feat-hermetic-integration"
+    monkeypatch.setattr(
+        "atdd.coach.handlers.spawn._resolve_worktree",
+        lambda ctx: worktree,
+    )
+
+    result = _watcher_runtime_dir(_Ctx(690), fallback=tmp_path / "coach-cwd-runtime")
+
+    assert result == worktree / ".atdd" / "runtime"
+    # Crucially: NOT the coach-cwd fallback — that is the #708 bug.
+    assert result != tmp_path / "coach-cwd-runtime"
+
+
+def test_watcher_runtime_dir_falls_back_on_resolution_failure(monkeypatch, tmp_path):
+    """When the worktree cannot be resolved, fall back to the coach runtime
+    dir rather than crash the event loop."""
+
+    def _boom(ctx):
+        raise RuntimeError("no branch metadata")
+
+    monkeypatch.setattr("atdd.coach.handlers.spawn._resolve_worktree", _boom)
+    fallback = tmp_path / "coach-runtime"
+
+    result = _watcher_runtime_dir(_Ctx(690), fallback=fallback)
+
+    assert result == fallback


### PR DESCRIPTION
Link 3 of 3 toward #708. This PR is a partial step and intentionally carries no auto-close keyword — #708 stays open for links 1 and 2.

## Summary — #708 link 3

The coach's cold-start event loop (`_process_watcher_events`) created a
`RuntimeWatcher` scanning the coach process's cwd `.atdd/runtime/agents/`.
A dispatched persona runs inside the issue's worktree and writes its runtime
artifacts to `<worktree>/.atdd/runtime/agents/`. The watcher scanned an empty
dir → no event queued → the coach looped on `queue.get()` indefinitely
without advancing (observed: coach 690 alive 1h15m, no PLANNED→RED).

- New `_watcher_runtime_dir(ctx, fallback)` — resolves the issue's worktree
  via `_resolve_worktree` and returns `<worktree>/.atdd/runtime`; falls back
  (logged) to the coach runtime dir if resolution fails.
- `_process_watcher_events` points the `RuntimeWatcher` there. The
  `CoachEventQueue` stays on the coach's own runtime dir (coach-side
  durability) — only the watcher's scan root follows the persona.
- 2 regression tests.

## Not in this PR (links 1 & 2 — remain on #708)

Link 3 alone does NOT make the coach advance — all three links are required:
- **Link 1** — personas must commit with `Issue:` / `Phase:` git trailers;
  no mechanism exists today (launch prompt does not mandate it).
- **Link 2** — `src/atdd/coach/runtime/git_watcher.py` is unwired dead code;
  nothing emits per-agent `commit_observed` events into `events.jsonl`.

Both are design-heavy (trailer mechanism; git_watcher wiring) and are
scoped on #708 for a focused planner pass.

## Test plan

- [x] `test_coach_watcher_runtime_dir.py` — 2 regression tests
- [x] watcher points at `<worktree>/.atdd/runtime`, not coach cwd
- [x] graceful fallback when worktree resolution fails

Generated with Claude Code