### PR TITLE
Bump version to 3.73.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.72.0"
+version = "3.73.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
Version bump for #793 fix: atdd init --force core.hooksPath worktree isolation.

Bumps from 3.72.0 (already tagged for #792) to 3.73.0.

## Summary
- Version collision: 3.72.0 was already tagged for #792 before #793 PR merged
- This bump disambiguates the release

## Change class
MINOR: new fix feature (worktree isolation for core.hooksPath, Wave 12 class)