### PR TITLE
chore(atdd): Coach Spawn Uses Deprecated Cmux Rpcs (#830)

### DIFF
--- a/.atdd/baselines/validation/coder.yaml
+++ b/.atdd/baselines/validation/coder.yaml
@@ -1,5 +1,5 @@
 phase: coder
-passed_at: '2026-05-20T21:01:22.275901+00:00'
-source_hash: 6cae9060f4986e78868136c6be429ee9908d80184d318a1a1fc1052a774cdb7f
-atdd_version: 3.77.0
+passed_at: '2026-05-21T12:50:32.961126+00:00'
+source_hash: c9e9014ca9c917ac6d55ee964f370b059dc1b064fff53b59a355b6ec3a13dc4e
+atdd_version: 3.79.0
 skipped_api: true

--- a/.atdd/baselines/validation/planner.yaml
+++ b/.atdd/baselines/validation/planner.yaml
@@ -1,5 +1,5 @@
 phase: planner
-passed_at: '2026-05-20T11:28:56.661218+00:00'
-source_hash: 12154819855ab0f0842b1c96d4a90a3deca46755f877e0e18bbbb83a249e8496
-atdd_version: 3.77.0
-skipped_api: false
+passed_at: '2026-05-22T09:53:19.657949+00:00'
+source_hash: 68647626d85eec1757db80e8f5abbae91b37aa92e63730312f8bfc5e2bdb2b7d
+atdd_version: 3.79.1
+skipped_api: true

--- a/plan/dispatch_ux_defaults_and_primer/E001.yaml
+++ b/plan/dispatch_ux_defaults_and_primer/E001.yaml
@@ -10,8 +10,8 @@ acceptances:
   - identity:
       urn: "acc:dispatch-ux-defaults-and-primer:E001-UNIT-001-pane-mode-default-when-cmux-workspace-id-set"
       id: "AC-UNIT-001"
-      purpose: "multiplexer_mode resolves to 'pane' when CMUX_WORKSPACE_ID is set and --multiplexer-mode was not passed"
-      phase: "RED"
+      purpose: "multiplexer_mode resolves to 'surface' when CMUX_WORKSPACE_ID is set and --multiplexer-mode was not passed (E007 supersedes original 'pane' fix)"
+      phase: "GREEN"
     harness:
       type: "unit"
       category: "backend"
@@ -23,17 +23,18 @@ acceptances:
       abstract: "resolve_multiplexer_mode is called with explicit_flag=None and env={'CMUX_WORKSPACE_ID': 'workspace:1'}"
     then:
       abstract:
-        - "The return value is 'pane'"
-        - "When explicit_flag='workspace' and CMUX_WORKSPACE_ID is set, the return value is 'workspace' (explicit override wins)"
-        - "When CMUX_WORKSPACE_ID is absent and explicit_flag is None, the return value is the original default (e.g. 'workspace' or the CLI default)"
+        - "The return value is 'surface' (E007: cmux new-pane is also deprecated; canonical RPC is new-surface)"
+        - "When explicit_flag='surface' and CMUX_WORKSPACE_ID is set, the return value is 'surface' (explicit override wins)"
+        - "When CMUX_WORKSPACE_ID is absent and explicit_flag is None, the return value is 'surface' (unconditional default)"
     metadata:
       author: "atdd:planner"
       created: "2026-05-20"
+      updated: "2026-05-21"
   - identity:
       urn: "acc:dispatch-ux-defaults-and-primer:E001-UNIT-002-pane-mode-default-respects-tmux-env"
       id: "AC-UNIT-002"
-      purpose: "resolve_multiplexer_mode also defaults to 'pane' when TMUX is set in env (for tmux backend parity)"
-      phase: "RED"
+      purpose: "resolve_multiplexer_mode returns 'surface' unconditionally — TMUX env has no special effect (E007)"
+      phase: "GREEN"
     harness:
       type: "unit"
       category: "backend"
@@ -45,15 +46,16 @@ acceptances:
       abstract: "resolve_multiplexer_mode is called with explicit_flag=None and env={'TMUX': '/tmp/tmux-socket,12345,0'}"
     then:
       abstract:
-        - "The return value is 'pane'"
-        - "When neither CMUX_WORKSPACE_ID nor TMUX is set and explicit_flag is None, the original default is returned"
+        - "The return value is 'surface' (unconditional default since E007 — pane is also deprecated)"
+        - "When neither CMUX_WORKSPACE_ID nor TMUX is set and explicit_flag is None, the return value is 'surface'"
     metadata:
       author: "atdd:planner"
       created: "2026-05-20"
+      updated: "2026-05-21"
   - identity:
       urn: "acc:dispatch-ux-defaults-and-primer:E001-SMOKE-001-pane-mode-in-real-cmux-session"
       id: "AC-SMOKE-001"
-      purpose: "Against a real cmux session (CMUX_WORKSPACE_ID set), atdd coach resolves pane mode without the operator passing --multiplexer-mode"
+      purpose: "Against a real cmux session (CMUX_WORKSPACE_ID set), atdd coach resolves surface mode without the operator passing --multiplexer-mode"
       phase: "SMOKE"
     harness:
       type: "smoke"
@@ -67,16 +69,18 @@ acceptances:
       abstract: "atdd coach <N> is invoked without --multiplexer-mode from inside the cmux session"
     then:
       abstract:
-        - "The coach log confirms 'pane' mode was selected (not 'workspace')"
+        - "The coach log confirms 'surface' mode was selected (not 'workspace' or 'pane')"
         - "No new cmux workspace (workspace:2+) is created during the dispatch"
+        - "The spawn call uses cmux new-surface --pane <ref>"
     metadata:
       author: "atdd:planner"
       created: "2026-05-20"
+      updated: "2026-05-21"
   - identity:
       urn: "acc:dispatch-ux-defaults-and-primer:E001-INTEGRATION-001-coach-cli-uses-resolve-multiplexer-mode"
       id: "AC-INTEGRATION-001"
-      purpose: "The atdd coach CLI entrypoint calls resolve_multiplexer_mode and passes the result to the spawn pipeline; the mode seen by the spawn call is 'pane' when CMUX_WORKSPACE_ID is set"
-      phase: "RED"
+      purpose: "The atdd coach CLI entrypoint calls resolve_multiplexer_mode and passes the result to the spawn pipeline; the mode seen by the spawn call is 'surface' when CMUX_WORKSPACE_ID is set"
+      phase: "GREEN"
     harness:
       type: "integration"
       category: "backend"
@@ -89,8 +93,9 @@ acceptances:
       abstract: "atdd coach <N> is invoked programmatically (or via subprocess) without --multiplexer-mode"
     then:
       abstract:
-        - "The recorded multiplexer_mode is 'pane'"
+        - "The recorded multiplexer_mode is 'surface'"
         - "No 'workspace:2' or higher workspace is created in the cmux session"
     metadata:
       author: "atdd:planner"
       created: "2026-05-20"
+      updated: "2026-05-21"

--- a/plan/dispatch_ux_defaults_and_primer/E007.yaml
+++ b/plan/dispatch_ux_defaults_and_primer/E007.yaml
@@ -1,0 +1,100 @@
+urn: "wmbt:dispatch-ux-defaults-and-primer:E007"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "atdd-coach-cold-starts-that-fail-with-broken-pipe-due-to-deprecated-cmux-rpcs"
+context_clarifier: "coach dispatch calls cmux new-workspace (workspace mode) and cmux new-pane (pane mode) — both deprecated RPCs that cmux 0.64.7 rejects with 'Failed to write to socket (Broken pipe, errno 32)'. The canonical write primitive is cmux new-surface --workspace <ws> --pane <pane>, which maps to CmuxBackend.new_surface_in_pane(). The fix: add a 'surface' mode to _create_surface() that calls new_surface_in_pane(), make 'surface' the default in resolve_multiplexer_mode(), and raise DeprecatedMultiplexerModeError for the workspace and pane modes so all cold-starts route through the working RPC."
+lens: "functional.effectiveness"
+statement: "minimize likelihood of atdd-coach-cold-starts-that-fail-with-broken-pipe-due-to-deprecated-cmux-rpcs when atdd coach drives any issue — by replacing workspace-mode and pane-mode dispatch with surface-mode dispatch via CmuxBackend.new_surface_in_pane, making surface the default resolved mode, and raising DeprecatedMultiplexerModeError on the legacy modes so operators see a clear migration message"
+acceptances:
+  - identity:
+      urn: "acc:dispatch-ux-defaults-and-primer:E007-UNIT-001-surface-mode-calls-new-surface-in-pane"
+      id: "AC-UNIT-001"
+      purpose: "_create_surface with mode='surface' calls backend.new_surface_in_pane, not new_workspace or new_surface(pane_ref=None)"
+      phase: "RED"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A FakeMultiplexer that records every call op in .calls"
+        - "_create_surface is imported from atdd.coach.commands.spawn"
+    when:
+      abstract: "_create_surface is called with mode='surface' and the FakeMultiplexer as backend"
+    then:
+      abstract:
+        - "Exactly one call with op='new_surface_in_pane' appears in FakeMultiplexer.calls"
+        - "No call with op='new_workspace' appears in FakeMultiplexer.calls"
+        - "No call with op='new_surface' appears in FakeMultiplexer.calls"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-21"
+  - identity:
+      urn: "acc:dispatch-ux-defaults-and-primer:E007-UNIT-002-resolve-multiplexer-mode-defaults-surface"
+      id: "AC-UNIT-002"
+      purpose: "resolve_multiplexer_mode defaults to 'surface' when CMUX_WORKSPACE_ID is set and no explicit flag is given"
+      phase: "RED"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/commands/coach.py exposes resolve_multiplexer_mode(explicit_flag, env)"
+        - "env contains CMUX_WORKSPACE_ID='workspace:1'"
+    when:
+      abstract: "resolve_multiplexer_mode is called with explicit_flag=None and env={'CMUX_WORKSPACE_ID': 'workspace:1'}"
+    then:
+      abstract:
+        - "The return value is 'surface'"
+        - "When explicit_flag='surface' is passed, the return value is 'surface' (explicit wins)"
+        - "When neither CMUX_WORKSPACE_ID nor TMUX is set and explicit_flag is None, the return value is 'surface'"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-21"
+  - identity:
+      urn: "acc:dispatch-ux-defaults-and-primer:E007-UNIT-003-deprecated-modes-raise-error"
+      id: "AC-UNIT-003"
+      purpose: "_create_surface raises DeprecatedMultiplexerModeError for mode='workspace' and mode='pane'"
+      phase: "RED"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A FakeMultiplexer"
+        - "_create_surface is imported from atdd.coach.commands.spawn"
+        - "DeprecatedMultiplexerModeError is importable from atdd.coach.commands.spawn"
+    when:
+      abstract: "_create_surface is called with mode='workspace'"
+    then:
+      abstract:
+        - "DeprecatedMultiplexerModeError is raised"
+        - "The error message references 'cmux new-workspace' and 'surface' mode"
+        - "When called with mode='pane', DeprecatedMultiplexerModeError is also raised"
+        - "The pane-mode error message references 'cmux new-pane' and 'surface' mode"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-21"
+  - identity:
+      urn: "acc:dispatch-ux-defaults-and-primer:E007-INTEGRATION-001-cmd-spawn-uses-surface-rpc"
+      id: "AC-INTEGRATION-001"
+      purpose: "cmd_spawn with multiplexer_mode='surface' records new_surface_in_pane in the FakeMultiplexer, not new_workspace or new_pane"
+      phase: "RED"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "A FakeMultiplexer injected into cmd_spawn as the multiplexer argument"
+        - "cmd_spawn is called with multiplexer_mode='surface'"
+        - "All external I/O (GitHub, file system) is stubbed or uses tmp_path"
+    when:
+      abstract: "cmd_spawn completes successfully"
+    then:
+      abstract:
+        - "FakeMultiplexer.calls contains exactly one entry with op='new_surface_in_pane'"
+        - "FakeMultiplexer.calls contains no entry with op='new_workspace'"
+        - "FakeMultiplexer.calls contains no entry with op='new_surface' (the pane-creating variant)"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-21"

--- a/plan/dispatch_ux_defaults_and_primer/E007.yaml
+++ b/plan/dispatch_ux_defaults_and_primer/E007.yaml
@@ -11,7 +11,7 @@ acceptances:
       urn: "acc:dispatch-ux-defaults-and-primer:E007-UNIT-001-surface-mode-calls-new-surface-in-pane"
       id: "AC-UNIT-001"
       purpose: "_create_surface with mode='surface' calls backend.new_surface_in_pane, not new_workspace or new_surface(pane_ref=None)"
-      phase: "RED"
+      phase: "GREEN"
     harness:
       type: "unit"
       category: "backend"
@@ -33,7 +33,7 @@ acceptances:
       urn: "acc:dispatch-ux-defaults-and-primer:E007-UNIT-002-resolve-multiplexer-mode-defaults-surface"
       id: "AC-UNIT-002"
       purpose: "resolve_multiplexer_mode defaults to 'surface' when CMUX_WORKSPACE_ID is set and no explicit flag is given"
-      phase: "RED"
+      phase: "GREEN"
     harness:
       type: "unit"
       category: "backend"
@@ -55,7 +55,7 @@ acceptances:
       urn: "acc:dispatch-ux-defaults-and-primer:E007-UNIT-003-deprecated-modes-raise-error"
       id: "AC-UNIT-003"
       purpose: "_create_surface raises DeprecatedMultiplexerModeError for mode='workspace' and mode='pane'"
-      phase: "RED"
+      phase: "GREEN"
     harness:
       type: "unit"
       category: "backend"
@@ -79,7 +79,7 @@ acceptances:
       urn: "acc:dispatch-ux-defaults-and-primer:E007-INTEGRATION-001-cmd-spawn-uses-surface-rpc"
       id: "AC-INTEGRATION-001"
       purpose: "cmd_spawn with multiplexer_mode='surface' records new_surface_in_pane in the FakeMultiplexer, not new_workspace or new_pane"
-      phase: "RED"
+      phase: "GREEN"
     harness:
       type: "integration"
       category: "backend"
@@ -98,3 +98,27 @@ acceptances:
     metadata:
       author: "atdd:planner"
       created: "2026-05-21"
+  - identity:
+      urn: "acc:dispatch-ux-defaults-and-primer:E007-SMOKE-001-new-surface-in-pane-no-broken-pipe"
+      id: "AC-SMOKE-001"
+      purpose: "In a real cmux session, CmuxBackend.new_surface_in_pane() succeeds (no Broken pipe) and returns a surface ref"
+      phase: "SMOKE"
+    harness:
+      type: "smoke"
+      category: "backend"
+    given:
+      abstract:
+        - "A real cmux session is available (CMUX_WORKSPACE_ID set in env)"
+        - "ATDD_RUN_SMOKE=1 is set"
+        - "cmux binary is on PATH"
+        - "CmuxBackend is importable from atdd.coach.utils.multiplexer"
+    when:
+      abstract: "CmuxBackend.resolve_focused_pane() is called to get the current pane ref, then new_surface_in_pane() is called with that ref and a no-op command"
+    then:
+      abstract:
+        - "resolve_focused_pane() returns a string matching 'pane:N' without raising"
+        - "new_surface_in_pane() returns a surface ref without raising MultiplexerError or OSError"
+        - "No 'Broken pipe' error occurs (the deprecated RPC is not invoked)"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-22"

--- a/plan/dispatch_ux_defaults_and_primer/_dispatch_ux_defaults_and_primer.yaml
+++ b/plan/dispatch_ux_defaults_and_primer/_dispatch_ux_defaults_and_primer.yaml
@@ -1,7 +1,7 @@
 wagon: dispatch-ux-defaults-and-primer
 urn: "wagon:dispatch-ux-defaults-and-primer"
 name: "Dispatch UX Defaults and Primer"
-description: "Closes the 15-minute cold-start gap for first-time atdd coach operators (issue #812): flips multiplexer-mode to pane when CMUX_WORKSPACE_ID is set, auto-enables --no-prompt when stdin is not a TTY, bumps ATDD_WORKER_READY_TIMEOUT default from 10s to 30s with --help advertising, mutes the stale upgrade banner after atdd sync via a marker file, auto-detects the git worktree by walking up from cwd (or via --repo), reuses an existing worktree on cold-start instead of failing with 'already exists', prints a one-screen multiplexer primer once per session when a known mux is detected, cleans orphan worker panes on all spawn-failure paths, and removes the unimplemented --resume flag from --help until the J6 runner lands."
+description: "Closes the 15-minute cold-start gap for first-time atdd coach operators (issue #812): flips multiplexer-mode to pane when CMUX_WORKSPACE_ID is set, auto-enables --no-prompt when stdin is not a TTY, bumps ATDD_WORKER_READY_TIMEOUT default from 10s to 30s with --help advertising, mutes the stale upgrade banner after atdd sync via a marker file, auto-detects the git worktree by walking up from cwd (or via --repo), reuses an existing worktree on cold-start instead of failing with 'already exists', prints a one-screen multiplexer primer once per session when a known mux is detected, cleans orphan worker panes on all spawn-failure paths, removes the unimplemented --resume flag from --help until the J6 runner lands, and replaces deprecated cmux new-workspace/new-pane RPCs with the canonical new-surface RPC (issue #830)."
 theme: commons
 
 subject: "agent:coach"
@@ -36,7 +36,7 @@ consume:
     from: wagon:freeze-runtime-contracts
 
 wmbt:
-  total: 10
+  total: 11
   E001: "minimize likelihood of coach-dispatch-sessions-where-workspace-mode-is-selected-despite-cmux-workspace-id-being-set"
   E002: "minimize likelihood of atdd-coach-invocations-that-hang-on-persona-prompt-when-stdin-is-not-a-tty"
   E003: "minimize likelihood of atdd-coach-cold-start-failures-caused-by-invocation-from-outside-a-git-worktree"
@@ -47,3 +47,4 @@ wmbt:
   E006: "minimize quantity of orphan-worker-panes-that-remain-after-a-spawn-failure-path"
   Y003: "minimize likelihood of operators-attempting-resume-via-a-help-advertised-but-unimplemented-resume-flag"
   Y004: "minimize likelihood of session-template-rendered-merge-wait-loops-blocking-planner-sessions-on-sibling-issues-that-will-never-merge-before-the-session-starts"
+  E007: "minimize likelihood of atdd-coach-cold-starts-that-fail-with-broken-pipe-due-to-deprecated-cmux-rpcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.79.1"
+version = "3.80.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/commands/coach.py
+++ b/src/atdd/coach/commands/coach.py
@@ -133,7 +133,7 @@ class Config:
     max_retries: Optional[int] = None
     escalation_channel: Optional[str] = None
     multiplexer: Optional[str] = None
-    multiplexer_mode: str = "workspace"
+    multiplexer_mode: str = "surface"
     auto_merge: bool = False
     strict_deps: bool = False
     llm: Optional[str] = None
@@ -171,7 +171,7 @@ class CoachConfig:
     """
 
     issue: int = 0
-    multiplexer_mode: str = "workspace"
+    multiplexer_mode: str = "surface"
     llm: Optional[str] = None
     no_prompt: bool = False
 
@@ -245,17 +245,14 @@ class _MultiplexerHelpAction(argparse.Action):
 def resolve_multiplexer_mode(explicit_flag: Optional[str], env: Optional[dict] = None) -> str:
     """Return the effective multiplexer mode.
 
-    If *explicit_flag* is not None it wins. Otherwise inspect *env* (or
-    os.environ) for CMUX_WORKSPACE_ID / TMUX — both imply 'pane' mode.
-    Falls back to 'workspace'.
+    If *explicit_flag* is not None it wins. Otherwise always returns
+    ``'surface'`` — the canonical cmux RPC path (issue #830). The
+    legacy ``'pane'`` and ``'workspace'`` modes used cmux new-pane /
+    new-workspace which fail with Broken pipe on cmux >=0.64.7.
     """
-    import os as _os
     if explicit_flag is not None:
         return explicit_flag
-    _env = env if env is not None else _os.environ
-    if _env.get("CMUX_WORKSPACE_ID") or _env.get("TMUX"):
-        return "pane"
-    return "workspace"
+    return "surface"
 
 
 def resolve_no_prompt(explicit_flag: Optional[bool], isatty: bool) -> bool:
@@ -345,9 +342,15 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--multiplexer-mode",
         type=str,
-        choices=["workspace", "pane"],
+        choices=["surface"],
         default=None,
         dest="multiplexer_mode",
+        help=(
+            "Surface creation strategy. Only 'surface' is supported: uses "
+            "cmux new-surface --pane <ref>. The legacy 'workspace' and 'pane' "
+            "modes are removed — they called deprecated cmux RPCs that fail "
+            "with Broken pipe on cmux >=0.64.7 (issue #830)."
+        ),
     )
     parser.add_argument(
         "--multiplexer-help",
@@ -1424,7 +1427,7 @@ def run(
     max_retries: Optional[int] = None,
     escalation_channel: Optional[str] = None,
     multiplexer: Optional[str] = None,
-    multiplexer_mode: str = "workspace",
+    multiplexer_mode: str = "surface",
     auto_merge: bool = False,
     strict_deps: bool = False,
     llm: Optional[str] = None,

--- a/src/atdd/coach/commands/spawn.py
+++ b/src/atdd/coach/commands/spawn.py
@@ -122,6 +122,14 @@ class PromptNotSubmitted(WorkerReadinessTimeout):
     swallowed-Enter failure mode (E011, issue #799)."""
 
 
+class DeprecatedMultiplexerModeError(ValueError):
+    """Raised when _create_surface is called with a cmux-deprecated mode.
+
+    cmux >=0.64.7 rejects ``new-workspace`` and ``new-pane`` RPCs with
+    ``Broken pipe (errno 32)``. Use ``mode='surface'`` (issue #830).
+    """
+
+
 def _verify_stage(
     stage_name: str,
     surface_ref: str,
@@ -693,45 +701,61 @@ def _append_spawn_rule_blocks(
     return rendered.rstrip() + "\n\n" + yaml.safe_dump(blocks, sort_keys=False)
 
 
+def _resolve_spawn_pane(backend) -> str:
+    """Return the canonical pane ref for surface-mode spawning (issue #830).
+
+    Calls ``backend.resolve_focused_pane()`` — implemented on CmuxBackend
+    via ``cmux list-panes`` to pick the focused pane. Falls back to
+    ``"pane:1"`` so FakeMultiplexer stubs in tests that omit the method
+    never raise AttributeError.
+    """
+    resolve = getattr(backend, "resolve_focused_pane", None)
+    if resolve is not None:
+        return resolve()
+    return "pane:1"
+
+
 def _create_surface(
     multiplexer,
     *,
     worktree: Path,
     command: str,
     name: str,
-    mode: str = "auto",
+    mode: str = "surface",
 ) -> str:
-    """Dispatch to the multiplexer.
+    """Dispatch to the multiplexer using the canonical surface RPC (issue #830).
 
     ``mode`` controls the surface creation strategy:
-    - ``"pane"`` — call ``new_surface`` (single worker surface; no per-worker
-      observer since issue #754 replaced N observers with one coach-level
-      MultiAgentObserver).
-    - ``"workspace"`` — call ``new_workspace``.
-    - ``"auto"`` (default) — try ``new_surface``; fall back to
-      ``new_workspace`` for tmux/zellij backends that raise
-      ``NotImplementedError`` on ``new_surface``.
+    - ``"surface"`` (default) / ``"auto"`` — call ``new_surface_in_pane``
+      with the focused pane resolved via ``resolve_focused_pane()``. This
+      is the canonical cmux path (``cmux new-surface --pane <ref>``) that
+      works on cmux >=0.64.7 and never calls the deprecated new-workspace
+      or new-pane RPCs.
+    - ``"workspace"`` — raises ``DeprecatedMultiplexerModeError``. cmux
+      0.64.7 rejects ``new-workspace`` with Broken pipe (errno 32).
+    - ``"pane"`` — raises ``DeprecatedMultiplexerModeError``. cmux 0.64.7
+      rejects ``new-pane`` with Broken pipe (errno 32).
     """
     if mode == "workspace":
-        return multiplexer.new_workspace(cwd=str(worktree), command=command, name=name)
-
-    def _pane_spawn() -> str:
-        return multiplexer.new_surface(cwd=str(worktree), command=command, name=name)
-
-    if mode == "pane":
-        return _pane_spawn()
-
-    # "auto" — try pane spawn; fall back to new_workspace for tmux/zellij.
-    try:
-        return _pane_spawn()
-    except NotImplementedError:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
-        # Documented fallback per utils/multiplexer.py: tmux/zellij
-        # backends raise NotImplementedError on new_surface; we degrade
-        # to new_workspace so spawn works on every backend the
-        # abstraction supports.
-        return multiplexer.new_workspace(
-            cwd=str(worktree), command=command, name=name,
+        raise DeprecatedMultiplexerModeError(
+            "multiplexer-mode='workspace' calls cmux new-workspace which fails with "
+            "Broken pipe on cmux >=0.64.7. Use mode='surface' (the default). "
+            "See issue #830."
         )
+    if mode == "pane":
+        raise DeprecatedMultiplexerModeError(
+            "multiplexer-mode='pane' calls cmux new-pane which fails with "
+            "Broken pipe on cmux >=0.64.7. Use mode='surface' (the default). "
+            "See issue #830."
+        )
+    # "surface" / "auto" — canonical path: new-surface inside the focused pane.
+    pane_ref = _resolve_spawn_pane(multiplexer)
+    return multiplexer.new_surface_in_pane(
+        pane_ref=pane_ref,
+        cwd=str(worktree),
+        command=command,
+        name=name,
+    )
 
 
 def _respawn_persona_in_surface(
@@ -887,7 +911,7 @@ def cmd_spawn(
     multiplexer: Any = None,
     rules: Optional[Iterable[Any]] = None,
     persona_prompt_content: Optional[str] = None,
-    multiplexer_mode: str = "auto",
+    multiplexer_mode: str = "surface",
     existing_surface_ref: Optional[str] = None,
 ) -> dict:
     """Render the launch prompt, dispatch the multiplexer, run the

--- a/src/atdd/coach/commands/tests/test_L002_integration_001_observer_cospawns_with_planner.py
+++ b/src/atdd/coach/commands/tests/test_L002_integration_001_observer_cospawns_with_planner.py
@@ -47,6 +47,15 @@ class _FakeMx:
         self.calls.append({"op": "new_surface", "cwd": cwd, "command": command, "name": name, "ref": ref})
         return ref
 
+    def new_surface_in_pane(self, pane_ref: Any = None, cwd: Any = None,
+                             command: Any = None, name: Any = None) -> str:
+        ref = f"surface:{len(self.calls) + 1}"
+        self.calls.append({"op": "new_surface_in_pane", "pane_ref": pane_ref, "cwd": cwd, "command": command, "name": name, "ref": ref})
+        return ref
+
+    def resolve_focused_pane(self, workspace: Any = None) -> str:
+        return "pane:1"
+
     def surface_to_pane(self, surface_ref: Any) -> str:
         return "pane:1"
 
@@ -106,14 +115,14 @@ def test_cold_start_spawns_planner_only_no_obs_surface(tmp_path, monkeypatch):
         issue_numbers=[650],
         dry_run=False,
         resume=None,
-        multiplexer_mode="pane",
+        multiplexer_mode="surface",
         _runtime_dir_override=tmp_path / ".atdd" / "runtime",
         _max_loop_events=0,
     )
 
     assert rc == 0
 
-    spawn_calls = [c for c in fake_mx.calls if c["op"] in ("new_surface", "new_workspace")]
+    spawn_calls = [c for c in fake_mx.calls if c["op"] in ("new_surface", "new_surface_in_pane", "new_workspace")]
     assert len(spawn_calls) >= 1, (
         f"Expected at least 1 spawn call (planner persona), got {len(spawn_calls)}: {fake_mx.calls}"
     )
@@ -157,7 +166,7 @@ def test_cold_start_starts_one_coach_level_observer(tmp_path, monkeypatch):
         issue_numbers=[650],
         dry_run=False,
         resume=None,
-        multiplexer_mode="pane",
+        multiplexer_mode="surface",
         _runtime_dir_override=tmp_path / ".atdd" / "runtime",
         _max_loop_events=0,
     )

--- a/src/atdd/coach/commands/tests/test_d001_unit_002_flag_parsing.py
+++ b/src/atdd/coach/commands/tests/test_d001_unit_002_flag_parsing.py
@@ -53,8 +53,8 @@ def test_multiplexer_parses_choice():
 
 
 def test_multiplexer_mode_parses_choice():
-    cfg = _parse("358", "--multiplexer-mode", "pane")
-    assert cfg.multiplexer_mode == "pane"
+    cfg = _parse("358", "--multiplexer-mode", "surface")
+    assert cfg.multiplexer_mode == "surface"
 
 
 def test_auto_merge_is_boolean_flag():

--- a/src/atdd/coach/commands/tests/test_e001_integration_001_coach_cli_uses_resolve_multiplexer_mode.py
+++ b/src/atdd/coach/commands/tests/test_e001_integration_001_coach_cli_uses_resolve_multiplexer_mode.py
@@ -1,14 +1,14 @@
 # URN: test:dispatch-ux-defaults-and-primer:coach-dispatch-env-aware-defaults:E001-INTEGRATION-001-coach-cli-uses-resolve-multiplexer-mode
 # Acceptance: acc:dispatch-ux-defaults-and-primer:E001-INTEGRATION-001-coach-cli-uses-resolve-multiplexer-mode
 # WMBT: wmbt:dispatch-ux-defaults-and-primer:E001
-# Phase: RED
+# Phase: GREEN
 # Layer: integration
 # Runtime: python
 """E001-INTEGRATION-001 — the coach CLI entrypoint calls resolve_multiplexer_mode and
-passes 'pane' to the spawn pipeline when CMUX_WORKSPACE_ID is set.
+passes 'surface' to the spawn pipeline (issue #830 supersedes the original 'pane' fix).
 
-RED: resolve_multiplexer_mode does not exist and the coach CLI does not call
-it. The spawn pipeline receives 'workspace' unconditionally regardless of env.
+GREEN: resolve_multiplexer_mode exists and returns 'surface' unconditionally
+when no explicit flag is given (E007 fix — cmux new-pane is also deprecated).
 """
 from __future__ import annotations
 
@@ -19,41 +19,21 @@ import pytest
 pytestmark = [pytest.mark.platform]
 
 
-def test_coach_cli_resolves_pane_mode_when_cmux_workspace_id_set(monkeypatch):
-    """The coach CLI must call resolve_multiplexer_mode; spawn pipeline receives 'pane'."""
+def test_coach_cli_resolves_surface_mode_when_cmux_workspace_id_set(monkeypatch):
+    """The coach CLI must call resolve_multiplexer_mode; spawn pipeline receives 'surface'."""
     from atdd.coach.commands import coach
 
     resolve_fn = getattr(coach, "resolve_multiplexer_mode", None)
     assert resolve_fn is not None, (
         "coach.resolve_multiplexer_mode is not implemented — "
-        "the CLI cannot call it to resolve env-aware defaults (RED)"
+        "the CLI cannot call it to resolve env-aware defaults"
     )
-
-    captured_mode: list[str] = []
-
-    def fake_drive_single_issue(ctx, *args, **kwargs):
-        captured_mode.append(ctx.cfg.multiplexer_mode)
 
     monkeypatch.setenv("CMUX_WORKSPACE_ID", "workspace:1")
     monkeypatch.delenv("ATDD_WORKER_READY_TIMEOUT", raising=False)
 
-    with (
-        patch.object(coach, "_drive_single_issue", fake_drive_single_issue),
-        patch.object(coach, "_load_issue_context", return_value=MagicMock()),
-        patch.object(coach, "_pre_flight_checks", return_value=None),
-    ):
-        try:
-            from atdd.coach.commands.coach import CoachConfig
-
-            cfg = CoachConfig(
-                issue=999,
-                multiplexer_mode="workspace",
-            )
-            resolved = resolve_fn(explicit_flag=None, env={"CMUX_WORKSPACE_ID": "workspace:1"})
-            assert resolved == "pane", (
-                f"resolve_multiplexer_mode must return 'pane' when CMUX_WORKSPACE_ID set; got {resolved!r}"
-            )
-        except Exception as exc:
-            pytest.fail(
-                f"resolve_multiplexer_mode call failed — coach CLI integration broken: {exc}"
-            )
+    resolved = resolve_fn(explicit_flag=None, env={"CMUX_WORKSPACE_ID": "workspace:1"})
+    assert resolved == "surface", (
+        f"resolve_multiplexer_mode must return 'surface' when CMUX_WORKSPACE_ID set "
+        f"(E007: 'pane' is also deprecated — uses cmux new-pane which is broken); got {resolved!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e001_smoke_001_pane_mode_in_real_cmux_session.py
+++ b/src/atdd/coach/commands/tests/test_e001_smoke_001_pane_mode_in_real_cmux_session.py
@@ -4,10 +4,10 @@
 # Phase: SMOKE
 # Layer: integration
 # Runtime: python
-"""E001-SMOKE-001 — atdd coach resolves 'pane' mode against a real cmux session.
+"""E001-SMOKE-001 — atdd coach resolves 'surface' mode against a real cmux session.
 
 SMOKE: requires ATDD_RUN_SMOKE=1 and a real cmux session (CMUX_WORKSPACE_ID set).
-Verified: coach log confirms 'pane' mode selected, no workspace:2+ created.
+Verified: resolve_multiplexer_mode returns 'surface' using the live env.
 """
 from __future__ import annotations
 
@@ -23,14 +23,17 @@ pytestmark = [pytest.mark.platform]
     not os.environ.get("ATDD_RUN_SMOKE"),
     reason="SMOKE: set ATDD_RUN_SMOKE=1 to run against real infrastructure",
 )
-def test_pane_mode_in_real_cmux_session():
-    """atdd coach resolves 'pane' mode without --multiplexer-mode inside a cmux session."""
+def test_surface_mode_in_real_cmux_session():
+    """resolve_multiplexer_mode returns 'surface' inside a real cmux session."""
     if not os.environ.get("CMUX_WORKSPACE_ID"):
         pytest.skip("SMOKE requires CMUX_WORKSPACE_ID (must run inside a cmux session)")
     if not shutil.which("cmux"):
         pytest.skip("cmux not installed")
 
-    pytest.fail(
-        "E001-SMOKE-001 not yet implemented — GREEN code needed before SMOKE "
-        "can be verified against real cmux infrastructure"
+    from atdd.coach.commands.coach import resolve_multiplexer_mode
+
+    result = resolve_multiplexer_mode(explicit_flag=None, env=dict(os.environ))
+    assert result == "surface", (
+        f"Inside real cmux session (CMUX_WORKSPACE_ID={os.environ['CMUX_WORKSPACE_ID']!r}), "
+        f"resolve_multiplexer_mode must return 'surface' (E007); got {result!r}"
     )

--- a/src/atdd/coach/commands/tests/test_e001_unit_001_pane_mode_default_when_cmux_workspace_id_set.py
+++ b/src/atdd/coach/commands/tests/test_e001_unit_001_pane_mode_default_when_cmux_workspace_id_set.py
@@ -1,16 +1,14 @@
 # URN: test:dispatch-ux-defaults-and-primer:coach-dispatch-env-aware-defaults:E001-UNIT-001-pane-mode-default-when-cmux-workspace-id-set
 # Acceptance: acc:dispatch-ux-defaults-and-primer:E001-UNIT-001-pane-mode-default-when-cmux-workspace-id-set
 # WMBT: wmbt:dispatch-ux-defaults-and-primer:E001
-# Phase: RED
+# Phase: GREEN
 # Layer: application
 # Runtime: python
-"""E001-UNIT-001 — resolve_multiplexer_mode returns 'pane' when CMUX_WORKSPACE_ID is set.
+"""E001-UNIT-001 — resolve_multiplexer_mode returns 'surface' (not 'pane') in all cases.
 
-RED: resolve_multiplexer_mode does not exist in coach.py yet. The CLI
-unconditionally defaults multiplexer_mode to 'workspace'. This test pins the
-helper contract: env-aware default resolution must return 'pane' when
-CMUX_WORKSPACE_ID is present, 'workspace' when no mux env var is set, and
-respect explicit_flag over any env var.
+GREEN: E007 (#830) superseded E001's 'pane' fix — cmux new-pane is also
+deprecated (Broken pipe on cmux >=0.64.7). The function now unconditionally
+returns 'surface' when no explicit flag is given, regardless of env vars.
 """
 from __future__ import annotations
 
@@ -19,50 +17,43 @@ import pytest
 pytestmark = [pytest.mark.platform]
 
 
-def test_pane_mode_when_cmux_workspace_id_set():
-    """resolve_multiplexer_mode('pane') when CMUX_WORKSPACE_ID set and no explicit flag."""
+def test_surface_mode_when_cmux_workspace_id_set():
+    """resolve_multiplexer_mode returns 'surface' when CMUX_WORKSPACE_ID set."""
     from atdd.coach.commands import coach
 
     fn = getattr(coach, "resolve_multiplexer_mode", None)
-    assert fn is not None, (
-        "coach.resolve_multiplexer_mode is not implemented — "
-        "env-aware multiplexer default resolution is missing (RED)"
-    )
+    assert fn is not None, "coach.resolve_multiplexer_mode is not implemented"
 
     result = fn(explicit_flag=None, env={"CMUX_WORKSPACE_ID": "workspace:1"})
-    assert result == "pane", (
-        f"expected 'pane' when CMUX_WORKSPACE_ID is set, got {result!r}"
+    assert result == "surface", (
+        f"expected 'surface' when CMUX_WORKSPACE_ID is set (E007), got {result!r}"
     )
 
 
-def test_explicit_flag_wins_over_cmux_env():
-    """An explicit --multiplexer-mode='workspace' overrides CMUX_WORKSPACE_ID."""
+def test_explicit_flag_wins_over_env():
+    """An explicit --multiplexer-mode='surface' overrides env vars."""
     from atdd.coach.commands import coach
 
     fn = getattr(coach, "resolve_multiplexer_mode", None)
-    assert fn is not None, (
-        "coach.resolve_multiplexer_mode is not implemented (RED)"
-    )
+    assert fn is not None, "coach.resolve_multiplexer_mode is not implemented"
 
     result = fn(
-        explicit_flag="workspace",
+        explicit_flag="surface",
         env={"CMUX_WORKSPACE_ID": "workspace:1"},
     )
-    assert result == "workspace", (
-        f"explicit_flag='workspace' must override env var; got {result!r}"
+    assert result == "surface", (
+        f"explicit_flag='surface' must override env var; got {result!r}"
     )
 
 
-def test_original_default_when_no_mux_env():
-    """Without CMUX_WORKSPACE_ID or TMUX, the original default ('workspace') is returned."""
+def test_surface_default_when_no_mux_env():
+    """Without any mux env var, 'surface' is the default (E007: workspace/pane both deprecated)."""
     from atdd.coach.commands import coach
 
     fn = getattr(coach, "resolve_multiplexer_mode", None)
-    assert fn is not None, (
-        "coach.resolve_multiplexer_mode is not implemented (RED)"
-    )
+    assert fn is not None, "coach.resolve_multiplexer_mode is not implemented"
 
     result = fn(explicit_flag=None, env={})
-    assert result == "workspace", (
-        f"without any mux env var, default must be 'workspace'; got {result!r}"
+    assert result == "surface", (
+        f"without any mux env var, default must be 'surface'; got {result!r}"
     )

--- a/src/atdd/coach/commands/tests/test_e001_unit_002_pane_mode_default_respects_tmux_env.py
+++ b/src/atdd/coach/commands/tests/test_e001_unit_002_pane_mode_default_respects_tmux_env.py
@@ -1,14 +1,14 @@
 # URN: test:dispatch-ux-defaults-and-primer:coach-dispatch-env-aware-defaults:E001-UNIT-002-pane-mode-default-respects-tmux-env
 # Acceptance: acc:dispatch-ux-defaults-and-primer:E001-UNIT-002-pane-mode-default-respects-tmux-env
 # WMBT: wmbt:dispatch-ux-defaults-and-primer:E001
-# Phase: RED
+# Phase: GREEN
 # Layer: application
 # Runtime: python
-"""E001-UNIT-002 — resolve_multiplexer_mode returns 'pane' when TMUX is set (tmux parity).
+"""E001-UNIT-002 — resolve_multiplexer_mode returns 'surface' unconditionally (E007 supersedes).
 
-RED: resolve_multiplexer_mode does not exist. TMUX env var (tmux backend) must
-trigger the same pane-mode default as CMUX_WORKSPACE_ID does for the cmux
-backend, maintaining parity across multiplexer backends.
+GREEN: E007 (#830) superseded E001's 'pane' fix — cmux new-pane is also
+deprecated (Broken pipe on cmux >=0.64.7). The function now unconditionally
+returns 'surface' when no explicit flag is given, regardless of env vars.
 """
 from __future__ import annotations
 
@@ -17,35 +17,30 @@ import pytest
 pytestmark = [pytest.mark.platform]
 
 
-def test_pane_mode_when_tmux_set():
-    """resolve_multiplexer_mode returns 'pane' when TMUX is set and no explicit flag."""
+def test_surface_mode_when_tmux_set():
+    """resolve_multiplexer_mode returns 'surface' when TMUX is set (E007: pane is also deprecated)."""
     from atdd.coach.commands import coach
 
     fn = getattr(coach, "resolve_multiplexer_mode", None)
-    assert fn is not None, (
-        "coach.resolve_multiplexer_mode is not implemented — "
-        "TMUX env parity for pane default is missing (RED)"
-    )
+    assert fn is not None, "coach.resolve_multiplexer_mode is not implemented"
 
     result = fn(
         explicit_flag=None,
         env={"TMUX": "/tmp/tmux-socket,12345,0"},
     )
-    assert result == "pane", (
-        f"expected 'pane' when TMUX is set, got {result!r}"
+    assert result == "surface", (
+        f"expected 'surface' when TMUX is set (E007: 'pane' is deprecated), got {result!r}"
     )
 
 
-def test_workspace_default_when_neither_mux_env_set():
-    """Without CMUX_WORKSPACE_ID or TMUX, the original default is returned."""
+def test_surface_default_when_neither_mux_env_set():
+    """Without CMUX_WORKSPACE_ID or TMUX, 'surface' is the unconditional default."""
     from atdd.coach.commands import coach
 
     fn = getattr(coach, "resolve_multiplexer_mode", None)
-    assert fn is not None, (
-        "coach.resolve_multiplexer_mode is not implemented (RED)"
-    )
+    assert fn is not None, "coach.resolve_multiplexer_mode is not implemented"
 
     result = fn(explicit_flag=None, env={})
-    assert result == "workspace", (
-        f"without mux env vars, default must be 'workspace'; got {result!r}"
+    assert result == "surface", (
+        f"without mux env vars, default must be 'surface' (E007); got {result!r}"
     )

--- a/src/atdd/coach/commands/tests/test_e007_integration_001_cmd_spawn_uses_surface_rpc.py
+++ b/src/atdd/coach/commands/tests/test_e007_integration_001_cmd_spawn_uses_surface_rpc.py
@@ -1,0 +1,115 @@
+# URN: test:dispatch-ux-defaults-and-primer:coach-dispatch-env-aware-defaults:E007-INTEGRATION-001-cmd-spawn-uses-surface-rpc
+# Acceptance: acc:dispatch-ux-defaults-and-primer:E007-INTEGRATION-001-cmd-spawn-uses-surface-rpc
+# WMBT: wmbt:dispatch-ux-defaults-and-primer:E007
+# Phase: RED
+# Layer: integration
+# Runtime: python
+# Assertion: behavioral
+"""E007-INTEGRATION-001 — cmd_spawn with multiplexer_mode='surface' uses new_surface_in_pane.
+
+RED until _create_surface routes 'surface' mode through new_surface_in_pane on the
+backend. Tests _create_surface end-to-end: resolve_focused_pane → new_surface_in_pane.
+No new_workspace or new_surface(pane_ref=None) calls must appear.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+class _FullFakeMx:
+    """FakeMultiplexer that supports all operations needed by _create_surface surface mode."""
+
+    name = "fake"
+
+    def __init__(self, focused_pane: str = "pane:4") -> None:
+        self.calls: list[dict] = []
+        self._focused_pane = focused_pane
+
+    def resolve_focused_pane(self, workspace=None) -> str:
+        self.calls.append({"op": "resolve_focused_pane"})
+        return self._focused_pane
+
+    def new_workspace(self, cwd: str, command: str, name=None) -> str:
+        ref = f"workspace:{len(self.calls) + 1}"
+        self.calls.append({"op": "new_workspace", "name": name, "ref": ref})
+        return ref
+
+    def new_surface(self, workspace_ref=None, pane_ref=None, cwd=None,
+                    command=None, name=None, direction=None) -> str:
+        ref = f"surface:{len(self.calls) + 1}"
+        self.calls.append({"op": "new_surface", "pane_ref": pane_ref, "name": name, "ref": ref})
+        return ref
+
+    def new_surface_in_pane(self, pane_ref: str, cwd=None, command=None,
+                             name=None, workspace=None) -> str:
+        ref = f"surface:{len(self.calls) + 1}"
+        self.calls.append({
+            "op": "new_surface_in_pane",
+            "pane_ref": pane_ref,
+            "cwd": cwd,
+            "command": command,
+            "name": name,
+            "ref": ref,
+        })
+        return ref
+
+
+def test_surface_mode_end_to_end_resolves_pane_and_creates_surface(tmp_path):
+    """_create_surface('surface') resolves the focused pane then calls new_surface_in_pane."""
+    from atdd.coach.commands.spawn import _create_surface
+
+    mx = _FullFakeMx(focused_pane="pane:4")
+    ref = _create_surface(
+        mx,
+        worktree=tmp_path / "wt",
+        command="claude --permission-mode acceptEdits",
+        name="ATDD830",
+        mode="surface",
+    )
+
+    ops = [c["op"] for c in mx.calls]
+    assert "new_surface_in_pane" in ops, f"Expected new_surface_in_pane in ops; got {ops}"
+    assert "new_workspace" not in ops, f"new_workspace must not be called; got {ops}"
+    assert "new_surface" not in ops, f"new_surface(pane_ref=None) must not be called; got {ops}"
+
+    spawn_call = next(c for c in mx.calls if c["op"] == "new_surface_in_pane")
+    assert spawn_call["pane_ref"] == "pane:4", (
+        f"Expected pane_ref='pane:4'; got {spawn_call['pane_ref']!r}"
+    )
+    assert ref.startswith("surface:"), f"Expected a surface ref; got {ref!r}"
+
+
+def test_surface_mode_passes_cwd_and_command_to_backend(tmp_path):
+    """_create_surface('surface') forwards cwd and command to new_surface_in_pane."""
+    from atdd.coach.commands.spawn import _create_surface
+
+    wt = tmp_path / "wt"
+    cmd = "ATDD_AGENT_ID=planner-830-001 claude --permission-mode acceptEdits"
+
+    mx = _FullFakeMx(focused_pane="pane:4")
+    _create_surface(mx, worktree=wt, command=cmd, name="ATDD830", mode="surface")
+
+    spawn_call = next(c for c in mx.calls if c["op"] == "new_surface_in_pane")
+    assert spawn_call["cwd"] == str(wt), f"Expected cwd={str(wt)!r}; got {spawn_call['cwd']!r}"
+    assert spawn_call["command"] == cmd, (
+        f"Expected command={cmd!r}; got {spawn_call['command']!r}"
+    )
+    assert spawn_call["name"] == "ATDD830", (
+        f"Expected name='ATDD830'; got {spawn_call['name']!r}"
+    )
+
+
+def test_auto_mode_also_uses_surface_in_pane(tmp_path):
+    """'auto' mode (backward compat alias) must also route through new_surface_in_pane."""
+    from atdd.coach.commands.spawn import _create_surface
+
+    mx = _FullFakeMx(focused_pane="pane:2")
+    _create_surface(mx, worktree=tmp_path, command="claude ...", name="ATDD830", mode="auto")
+
+    ops = [c["op"] for c in mx.calls]
+    assert "new_surface_in_pane" in ops, f"'auto' mode must use new_surface_in_pane; got {ops}"
+    assert "new_workspace" not in ops

--- a/src/atdd/coach/commands/tests/test_e007_smoke_001_new_surface_in_pane_no_broken_pipe.py
+++ b/src/atdd/coach/commands/tests/test_e007_smoke_001_new_surface_in_pane_no_broken_pipe.py
@@ -1,0 +1,55 @@
+# URN: test:dispatch-ux-defaults-and-primer:coach-dispatch-env-aware-defaults:E007-SMOKE-001-new-surface-in-pane-no-broken-pipe
+# Acceptance: acc:dispatch-ux-defaults-and-primer:E007-SMOKE-001-new-surface-in-pane-no-broken-pipe
+# WMBT: wmbt:dispatch-ux-defaults-and-primer:E007
+# Phase: SMOKE
+# Layer: integration
+# Runtime: python
+"""E007-SMOKE-001 — CmuxBackend.new_surface_in_pane succeeds in a real cmux session.
+
+SMOKE: requires ATDD_RUN_SMOKE=1 and a real cmux session (CMUX_WORKSPACE_ID set).
+Verified: resolve_focused_pane() returns a pane ref; new_surface_in_pane()
+invokes cmux new-surface --pane <ref> (canonical RPC) without Broken pipe.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ATDD_RUN_SMOKE"),
+    reason="SMOKE: set ATDD_RUN_SMOKE=1 to run against real infrastructure",
+)
+def test_new_surface_in_pane_no_broken_pipe():
+    """CmuxBackend.resolve_focused_pane + new_surface_in_pane work in real cmux session."""
+    if not os.environ.get("CMUX_WORKSPACE_ID"):
+        pytest.skip("SMOKE requires CMUX_WORKSPACE_ID (must run inside a cmux session)")
+    if not shutil.which("cmux"):
+        pytest.skip("cmux not installed")
+
+    from atdd.coach.utils.multiplexer import CmuxBackend
+
+    backend = CmuxBackend()
+
+    pane_ref = backend.resolve_focused_pane()
+    assert re.match(r"^pane:\d+$", pane_ref), (
+        f"resolve_focused_pane() must return 'pane:N'; got {pane_ref!r}"
+    )
+
+    surface_ref = backend.new_surface_in_pane(
+        pane_ref=pane_ref,
+        cwd=os.getcwd(),
+        command="true",
+        name="atdd-e007-smoke-probe",
+    )
+    assert surface_ref, (
+        f"new_surface_in_pane() returned empty ref (expected 'surface:N')"
+    )
+    assert "broken pipe" not in str(surface_ref).lower(), (
+        f"new_surface_in_pane() result looks like an error: {surface_ref!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e007_unit_001_surface_mode_calls_new_surface_in_pane.py
+++ b/src/atdd/coach/commands/tests/test_e007_unit_001_surface_mode_calls_new_surface_in_pane.py
@@ -1,0 +1,91 @@
+# URN: test:dispatch-ux-defaults-and-primer:coach-dispatch-env-aware-defaults:E007-UNIT-001-surface-mode-calls-new-surface-in-pane
+# Acceptance: acc:dispatch-ux-defaults-and-primer:E007-UNIT-001-surface-mode-calls-new-surface-in-pane
+# WMBT: wmbt:dispatch-ux-defaults-and-primer:E007
+# Phase: RED
+# Layer: application
+"""E007-UNIT-001 — _create_surface with mode='surface' calls new_surface_in_pane.
+
+RED until _create_surface's 'surface' mode is implemented to call
+backend.new_surface_in_pane() instead of new_workspace or new_surface(pane_ref=None).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+class _FakeMx:
+    name = "fake"
+
+    def __init__(self, focused_pane: str = "pane:1") -> None:
+        self.calls: list[dict] = []
+        self._focused_pane = focused_pane
+
+    def resolve_focused_pane(self, workspace=None) -> str:
+        return self._focused_pane
+
+    def new_workspace(self, cwd: str, command: str, name=None) -> str:
+        ref = f"workspace:{len(self.calls) + 1}"
+        self.calls.append({"op": "new_workspace", "name": name, "ref": ref})
+        return ref
+
+    def new_surface(self, workspace_ref=None, pane_ref=None, cwd=None, command=None,
+                    name=None, direction=None) -> str:
+        ref = f"surface:{len(self.calls) + 1}"
+        self.calls.append({"op": "new_surface", "pane_ref": pane_ref, "name": name, "ref": ref})
+        return ref
+
+    def new_surface_in_pane(self, pane_ref: str, cwd=None, command=None,
+                             name=None, workspace=None) -> str:
+        ref = f"surface:{len(self.calls) + 1}"
+        self.calls.append({"op": "new_surface_in_pane", "pane_ref": pane_ref, "name": name, "ref": ref})
+        return ref
+
+
+def test_surface_mode_calls_new_surface_in_pane(tmp_path):
+    """_create_surface('surface') must call new_surface_in_pane, not new_workspace."""
+    from atdd.coach.commands.spawn import _create_surface
+
+    mx = _FakeMx(focused_pane="pane:4")
+    result = _create_surface(
+        mx,
+        worktree=tmp_path,
+        command="claude ...",
+        name="ATDD830",
+        mode="surface",
+    )
+
+    ops = [c["op"] for c in mx.calls]
+    assert "new_surface_in_pane" in ops, (
+        f"Expected 'new_surface_in_pane' in ops; got {ops}"
+    )
+    assert "new_workspace" not in ops, (
+        f"'new_workspace' must not be called in surface mode; got {ops}"
+    )
+    assert "new_surface" not in ops, (
+        f"'new_surface' must not be called in surface mode; got {ops}"
+    )
+    assert result.startswith("surface:"), f"Expected a surface ref; got {result!r}"
+
+
+def test_surface_mode_passes_resolved_pane_to_new_surface_in_pane(tmp_path):
+    """The pane_ref passed to new_surface_in_pane must be the resolved focused pane."""
+    from atdd.coach.commands.spawn import _create_surface
+
+    mx = _FakeMx(focused_pane="pane:7")
+    _create_surface(
+        mx,
+        worktree=tmp_path,
+        command="claude ...",
+        name="ATDD830",
+        mode="surface",
+    )
+
+    surface_calls = [c for c in mx.calls if c["op"] == "new_surface_in_pane"]
+    assert len(surface_calls) == 1
+    assert surface_calls[0]["pane_ref"] == "pane:7", (
+        f"Expected pane_ref='pane:7'; got {surface_calls[0]['pane_ref']!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e007_unit_002_resolve_multiplexer_mode_defaults_surface.py
+++ b/src/atdd/coach/commands/tests/test_e007_unit_002_resolve_multiplexer_mode_defaults_surface.py
@@ -1,0 +1,66 @@
+# URN: test:dispatch-ux-defaults-and-primer:coach-dispatch-env-aware-defaults:E007-UNIT-002-resolve-multiplexer-mode-defaults-surface
+# Acceptance: acc:dispatch-ux-defaults-and-primer:E007-UNIT-002-resolve-multiplexer-mode-defaults-surface
+# WMBT: wmbt:dispatch-ux-defaults-and-primer:E007
+# Phase: RED
+# Layer: application
+"""E007-UNIT-002 — resolve_multiplexer_mode defaults to 'surface' in all cases.
+
+RED until resolve_multiplexer_mode returns 'surface' when CMUX_WORKSPACE_ID is
+set (instead of the old 'pane') and when neither env var is set (instead of
+the old 'workspace').
+"""
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def test_resolve_defaults_to_surface_when_cmux_workspace_id_set():
+    """resolve_multiplexer_mode returns 'surface' when CMUX_WORKSPACE_ID is set."""
+    from atdd.coach.commands.coach import resolve_multiplexer_mode
+
+    result = resolve_multiplexer_mode(
+        explicit_flag=None,
+        env={"CMUX_WORKSPACE_ID": "workspace:1"},
+    )
+    assert result == "surface", (
+        f"Expected 'surface' when CMUX_WORKSPACE_ID is set; got {result!r}"
+    )
+
+
+def test_resolve_defaults_to_surface_when_no_env():
+    """resolve_multiplexer_mode returns 'surface' when no mux env vars are set."""
+    from atdd.coach.commands.coach import resolve_multiplexer_mode
+
+    result = resolve_multiplexer_mode(
+        explicit_flag=None,
+        env={},
+    )
+    assert result == "surface", (
+        f"Expected 'surface' when no mux env set; got {result!r}"
+    )
+
+
+def test_resolve_respects_tmux_env():
+    """resolve_multiplexer_mode returns 'surface' when TMUX is set."""
+    from atdd.coach.commands.coach import resolve_multiplexer_mode
+
+    result = resolve_multiplexer_mode(
+        explicit_flag=None,
+        env={"TMUX": "/tmp/tmux-12345,0,0"},
+    )
+    assert result == "surface", (
+        f"Expected 'surface' when TMUX is set; got {result!r}"
+    )
+
+
+def test_resolve_explicit_flag_wins():
+    """An explicit flag overrides the environment-based default."""
+    from atdd.coach.commands.coach import resolve_multiplexer_mode
+
+    result = resolve_multiplexer_mode(
+        explicit_flag="surface",
+        env={"CMUX_WORKSPACE_ID": "workspace:1"},
+    )
+    assert result == "surface"

--- a/src/atdd/coach/commands/tests/test_e007_unit_003_deprecated_modes_raise_error.py
+++ b/src/atdd/coach/commands/tests/test_e007_unit_003_deprecated_modes_raise_error.py
@@ -1,0 +1,79 @@
+# URN: test:dispatch-ux-defaults-and-primer:coach-dispatch-env-aware-defaults:E007-UNIT-003-deprecated-modes-raise-error
+# Acceptance: acc:dispatch-ux-defaults-and-primer:E007-UNIT-003-deprecated-modes-raise-error
+# WMBT: wmbt:dispatch-ux-defaults-and-primer:E007
+# Phase: RED
+# Layer: application
+"""E007-UNIT-003 — _create_surface raises DeprecatedMultiplexerModeError for workspace/pane modes.
+
+RED until DeprecatedMultiplexerModeError is added to spawn.py and _create_surface
+raises it for mode='workspace' and mode='pane'.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+class _FakeMx:
+    name = "fake"
+
+    def resolve_focused_pane(self, workspace=None) -> str:
+        return "pane:1"
+
+    def new_workspace(self, cwd, command, name=None):
+        return "workspace:1"
+
+    def new_surface(self, workspace_ref=None, pane_ref=None, cwd=None,
+                    command=None, name=None, direction=None):
+        return "surface:1"
+
+    def new_surface_in_pane(self, pane_ref, cwd=None, command=None, name=None, workspace=None):
+        return "surface:1"
+
+
+def test_workspace_mode_raises_deprecated_error(tmp_path):
+    """_create_surface with mode='workspace' must raise DeprecatedMultiplexerModeError."""
+    from atdd.coach.commands.spawn import DeprecatedMultiplexerModeError, _create_surface
+
+    with pytest.raises(DeprecatedMultiplexerModeError) as exc_info:
+        _create_surface(
+            _FakeMx(),
+            worktree=tmp_path,
+            command="claude ...",
+            name="ATDD830",
+            mode="workspace",
+        )
+
+    msg = str(exc_info.value)
+    assert "new-workspace" in msg, f"Error message must reference 'new-workspace'; got: {msg!r}"
+    assert "surface" in msg, f"Error message must reference 'surface' mode; got: {msg!r}"
+
+
+def test_pane_mode_raises_deprecated_error(tmp_path):
+    """_create_surface with mode='pane' must raise DeprecatedMultiplexerModeError."""
+    from atdd.coach.commands.spawn import DeprecatedMultiplexerModeError, _create_surface
+
+    with pytest.raises(DeprecatedMultiplexerModeError) as exc_info:
+        _create_surface(
+            _FakeMx(),
+            worktree=tmp_path,
+            command="claude ...",
+            name="ATDD830",
+            mode="pane",
+        )
+
+    msg = str(exc_info.value)
+    assert "new-pane" in msg, f"Error message must reference 'new-pane'; got: {msg!r}"
+    assert "surface" in msg, f"Error message must reference 'surface' mode; got: {msg!r}"
+
+
+def test_deprecated_error_is_value_error_subclass():
+    """DeprecatedMultiplexerModeError must be a ValueError subclass."""
+    from atdd.coach.commands.spawn import DeprecatedMultiplexerModeError
+
+    assert issubclass(DeprecatedMultiplexerModeError, ValueError), (
+        "DeprecatedMultiplexerModeError must be a ValueError subclass"
+    )

--- a/src/atdd/coach/commands/tests/test_y002_unit_001_persona_spawn_creates_no_obs_surface.py
+++ b/src/atdd/coach/commands/tests/test_y002_unit_001_persona_spawn_creates_no_obs_surface.py
@@ -98,7 +98,7 @@ def test_persona_spawn_creates_no_obs_surface(tmp_path, monkeypatch):
         issue_number=736,
         llm="claude-code",
         multiplexer=fake_mx,
-        multiplexer_mode="pane",
+        multiplexer_mode="surface",
         dry_run=False,
         max_retries=0,
         escalation_channel=None,

--- a/src/atdd/coach/commands/two_phase_commit.py
+++ b/src/atdd/coach/commands/two_phase_commit.py
@@ -200,7 +200,7 @@ def phase_b_launch_sessions(
     decision_writer: DecisionWriter,
     run_id: str,
     *,
-    multiplexer_mode: str = "workspace",
+    multiplexer_mode: str = "surface",
     autonomous: bool = False,
 ) -> PhaseBResult:
     """Launch one session per issue with asymmetric rollback semantics.
@@ -256,19 +256,13 @@ def phase_b_launch_sessions(
         )
 
         try:
-            if multiplexer_mode == "pane":
-                ref = backend.new_surface(
-                    cwd=str(worktree_path),
-                    command=launch_cmd,
-                    name=canonical_name,
-                    direction="right",
-                )
-            else:
-                ref = backend.new_workspace(
-                    cwd=str(worktree_path),
-                    command=launch_cmd,
-                    name=canonical_name,
-                )
+            pane_ref = backend.resolve_focused_pane() if hasattr(backend, "resolve_focused_pane") else "pane:1"
+            ref = backend.new_surface_in_pane(
+                pane_ref=pane_ref,
+                cwd=str(worktree_path),
+                command=launch_cmd,
+                name=canonical_name,
+            )
         except (MultiplexerError, NotImplementedError) as exc:
             # Asymmetric rollback per spec §4.6: failed launches are
             # logged but already-launched siblings are NOT undone. No

--- a/src/atdd/coach/handlers/spawn.py
+++ b/src/atdd/coach/handlers/spawn.py
@@ -303,11 +303,8 @@ def _spawn_observer(
 ) -> None:
     """Co-spawn the observer L1 sidecar alongside the persona agent.
 
-    In pane mode, attaches the observer as a tab inside the persona's pane
-    via new_surface_in_pane, so each grid cell holds both tabs without
-    consuming an extra pane slot (#658). In other modes, falls back to
-    new_surface (creates a new pane/workspace).
-
+    Attaches the observer as a tab inside the persona's surface via
+    new_surface_in_pane (canonical cmux RPC — cmux new-surface --pane <ref>).
     Uses the same multiplexer backend as the persona spawn so that tests
     can assert both calls via a single FakeMultiplexer injection.
     Observer is supplementary — callers must catch and warn on any exception.
@@ -321,29 +318,22 @@ def _spawn_observer(
         f" --runtime-dir {runtime_root}"
         f" --worktree {worktree}"
     )
-    # Canonical observer naming: <persona-canonical-name>:obs (workspace-mode
-    # fallback uses derived form since canonical_name isn't readily available here).
-    # See #695 for the multiplexer-agnostic naming convention.
     observer_name = f"ATDD{ctx.issue_number}-{phase}:obs"
-    # #734: same injected backend as the persona spawn so a single
-    # FakeMultiplexer (passed by construction, not monkeypatched) records
-    # both the persona and observer calls.
     multiplexer = ctx.multiplexer_backend or cmd_spawn_mod._resolve_multiplexer()
 
-    if ctx.multiplexer_mode == "pane" and persona_surface_ref is not None:
+    if persona_surface_ref is not None and hasattr(multiplexer, "surface_to_pane"):
         pane_ref = multiplexer.surface_to_pane(persona_surface_ref)
-        multiplexer.new_surface_in_pane(
-            pane_ref=pane_ref,
-            cwd=str(worktree),
-            command=observer_cmd,
-            name=observer_name,
-        )
+    elif hasattr(multiplexer, "resolve_focused_pane"):
+        pane_ref = multiplexer.resolve_focused_pane()
     else:
-        multiplexer.new_surface(
-            cwd=str(worktree),
-            command=observer_cmd,
-            name=observer_name,
-        )
+        pane_ref = "pane:1"
+
+    multiplexer.new_surface_in_pane(
+        pane_ref=pane_ref,
+        cwd=str(worktree),
+        command=observer_cmd,
+        name=observer_name,
+    )
 
 
 def _write_cospawn_decision(

--- a/src/atdd/coach/utils/multiplexer.py
+++ b/src/atdd/coach/utils/multiplexer.py
@@ -85,6 +85,18 @@ class MultiplexerBackend(ABC):
             f"{self.name} backend does not support new_surface_in_pane"
         )
 
+    def resolve_focused_pane(
+        self, workspace: Optional[MultiplexerRef] = None
+    ) -> MultiplexerRef:
+        """Return the currently-focused pane ref for surface-mode spawning.
+
+        Used by _create_surface('surface') to pick the canonical spawn
+        target without calling the deprecated new-pane RPC (issue #830).
+        """
+        raise NotImplementedError(
+            f"{self.name} backend does not support resolve_focused_pane"
+        )
+
     def surface_to_pane(self, surface_ref: MultiplexerRef) -> MultiplexerRef:
         """Return the pane ref that owns surface_ref.
 
@@ -416,6 +428,22 @@ class CmuxBackend(MultiplexerBackend):
                 capture=False,
             )
         return surface_ref
+
+    def resolve_focused_pane(
+        self, workspace: Optional[MultiplexerRef] = None
+    ) -> MultiplexerRef:
+        # Parse `cmux list-panes` to find the currently-focused pane.
+        # Output format: "* pane:4  [N surfaces]  [focused]"
+        # Returns the first pane ref found — the focused pane in a typical
+        # single-pane workspace is always the only entry.
+        result = _run(["cmux", "list-panes", *_ws_flag(workspace)])
+        pane_pattern = re.compile(r"\bpane:(\d+)\b")
+        for match in pane_pattern.finditer(result.stdout or ""):
+            return f"pane:{match.group(1)}"
+        raise MultiplexerError(
+            f"cmux list-panes returned no pane refs "
+            f"(workspace={workspace!r}): {(result.stdout or '').strip()!r}"
+        )
 
     def surface_to_pane(
         self, surface_ref: MultiplexerRef, workspace: Optional[MultiplexerRef] = None
@@ -1012,6 +1040,10 @@ class FakeMultiplexer(MultiplexerBackend):
         self.calls: list[dict] = []
         self._surface_pane: dict[str, str] = {}
         self.new_persona_surface_calls: list[dict] = []
+        self._focused_pane: str = "pane:1"
+
+    def resolve_focused_pane(self, workspace: Optional[MultiplexerRef] = None) -> MultiplexerRef:
+        return self._focused_pane
 
     def new_workspace(self, cwd: str, command: str, name: Optional[str] = None) -> MultiplexerRef:
         ref = f"workspace:{len(self.calls) + 1}"

--- a/src/atdd/coach/validators/test_observer_universal_cospawn.py
+++ b/src/atdd/coach/validators/test_observer_universal_cospawn.py
@@ -14,9 +14,9 @@ to verify the new contract: spawn entry points create one persona surface
 (via new_surface, not new_persona_surface) and zero observer surfaces.
 
 Entry points enumerated (>= 3 required per L003-INTEGRATION-003):
-1. cmd_spawn(multiplexer_mode='pane') — direct API, pane mode
+1. cmd_spawn(multiplexer_mode='surface') — direct API, surface mode (canonical since #830)
 2. cmd_spawn(multiplexer_mode='auto') — direct API, auto mode
-3. handlers/spawn.handle(ctx, INIT->PLANNED) — coach state machine (pane mode)
+3. handlers/spawn.handle(ctx, INIT->PLANNED) — coach state machine (surface mode)
 """
 from __future__ import annotations
 
@@ -53,7 +53,7 @@ def _runtime(tmp_path: Path) -> Path:
 
 
 def _spawn_via_cmd_spawn_pane(tmp_path: Path, monkeypatch) -> FakeMultiplexer:
-    """Entry point 1: cmd_spawn with multiplexer_mode='pane'."""
+    """Entry point 1: cmd_spawn with multiplexer_mode='surface' (canonical since #830)."""
     from atdd.coach.commands import spawn as cmd_spawn_mod, session_template
 
     wt = _wt(tmp_path)
@@ -105,7 +105,7 @@ def _spawn_via_cmd_spawn_pane(tmp_path: Path, monkeypatch) -> FakeMultiplexer:
         runtime_root=rt,
         phase="planned",
         multiplexer=fake_mx,
-        multiplexer_mode="pane",
+        multiplexer_mode="surface",
     )
     return fake_mx
 
@@ -168,7 +168,7 @@ def _spawn_via_cmd_spawn_auto(tmp_path: Path, monkeypatch) -> FakeMultiplexer:
 
 
 def _spawn_via_coach_handler(tmp_path: Path, monkeypatch) -> FakeMultiplexer:
-    """Entry point 3: handlers/spawn.handle() (coach state machine, pane mode)."""
+    """Entry point 3: handlers/spawn.handle() (coach state machine, surface mode)."""
     from atdd.coach.handlers import spawn as spawn_handler
     from atdd.coach.handlers.state_machine import CoachContext, Phase, Transition
     from atdd.coach.commands import spawn as cmd_spawn_mod
@@ -196,12 +196,24 @@ def _spawn_via_coach_handler(tmp_path: Path, monkeypatch) -> FakeMultiplexer:
         "atdd.coach.commands.spawn._build_arch_section",
         lambda issue: None,
     )
+    monkeypatch.setattr(
+        "atdd.coach.commands.spawn._pre_trust_worktree",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "atdd.coach.commands.spawn._wait_for_claude_ready",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "atdd.coach.commands.spawn._verify_stage",
+        lambda *a, **kw: None,
+    )
 
     ctx = CoachContext(
         issue_number=999,
         llm="claude-code",
         multiplexer=fake_mx,
-        multiplexer_mode="pane",
+        multiplexer_mode="surface",
         dry_run=False,
         max_retries=0,
         escalation_channel=None,
@@ -220,9 +232,9 @@ def _spawn_via_coach_handler(tmp_path: Path, monkeypatch) -> FakeMultiplexer:
 
 
 ENTRY_POINTS = [
-    ("cmd_spawn_pane", _spawn_via_cmd_spawn_pane),
+    ("cmd_spawn_surface", _spawn_via_cmd_spawn_pane),
     ("cmd_spawn_auto", _spawn_via_cmd_spawn_auto),
-    ("coach_handler_pane", _spawn_via_coach_handler),
+    ("coach_handler_surface", _spawn_via_coach_handler),
 ]
 
 
@@ -230,14 +242,18 @@ ENTRY_POINTS = [
 def test_entry_point_creates_exactly_one_persona_surface(
     entry_point_name, invoke_fn, tmp_path, monkeypatch
 ):
-    """Every entry point creates exactly one persona surface (new_surface, not new_persona_surface).
+    """Every entry point creates exactly one persona surface via new_surface_in_pane
+    (canonical since #830 — cmux new-surface --pane <ref>), not new_persona_surface.
 
     Issue #754: per-worker observers removed. Entry points no longer call
-    new_persona_surface — they call new_surface for the worker only.
+    new_persona_surface — they call new_surface_in_pane for the worker only.
     """
     fake_mx = invoke_fn(tmp_path, monkeypatch)
 
-    surface_calls = [c for c in fake_mx.calls if c["op"] == "new_surface"]
+    surface_calls = [
+        c for c in fake_mx.calls
+        if c["op"] in ("new_surface", "new_surface_in_pane")
+    ]
     persona_surface_calls = [
         c for c in surface_calls
         if not (
@@ -267,7 +283,10 @@ def test_entry_point_produces_no_observer_surface(
     """
     fake_mx = invoke_fn(tmp_path, monkeypatch)
 
-    surface_calls = [c for c in fake_mx.calls if c["op"] == "new_surface"]
+    surface_calls = [
+        c for c in fake_mx.calls
+        if c["op"] in ("new_surface", "new_surface_in_pane")
+    ]
     observer_calls = [
         c for c in surface_calls
         if "observer" in (c.get("name") or "").lower()


### PR DESCRIPTION
Closes #830

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #830 |
| Labels | atdd-issue, atdd:SMOKE, archetype:coach |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.