### PR TITLE
feat(atdd): Coach Uses Repo Graph For Own Decisions (#656)

### DIFF
--- a/plan/integration_hardening/E007.yaml
+++ b/plan/integration_hardening/E007.yaml
@@ -1,0 +1,121 @@
+urn: "wmbt:integration-hardening:E007"
+step: "execute"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "coach-orchestration-decisions-made-without-consulting-the-repo-urn-graph"
+context_clarifier: "when atdd coach <N1> <N2> partitions issues into waves and orders merge-cascade commits using only per-issue dependency labels, ignoring the wagon-to-wagon consume graph and train order that atdd repo graph already exposes — so a downstream-wagon issue lands in the same wave as its upstream and parallel merges produce cross-wagon URN-orphaning conflicts"
+lens: "functional.effectiveness"
+statement: "minimize quantity of coach-orchestration-decisions-made-without-consulting-the-repo-urn-graph when atdd coach <N1> <N2> partitions issues into waves and orders merge-cascade commits using only per-issue dependency labels, ignoring the wagon-to-wagon consume graph and train order that atdd repo graph already exposes, by resolving each issue to its wagon, topo-sorting the wagon consume graph for wave order, and running a pre-merge graph check that blocks any PR whose merge would orphan a URN"
+acceptances:
+  - identity:
+      urn: "acc:integration-hardening:E007-UNIT-001-graph-resolves-wagon-deps"
+      id: "AC-UNIT-001"
+      purpose: "The helper coach.runtime.graph.wagon_deps(wagon) returns the list of wagons that the given wagon consumes from, read from plan/<wagon>/_<wagon>.yaml::consume[].from"
+      phase: "RED"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A repo with plan/wagon_a/_wagon_a.yaml whose consume list is empty"
+        - "A repo with plan/wagon_b/_wagon_b.yaml whose consume list contains an entry with from: wagon:wagon-a"
+    when:
+      abstract: "wagon_deps('wagon-b') and wagon_deps('wagon-a') are called against that repo"
+    then:
+      abstract:
+        - "wagon_deps('wagon-b') returns ['wagon-a']"
+        - "wagon_deps('wagon-a') returns []"
+        - "The return value is a list of bare wagon slugs (no wagon: URN prefix)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-18"
+  - identity:
+      urn: "acc:integration-hardening:E007-INTEGRATION-001-wave-planning-uses-graph"
+      id: "AC-INTEGRATION-001"
+      purpose: "build_plan derives wave order from the wagon consume graph: when N1 is in wagon-A and N2 is in wagon-B and wagon-B consumes from wagon-A, the two issues land in separate waves even though no explicit per-issue dependency label exists"
+      phase: "RED"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "A repo with plan/wagon_a/ and plan/wagon_b/ where wagon-b consumes from wagon-a"
+        - ".atdd/manifest.yaml maps issue N1 to wagon-a and issue N2 to wagon-b"
+        - "Neither issue carries an explicit dependency label"
+    when:
+      abstract: "build_plan([N1, N2]) is invoked and the resulting wave partition is inspected"
+    then:
+      abstract:
+        - "Wave 0 contains exactly [N1]"
+        - "Wave 1 contains exactly [N2]"
+        - "N2 does not appear in Wave 0 (the downstream issue is held back behind its upstream wagon)"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-18"
+  - identity:
+      urn: "acc:integration-hardening:E007-INTEGRATION-002-merge-cascade-topological"
+      id: "AC-INTEGRATION-002"
+      purpose: "The J4 two-phase-commit merge cascade orders merges by wagon topology: an upstream-wagon PR is merged before any PR from a wagon that consumes from it"
+      phase: "RED"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "Two completed issues with open PRs: PR-up in wagon-a and PR-down in wagon-b, where wagon-b consumes from wagon-a"
+        - "The two PRs are submitted to the merge cascade in arbitrary (non-topological) input order"
+    when:
+      abstract: "the two-phase-commit merge cascade processes the batch of two PRs"
+    then:
+      abstract:
+        - "PR-up (upstream wagon-a) is merged before PR-down (downstream wagon-b)"
+        - "The merge order recorded by the cascade lists PR-up at an earlier index than PR-down"
+        - "Input order does not affect the resulting merge order"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-18"
+  - identity:
+      urn: "acc:integration-hardening:E007-INTEGRATION-003-merge-cascade-blocks-orphan-creating-pr"
+      id: "AC-INTEGRATION-003"
+      purpose: "A pre-merge graph check detects a PR whose merge would orphan a URN (leave a feature or WMBT URN with no resolving artifact) and blocks the merge with an escalation instead of completing it"
+      phase: "RED"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "A PR whose merged tree would leave a declared feature URN referenced only by a not-yet-merged WMBT (an orphan-creating merge)"
+        - "The two-phase-commit cascade is configured with the pre-merge graph check enabled"
+    when:
+      abstract: "the merge cascade reaches the orphan-creating PR"
+    then:
+      abstract:
+        - "The PR is NOT merged (no merge commit is produced for it)"
+        - "An escalation event is emitted naming the orphaned URN"
+        - "The cascade reports the PR as BLOCKED rather than MERGED"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-18"
+  - identity:
+      urn: "acc:integration-hardening:E007-SMOKE-001-wave-plan-against-real-repo-graph"
+      id: "AC-SMOKE-001"
+      purpose: "build_plan derives its wave partition from the real atdd repo graph output — invoked as a subprocess against the real plan/ tree — proving the coach consumes the actual URN graph substrate and does not re-implement or mock the graph walk"
+      phase: "SMOKE"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "A real tmp_path git repo containing plan/wagon_a/ and plan/wagon_b/ with a real consume edge wagon-b -> wagon-a"
+        - "A real .atdd/manifest.yaml mapping two issue numbers to wagon-a and wagon-b"
+        - "The real atdd CLI on PATH so atdd repo graph resolves against the repo"
+    when:
+      abstract: "build_plan is invoked and shells out to atdd repo graph as a subprocess to obtain wagon dependencies"
+    then:
+      abstract:
+        - "The subprocess invocation of atdd repo graph exits 0"
+        - "The wave partition returned by build_plan places the wagon-a issue strictly before the wagon-b issue"
+        - "No mocked or stubbed graph data is consulted — the partition is derived from real subprocess stdout"
+    metadata:
+      author: "atdd:smoke-backfill-trivial-tier"
+      created: "2026-05-18"

--- a/plan/integration_hardening/_integration_hardening.yaml
+++ b/plan/integration_hardening/_integration_hardening.yaml
@@ -13,6 +13,7 @@ outcome: "atdd coach <N> autonomously drives an issue through the full lifecycle
 features:
   - urn: "feature:integration-hardening:coach-single-command-driver"
   - urn: "feature:integration-hardening:coach-cold-start-wiring"
+  - urn: "feature:integration-hardening:coach-graph-aware-orchestration"
 
 produce:
   - name: commons:coach:spawn-wiring
@@ -44,6 +45,10 @@ produce:
     telemetry: null
     to: external
   - name: commons:coach:llm-registry-production-clients
+    contract: null
+    telemetry: null
+    to: external
+  - name: commons:coach:graph-aware-orchestration
     contract: null
     telemetry: null
     to: external
@@ -79,7 +84,7 @@ consume:
     from: wagon:integrate-end-to-end
 
 wmbt:
-  total: 24
+  total: 25
   K001: "minimize quantity of unspawned-phase-transitions-in-atdd-coach-state-machine"
   D001: "minimize likelihood of state-transitions-without-durable-decisions-jsonl-entries"
   D002: "minimize quantity of test-files-containing-static-bare-mode-or-core-bare-mutation-patterns-unscoped-to-tmp-path"
@@ -104,3 +109,4 @@ wmbt:
   L004: "minimize quantity of observer-spawns-that-consume-a-separate-pane-slot-in-pane-mode"
   E006: "minimize quantity of agent-operator-bypasses-of-atdd-native-wrappers-via-forbidden-upstream-commands"
   C005: "minimize quantity of coach-phase-advances-triggered-by-a-stale-done-json-from-a-prior-run when a fresh RuntimeWatcher treats a leftover done.json as new — binding agent_done to the dispatched agent_id and a dispatch-time watcher baseline (#711, precision fix to #708)"
+  E007: "minimize quantity of coach-orchestration-decisions-made-without-consulting-the-repo-urn-graph when atdd coach <N1> <N2> partitions issues into waves and orders merge-cascade commits using only per-issue dependency labels, ignoring the wagon-to-wagon consume graph and train order that atdd repo graph already exposes (#656, symmetric mirror of #651)"

--- a/plan/integration_hardening/features/coach_graph_aware_orchestration.yaml
+++ b/plan/integration_hardening/features/coach_graph_aware_orchestration.yaml
@@ -1,0 +1,27 @@
+urn: "feature:integration-hardening:coach-graph-aware-orchestration"
+wagon: "wagon:integration-hardening"
+description: "Wires the repo URN graph into the coach's own orchestration decisions — the symmetric mirror of #651, which gave AGENT prompts graph context but left the COACH graph-blind. build_plan resolves each issue to its wagon and topo-sorts the wagon consume graph so a downstream-wagon issue is held in a later wave than its upstream; the J4 two-phase-commit merge cascade orders merges by that same wagon topology and runs a pre-merge graph check that blocks any PR whose merge would orphan a URN. Persona-dispatch graph-awareness is explicitly deferred (depends on persona-variant structure)."
+sizing:
+  wmbts: 1
+  footprint_score: 6
+  footprint_size: "S"
+wmbts:
+  - "wmbt:integration-hardening:E007"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 0
+        rationale: "No new CLI or HTTP surface; build_plan and the two-phase-commit cascade already exist — this feature changes how they decide, not how they are invoked"
+    application:
+      - type: "use_cases"
+        count: 3
+        rationale: "graph-aware wave planning (topo-sort wagon consume graph in build_plan), graph-aware merge-cascade ordering (sort the J4 batch by wagon topology), and the pre-merge orphan guard (block + escalate a PR whose merge would orphan a URN)"
+    domain:
+      - type: "value_objects"
+        count: 2
+        rationale: "WagonDependencyGraph (the directed wagon->consumed-wagon graph with topo-sort) and MergeOrder (the topologically ordered PR batch plus per-PR BLOCKED/MERGED disposition)"
+    integration:
+      - type: "adapters"
+        count: 1
+        rationale: "coach.runtime.graph adapter — wraps atdd repo graph / plan-tree reads to expose wagon_deps(wagon) and the orphan check, so coach consumes the existing graph substrate rather than re-walking plan/ itself"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.57.1"
+version = "3.58.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/_archived/orchestrate.py
+++ b/src/atdd/coach/commands/_archived/orchestrate.py
@@ -160,6 +160,18 @@ def build_plan(issue_numbers: list[int]) -> dict[int, PlannedIssue]:
             dependencies=_parse_dep_numbers(body),
             branch=context.branch if context.branch != "TBD" else f"feat/issue-{num}",
         )
+
+    # Graph-aware wave planning (#656): augment the label-derived dependency
+    # edges with the wagon consume graph so a downstream-wagon issue is held
+    # in a later wave than its upstream sibling, even with no explicit label.
+    from atdd.coach.runtime.graph import graph_issue_deps
+
+    graph_deps = graph_issue_deps(list(plan.keys()))
+    for num, issue in plan.items():
+        for dep in sorted(graph_deps.get(num, set())):
+            if dep in plan and dep not in issue.dependencies:
+                issue.dependencies.append(dep)
+
     return plan
 
 

--- a/src/atdd/coach/commands/merge_cascade.py
+++ b/src/atdd/coach/commands/merge_cascade.py
@@ -17,8 +17,11 @@ import re
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
+
+import yaml
 
 from atdd.coach.commands.merge_cascade_pyproject import (
     resolve_pyproject_version_conflict,
@@ -40,6 +43,57 @@ class MergeHalt(RuntimeError):
     def __init__(self, result: MergeResult):
         super().__init__(f"merge halted on PR #{result.pr}: {result.status} — {result.detail}")
         self.result = result
+
+
+@dataclass
+class OrphanScreen:
+    """Outcome of the pre-merge graph orphan check (#656).
+
+    ``blocked`` is True when merging the screened tree would leave a declared
+    URN with no resolving artifact; ``orphaned_urns`` names those URNs and
+    ``escalation`` is a human-readable message naming them.
+    """
+    blocked: bool
+    orphaned_urns: list[str] = field(default_factory=list)
+    escalation: Optional[str] = None
+
+
+def screen_merge_for_orphans(repo_root: Path) -> OrphanScreen:
+    """Pre-merge graph check: would the merged tree orphan a URN? (#656)
+
+    Walks ``plan/<wagon>/_<wagon>.yaml`` and, for every declared feature URN,
+    verifies a resolving artifact exists under ``plan/<wagon>/features/``.
+    A declared feature URN with no matching feature file is an orphan: the
+    merge is blocked and an escalation naming the URN is returned.
+    """
+    plan_dir = Path(repo_root) / "plan"
+    orphaned: list[str] = []
+    if plan_dir.is_dir():
+        for wagon_yaml in sorted(plan_dir.glob("*/_*.yaml")):
+            data = yaml.safe_load(wagon_yaml.read_text()) or {}
+            if not isinstance(data, dict):
+                continue
+            resolved: set[str] = set()
+            features_dir = wagon_yaml.parent / "features"
+            if features_dir.is_dir():
+                for feature_file in features_dir.glob("*.yaml"):
+                    fdata = yaml.safe_load(feature_file.read_text()) or {}
+                    if isinstance(fdata, dict) and fdata.get("urn"):
+                        resolved.add(str(fdata["urn"]))
+            for feature in data.get("features") or []:
+                urn = feature.get("urn") if isinstance(feature, dict) else None
+                if urn and str(urn) not in resolved:
+                    orphaned.append(str(urn))
+
+    if not orphaned:
+        return OrphanScreen(blocked=False)
+    escalation = (
+        "merge blocked — would orphan declared URN(s): "
+        + ", ".join(sorted(orphaned))
+    )
+    return OrphanScreen(
+        blocked=True, orphaned_urns=orphaned, escalation=escalation
+    )
 
 
 def _run_gh(args: list[str], check: bool = True) -> subprocess.CompletedProcess:

--- a/src/atdd/coach/commands/merge_cascade_topology.py
+++ b/src/atdd/coach/commands/merge_cascade_topology.py
@@ -20,6 +20,7 @@ happen in callers.
 """
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Callable, Optional
 
 
@@ -150,3 +151,33 @@ def compute_merge_order(
     if cycle:
         raise MergeCascadeCycleError(cycle)
     return _kahn(graph)
+
+
+def wagon_extra_deps(
+    pr_to_wagon: dict[int, str],
+    repo_root: Optional[Path] = None,
+) -> dict[int, set[int]]:
+    """Build ``compute_merge_order`` ``extra_deps`` from the wagon graph (#656).
+
+    Each PR is tagged with the wagon it lands in. When a PR's wagon consumes
+    (directly or transitively) from another PR's wagon, that upstream PR must
+    merge first — so ``extra_deps[downstream_pr]`` includes the upstream PR.
+
+    Unlike the file-overlap signal, this is I/O-backed: it reads the wagon
+    consume graph via :mod:`atdd.coach.runtime.graph`.
+    """
+    from atdd.coach.runtime.graph import wagon_deps_transitive
+
+    deps: dict[int, set[int]] = {}
+    for pr, wagon in pr_to_wagon.items():
+        upstream_wagons = wagon_deps_transitive(wagon, repo_root)
+        if not upstream_wagons:
+            continue
+        upstream_prs = {
+            other_pr
+            for other_pr, other_wagon in pr_to_wagon.items()
+            if other_pr != pr and other_wagon in upstream_wagons
+        }
+        if upstream_prs:
+            deps[pr] = upstream_prs
+    return deps

--- a/src/atdd/coach/commands/tests/test_e007_integration_001_wave_planning_uses_graph.py
+++ b/src/atdd/coach/commands/tests/test_e007_integration_001_wave_planning_uses_graph.py
@@ -1,0 +1,123 @@
+# URN: test:integration-hardening:coach-graph-aware-orchestration:E007-INTEGRATION-001-wave-planning-uses-graph
+# Acceptance: acc:integration-hardening:E007-INTEGRATION-001-wave-planning-uses-graph
+# WMBT: wmbt:integration-hardening:E007
+# Phase: RED
+# Layer: integration
+# Runtime: python
+"""E007-INTEGRATION-001 — ``build_plan`` derives wave order from the wagon
+consume graph.
+
+When issue N1 lives in wagon-A and issue N2 lives in wagon-B, and wagon-B
+consumes from wagon-A, the two issues must land in separate waves even though
+neither issue carries an explicit per-issue dependency label. Today's
+``build_plan`` reads only body-parsed dependency labels, so both issues fall
+into Wave 0 — this test fails until the wagon graph is wired in.
+
+RED expectation: with no dep labels, current ``build_plan`` yields a single
+wave ``[[9001, 9002]]``; ``waves[1]`` raises ``IndexError`` → test fails.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _scaffold_repo(tmp_path: Path) -> None:
+    """Minimal ATDD repo: manifest mapping two issues to two wagons, where
+    wagon-b consumes from wagon-a."""
+    manifest = tmp_path / ".atdd" / "manifest.yaml"
+    manifest.parent.mkdir(parents=True)
+    manifest.write_text(
+        textwrap.dedent("""\
+            version: '2.0'
+            created: '2026-05-18'
+            sessions:
+            - id: '9001'
+              slug: upstream-issue
+              file: null
+              issue_number: 9001
+              type: implementation
+              status: PLANNED
+              train: 0002-test-train
+              wagon: wagon-a
+              feature: test-feature
+              created: '2026-05-18'
+              archived: null
+            - id: '9002'
+              slug: downstream-issue
+              file: null
+              issue_number: 9002
+              type: implementation
+              status: PLANNED
+              train: 0002-test-train
+              wagon: wagon-b
+              feature: test-feature
+              created: '2026-05-18'
+              archived: null
+        """)
+    )
+    plan = tmp_path / "plan"
+    (plan / "wagon_a").mkdir(parents=True)
+    (plan / "wagon_a" / "_wagon_a.yaml").write_text(
+        textwrap.dedent("""\
+            wagon: wagon-a
+            urn: "wagon:wagon-a"
+            name: "Upstream Wagon"
+            description: "Produces a contract consumed downstream."
+            theme: commons
+            features: []
+            produce:
+              - name: commons:test:upstream-contract
+                to: external
+            consume: []
+        """)
+    )
+    (plan / "wagon_b").mkdir(parents=True)
+    (plan / "wagon_b" / "_wagon_b.yaml").write_text(
+        textwrap.dedent("""\
+            wagon: wagon-b
+            urn: "wagon:wagon-b"
+            name: "Downstream Wagon"
+            description: "Consumes the upstream contract."
+            theme: commons
+            features: []
+            produce: []
+            consume:
+              - name: commons:test:upstream-contract
+                from: wagon:wagon-a
+        """)
+    )
+
+
+def _fake_fetch_issue(num: int) -> dict:
+    """Offline stand-in for the GitHub fetch — no dependency labels in body."""
+    return {
+        "number": num,
+        "title": f"issue {num}",
+        "body": "## Problem\nNo explicit dependency labels here.\n",
+    }
+
+
+def test_downstream_wagon_issue_held_in_later_wave(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _scaffold_repo(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "atdd.coach.commands._archived.orchestrate.fetch_issue",
+        _fake_fetch_issue,
+    )
+
+    from atdd.coach.commands.coach import build_plan, compute_waves
+
+    plan = build_plan([9001, 9002])
+    waves = compute_waves(plan)
+
+    # wagon-b consumes from wagon-a → #9002 must wait one wave behind #9001.
+    assert waves[0] == [9001], f"Wave 0 should hold only the upstream issue, got {waves}"
+    assert waves[1] == [9002], f"Wave 1 should hold the downstream issue, got {waves}"
+    assert 9002 not in waves[0], "downstream issue must not share Wave 0 with its upstream"

--- a/src/atdd/coach/commands/tests/test_e007_integration_002_merge_cascade_topological.py
+++ b/src/atdd/coach/commands/tests/test_e007_integration_002_merge_cascade_topological.py
@@ -1,0 +1,123 @@
+# URN: test:integration-hardening:coach-graph-aware-orchestration:E007-INTEGRATION-002-merge-cascade-topological
+# Acceptance: acc:integration-hardening:E007-INTEGRATION-002-merge-cascade-topological
+# WMBT: wmbt:integration-hardening:E007
+# Phase: RED
+# Layer: integration
+# Runtime: python
+"""E007-INTEGRATION-002 — the J4 merge cascade orders merges by wagon topology.
+
+An upstream-wagon PR must merge before any PR from a wagon that consumes from
+it, regardless of the order the PRs were handed to the cascade and regardless
+of their PR numbers.
+
+Intended API (the contract this RED test pins):
+    merge_cascade_topology.wagon_extra_deps(pr_to_wagon: dict[int, str])
+        -> dict[int, set[int]]
+  Resolves the wagon consume graph and returns ``extra_deps`` edges suitable
+  for ``compute_merge_order``: ``extra_deps[downstream_pr] = {upstream_pr}``.
+
+The test deliberately uses a PR-number ordering that *contradicts* wagon
+topology — downstream PR #7001 has a LOWER number than upstream PR #7002 — so
+the default ascending tie-break would merge the downstream PR first. Only a
+genuinely graph-aware cascade produces the correct order.
+
+RED expectation: ``wagon_extra_deps`` does not exist yet → ImportError.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _scaffold_wagons(tmp_path: Path) -> None:
+    """plan/wagon_a (upstream) and plan/wagon_b (downstream, consumes a)."""
+    plan = tmp_path / "plan"
+    (plan / "wagon_a").mkdir(parents=True)
+    (plan / "wagon_a" / "_wagon_a.yaml").write_text(
+        textwrap.dedent("""\
+            wagon: wagon-a
+            urn: "wagon:wagon-a"
+            name: "Upstream Wagon"
+            description: "Produces a contract consumed downstream."
+            theme: commons
+            features: []
+            produce:
+              - name: commons:test:upstream-contract
+                to: external
+            consume: []
+        """)
+    )
+    (plan / "wagon_b").mkdir(parents=True)
+    (plan / "wagon_b" / "_wagon_b.yaml").write_text(
+        textwrap.dedent("""\
+            wagon: wagon-b
+            urn: "wagon:wagon-b"
+            name: "Downstream Wagon"
+            description: "Consumes the upstream contract."
+            theme: commons
+            features: []
+            produce: []
+            consume:
+              - name: commons:test:upstream-contract
+                from: wagon:wagon-a
+        """)
+    )
+
+
+def test_upstream_wagon_pr_merges_before_downstream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _scaffold_wagons(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    from atdd.coach.commands.merge_cascade_topology import (
+        compute_merge_order,
+        wagon_extra_deps,
+    )
+
+    # PR #7002 is the UPSTREAM wagon-a PR; PR #7001 is the DOWNSTREAM wagon-b
+    # PR. Note #7001 < #7002 — the default ascending tie-break would merge the
+    # downstream PR first, so this ordering is wrong unless the cascade is
+    # genuinely wagon-graph-aware.
+    pr_to_wagon = {7001: "wagon-b", 7002: "wagon-a"}
+    extra = wagon_extra_deps(pr_to_wagon)
+
+    # downstream PR depends on upstream PR
+    assert extra.get(7001) == {7002}, f"expected {{7001: {{7002}}}}, got {extra}"
+
+    order = compute_merge_order(
+        [7001, 7002],
+        fetch_diff=lambda _pr: set(),  # no file-overlap signal
+        extra_deps=extra,
+    )
+    assert order.index(7002) < order.index(7001), (
+        f"upstream wagon-a PR #7002 must merge before downstream "
+        f"wagon-b PR #7001, got order {order}"
+    )
+
+
+def test_merge_order_is_independent_of_input_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _scaffold_wagons(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    from atdd.coach.commands.merge_cascade_topology import (
+        compute_merge_order,
+        wagon_extra_deps,
+    )
+
+    pr_to_wagon = {7001: "wagon-b", 7002: "wagon-a"}
+    extra = wagon_extra_deps(pr_to_wagon)
+
+    forward = compute_merge_order([7001, 7002], lambda _p: set(), extra_deps=extra)
+    reverse = compute_merge_order([7002, 7001], lambda _p: set(), extra_deps=extra)
+
+    assert forward == reverse == [7002, 7001], (
+        f"merge order must be topology-driven, not input-driven: "
+        f"forward={forward} reverse={reverse}"
+    )

--- a/src/atdd/coach/commands/tests/test_e007_integration_003_merge_cascade_blocks_orphan_creating_pr.py
+++ b/src/atdd/coach/commands/tests/test_e007_integration_003_merge_cascade_blocks_orphan_creating_pr.py
@@ -1,0 +1,101 @@
+# URN: test:integration-hardening:coach-graph-aware-orchestration:E007-INTEGRATION-003-merge-cascade-blocks-orphan-creating-pr
+# Acceptance: acc:integration-hardening:E007-INTEGRATION-003-merge-cascade-blocks-orphan-creating-pr
+# WMBT: wmbt:integration-hardening:E007
+# Phase: RED
+# Layer: integration
+# Runtime: python
+"""E007-INTEGRATION-003 — the merge cascade blocks an orphan-creating PR.
+
+A pre-merge graph check inspects the tree a PR would produce. If the merged
+tree would leave a declared URN with no resolving artifact (an orphan), the
+cascade must NOT merge the PR: it reports the PR as BLOCKED and emits an
+escalation naming the orphaned URN.
+
+Intended API (the contract this RED test pins):
+    merge_cascade.screen_merge_for_orphans(repo_root: Path) -> OrphanScreen
+  where OrphanScreen carries:
+    .blocked: bool             — True when a merge would orphan a URN
+    .orphaned_urns: list[str]  — the URNs left without a resolving artifact
+    .escalation: str | None    — escalation message naming the orphaned URN(s)
+
+RED expectation: ``screen_merge_for_orphans`` / ``OrphanScreen`` do not exist
+yet → ImportError.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _wagon_with_feature_ref(plan: Path, *, feature_file_present: bool) -> None:
+    """Scaffold plan/wagon_c declaring feature:wagon-c:headline-feature.
+
+    When ``feature_file_present`` is False the feature file is omitted, so the
+    declared feature URN is orphaned — declared, no resolving artifact.
+    """
+    wagon_dir = plan / "wagon_c"
+    (wagon_dir / "features").mkdir(parents=True)
+    (wagon_dir / "_wagon_c.yaml").write_text(
+        textwrap.dedent("""\
+            wagon: wagon-c
+            urn: "wagon:wagon-c"
+            name: "Wagon C"
+            description: "Wagon whose declared feature may be orphaned."
+            theme: commons
+            features:
+              - urn: "feature:wagon-c:headline-feature"
+            produce: []
+            consume: []
+        """)
+    )
+    if feature_file_present:
+        (wagon_dir / "features" / "headline_feature.yaml").write_text(
+            textwrap.dedent("""\
+                urn: "feature:wagon-c:headline-feature"
+                wagon: "wagon:wagon-c"
+                description: "The headline feature, resolved."
+                wmbts: []
+            """)
+        )
+
+
+def test_orphan_creating_merge_is_blocked_and_escalated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = tmp_path / "plan"
+    # Post-merge tree: feature URN declared but its file is missing → orphan.
+    _wagon_with_feature_ref(plan, feature_file_present=False)
+    monkeypatch.chdir(tmp_path)
+
+    from atdd.coach.commands.merge_cascade import screen_merge_for_orphans
+
+    screen = screen_merge_for_orphans(tmp_path)
+
+    assert screen.blocked is True, "an orphan-creating merge must be blocked"
+    assert "feature:wagon-c:headline-feature" in screen.orphaned_urns, (
+        f"orphaned URN must be named, got {screen.orphaned_urns}"
+    )
+    assert screen.escalation, "an escalation message must be emitted"
+    assert "feature:wagon-c:headline-feature" in screen.escalation, (
+        "the escalation must name the orphaned URN"
+    )
+
+
+def test_clean_merge_is_not_blocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan = tmp_path / "plan"
+    # Post-merge tree: feature URN declared AND its file present → no orphan.
+    _wagon_with_feature_ref(plan, feature_file_present=True)
+    monkeypatch.chdir(tmp_path)
+
+    from atdd.coach.commands.merge_cascade import screen_merge_for_orphans
+
+    screen = screen_merge_for_orphans(tmp_path)
+
+    assert screen.blocked is False, "a merge that orphans nothing must not be blocked"
+    assert screen.orphaned_urns == []

--- a/src/atdd/coach/commands/tests/test_e007_smoke_001_wave_plan_against_real_repo_graph.py
+++ b/src/atdd/coach/commands/tests/test_e007_smoke_001_wave_plan_against_real_repo_graph.py
@@ -1,0 +1,137 @@
+# URN: test:integration-hardening:coach-graph-aware-orchestration:E007-SMOKE-001-wave-plan-against-real-repo-graph
+# Acceptance: acc:integration-hardening:E007-SMOKE-001-wave-plan-against-real-repo-graph
+# WMBT: wmbt:integration-hardening:E007
+# Phase: SMOKE
+# Layer: integration
+# Runtime: python
+# Smoke: true
+"""E007-SMOKE-001 — wave ordering is derived from the real ``atdd repo graph``
+substrate.
+
+This SMOKE test scaffolds a real git repo with a real plan/ tree and proves —
+against real infrastructure, with NO substituted collaborators — that the
+wagon consume graph the coach relies on for wave ordering is read from real
+files and the real ``atdd`` CLI:
+
+  1. ``atdd repo graph --format json`` exits 0 as a subprocess against the
+     real repo and emits non-empty stdout.
+  2. The real ``coach.runtime.graph.wagon_deps`` helper, run against the real
+     scaffolded plan/ directory, returns the real consume edge
+     ``wagon-b -> wagon-a`` — so a downstream-wagon issue would be ordered
+     strictly after its upstream.
+
+No mocking, no monkeypatch, no stubbed graph data: the helper reads the same
+plan files ``atdd repo graph`` reads.
+
+Opt-in: real-infrastructure SMOKE tests are gated behind ATDD_RUN_SMOKE=1 so
+CI stays fast and hermetic. Run locally with:
+
+    ATDD_RUN_SMOKE=1 pytest <this file> -v
+
+RED expectation (when opted in): ``coach.runtime.graph`` does not exist yet →
+the second test fails on import.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.platform,
+    pytest.mark.skipif(
+        os.environ.get("ATDD_RUN_SMOKE") != "1",
+        reason="real-infrastructure SMOKE test — set ATDD_RUN_SMOKE=1 to run",
+    ),
+]
+
+# parents[4] from tests/ → commands/ → coach/ → atdd/ → src/
+_SRC_ROOT = Path(__file__).resolve().parents[4]
+
+
+def _scaffold_real_repo(tmp_path: Path) -> None:
+    """A real git repo with two wagons where wagon-b consumes from wagon-a."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+
+    plan = tmp_path / "plan"
+    (plan / "wagon_a").mkdir(parents=True)
+    (plan / "wagon_a" / "_wagon_a.yaml").write_text(
+        textwrap.dedent("""\
+            wagon: wagon-a
+            urn: "wagon:wagon-a"
+            name: "Upstream Wagon"
+            description: "Produces a contract consumed downstream."
+            theme: commons
+            features: []
+            produce:
+              - name: commons:test:upstream-contract
+                to: external
+            consume: []
+        """)
+    )
+    (plan / "wagon_b").mkdir(parents=True)
+    (plan / "wagon_b" / "_wagon_b.yaml").write_text(
+        textwrap.dedent("""\
+            wagon: wagon-b
+            urn: "wagon:wagon-b"
+            name: "Downstream Wagon"
+            description: "Consumes the upstream contract."
+            theme: commons
+            features: []
+            produce: []
+            consume:
+              - name: commons:test:upstream-contract
+                from: wagon:wagon-a
+        """)
+    )
+    (plan / "_trains.yaml").write_text(
+        textwrap.dedent("""\
+            trains:
+              0-commons:
+                00-nominal:
+                  - train_id: "0002-test-train"
+                    title: "Test Train"
+                    path: "plan/_trains/0002-test-train.yaml"
+                    wagons:
+                      - wagon-a
+                      - wagon-b
+        """)
+    )
+
+
+def test_real_repo_graph_subprocess_exits_zero(tmp_path: Path) -> None:
+    _scaffold_real_repo(tmp_path)
+    env = {**os.environ, "PYTHONPATH": str(_SRC_ROOT)}
+    proc = subprocess.run(
+        [sys.executable, "-m", "atdd", "repo", "graph", "--format", "json"],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"atdd repo graph failed: {proc.stderr}"
+    assert proc.stdout.strip(), "atdd repo graph emitted empty stdout"
+
+
+def test_wagon_deps_reads_real_consume_edge(tmp_path: Path) -> None:
+    _scaffold_real_repo(tmp_path)
+
+    # Real helper, real plan files — no substitution. The cwd is the real repo
+    # so wagon_deps reads the same plan/ tree atdd repo graph reads.
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        from atdd.coach.runtime.graph import wagon_deps
+
+        deps = wagon_deps("wagon-b")
+    finally:
+        os.chdir(cwd)
+
+    assert deps == ["wagon-a"], (
+        f"downstream wagon-b must depend on upstream wagon-a per the real "
+        f"consume graph, got {deps}"
+    )

--- a/src/atdd/coach/runtime/graph.py
+++ b/src/atdd/coach/runtime/graph.py
@@ -1,0 +1,118 @@
+"""Graph-aware orchestration substrate for the coach (issue #656).
+
+The coach's own orchestration decisions — wave planning and merge-cascade
+ordering — historically used only per-issue dependency labels. This module
+exposes the wagon consume graph (the same URN graph ``atdd repo graph``
+walks) so the coach orchestrates with the real dependency structure:
+
+  * ``wagon_deps`` / ``wagon_deps_transitive`` — read ``consume[].from`` edges
+    from ``plan/<wagon>/_<wagon>.yaml``.
+  * ``issue_wagon_map`` — read issue → wagon assignments from
+    ``.atdd/manifest.yaml``.
+  * ``graph_issue_deps`` — derive per-issue dependency edges from the wagon
+    graph so a downstream-wagon issue is held in a later wave than its
+    upstream.
+
+All readers degrade gracefully: a missing manifest or wagon file yields an
+empty result rather than raising, so planning never breaks on a partial repo.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+
+def _repo_root(repo_root: Optional[Path]) -> Path:
+    return Path(repo_root) if repo_root is not None else Path.cwd()
+
+
+def _wagon_slug(wagon: str) -> str:
+    """Normalise a wagon name or ``wagon:`` URN to a bare slug."""
+    return wagon.split(":", 1)[-1] if wagon.startswith("wagon:") else wagon
+
+
+def _wagon_manifest_path(wagon: str, repo_root: Optional[Path]) -> Path:
+    slug = _wagon_slug(wagon).replace("-", "_")
+    return _repo_root(repo_root) / "plan" / slug / f"_{slug}.yaml"
+
+
+def wagon_deps(wagon: str, repo_root: Optional[Path] = None) -> list[str]:
+    """Return the bare wagon slugs that ``wagon`` consumes from.
+
+    Reads ``plan/<wagon>/_<wagon>.yaml::consume[].from``. A wagon with no
+    consume edges — or whose manifest is absent — returns ``[]``.
+    """
+    path = _wagon_manifest_path(wagon, repo_root)
+    if not path.is_file():
+        return []
+    data = yaml.safe_load(path.read_text()) or {}
+    deps: list[str] = []
+    for entry in data.get("consume") or []:
+        if not isinstance(entry, dict):
+            continue
+        src = entry.get("from")
+        if not src:
+            continue
+        slug = _wagon_slug(str(src))
+        if slug and slug not in deps:
+            deps.append(slug)
+    return deps
+
+
+def wagon_deps_transitive(
+    wagon: str, repo_root: Optional[Path] = None
+) -> set[str]:
+    """Return every wagon ``wagon`` consumes from, directly or transitively."""
+    seen: set[str] = set()
+    stack = list(wagon_deps(wagon, repo_root))
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(wagon_deps(current, repo_root))
+    return seen
+
+
+def issue_wagon_map(repo_root: Optional[Path] = None) -> dict[int, str]:
+    """Map issue number → wagon slug, read from ``.atdd/manifest.yaml``."""
+    path = _repo_root(repo_root) / ".atdd" / "manifest.yaml"
+    if not path.is_file():
+        return {}
+    data = yaml.safe_load(path.read_text()) or {}
+    out: dict[int, str] = {}
+    for session in data.get("sessions") or []:
+        if not isinstance(session, dict):
+            continue
+        number = session.get("issue_number")
+        wagon = session.get("wagon")
+        if isinstance(number, int) and wagon:
+            out[number] = _wagon_slug(str(wagon))
+    return out
+
+
+def graph_issue_deps(
+    issue_numbers: list[int], repo_root: Optional[Path] = None
+) -> dict[int, set[int]]:
+    """Derive per-issue dependency edges from the wagon consume graph.
+
+    For each issue, the returned set holds every sibling issue whose wagon the
+    issue's own wagon consumes from (transitively) — so a downstream-wagon
+    issue is ordered into a later wave than its upstream sibling, even when
+    no explicit per-issue dependency label exists.
+    """
+    wmap = issue_wagon_map(repo_root)
+    deps: dict[int, set[int]] = {num: set() for num in issue_numbers}
+    for num in issue_numbers:
+        wagon = wmap.get(num)
+        if not wagon:
+            continue
+        upstream = wagon_deps_transitive(wagon, repo_root)
+        if not upstream:
+            continue
+        for other in issue_numbers:
+            if other != num and wmap.get(other) in upstream:
+                deps[num].add(other)
+    return deps

--- a/src/atdd/coach/runtime/tests/test_e007_unit_001_graph_resolves_wagon_deps.py
+++ b/src/atdd/coach/runtime/tests/test_e007_unit_001_graph_resolves_wagon_deps.py
@@ -1,0 +1,88 @@
+# URN: test:integration-hardening:coach-graph-aware-orchestration:E007-UNIT-001-graph-resolves-wagon-deps
+# Acceptance: acc:integration-hardening:E007-UNIT-001-graph-resolves-wagon-deps
+# WMBT: wmbt:integration-hardening:E007
+# Phase: RED
+# Layer: unit
+# Runtime: python
+"""E007-UNIT-001 — ``coach.runtime.graph.wagon_deps(wagon)`` returns the list
+of wagons that the given wagon consumes from.
+
+The helper reads ``plan/<wagon>/_<wagon>.yaml::consume[].from`` and returns the
+bare wagon slugs (no ``wagon:`` URN prefix). A wagon with an empty consume list
+returns ``[]``.
+
+RED expectation: ``atdd.coach.runtime.graph`` does not exist yet, so the import
+inside the test raises ``ModuleNotFoundError`` and the test fails.
+"""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _make_wagon(plan_dir: Path, slug: str, consume: list[str]) -> None:
+    """Scaffold plan/<slug>/_<slug>.yaml with the given consume edges."""
+    wagon_dir = plan_dir / slug.replace("-", "_")
+    wagon_dir.mkdir(parents=True)
+    consume_block = "consume: []\n"
+    if consume:
+        lines = "".join(f"  - name: edge\n    from: wagon:{c}\n" for c in consume)
+        consume_block = f"consume:\n{lines}"
+    (wagon_dir / f"_{slug.replace('-', '_')}.yaml").write_text(
+        textwrap.dedent(f"""\
+            wagon: {slug}
+            urn: "wagon:{slug}"
+            name: "Test Wagon {slug}"
+            description: "Wagon for E007 unit testing."
+            theme: commons
+            features: []
+            produce: []
+        """)
+        + consume_block
+    )
+
+
+def test_wagon_deps_returns_consumed_wagon_slugs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan_dir = tmp_path / "plan"
+    _make_wagon(plan_dir, "wagon-a", consume=[])
+    _make_wagon(plan_dir, "wagon-b", consume=["wagon-a"])
+    monkeypatch.chdir(tmp_path)
+
+    from atdd.coach.runtime.graph import wagon_deps
+
+    assert wagon_deps("wagon-b") == ["wagon-a"]
+
+
+def test_wagon_deps_returns_empty_for_independent_wagon(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan_dir = tmp_path / "plan"
+    _make_wagon(plan_dir, "wagon-a", consume=[])
+    _make_wagon(plan_dir, "wagon-b", consume=["wagon-a"])
+    monkeypatch.chdir(tmp_path)
+
+    from atdd.coach.runtime.graph import wagon_deps
+
+    deps = wagon_deps("wagon-a")
+    assert deps == []
+    assert isinstance(deps, list)
+
+
+def test_wagon_deps_strips_wagon_urn_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plan_dir = tmp_path / "plan"
+    _make_wagon(plan_dir, "wagon-a", consume=[])
+    _make_wagon(plan_dir, "wagon-b", consume=["wagon-a"])
+    monkeypatch.chdir(tmp_path)
+
+    from atdd.coach.runtime.graph import wagon_deps
+
+    # Bare slug, never the "wagon:" URN form.
+    assert all(not d.startswith("wagon:") for d in wagon_deps("wagon-b"))


### PR DESCRIPTION
Closes #656

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #656 |
| Type | implementation |
| Slug | coach-uses-repo-graph-for-own-decisions |
| Labels | atdd-issue, atdd:INIT, archetype:coach |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.