### PR TITLE
feat(atdd): Pre Push Version Gate Must Not Auto Upgrade (#776)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -976,3 +976,14 @@ sessions:
   wagon: observe-and-correct
   feature: feature:observe-and-correct:observer-runtime-and-rules
   train: 0002-coach-drives-lifecycle
+- id: '776'
+  slug: pre-push-version-gate-must-not-auto-upgrade
+  file: plan/integration_hardening/Y004.yaml
+  issue_number: 776
+  type: implementation
+  status: PLANNED
+  created: '2026-05-19'
+  archived: null
+  wagon: integration-hardening
+  feature: feature:integration-hardening:pre-push-version-gate-never-auto-upgrades
+  train: 0002-coach-drives-lifecycle

--- a/plan/integration_hardening/Y004.yaml
+++ b/plan/integration_hardening/Y004.yaml
@@ -1,0 +1,141 @@
+urn: "wmbt:integration-hardening:Y004"
+step: "modify"
+direction: "minimize"
+dimension: "quantity"
+object_of_control: "git-hooks-that-run-pip-install-during-push"
+context_clarifier: "when the pre-push hook invokes _gate_main and atdd is outdated, the current implementation calls auto_upgrade() which runs pip install --upgrade atdd inside the git hook — this is unsafe on PEP 668 systems, inside virtualenvs, and in CI, and violates the contract that git hooks must not mutate the system environment"
+lens: "functional.effectiveness"
+statement: "minimize quantity of git-hooks-that-run-pip-install-during-push by stripping auto_upgrade() from _gate_main so the version gate only checks and exits 1 with a message telling the user to run 'atdd upgrade' then retry, never spawning pip or any subprocess for installation"
+acceptances:
+  - identity:
+      urn: "acc:integration-hardening:Y004-UNIT-001-gate-never-calls-auto-upgrade"
+      id: "GT-Y004-001"
+      purpose: "_gate_main must not call auto_upgrade() when atdd is outdated — it must exit 1 immediately"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "is_outdated() returns (True, '3.0.0', '4.0.0')"
+        - "auto_upgrade is monkeypatched and its call is tracked"
+    when:
+      abstract: "_gate_main() is called"
+    then:
+      abstract:
+        - "auto_upgrade() is never called"
+        - "sys.exit(1) is raised (SystemExit with code 1)"
+    metadata:
+      author: "atdd:pre-push-version-gate-must-not-auto-upgrade"
+      created: "2026-05-19"
+
+  - identity:
+      urn: "acc:integration-hardening:Y004-UNIT-002-gate-prints-upgrade-instruction"
+      id: "GT-Y004-002"
+      purpose: "When outdated, _gate_main prints a message telling the user to run 'atdd upgrade' then retry"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "is_outdated() returns (True, '3.0.0', '4.0.0')"
+    when:
+      abstract: "_gate_main() is called (catching SystemExit)"
+    then:
+      abstract:
+        - "The printed output (stdout or stderr) contains 'atdd upgrade'"
+        - "The printed output contains '4.0.0' (the latest version)"
+        - "The printed output does NOT contain 'pip install'"
+    metadata:
+      author: "atdd:pre-push-version-gate-must-not-auto-upgrade"
+      created: "2026-05-19"
+
+  - identity:
+      urn: "acc:integration-hardening:Y004-UNIT-003-gate-allows-when-up-to-date"
+      id: "GT-Y004-003"
+      purpose: "When atdd is up to date, _gate_main exits 0 and prints an up-to-date confirmation"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "is_outdated() returns (False, '4.0.0', '4.0.0')"
+    when:
+      abstract: "_gate_main() is called"
+    then:
+      abstract:
+        - "No SystemExit is raised (or SystemExit code 0)"
+        - "auto_upgrade() is never called"
+    metadata:
+      author: "atdd:pre-push-version-gate-must-not-auto-upgrade"
+      created: "2026-05-19"
+
+  - identity:
+      urn: "acc:integration-hardening:Y004-UNIT-004-gate-skips-when-pypi-unreachable"
+      id: "GT-Y004-004"
+      purpose: "When PyPI is unreachable (latest=''), _gate_main exits 0 with a warning — it must not block the push"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "is_outdated() returns (False, '4.0.0', '') — PyPI unreachable"
+    when:
+      abstract: "_gate_main() is called"
+    then:
+      abstract:
+        - "No SystemExit(1) is raised"
+        - "auto_upgrade() is never called"
+        - "A warning mentioning PyPI or 'skipping' is printed"
+    metadata:
+      author: "atdd:pre-push-version-gate-must-not-auto-upgrade"
+      created: "2026-05-19"
+
+  - identity:
+      urn: "acc:integration-hardening:Y004-UNIT-005-no-pip-subprocess-in-gate-path"
+      id: "GT-Y004-005"
+      purpose: "_gate_main must not spawn any subprocess that contains 'pip' or 'install'"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "is_outdated() returns (True, '3.0.0', '4.0.0')"
+        - "subprocess.run is monkeypatched to track calls"
+    when:
+      abstract: "_gate_main() is called (catching SystemExit)"
+    then:
+      abstract:
+        - "subprocess.run is never called with any command containing 'pip' or 'install'"
+    metadata:
+      author: "atdd:pre-push-version-gate-must-not-auto-upgrade"
+      created: "2026-05-19"
+
+  - identity:
+      urn: "acc:integration-hardening:Y004-SMOKE-001-pre-push-hook-with-outdated-version-exits-1-cleanly"
+      id: "GT-Y004-S01"
+      purpose: "SMOKE: when the pre-push hook is run in a tmp repo with a mocked _gate_main that simulates outdated version, the hook exits 1 and no pip command is found in the hook output"
+      phase: "SMOKE"
+    harness:
+      type: "smoke"
+      category: "backend"
+    given:
+      abstract:
+        - "A fresh tmp git repo is initialised"
+        - "ATDD_SKIP_BARE_CHECK=1 is set (bare check irrelevant to this test)"
+        - "The version gate is invoked via the pre-push hook template"
+        - "The installed atdd is patched via env to simulate an outdated version"
+    when:
+      abstract: "The pre-push hook is executed"
+    then:
+      abstract:
+        - "The hook exits with code 1"
+        - "The hook output contains 'atdd upgrade' (user instruction)"
+        - "The hook output does NOT contain 'pip install' or 'Upgrading'"
+    metadata:
+      author: "atdd:pre-push-version-gate-must-not-auto-upgrade"
+      created: "2026-05-19"

--- a/plan/integration_hardening/_integration_hardening.yaml
+++ b/plan/integration_hardening/_integration_hardening.yaml
@@ -15,6 +15,7 @@ features:
   - urn: "feature:integration-hardening:coach-cold-start-wiring"
   - urn: "feature:integration-hardening:coach-graph-aware-orchestration"
   - urn: "feature:integration-hardening:coach-resume-wiring"
+  - urn: "feature:integration-hardening:pre-push-version-gate-never-auto-upgrades"
 
 produce:
   - name: commons:coach:spawn-wiring
@@ -89,7 +90,7 @@ consume:
     from: wagon:integrate-end-to-end
 
 wmbt:
-  total: 28
+  total: 29
   K001: "minimize quantity of unspawned-phase-transitions-in-atdd-coach-state-machine"
   D001: "minimize likelihood of state-transitions-without-durable-decisions-jsonl-entries"
   D002: "minimize quantity of test-files-containing-static-bare-mode-or-core-bare-mutation-patterns-unscoped-to-tmp-path"
@@ -118,3 +119,4 @@ wmbt:
   E008: "minimize quantity of review-gate-failures-caused-by-pr-resolution-errors-bypassing-the-in-process-broken-sentinel when run() step 1 catches a _resolve_pr_commit RuntimeError and, in in-process mode, routes through _write_broken_sentinel instead of returning 2 (#732, residual gap from #672/#673)"
   Y003: "minimize quantity of test-sessions-that-leave-core-bare-mutated-in-the-live-worktree when pytest runs any src/atdd test"
   E009: "minimize quantity of resume-driver-phase-transitions-recorded-without-dispatching-orchestration when atdd coach --resume <RUN_ID> walks a reconstructed issue — wiring a real transition_action into ResumeRunner and failing loudly when it is absent (#734, resume-path analog of E002/#645)"
+  Y004: "minimize quantity of git-hooks-that-run-pip-install-during-push by stripping auto_upgrade() from _gate_main so the version gate only checks and exits 1 with a message telling the user to run 'atdd upgrade' then retry"

--- a/plan/integration_hardening/features/pre_push_version_gate_never_auto_upgrades.yaml
+++ b/plan/integration_hardening/features/pre_push_version_gate_never_auto_upgrades.yaml
@@ -1,0 +1,27 @@
+urn: "feature:integration-hardening:pre-push-version-gate-never-auto-upgrades"
+wagon: "wagon:integration-hardening"
+description: "The pre-push version gate (_gate_main in atdd.version_check) must gate only — never call auto_upgrade() or run pip install from inside a git hook. When atdd is outdated, the gate exits 1 and prints a message instructing the user to run 'atdd upgrade' then retry. Running pip install from a git hook is an unsafe side-effect that can corrupt environments (PEP 668 systems, CI, virtualenvs) and violates the principle that hooks must not mutate the system."
+sizing:
+  wmbts: 1
+  footprint_score: 2
+  footprint_size: "XS"
+wmbts:
+  - "wmbt:integration-hardening:Y004"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 0
+        rationale: "No new CLI surface; change is inside _gate_main which is called by the pre-push hook"
+    application:
+      - type: "use_cases"
+        count: 1
+        rationale: "One behaviour change: _gate_main exits 1 with upgrade instruction instead of calling auto_upgrade()"
+    domain:
+      - type: "entities"
+        count: 0
+        rationale: "No new domain entities"
+    integration:
+      - type: "adapters"
+        count: 0
+        rationale: "No new adapters; auto_upgrade() call is simply removed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.65.0"
+version = "3.65.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/templates/hooks/tests/test_Y004_smoke_pre_push_version_gate_no_pip.py
+++ b/src/atdd/coach/templates/hooks/tests/test_Y004_smoke_pre_push_version_gate_no_pip.py
@@ -1,0 +1,95 @@
+# Acceptance: acc:integration-hardening:Y004-SMOKE-001-pre-push-hook-with-outdated-version-exits-1-cleanly
+"""SMOKE: pre-push hook version gate exits 1 cleanly — no pip subprocess.
+
+Issue #776: when _gate_main detects an outdated atdd, it must exit 1 with
+'atdd upgrade' instruction and must never run 'pip install'. This smoke test
+runs _gate_main in a real subprocess with a mocked is_outdated to confirm
+the gate's output and exit code against real runtime infrastructure.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[6]
+
+
+def _run_gate_subprocess() -> subprocess.CompletedProcess:
+    """Run _gate_main in a fresh subprocess via a driver script.
+
+    A fresh subprocess is required because:
+    - importlib.metadata caches are per-process; a real install check would
+      hit PyPI or cache — unreliable in CI.
+    - We patch is_outdated at module level so the hook path is exercised
+      exactly as it runs from the pre-push shell, just with a mocked oracle.
+
+    PYTHONPATH is prepended with the repo src/ dir so the subprocess loads
+    the local development version of atdd, not the installed package.
+    """
+    driver = textwrap.dedent("""
+        import sys
+        from unittest.mock import patch
+
+        # Patch is_outdated to simulate the outdated case without hitting PyPI.
+        with patch("atdd.version_check.is_outdated", return_value=(True, "3.0.0", "4.0.0")):
+            from atdd.version_check import _gate_main
+            try:
+                _gate_main()
+            except SystemExit as e:
+                sys.exit(e.code)
+    """)
+    import os
+    env = os.environ.copy()
+    src_dir = str(REPO_ROOT / "src")
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = f"{src_dir}:{existing}" if existing else src_dir
+    return subprocess.run(
+        [sys.executable, "-c", driver],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestVersionGateSmokeNoPip:
+    """Y004-SMOKE-001: version gate exits 1 without spawning pip."""
+
+    def test_hook_exits_1_when_outdated(self):
+        result = _run_gate_subprocess()
+        assert result.returncode == 1, (
+            f"Expected exit code 1 when outdated; got {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_hook_output_contains_atdd_upgrade(self):
+        result = _run_gate_subprocess()
+        output = result.stdout + result.stderr
+        assert "atdd upgrade" in output, (
+            f"Expected 'atdd upgrade' in output; got:\n{output}"
+        )
+
+    def test_hook_output_does_not_contain_pip_install(self):
+        result = _run_gate_subprocess()
+        output = result.stdout + result.stderr
+        assert "pip install" not in output, (
+            f"Output must not contain 'pip install'; got:\n{output}"
+        )
+
+    def test_hook_output_does_not_contain_upgrading(self):
+        result = _run_gate_subprocess()
+        output = result.stdout + result.stderr
+        assert "Upgrading..." not in output, (
+            f"Output must not contain 'Upgrading...' (removed with auto_upgrade); got:\n{output}"
+        )
+
+    def test_hook_output_mentions_latest_version(self):
+        result = _run_gate_subprocess()
+        output = result.stdout + result.stderr
+        assert "4.0.0" in output, (
+            f"Expected latest version '4.0.0' in gate output; got:\n{output}"
+        )

--- a/src/atdd/coach/templates/hooks/tests/test_Y004_unit_pre_push_version_gate_never_auto_upgrades.py
+++ b/src/atdd/coach/templates/hooks/tests/test_Y004_unit_pre_push_version_gate_never_auto_upgrades.py
@@ -1,0 +1,138 @@
+# Acceptance: acc:integration-hardening:Y004-UNIT-001-gate-never-calls-auto-upgrade
+# Acceptance: acc:integration-hardening:Y004-UNIT-002-gate-prints-upgrade-instruction
+# Acceptance: acc:integration-hardening:Y004-UNIT-003-gate-allows-when-up-to-date
+# Acceptance: acc:integration-hardening:Y004-UNIT-004-gate-skips-when-pypi-unreachable
+# Acceptance: acc:integration-hardening:Y004-UNIT-005-no-pip-subprocess-in-gate-path
+"""Unit tests for _gate_main() — version gate must not call auto_upgrade().
+
+Issue #776: the pre-push version gate ran pip install inside a git hook,
+which is unsafe on PEP 668 systems, inside virtualenvs, and in CI.
+The gate must only check and exit 1 with an 'atdd upgrade' instruction.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from io import StringIO
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from atdd.version_check import _gate_main
+
+
+class TestGateNeverCallsAutoUpgrade:
+    """Y004-UNIT-001: _gate_main must never call auto_upgrade() when outdated."""
+
+    def test_auto_upgrade_not_called_when_outdated(self):
+        with patch("atdd.version_check.is_outdated", return_value=(True, "3.0.0", "4.0.0")), \
+             patch("atdd.version_check.auto_upgrade") as mock_upgrade, \
+             pytest.raises(SystemExit):
+            _gate_main()
+        mock_upgrade.assert_not_called()
+
+    def test_auto_upgrade_not_called_when_up_to_date(self):
+        with patch("atdd.version_check.is_outdated", return_value=(False, "4.0.0", "4.0.0")), \
+             patch("atdd.version_check.auto_upgrade") as mock_upgrade:
+            _gate_main()
+        mock_upgrade.assert_not_called()
+
+    def test_auto_upgrade_not_called_when_pypi_unreachable(self):
+        with patch("atdd.version_check.is_outdated", return_value=(False, "4.0.0", "")), \
+             patch("atdd.version_check.auto_upgrade") as mock_upgrade:
+            _gate_main()
+        mock_upgrade.assert_not_called()
+
+
+class TestGatePrintsUpgradeInstruction:
+    """Y004-UNIT-002: when outdated, _gate_main prints 'atdd upgrade' instruction."""
+
+    def test_prints_atdd_upgrade_instruction(self, capsys):
+        with patch("atdd.version_check.is_outdated", return_value=(True, "3.0.0", "4.0.0")), \
+             pytest.raises(SystemExit):
+            _gate_main()
+        captured = capsys.readouterr()
+        output = captured.out + captured.err
+        assert "atdd upgrade" in output, (
+            f"Expected 'atdd upgrade' in output; got:\n{output}"
+        )
+
+    def test_prints_latest_version(self, capsys):
+        with patch("atdd.version_check.is_outdated", return_value=(True, "3.0.0", "4.0.0")), \
+             pytest.raises(SystemExit):
+            _gate_main()
+        captured = capsys.readouterr()
+        output = captured.out + captured.err
+        assert "4.0.0" in output, (
+            f"Expected latest version '4.0.0' in output; got:\n{output}"
+        )
+
+    def test_does_not_print_pip_install(self, capsys):
+        with patch("atdd.version_check.is_outdated", return_value=(True, "3.0.0", "4.0.0")), \
+             pytest.raises(SystemExit):
+            _gate_main()
+        captured = capsys.readouterr()
+        output = captured.out + captured.err
+        assert "pip install" not in output, (
+            f"Output must not contain 'pip install'; got:\n{output}"
+        )
+
+    def test_exits_with_code_1_when_outdated(self):
+        with patch("atdd.version_check.is_outdated", return_value=(True, "3.0.0", "4.0.0")):
+            with pytest.raises(SystemExit) as exc_info:
+                _gate_main()
+        assert exc_info.value.code == 1
+
+
+class TestGateAllowsWhenUpToDate:
+    """Y004-UNIT-003: _gate_main exits 0 when up to date."""
+
+    def test_no_exit_when_up_to_date(self):
+        with patch("atdd.version_check.is_outdated", return_value=(False, "4.0.0", "4.0.0")):
+            _gate_main()  # must not raise
+
+    def test_prints_up_to_date_message(self, capsys):
+        with patch("atdd.version_check.is_outdated", return_value=(False, "4.0.0", "4.0.0")):
+            _gate_main()
+        captured = capsys.readouterr()
+        output = captured.out + captured.err
+        assert "up to date" in output.lower() or "4.0.0" in output, (
+            f"Expected up-to-date confirmation in output; got:\n{output}"
+        )
+
+
+class TestGateSkipsWhenPyPIUnreachable:
+    """Y004-UNIT-004: _gate_main exits 0 with a warning when PyPI is unreachable."""
+
+    def test_no_exit_1_when_pypi_unreachable(self):
+        with patch("atdd.version_check.is_outdated", return_value=(False, "4.0.0", "")):
+            _gate_main()  # must not raise SystemExit(1)
+
+    def test_prints_warning_when_pypi_unreachable(self, capsys):
+        with patch("atdd.version_check.is_outdated", return_value=(False, "4.0.0", "")):
+            _gate_main()
+        captured = capsys.readouterr()
+        output = captured.out + captured.err
+        assert output.strip(), "Expected some output when PyPI is unreachable"
+
+
+class TestGateNoPipSubprocess:
+    """Y004-UNIT-005: _gate_main must not spawn any pip subprocess."""
+
+    def test_no_subprocess_run_with_pip(self):
+        with patch("atdd.version_check.is_outdated", return_value=(True, "3.0.0", "4.0.0")), \
+             patch("subprocess.run") as mock_subproc, \
+             pytest.raises(SystemExit):
+            _gate_main()
+        for c in mock_subproc.call_args_list:
+            cmd = c.args[0] if c.args else []
+            cmd_str = " ".join(str(x) for x in cmd)
+            assert "pip" not in cmd_str and "install" not in cmd_str, (
+                f"_gate_main spawned a pip/install subprocess: {cmd_str}"
+            )
+
+    def test_no_subprocess_run_when_up_to_date(self):
+        with patch("atdd.version_check.is_outdated", return_value=(False, "4.0.0", "4.0.0")), \
+             patch("subprocess.run") as mock_subproc:
+            _gate_main()
+        mock_subproc.assert_not_called()

--- a/src/atdd/version_check.py
+++ b/src/atdd/version_check.py
@@ -453,7 +453,12 @@ def auto_upgrade() -> bool:
 def _gate_main() -> None:
     """CLI entry point for version-gate hook.
 
-    Exit 0 = allow, exit 1 = block (outdated, upgraded, retry needed).
+    Gate only — never runs pip install or auto_upgrade().
+    Exit 0 = allow push, exit 1 = block push (atdd is outdated).
+
+    When outdated the user must run `atdd upgrade` manually and retry.
+    Running pip install from inside a git hook is unsafe on PEP 668
+    systems (Homebrew/Debian Python), inside virtualenvs, and in CI.
     """
     outdated, current, latest = is_outdated()
 
@@ -465,11 +470,11 @@ def _gate_main() -> None:
             print(f"atdd {current} is up to date")
         return  # exit 0
 
-    print(f"atdd {current} is outdated (latest: {latest}). Upgrading...")
-    if auto_upgrade():
-        print(f"Upgraded atdd to {latest}. Please retry your git operation.")
-    else:
-        print(f"Auto-upgrade failed. Run manually: pip install --upgrade atdd")
+    print(
+        f"atdd {current} is outdated (latest: {latest}).\n"
+        f"Run `atdd upgrade` then retry your git operation.",
+        file=sys.stderr,
+    )
     sys.exit(1)
 
 


### PR DESCRIPTION
Closes #776

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #776 |
| Type | implementation |
| Slug | pre-push-version-gate-must-not-auto-upgrade |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd-issue, atdd:INIT, archetype:coach |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.