### PR TITLE
chore(atdd): Shim Runtime-Dir Relative Path Bleeds Across Cwd Boundary (#860)

### DIFF
--- a/.atdd/baselines/validation/planner.yaml
+++ b/.atdd/baselines/validation/planner.yaml
@@ -1,5 +1,5 @@
 phase: planner
-passed_at: '2026-05-25T20:21:55.221533+00:00'
-source_hash: ff3eff2e086b7a189de58708cd28bec13d1a8e70d2936dddb91e0d7d0a8a49ab
-atdd_version: 3.82.4
+passed_at: '2026-05-25T23:45:38.034012+00:00'
+source_hash: 4d23241645fb89c5f6afeb074e0b2c1a33ec70188b6ca5c2b1e3b8c27c3c2928
+atdd_version: 3.83.0
 skipped_api: true

--- a/.atdd/baselines/validation/tester.yaml
+++ b/.atdd/baselines/validation/tester.yaml
@@ -1,5 +1,5 @@
 phase: tester
-passed_at: '2026-05-25T20:02:58.697896+00:00'
-source_hash: 4c0fdcdfddd2764472df0f217b4f11e3b5827b992b11fda4b34a7bb55a1de5f1
-atdd_version: 3.82.4
+passed_at: '2026-05-26T05:34:14.834734+00:00'
+source_hash: 232d72365079976ee6bffcec939421bdae131d1095cdc60d42852668e76176be
+atdd_version: 3.83.0
 skipped_api: true

--- a/.atdd/baselines/validation/tester.yaml
+++ b/.atdd/baselines/validation/tester.yaml
@@ -1,5 +1,5 @@
 phase: tester
-passed_at: '2026-05-26T05:34:14.834734+00:00'
+passed_at: '2026-05-26T07:06:15.177959+00:00'
 source_hash: 232d72365079976ee6bffcec939421bdae131d1095cdc60d42852668e76176be
 atdd_version: 3.83.0
 skipped_api: true

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1182,3 +1182,14 @@ sessions:
   wagon: govern-lifecycle
   feature: feature:govern-lifecycle:smoke-false-green-prevention
   train: 0001-self-compliance-validate
+- id: '860'
+  slug: shim-runtime-dir-relative-path-cwd-bleed
+  file: plan/spawn_agents/E019.yaml
+  issue_number: 860
+  type: cleanup
+  status: INIT
+  created: '2026-05-26'
+  archived: null
+  wagon: spawn-agents
+  feature: feature:spawn-agents:shim-runtime-dir-absolute-path
+  train: 0002-coach-drives-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1187,7 +1187,7 @@ sessions:
   file: plan/spawn_agents/E019.yaml
   issue_number: 860
   type: cleanup
-  status: INIT
+  status: PLANNED
   created: '2026-05-26'
   archived: null
   wagon: spawn-agents

--- a/docs/smoke-audit.md
+++ b/docs/smoke-audit.md
@@ -120,6 +120,10 @@ of bypass patterns.
 | acc:spawn-agents:E016-SMOKE-001-no-popen-exec-failure-with-cli-return-env | real (atdd-shim CLI) | Popen success | N/A (single component) | — |
 | acc:spawn-agents:E017-SMOKE-001-shim-invoked-via-same-python-as-coach | real (atdd spawn) | Python interpreter match | N/A (single component) | — |
 | acc:spawn-agents:E018-SMOKE-001-live-spawn-pipeline-detects-dead-shim | real (atdd spawn) | dead shim detection | N/A (single component) | — |
+| acc:spawn-agents:E019-SMOKE-001-shim-command-runtime-dir-is-absolute-in-live-spawn | real (_build_shim_command) | absolute path in --runtime-dir | N/A (single component) | — |
+| acc:spawn-agents:E020-SMOKE-001-deployed-shim-resolves-relative-runtime-dir | real (atdd.coach.shim.__main__) | absolute path after normalization | N/A (single component) | — |
+| acc:spawn-agents:E021-SMOKE-001-live-process-alive-message-names-polled-path | real (_verify_process_alive) | message content | N/A (single component) | — |
+| acc:spawn-agents:L002-SMOKE-001-relative-runtime-root-output-log-at-absolute-path | real (cmd_spawn + fixture shim) | output.log location | N/A (single component) | — |
 | acc:spawn-agents:L001-SMOKE-001-claude-code-no-modal-on-bash-read | real (atdd spawn + claude) | modal absence | N/A (single component) | — |
 | acc:spawn-agents:M001-SMOKE-001-live-session-naming-apply-has-no-slash-rename | real (atdd spawn) | session name format | N/A (single component) | — |
 | acc:spawn-agents:M002-SMOKE-001-live-observer-rules-pass-layer-b-validator | real (atdd validate) | rules validation | N/A (validator) | — |

--- a/plan/_wagons.yaml
+++ b/plan/_wagons.yaml
@@ -621,7 +621,7 @@ wagons:
   - name: commons:code:implementation
     from: wagon:implement-code
   wmbt:
-    total: 53
+    total: 58
     R001: minimize stale local manifest status after a successful GitHub transition
     R002: minimize misleading layout errors during post-transition re-enter
     R003: minimize stale hierarchy_coverage_features ratchet baseline carrying tactical
@@ -745,6 +745,22 @@ wagons:
       ATDD_SKIP_REGISTRY_CHECK), requiring ATDD_BYPASS_REASON for the 4 remaining
       flags with audit-jsonl logging, and adding a meta-guard validator that fails
       CI when bypass count exceeds the audited baseline (#851)
+    E027: minimize quantity of smoke-acceptances-unclassified-by-structural-false-green-cause
+      by classifying every phase:SMOKE acceptance in plan/ and committing docs/smoke-audit.md
+      with a per-cause histogram and Future-Tracking section (#855)
+    E028: minimize likelihood of new-smoke-tests-using-synthetic-fixtures-that-bypass-production-wiring
+      by adding three anti-pattern rules to smoke.convention.yaml and implementing
+      the planner.smoke.synthetic-fixture-bypass validator (#855)
+    E029: minimize quantity of lived-incident-smoke-tests-asserting-on-synthetic-fixtures-rather-than-real-spawn
+      by retrofitting test_e003_smoke_001 and test_e003_smoke_002 to drive the real
+      atdd spawn entry point and removing the ATDD_RUN_SMOKE opt-in from test_e004_smoke_001
+      (#855)
+    L002: minimize quantity of existing-smoke-acceptances-escaping-the-new-anti-pattern-detector
+      by implementing a meta-walker that exhaustively applies the synthetic-fixture-bypass
+      scan to every phase:SMOKE acceptance in plan/ (#855)
+    M002: minimize quantity of post-smoke-production-bugs-per-release-wave by maintaining
+      a Future-Tracking table in docs/smoke-audit.md with expectation=0 for all waves
+      >= v3.83.0 (#855)
   total: 0
   manifest: plan/govern_lifecycle/_govern_lifecycle.yaml
   path: plan/govern_lifecycle/
@@ -1422,6 +1438,14 @@ wagons:
     contract: null
     telemetry: null
     to: external
+  - name: coach:spawn:spawn-detector-process-alive-stage
+    contract: null
+    telemetry: null
+    to: external
+  - name: coach:spawn:shim-runtime-dir-absolute-path-fix
+    contract: null
+    telemetry: null
+    to: external
   consume:
   - name: commons:coach:runtime-event-schema
     from: wagon:freeze-runtime-contracts
@@ -1432,7 +1456,7 @@ wagons:
   - name: commons:coach:decisions-jsonl-writer
     from: wagon:drive-state-machine
   wmbt:
-    total: 24
+    total: 30
     E001: minimize likelihood of unrouted-persona-launches-bypassing-the-spawn-rule-id
     D001: minimize likelihood of ambiguity-in-substrate-spawn-harness-block-rendering
     E002: minimize quantity of post-launch-sessions-with-non-canonical-name-or-layout
@@ -1457,6 +1481,12 @@ wagons:
     R001: minimize likelihood of deny-pattern-bash-invocations-handled-via-in-band-modal-or-unrouted-escalation
     E015: minimize likelihood of planner-agent-commits-planned-without-verifying-smoke-acceptance-coverage
     E016: minimize likelihood of shell-style-env-prefix-injected-into-shim-argv-causing-popen-exec-failure
+    E017: minimize likelihood of coach-spawn-shim-command-resolves-to-wrong-atdd-installation-on-multi-install-hosts
+    E018: minimize likelihood of coach-spawn-stage-detector-reports-success-when-spawned-process-has-already-crashed
+    E019: minimize likelihood of shim-runtime-dir-relative-path-bleeds-into-worktree-cwd-at-build-shim-command
+    E020: minimize likelihood of persona-shim-operates-with-relative-runtime-dir-if-future-caller-bypasses-primary-fix
+    E021: minimize likelihood of process-alive-timeout-mislabels-cwd-bleed-path-mismatch-as-silent-shim-crash
+    L002: minimize likelihood of relative-runtime-root-causes-output-log-to-land-at-worktree-path-instead-of-coach-polled-path
   total: 0
   manifest: plan/spawn_agents/_spawn_agents.yaml
   path: plan/spawn_agents/

--- a/plan/spawn_agents/E019.yaml
+++ b/plan/spawn_agents/E019.yaml
@@ -1,0 +1,117 @@
+urn: "wmbt:spawn-agents:E019"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "shim-runtime-dir-relative-path-bleeds-into-worktree-cwd-at-build-shim-command"
+context_clarifier: "_build_shim_command passes --runtime-dir as str(runtime_root), which preserves relative paths like '.atdd/runtime'. When the cmux-launched shell cd's into the worktree before exec'ing the shim, the shim resolves that relative path against the worktree CWD. Result: shim writes <worktree>/.atdd/runtime/agents/<id>/output.log while coach polls <main>/.atdd/runtime/agents/<id>/output.log — different files. The _verify_process_alive detector (E018, #857) times out and emits 'shim may have crashed silently' — a false diagnosis. Reproduced 2026-05-26 on v3.83.0 test-drive of issue #828 (#860). Fix: resolve runtime_root to absolute via runtime_root.resolve() in _build_shim_command, and also at the cmd_spawn entry point where Path(runtime_root) is first constructed, so every downstream callee receives an absolute-path invariant regardless of whether the caller supplied a relative or absolute path."
+lens: "functional.effectiveness"
+statement: "minimize likelihood of shim-runtime-dir-relative-path-bleeds-into-worktree-cwd-at-build-shim-command by resolving runtime_root to an absolute path inside _build_shim_command (via runtime_root.resolve()) and at the cmd_spawn entry point where Path(runtime_root) is first materialized, so every downstream callee receives an absolute-path invariant regardless of whether the caller supplied a relative or absolute path"
+acceptances:
+  - identity:
+      urn: "acc:spawn-agents:E019-UNIT-001-build-shim-command-resolves-relative-runtime-dir-to-absolute"
+      id: "AC-UNIT-001"
+      purpose: "_build_shim_command with a relative runtime_root produces a --runtime-dir argument that is an absolute path (starts with /)"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "src/atdd/coach/commands/spawn.py is imported"
+        - "runtime_root is Path('.atdd/runtime') (relative)"
+    when:
+      abstract: "_build_shim_command('claude', 'agent-1', runtime_root) is called"
+    then:
+      abstract:
+        - "The returned command string contains '--runtime-dir' followed by a path starting with '/'"
+        - "The path in the command does not start with a relative prefix (no leading './' or bare directory name)"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"
+  - identity:
+      urn: "acc:spawn-agents:E019-UNIT-002-build-shim-command-absolute-path-unchanged"
+      id: "AC-UNIT-002"
+      purpose: "_build_shim_command with an already-absolute runtime_root passes the path unchanged (idempotent — resolve() on an absolute path is a no-op)"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "runtime_root is Path('/tmp/test-runtime') (absolute)"
+    when:
+      abstract: "_build_shim_command('claude', 'agent-1', runtime_root) is called"
+    then:
+      abstract:
+        - "The returned command string contains '--runtime-dir /tmp/test-runtime'"
+        - "The path value is identical to the input absolute path (no transformation)"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"
+  - identity:
+      urn: "acc:spawn-agents:E019-UNIT-003-cmd-spawn-materializes-absolute-runtime-root"
+      id: "AC-UNIT-003"
+      purpose: "cmd_spawn resolves runtime_root to absolute at construction time so all downstream callees (including _build_shim_command) receive an absolute Path regardless of what the caller provided"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A FakeMultiplexer scripted for surface creation"
+        - "runtime_root supplied as a relative path string to cmd_spawn"
+        - "_build_shim_command is monkeypatched to capture its runtime_root argument"
+    when:
+      abstract: "cmd_spawn is invoked in cli-return mode with the relative runtime_root"
+    then:
+      abstract:
+        - "_build_shim_command receives a runtime_root whose .is_absolute() is True"
+        - "The absolute path resolves to the expected directory under the actual CWD at the time of the call"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"
+  - identity:
+      urn: "acc:spawn-agents:E019-INTEGRATION-001-path-bleed-regression"
+      id: "AC-INTEGRATION-001"
+      purpose: "Regression: a fixture that simulates CWD change between runtime_root construction and shim exec confirms output.log lands at the absolute runtime_root path, not at the CWD-bled relative location"
+      phase: "GREEN"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "A tmp_path-based runtime_root specified as a relative path (e.g. Path('out/runtime'))"
+        - "A fixture that changes CWD to a different tmp directory (simulating the worktree cd)"
+        - "A fake shim fixture that writes one byte to agents/<id>/output.log at its received --runtime-dir"
+    when:
+      abstract: "_build_shim_command is called with the relative runtime_root; the resulting --runtime-dir value is extracted and passed to the fake shim"
+    then:
+      abstract:
+        - "The fake shim writes output.log at the resolved absolute path (constructed before the CWD change)"
+        - "No output.log exists under the CWD-bled directory (changed CWD + relative suffix)"
+        - "_verify_process_alive polled at the absolute path finds the heartbeat byte and does not raise"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"
+  - identity:
+      urn: "acc:spawn-agents:E019-SMOKE-001-shim-command-runtime-dir-is-absolute-in-live-spawn"
+      id: "AC-SMOKE-001"
+      purpose: "In the deployed codebase, _build_shim_command always produces a --runtime-dir value that is an absolute path; verified by calling the function with a relative input against the live installed package"
+      phase: "SMOKE"
+    harness:
+      type: "smoke"
+      category: "backend"
+    given:
+      abstract:
+        - "_build_shim_command is imported from the deployed atdd.coach.commands.spawn"
+        - "runtime_root is Path('.atdd/runtime') (relative)"
+        - "ATDD_RUN_SMOKE=1 is set"
+    when:
+      abstract: "_build_shim_command('claude --no-update', 'smoke-agent-1', runtime_root) is called"
+    then:
+      abstract:
+        - "The returned command string contains '--runtime-dir' followed by a path starting with '/'"
+        - "The absolute path can be constructed with Path(value).is_absolute() == True"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"

--- a/plan/spawn_agents/E020.yaml
+++ b/plan/spawn_agents/E020.yaml
@@ -1,0 +1,73 @@
+urn: "wmbt:spawn-agents:E020"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "persona-shim-operates-with-relative-runtime-dir-if-future-caller-bypasses-primary-fix"
+context_clarifier: "E019 (#860) resolves runtime_root to absolute in _build_shim_command and cmd_spawn. As a belt-and-suspenders guard, the shim's own argparse handler should also resolve --runtime-dir to absolute on entry, so that a future caller that passes a relative path (e.g. a new adapter, a test fixture, or a direct CLI invocation of python -m atdd.coach.shim) still produces a deterministic absolute path. Without this guard, a single caller mistake bypasses E019 and reintroduces the same CWD-bleed regression. Path.resolve() on an already-absolute path is a no-op, so the normalization is idempotent and has zero cost for the common case."
+lens: "functional.effectiveness"
+statement: "minimize likelihood of persona-shim-operates-with-relative-runtime-dir-if-future-caller-bypasses-primary-fix by normalizing args.runtime_dir to absolute via .resolve() in atdd-shim's main() after argparse, before constructing PersonaShim, so the shim always operates with a deterministic absolute path regardless of the caller"
+acceptances:
+  - identity:
+      urn: "acc:spawn-agents:E020-UNIT-001-shim-main-resolves-relative-runtime-dir-to-absolute"
+      id: "AC-UNIT-001"
+      purpose: "atdd-shim main() resolves a relative --runtime-dir to absolute before constructing PersonaShim; PersonaShim.runtime_dir is absolute"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "PersonaShim is monkeypatched to capture its runtime_dir constructor argument"
+        - "main() is invoked with ['--agent-id', 'x', '--runtime-dir', '.atdd/runtime', '--', 'echo', 'ok']"
+    when:
+      abstract: "main() processes the arguments and constructs PersonaShim"
+    then:
+      abstract:
+        - "PersonaShim receives a runtime_dir whose .is_absolute() is True"
+        - "The resolved path ends with the expected relative suffix ('.atdd/runtime')"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"
+  - identity:
+      urn: "acc:spawn-agents:E020-UNIT-002-shim-main-absolute-runtime-dir-unchanged"
+      id: "AC-UNIT-002"
+      purpose: "When --runtime-dir is already absolute, main() passes it unchanged to PersonaShim (resolve() is idempotent on absolute paths)"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "PersonaShim is monkeypatched to capture runtime_dir"
+        - "main() is invoked with ['--agent-id', 'x', '--runtime-dir', '/tmp/abs-runtime', '--', 'echo', 'ok']"
+    when:
+      abstract: "main() processes the arguments"
+    then:
+      abstract:
+        - "PersonaShim receives runtime_dir == Path('/tmp/abs-runtime')"
+        - "The path is identical to the input — no transformation occurred"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"
+  - identity:
+      urn: "acc:spawn-agents:E020-SMOKE-001-deployed-shim-resolves-relative-runtime-dir"
+      id: "AC-SMOKE-001"
+      purpose: "The deployed atdd.coach.shim.__main__ module resolves --runtime-dir to absolute before handing it to PersonaShim; confirmed against the live installed package"
+      phase: "SMOKE"
+    harness:
+      type: "smoke"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd.coach.shim.__main__ is importable from the deployed package"
+        - "PersonaShim is monkeypatched to capture runtime_dir"
+        - "ATDD_RUN_SMOKE=1 is set"
+    when:
+      abstract: "main() is called with ['--agent-id', 'smoke-x', '--runtime-dir', '.atdd/runtime', '--', 'echo', 'ok'] via the deployed entry point"
+    then:
+      abstract:
+        - "PersonaShim receives a runtime_dir that is absolute (.is_absolute() is True)"
+        - "The normalization works against the actual installed package, not just the source tree"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"

--- a/plan/spawn_agents/E021.yaml
+++ b/plan/spawn_agents/E021.yaml
@@ -1,0 +1,80 @@
+urn: "wmbt:spawn-agents:E021"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "process-alive-timeout-mislabels-cwd-bleed-path-mismatch-as-silent-shim-crash"
+context_clarifier: "When _verify_process_alive times out waiting for agents/<id>/output.log, it raises ProcessNotAlive('...shim may have crashed silently inside its pty'). This message is accurate for a real crash but misleading when the root cause is a CWD-bleed path mismatch (E019, #860): the shim is alive and writing output.log at a different absolute path than the one coach polls. On the 2026-05-26 test-drive, this message cost ~45 minutes of false-crash diagnosis before the operator surfaced the worker pane and confirmed the shim was healthy. The secondary fix: on timeout, scan for agents/<id>/output.log under common CWD-bleed candidate paths (e.g. Path.cwd() / relative_runtime_suffix / _AGENTS_SUBDIR / agent_id / 'output.log'). If found, emit an explicit 'path-mismatch: shim wrote to <found_path> but coach polled <expected_path>' message, turning the next occurrence from a 45-minute debug into a 30-second read. If not found, fall back to the existing 'may have crashed silently' phrasing, which remains correct for the true-crash case."
+lens: "functional.effectiveness"
+statement: "minimize likelihood of process-alive-timeout-mislabels-cwd-bleed-path-mismatch-as-silent-shim-crash by enhancing _verify_process_alive timeout handling to scan for agents/<id>/output.log under CWD-relative bleed candidates and, when found, emit an explicit 'path-mismatch' message naming both the polled and found paths rather than 'shim may have crashed silently'"
+acceptances:
+  - identity:
+      urn: "acc:spawn-agents:E021-UNIT-001-timeout-message-names-polled-path-and-scan-outcome"
+      id: "AC-UNIT-001"
+      purpose: "When _verify_process_alive times out with proc alive and output.log absent at the polled path (no bleed candidate found either), the ProcessNotAlive message includes the absolute polled path and a note indicating no candidate was found at alternate locations"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A fake proc whose poll() returns None (alive)"
+        - "A tmp runtime_dir where agents/<id>/output.log does not exist"
+        - "No output.log exists at any CWD-relative bleed candidate path"
+    when:
+      abstract: "_verify_process_alive(proc, agent_id, runtime_dir, transport='cli-return', timeout_s=0.05) times out"
+    then:
+      abstract:
+        - "ProcessNotAlive is raised"
+        - "str(exception) contains the absolute path of the polled output_log"
+        - "str(exception) does not exclusively say 'crashed silently' without further context (it names the path)"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"
+  - identity:
+      urn: "acc:spawn-agents:E021-UNIT-002-timeout-names-bleed-path-when-candidate-found"
+      id: "AC-UNIT-002"
+      purpose: "When output.log is absent at the polled path but present at a CWD-bleed candidate, ProcessNotAlive message explicitly labels it a path-mismatch and names both the expected and found paths"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A fake proc whose poll() returns None (alive)"
+        - "tmp_runtime_dir: agents/<id>/output.log does NOT exist (coach's polled side)"
+        - "A second tmp directory where agents/<id>/output.log DOES exist with 1+ bytes (simulates shim's CWD-bled write)"
+        - "_verify_process_alive is given tmp_runtime_dir and the second tmp dir is detectable as a bleed candidate"
+    when:
+      abstract: "_verify_process_alive times out; bleed candidate scan runs"
+    then:
+      abstract:
+        - "ProcessNotAlive is raised"
+        - "str(exception) contains 'path-mismatch' or 'found at' identifying the alternate location"
+        - "str(exception) does NOT say 'shim may have crashed silently' (crash is explicitly ruled out)"
+        - "str(exception) names both the polled (expected) path and the found (alternate) path"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"
+  - identity:
+      urn: "acc:spawn-agents:E021-SMOKE-001-live-process-alive-message-names-polled-path"
+      id: "AC-SMOKE-001"
+      purpose: "The deployed _verify_process_alive produces a ProcessNotAlive message that includes the absolute path being polled; confirmed against the live installed package"
+      phase: "SMOKE"
+    harness:
+      type: "smoke"
+      category: "backend"
+    given:
+      abstract:
+        - "A tmp runtime_dir; agents/<id>/output.log does not exist"
+        - "A fake proc (poll() returns None) passed to the deployed _verify_process_alive"
+        - "ATDD_RUN_SMOKE=1 is set"
+    when:
+      abstract: "_verify_process_alive is called with transport='cli-return' and a short timeout (0.1s)"
+    then:
+      abstract:
+        - "ProcessNotAlive is raised within timeout + 1s"
+        - "str(exception) contains the absolute path of agents/<id>/output.log"
+        - "The message provides actionable path information (not just 'crashed silently')"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"

--- a/plan/spawn_agents/L002.yaml
+++ b/plan/spawn_agents/L002.yaml
@@ -1,0 +1,35 @@
+urn: "wmbt:spawn-agents:L002"
+step: "locate"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "relative-runtime-root-causes-output-log-to-land-at-worktree-path-instead-of-coach-polled-path"
+context_clarifier: "The three-phase fix (E019: _build_shim_command resolution, E020: shim argparse normalization, E021: improved failure message) eliminates the relative-path CWD bleed identified in issue #860. An end-to-end SMOKE test closes the validation loop by reproducing the exact setup that caused the 2026-05-26 false-crash incident: runtime_root supplied as a relative path, CWD changed to a worktree directory before shim exec, then asserting output.log lands at the resolved absolute path — not at the worktree-relative candidate. This SMOKE test is the definitive regression gate: any future change that reintroduces relative-path bleed will cause _verify_process_alive to raise in this test before it causes a false-crash in production."
+lens: "functional.effectiveness"
+statement: "minimize likelihood of relative-runtime-root-causes-output-log-to-land-at-worktree-path-instead-of-coach-polled-path by adding an end-to-end SMOKE test that invokes cmd_spawn with a relative runtime_root, asserts output.log exists at the resolved absolute path after the shim runs, and asserts no output.log exists at any worktree-relative CWD-bleed candidate"
+acceptances:
+  - identity:
+      urn: "acc:spawn-agents:L002-SMOKE-001-relative-runtime-root-output-log-at-absolute-path"
+      id: "AC-SMOKE-001"
+      purpose: "End-to-end: with runtime_root specified as a relative path, the shim writes output.log at the resolved absolute path and no output.log appears at any CWD-bled worktree-relative location; _verify_process_alive does not raise"
+      phase: "SMOKE"
+    harness:
+      type: "smoke"
+      category: "backend"
+    given:
+      abstract:
+        - "ATDD_CORRECTION_TRANSPORT=cli-return is set"
+        - "A fixture issue with a known agent_id is available in a tmp_path context"
+        - "runtime_root is supplied as a relative path (e.g. '.atdd/runtime') to cmd_spawn"
+        - "A FakeMultiplexer is scripted for surface creation success"
+        - "A fixture shim command (e.g. python3 -c 'open(path, \"w\").write(\"x\")') writes one byte to its received --runtime-dir agents/<id>/output.log"
+        - "ATDD_RUN_SMOKE=1 is set"
+    when:
+      abstract: "cmd_spawn is invoked; the fixture shim runs and writes its output.log"
+    then:
+      abstract:
+        - "agents/<id>/output.log exists at <resolved_abs_runtime_root>/agents/<id>/output.log (non-empty)"
+        - "No output.log exists under any worktree-relative or alternative CWD directory for this agent_id"
+        - "_verify_process_alive does NOT raise ProcessNotAlive (heartbeat byte visible at the polled absolute path)"
+    metadata:
+      author: "atdd:planner"
+      created: "2026-05-26"

--- a/plan/spawn_agents/_spawn_agents.yaml
+++ b/plan/spawn_agents/_spawn_agents.yaml
@@ -26,6 +26,7 @@ features:
   - urn: "feature:spawn-agents:surface-smoke-acceptance-rule-in-planner-flow"
   - urn: "feature:spawn-agents:shim-popen-env-var-prefix-fix"
   - urn: "feature:spawn-agents:coach-spawn-detector-process-alive"
+  - urn: "feature:spawn-agents:shim-runtime-dir-absolute-path"
 
 produce:
   - name: coach:spawn:atdd-spawn-cli
@@ -100,6 +101,10 @@ produce:
     contract: null
     telemetry: null
     to: external
+  - name: coach:spawn:shim-runtime-dir-absolute-path-fix
+    contract: null
+    telemetry: null
+    to: external
 
 consume:
   - name: commons:coach:runtime-event-schema
@@ -112,7 +117,7 @@ consume:
     from: wagon:drive-state-machine
 
 wmbt:
-  total: 26
+  total: 30
   E001: "minimize likelihood of unrouted-persona-launches-bypassing-the-spawn-rule-id"
   D001: "minimize likelihood of ambiguity-in-substrate-spawn-harness-block-rendering"
   E002: "minimize quantity of post-launch-sessions-with-non-canonical-name-or-layout"
@@ -139,3 +144,7 @@ wmbt:
   E016: "minimize likelihood of shell-style-env-prefix-injected-into-shim-argv-causing-popen-exec-failure"
   E017: "minimize likelihood of coach-spawn-shim-command-resolves-to-wrong-atdd-installation-on-multi-install-hosts"
   E018: "minimize likelihood of coach-spawn-stage-detector-reports-success-when-spawned-process-has-already-crashed"
+  E019: "minimize likelihood of shim-runtime-dir-relative-path-bleeds-into-worktree-cwd-at-build-shim-command"
+  E020: "minimize likelihood of persona-shim-operates-with-relative-runtime-dir-if-future-caller-bypasses-primary-fix"
+  E021: "minimize likelihood of process-alive-timeout-mislabels-cwd-bleed-path-mismatch-as-silent-shim-crash"
+  L002: "minimize likelihood of relative-runtime-root-causes-output-log-to-land-at-worktree-path-instead-of-coach-polled-path"

--- a/plan/spawn_agents/features/shim_runtime_dir_absolute_path.yaml
+++ b/plan/spawn_agents/features/shim_runtime_dir_absolute_path.yaml
@@ -1,0 +1,31 @@
+urn: "feature:spawn-agents:shim-runtime-dir-absolute-path"
+wagon: "wagon:spawn-agents"
+description: "Fixes the relative-path CWD bleed introduced in #841: _build_shim_command passes --runtime-dir as a relative path (str(Path('.atdd/runtime'))), which resolves to the worktree CWD when the cmux surface cd's into the worktree before exec'ing the shim. Coach polls <main>/.atdd/runtime/agents/<id>/output.log but shim writes to <worktree>/.atdd/runtime/agents/<id>/output.log — causing the E018 process-alive detector to report a false 'silent crash'. Three-layer fix: (E019) resolve runtime_root to absolute in _build_shim_command and cmd_spawn entry; (E020) defensive normalization in atdd-shim argparse; (E021) improved _verify_process_alive message that names path-mismatch vs silent-crash. End-to-end SMOKE test (L002) closes the validation loop (issue #860)."
+sizing:
+  wmbts: 4
+  footprint_score: 5
+  footprint_size: "XS"
+wmbts:
+  - "wmbt:spawn-agents:E019"
+  - "wmbt:spawn-agents:E020"
+  - "wmbt:spawn-agents:E021"
+  - "wmbt:spawn-agents:L002"
+components:
+  backend:
+    presentation:
+      - type: "controllers"
+        count: 0
+        rationale: "No new CLI surface — changes are confined to spawn.py and shim/__main__.py internals"
+    application:
+      - type: "use_cases"
+        count: 3
+        rationale: "_build_shim_command (runtime_root.resolve() before str()), cmd_spawn entry (Path(runtime_root).resolve()), and _verify_process_alive (path-mismatch scan + improved message) — all in spawn.py; plus shim/__main__.py args.runtime_dir normalization"
+    domain:
+      - type: "value_objects"
+        count: 0
+        rationale: "No new domain primitives — reuses Path.resolve() stdlib and existing ProcessNotAlive exception"
+  frontend:
+    presentation:
+      - type: "components"
+        count: 0
+        rationale: "No frontend surface — coach is a CLI-only orchestrator"

--- a/src/atdd/coach/commands/spawn.py
+++ b/src/atdd/coach/commands/spawn.py
@@ -237,10 +237,20 @@ def _verify_process_alive(
             )
         time.sleep(poll_interval_s)
 
+    bleed_candidate = (
+        Path.cwd() / ".atdd" / "runtime" / "agents" / agent_id / "output.log"
+    )
+    if bleed_candidate.exists() and bleed_candidate.stat().st_size > 0:
+        raise ProcessNotAlive(
+            f"Shim process for {agent_id!r} path-mismatch: "
+            f"polled {output_log} but bleed candidate found at alternate path "
+            f"{bleed_candidate} — shim wrote output to CWD-relative path instead of "
+            f"the absolute runtime-dir. ({SPAWN_RULE_ID})"
+        )
     raise ProcessNotAlive(
         f"Shim process for {agent_id!r} is alive but {output_log} never received "
-        f"a heartbeat byte within {timeout_s:.1f}s — shim may have crashed silently "
-        f"inside its pty. ({SPAWN_RULE_ID})"
+        f"a heartbeat byte within {timeout_s:.1f}s — no bleed candidate found at alternate path. "
+        f"({SPAWN_RULE_ID})"
     )
 
 
@@ -727,7 +737,7 @@ def _build_shim_command(
     return (
         f"{shlex.quote(sys.executable)} -m atdd.coach.shim"
         f" --agent-id {shlex.quote(agent_id)}"
-        f" --runtime-dir {shlex.quote(str(runtime_root))}"
+        f" --runtime-dir {shlex.quote(str(runtime_root.resolve()))}"
         f"{env_flags}"
         f" -- {adapter_command}"
     )
@@ -1186,7 +1196,7 @@ def cmd_spawn(
         )
 
     worktree = Path(worktree)
-    runtime_root = Path(runtime_root)
+    runtime_root = Path(runtime_root).resolve()
 
     prompt_path = _render_launch_prompt(
         issue, worktree, phase=phase, rules=rules, persona=persona, agent_id=agent_id,

--- a/src/atdd/coach/commands/tests/test_e019_integration_001_path_bleed_regression.py
+++ b/src/atdd/coach/commands/tests/test_e019_integration_001_path_bleed_regression.py
@@ -1,0 +1,103 @@
+# URN: test:spawn-agents:E019-INTEGRATION-001-path-bleed-regression
+# Acceptance: acc:spawn-agents:E019-INTEGRATION-001-path-bleed-regression
+# WMBT: wmbt:spawn-agents:E019
+# Phase: GREEN
+# Layer: integration
+# Runtime: python
+# Assertion: behavioral
+"""E019-INTEGRATION-001 — regression: when the caller supplies a relative runtime_root
+and the process CWD changes between construction and shim exec (simulating the worktree
+cd), the shim writes output.log at the pre-resolved absolute path.
+
+_verify_process_alive polled at the absolute path finds the heartbeat byte and does
+not raise ProcessNotAlive.  No output.log appears at the CWD-bled path.
+
+RED: fails until _build_shim_command resolves runtime_root to absolute so the --runtime-dir
+passed to the fake shim refers to the original (pre-CWD-change) location.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_path_bleed_regression_output_log_at_absolute_not_bled_path(tmp_path, monkeypatch):
+    from atdd.coach.commands.spawn import _build_shim_command, _verify_process_alive
+
+    # ── Setup ───────────────────────────────────────────────────────────────
+    agent_id = "integration-860-bleed"
+
+    # The runtime_root the caller supplies — relative (the CWD-bleed scenario).
+    relative_suffix = "out/runtime"
+
+    # Absolute pre-CWD-change root (what the resolved path should be).
+    original_cwd = tmp_path / "original_cwd"
+    original_cwd.mkdir()
+    expected_abs_runtime = original_cwd / relative_suffix
+
+    # A different directory that simulates the worktree CWD after the cd.
+    worktree_cwd = tmp_path / "worktree_dir"
+    worktree_cwd.mkdir()
+
+    # Work with the original CWD first so relative_suffix resolves to expected_abs_runtime.
+    monkeypatch.chdir(original_cwd)
+
+    runtime_root_rel = Path(relative_suffix)
+    assert not runtime_root_rel.is_absolute(), "precondition: input is relative"
+
+    # Build the shim command while CWD == original_cwd.
+    cmd = _build_shim_command("echo ok", agent_id, runtime_root_rel)
+
+    # Extract --runtime-dir value from the built command.
+    import shlex
+    tokens = shlex.split(cmd)
+    idx = tokens.index("--runtime-dir")
+    runtime_dir_in_cmd = tokens[idx + 1]
+
+    # ── Simulate CWD change (the worktree cd) ───────────────────────────────
+    monkeypatch.chdir(worktree_cwd)
+
+    # The fake shim: writes one byte to agents/<id>/output.log at the path it received.
+    agent_out_dir = Path(runtime_dir_in_cmd) / "agents" / agent_id
+    agent_out_dir.mkdir(parents=True, exist_ok=True)
+    output_log_at_received = agent_out_dir / "output.log"
+    output_log_at_received.write_bytes(b"shim heartbeat\n")
+
+    # ── Assertions ──────────────────────────────────────────────────────────
+    # 1. The received --runtime-dir is absolute (no relative bleed possible).
+    assert Path(runtime_dir_in_cmd).is_absolute(), (
+        f"E019-INTEGRATION-001: --runtime-dir must be absolute. Got: {runtime_dir_in_cmd!r}"
+    )
+
+    # 2. output.log exists at the resolved absolute path (not the CWD-bled path).
+    abs_agent_dir = expected_abs_runtime / "agents" / agent_id
+    abs_output_log = abs_agent_dir / "output.log"
+    assert abs_output_log.exists(), (
+        f"E019-INTEGRATION-001: output.log must exist at the pre-resolved absolute path "
+        f"{abs_output_log}. This fails when _build_shim_command does not call .resolve() "
+        "and the CWD changes before shim exec."
+    )
+
+    # 3. No output.log at the CWD-bled location.
+    bled_output_log = worktree_cwd / relative_suffix / "agents" / agent_id / "output.log"
+    assert not bled_output_log.exists(), (
+        f"E019-INTEGRATION-001: output.log must NOT exist at CWD-bled path {bled_output_log}."
+    )
+
+    # 4. _verify_process_alive does not raise when polled at the absolute location.
+    class _AliveProc:
+        def poll(self):
+            return None
+
+    _verify_process_alive(
+        proc=_AliveProc(),
+        agent_id=agent_id,
+        runtime_dir=abs_agent_dir,
+        transport="cli-return",
+        timeout_s=0.5,
+    )
+    # Must not raise — heartbeat byte is visible at the absolute polled path.

--- a/src/atdd/coach/commands/tests/test_e019_smoke_001_shim_command_runtime_dir_is_absolute_in_live_spawn.py
+++ b/src/atdd/coach/commands/tests/test_e019_smoke_001_shim_command_runtime_dir_is_absolute_in_live_spawn.py
@@ -1,0 +1,62 @@
+# URN: test:spawn-agents:E019-SMOKE-001-shim-command-runtime-dir-is-absolute-in-live-spawn
+# Acceptance: acc:spawn-agents:E019-SMOKE-001-shim-command-runtime-dir-is-absolute-in-live-spawn
+# WMBT: wmbt:spawn-agents:E019
+# Phase: SMOKE
+# Layer: backend.smoke
+# Runtime: python
+# Assertion: behavioral
+"""E019-SMOKE-001 — against the deployed (installed) atdd package, _build_shim_command
+always produces a --runtime-dir value that is an absolute path when given a relative input.
+
+Smoke gate: requires ATDD_RUN_SMOKE=1.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.smoke]
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ATDD_RUN_SMOKE"),
+    reason="E019-SMOKE-001 requires ATDD_RUN_SMOKE=1",
+)
+def test_deployed_build_shim_command_resolves_relative_runtime_dir():
+    from atdd.coach.commands.spawn import _build_shim_command
+
+    runtime_root = Path(".atdd/runtime")
+    assert not runtime_root.is_absolute(), "precondition: input is relative"
+
+    cmd = _build_shim_command("claude --no-update", "smoke-agent-e019", runtime_root)
+
+    tokens = shlex.split(cmd)
+    idx = tokens.index("--runtime-dir")
+    value = tokens[idx + 1]
+
+    assert Path(value).is_absolute(), (
+        f"E019-SMOKE-001: deployed _build_shim_command must produce an absolute --runtime-dir. "
+        f"Got: {value!r}"
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ATDD_RUN_SMOKE"),
+    reason="E019-SMOKE-001 requires ATDD_RUN_SMOKE=1",
+)
+def test_deployed_build_shim_command_absolute_input_unchanged():
+    from atdd.coach.commands.spawn import _build_shim_command
+
+    runtime_root = Path("/tmp/smoke-e019-abs-runtime")
+    cmd = _build_shim_command("claude --no-update", "smoke-agent-e019-abs", runtime_root)
+
+    tokens = shlex.split(cmd)
+    idx = tokens.index("--runtime-dir")
+    value = tokens[idx + 1]
+
+    assert Path(value).is_absolute(), (
+        f"E019-SMOKE-001: absolute input must remain absolute after resolve(). Got: {value!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e019_unit_001_build_shim_command_resolves_relative_runtime_dir_to_absolute.py
+++ b/src/atdd/coach/commands/tests/test_e019_unit_001_build_shim_command_resolves_relative_runtime_dir_to_absolute.py
@@ -1,0 +1,62 @@
+# URN: test:spawn-agents:E019-UNIT-001-build-shim-command-resolves-relative-runtime-dir-to-absolute
+# Acceptance: acc:spawn-agents:E019-UNIT-001-build-shim-command-resolves-relative-runtime-dir-to-absolute
+# WMBT: wmbt:spawn-agents:E019
+# Phase: GREEN
+# Assertion: behavioral
+"""E019-UNIT-001 — _build_shim_command with a relative runtime_root resolves it to
+an absolute path before embedding it as --runtime-dir in the command string.
+
+RED: fails until _build_shim_command calls runtime_root.resolve() so the shim
+always receives an absolute path regardless of the caller's CWD.
+"""
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+
+def _extract_runtime_dir_value(cmd: str) -> str:
+    tokens = shlex.split(cmd)
+    idx = tokens.index("--runtime-dir")
+    return tokens[idx + 1]
+
+
+def test_relative_runtime_root_produces_absolute_runtime_dir_flag():
+    from atdd.coach.commands.spawn import _build_shim_command
+
+    runtime_root = Path(".atdd/runtime")
+    assert not runtime_root.is_absolute(), "precondition: input is relative"
+
+    cmd = _build_shim_command("claude --no-update", "agent-860-rel", runtime_root)
+
+    value = _extract_runtime_dir_value(cmd)
+    assert Path(value).is_absolute(), (
+        f"E019-UNIT-001: --runtime-dir must be an absolute path when runtime_root is "
+        f"relative. Got: {value!r} (not absolute). "
+        "Fix: call runtime_root.resolve() inside _build_shim_command."
+    )
+
+
+def test_relative_runtime_root_does_not_start_with_dot():
+    from atdd.coach.commands.spawn import _build_shim_command
+
+    runtime_root = Path(".atdd/runtime")
+    cmd = _build_shim_command("claude --no-update", "agent-860-dot", runtime_root)
+
+    value = _extract_runtime_dir_value(cmd)
+    assert not value.startswith("."), (
+        f"E019-UNIT-001: --runtime-dir must not begin with '.' Got: {value!r}"
+    )
+
+
+def test_relative_runtime_root_with_subdir_segment_also_resolved():
+    from atdd.coach.commands.spawn import _build_shim_command
+
+    runtime_root = Path("out/runtime")
+    cmd = _build_shim_command("echo ok", "agent-860-sub", runtime_root)
+
+    value = _extract_runtime_dir_value(cmd)
+    assert Path(value).is_absolute(), (
+        f"E019-UNIT-001: any relative runtime_root variant must resolve to absolute. "
+        f"Got: {value!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e019_unit_002_build_shim_command_absolute_path_unchanged.py
+++ b/src/atdd/coach/commands/tests/test_e019_unit_002_build_shim_command_absolute_path_unchanged.py
@@ -1,0 +1,71 @@
+# URN: test:spawn-agents:E019-UNIT-002-build-shim-command-absolute-path-unchanged
+# Acceptance: acc:spawn-agents:E019-UNIT-002-build-shim-command-absolute-path-unchanged
+# WMBT: wmbt:spawn-agents:E019
+# Phase: GREEN
+# Assertion: behavioral
+"""E019-UNIT-002 — _build_shim_command with an already-absolute runtime_root passes
+the path through unchanged (resolve() on an absolute path is idempotent).
+
+RED: fails until _build_shim_command applies resolve() and the absolute-path invariant
+is verified by the presence of the exact path in the command string.
+"""
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+
+def _extract_runtime_dir_value(cmd: str) -> str:
+    tokens = shlex.split(cmd)
+    idx = tokens.index("--runtime-dir")
+    return tokens[idx + 1]
+
+
+def test_absolute_runtime_root_preserved_in_command():
+    from atdd.coach.commands.spawn import _build_shim_command
+
+    runtime_root = Path("/tmp/test-runtime-e019")
+    assert runtime_root.is_absolute(), "precondition: input is already absolute"
+
+    cmd = _build_shim_command("claude --no-update", "agent-860-abs", runtime_root)
+
+    value = _extract_runtime_dir_value(cmd)
+    assert Path(value).is_absolute(), (
+        f"E019-UNIT-002: absolute input must produce an absolute --runtime-dir. "
+        f"Got: {value!r}"
+    )
+    assert "/tmp/test-runtime-e019" in value, (
+        f"E019-UNIT-002: absolute path must appear verbatim in the command. "
+        f"Got: {value!r}"
+    )
+
+
+def test_absolute_runtime_root_resolve_is_idempotent():
+    from atdd.coach.commands.spawn import _build_shim_command
+
+    runtime_root = Path("/tmp/test-runtime-e019-idem")
+    cmd = _build_shim_command("echo ok", "agent-860-idem", runtime_root)
+
+    value = _extract_runtime_dir_value(cmd)
+    resolved = str(runtime_root.resolve())
+    # After resolve(), an already-absolute path is identical (or differs only by
+    # symlink expansion — either is acceptable as long as is_absolute() is True).
+    assert Path(value).is_absolute(), (
+        f"E019-UNIT-002: resolve() on absolute path must still yield absolute. "
+        f"Got: {value!r}"
+    )
+
+
+def test_absolute_path_not_transformed_to_relative():
+    from atdd.coach.commands.spawn import _build_shim_command
+
+    runtime_root = Path("/abs/path/runtime")
+    cmd = _build_shim_command("echo ok", "agent-860-norel", runtime_root)
+
+    value = _extract_runtime_dir_value(cmd)
+    assert not value.startswith("."), (
+        f"E019-UNIT-002: absolute path must never become relative. Got: {value!r}"
+    )
+    assert value.startswith("/"), (
+        f"E019-UNIT-002: resolved value must start with '/'. Got: {value!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e019_unit_003_cmd_spawn_materializes_absolute_runtime_root.py
+++ b/src/atdd/coach/commands/tests/test_e019_unit_003_cmd_spawn_materializes_absolute_runtime_root.py
@@ -1,0 +1,119 @@
+# URN: test:spawn-agents:E019-UNIT-003-cmd-spawn-materializes-absolute-runtime-root
+# Acceptance: acc:spawn-agents:E019-UNIT-003-cmd-spawn-materializes-absolute-runtime-root
+# WMBT: wmbt:spawn-agents:E019
+# Phase: GREEN
+# Assertion: behavioral
+"""E019-UNIT-003 — cmd_spawn resolves runtime_root to absolute at construction time
+so every downstream callee (including _build_shim_command) receives an absolute Path.
+
+Monkeypatches _build_shim_command to capture its runtime_root argument without
+executing the shim; verifies the received Path.is_absolute() is True.
+
+RED: fails until cmd_spawn calls Path(runtime_root).resolve() before passing
+runtime_root to _build_shim_command.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+class _FakeMux:
+    name = "fake"
+
+    def resolve_focused_pane(self, workspace=None) -> str:
+        return "pane:860"
+
+    def new_surface(self, *a, **kw):
+        return "surface:860"
+
+    def new_surface_in_pane(self, pane_ref=None, cwd=None, command=None, name=None, **kw) -> str:
+        return "surface:860"
+
+    def new_workspace(self, *a, **kw):
+        return "ws-860"
+
+    def paste_text(self, *a, **kw):
+        pass
+
+    def send_key(self, *a, **kw):
+        pass
+
+    def send(self, *a, **kw):
+        pass
+
+    def rename(self, *a, **kw):
+        pass
+
+    def list_surfaces(self, **kw):
+        return []
+
+    def capture_pane_text(self, *a, **kw):
+        return ""
+
+
+class _CaptureBuildShimCommand(Exception):
+    """Raised by the spy to abort cmd_spawn early while carrying runtime_root."""
+    def __init__(self, runtime_root: Path):
+        self.runtime_root = runtime_root
+
+
+def test_cmd_spawn_passes_absolute_runtime_root_to_build_shim_command(tmp_path, monkeypatch):
+    from atdd.coach.commands.spawn import cmd_spawn
+
+    monkeypatch.setenv("ATDD_CORRECTION_TRANSPORT", "cli-return")
+
+    worktree = tmp_path / "issue-860-wt"
+    worktree.mkdir()
+
+    # Relative runtime_root — the key input for this test
+    relative_runtime_root = ".atdd/runtime"
+
+    captured: list[Path] = []
+
+    def _spy_build_shim_command(adapter_command, agent_id, runtime_root, **kw):
+        captured.append(runtime_root)
+        raise _CaptureBuildShimCommand(runtime_root)
+
+    with (
+        patch("atdd.coach.commands.spawn._build_shim_command", side_effect=_spy_build_shim_command),
+        patch("atdd.coach.commands.spawn._render_launch_prompt", return_value=worktree / ".lp.txt"),
+        patch("atdd.coach.commands.spawn.apply_canonical_name_and_layout"),
+        patch("atdd.coach.commands.spawn._pre_trust_worktree"),
+        patch("atdd.coach.commands.spawn.compute_repo_short_name", return_value="test"),
+        patch("atdd.coach.commands.spawn.compute_issue_surface_name", return_value="ATDD860"),
+        patch("atdd.coach.utils.config.load_atdd_config", return_value=MagicMock()),
+        patch("atdd.coach.commands.spawn._prime_cli_return_inbox"),
+        patch("atdd.coach.commands.spawn._inject_agent_env", return_value=({}, "echo ok")),
+        patch("atdd.coach.commands.spawn._assert_no_forbidden_flags"),
+    ):
+        # Create a minimal launch-prompt file so _render_launch_prompt stub works
+        lp = worktree / ".lp.txt"
+        lp.write_text("launch prompt")
+
+        try:
+            cmd_spawn(
+                persona="planner",
+                llm="claude-code",
+                worktree=worktree,
+                issue=860,
+                agent_id="planner-860-unit003",
+                runtime_root=relative_runtime_root,
+                multiplexer=_FakeMux(),
+            )
+        except _CaptureBuildShimCommand:
+            pass
+
+    assert captured, (
+        "E019-UNIT-003: _build_shim_command was never called — "
+        "check that ATDD_CORRECTION_TRANSPORT=cli-return is set and cmd_spawn reaches the shim path."
+    )
+    received = captured[0]
+    assert isinstance(received, Path), (
+        f"E019-UNIT-003: _build_shim_command must receive a Path, got {type(received)!r}"
+    )
+    assert received.is_absolute(), (
+        f"E019-UNIT-003: cmd_spawn must resolve runtime_root to absolute before passing it "
+        f"to _build_shim_command. Got: {received!r} (relative). "
+        "Fix: add runtime_root = Path(runtime_root).resolve() in cmd_spawn."
+    )

--- a/src/atdd/coach/commands/tests/test_e020_smoke_001_deployed_shim_resolves_relative_runtime_dir.py
+++ b/src/atdd/coach/commands/tests/test_e020_smoke_001_deployed_shim_resolves_relative_runtime_dir.py
@@ -1,0 +1,85 @@
+# URN: test:spawn-agents:E020-SMOKE-001-deployed-shim-resolves-relative-runtime-dir
+# Acceptance: acc:spawn-agents:E020-SMOKE-001-deployed-shim-resolves-relative-runtime-dir
+# WMBT: wmbt:spawn-agents:E020
+# Phase: SMOKE
+# Layer: backend.smoke
+# Runtime: python
+# Assertion: behavioral
+"""E020-SMOKE-001 — the deployed atdd.coach.shim.__main__ module resolves
+--runtime-dir to absolute before handing it to PersonaShim; confirmed against
+the live installed package.
+
+Smoke gate: requires ATDD_RUN_SMOKE=1.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = [pytest.mark.smoke]
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ATDD_RUN_SMOKE"),
+    reason="E020-SMOKE-001 requires ATDD_RUN_SMOKE=1",
+)
+def test_deployed_shim_main_resolves_relative_runtime_dir(tmp_path, monkeypatch):
+    from atdd.coach.shim.__main__ import main
+
+    captured: list[Path] = []
+
+    class _CapturingShim:
+        def __init__(self, agent_id, spawn_command, runtime_dir, env_overrides=None):
+            captured.append(runtime_dir)
+
+        def run(self):
+            return 0
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("atdd.coach.shim.persona_shim.PersonaShim", _CapturingShim):
+        main([
+            "--agent-id", "smoke-x-e020",
+            "--runtime-dir", ".atdd/runtime",
+            "--", "echo", "ok",
+        ])
+
+    assert captured, "E020-SMOKE-001: PersonaShim was never instantiated"
+    received = captured[0]
+    assert received.is_absolute(), (
+        f"E020-SMOKE-001: deployed shim main() must resolve relative --runtime-dir to absolute. "
+        f"Got: {received!r}"
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ATDD_RUN_SMOKE"),
+    reason="E020-SMOKE-001 requires ATDD_RUN_SMOKE=1",
+)
+def test_deployed_shim_main_absolute_runtime_dir_unchanged():
+    from atdd.coach.shim.__main__ import main
+
+    captured: list[Path] = []
+
+    class _CapturingShim:
+        def __init__(self, agent_id, spawn_command, runtime_dir, env_overrides=None):
+            captured.append(runtime_dir)
+
+        def run(self):
+            return 0
+
+    with patch("atdd.coach.shim.persona_shim.PersonaShim", _CapturingShim):
+        main([
+            "--agent-id", "smoke-x-e020-abs",
+            "--runtime-dir", "/tmp/smoke-e020-abs",
+            "--", "echo", "ok",
+        ])
+
+    assert captured
+    received = captured[0]
+    assert received.is_absolute(), (
+        f"E020-SMOKE-001: absolute --runtime-dir must remain absolute. Got: {received!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e020_unit_001_shim_main_resolves_relative_runtime_dir_to_absolute.py
+++ b/src/atdd/coach/commands/tests/test_e020_unit_001_shim_main_resolves_relative_runtime_dir_to_absolute.py
@@ -1,0 +1,76 @@
+# URN: test:spawn-agents:E020-UNIT-001-shim-main-resolves-relative-runtime-dir-to-absolute
+# Acceptance: acc:spawn-agents:E020-UNIT-001-shim-main-resolves-relative-runtime-dir-to-absolute
+# WMBT: wmbt:spawn-agents:E020
+# Phase: GREEN
+# Assertion: behavioral
+"""E020-UNIT-001 — atdd-shim main() resolves a relative --runtime-dir to absolute
+before constructing PersonaShim; PersonaShim.runtime_dir is absolute.
+
+Belt-and-suspenders guard: even if a caller bypasses the E019 fix in cmd_spawn,
+the shim normalizes the path on entry.
+
+RED: fails until main() calls args.runtime_dir.resolve() before passing it to PersonaShim.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_shim_main_resolves_relative_runtime_dir(tmp_path, monkeypatch):
+    from atdd.coach.shim.__main__ import main
+
+    captured_runtime_dir: list[Path] = []
+
+    class _CapturingShim:
+        def __init__(self, agent_id, spawn_command, runtime_dir, env_overrides=None):
+            captured_runtime_dir.append(runtime_dir)
+
+        def run(self):
+            return 0
+
+    monkeypatch.chdir(tmp_path)
+
+    # PersonaShim is imported lazily inside main() from atdd.coach.shim.persona_shim.
+    with patch("atdd.coach.shim.persona_shim.PersonaShim", _CapturingShim):
+        main(["--agent-id", "shim-860-rel", "--runtime-dir", ".atdd/runtime", "--", "echo", "ok"])
+
+    assert captured_runtime_dir, "E020-UNIT-001: PersonaShim was never instantiated"
+    received = captured_runtime_dir[0]
+
+    assert isinstance(received, Path), (
+        f"E020-UNIT-001: runtime_dir passed to PersonaShim must be a Path. Got: {type(received)!r}"
+    )
+    assert received.is_absolute(), (
+        f"E020-UNIT-001: PersonaShim must receive an absolute runtime_dir. "
+        f"Got: {received!r} (relative). "
+        "Fix: add args.runtime_dir = args.runtime_dir.resolve() after argparse in main()."
+    )
+
+
+def test_shim_main_resolved_path_ends_with_expected_suffix(tmp_path, monkeypatch):
+    from atdd.coach.shim.__main__ import main
+
+    captured: list[Path] = []
+
+    class _CapturingShim:
+        def __init__(self, agent_id, spawn_command, runtime_dir, env_overrides=None):
+            captured.append(runtime_dir)
+
+        def run(self):
+            return 0
+
+    monkeypatch.chdir(tmp_path)
+
+    with patch("atdd.coach.shim.persona_shim.PersonaShim", _CapturingShim):
+        main(["--agent-id", "shim-860-suffix", "--runtime-dir", ".atdd/runtime", "--", "echo", "ok"])
+
+    assert captured
+    received = captured[0]
+    # The resolved absolute path must end with the relative suffix we passed.
+    assert str(received).endswith(".atdd/runtime"), (
+        f"E020-UNIT-001: resolved path must end with '.atdd/runtime'. Got: {received!r}"
+    )
+    assert received.is_absolute(), (
+        f"E020-UNIT-001: resolved path must be absolute. Got: {received!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e020_unit_002_shim_main_absolute_runtime_dir_unchanged.py
+++ b/src/atdd/coach/commands/tests/test_e020_unit_002_shim_main_absolute_runtime_dir_unchanged.py
@@ -1,0 +1,69 @@
+# URN: test:spawn-agents:E020-UNIT-002-shim-main-absolute-runtime-dir-unchanged
+# Acceptance: acc:spawn-agents:E020-UNIT-002-shim-main-absolute-runtime-dir-unchanged
+# WMBT: wmbt:spawn-agents:E020
+# Phase: GREEN
+# Assertion: behavioral
+"""E020-UNIT-002 — when --runtime-dir is already absolute, main() passes it unchanged
+to PersonaShim (resolve() is idempotent on absolute paths).
+
+RED: fails until main() applies .resolve() and the idempotent behaviour is documented
+with an explicit assertion on the received Path object.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_shim_main_absolute_runtime_dir_passed_unchanged():
+    from atdd.coach.shim.__main__ import main
+
+    captured: list[Path] = []
+
+    class _CapturingShim:
+        def __init__(self, agent_id, spawn_command, runtime_dir, env_overrides=None):
+            captured.append(runtime_dir)
+
+        def run(self):
+            return 0
+
+    with patch("atdd.coach.shim.persona_shim.PersonaShim", _CapturingShim):
+        main(["--agent-id", "shim-860-abs", "--runtime-dir", "/tmp/abs-runtime-e020", "--", "echo", "ok"])
+
+    assert captured, "E020-UNIT-002: PersonaShim was never instantiated"
+    received = captured[0]
+
+    assert isinstance(received, Path), (
+        f"E020-UNIT-002: runtime_dir must be a Path. Got: {type(received)!r}"
+    )
+    assert received.is_absolute(), (
+        f"E020-UNIT-002: absolute input must remain absolute after resolve(). Got: {received!r}"
+    )
+    # The path string must contain the expected segment — resolve() on an absolute
+    # path is a no-op modulo symlink expansion (e.g. /tmp → /private/tmp on macOS).
+    assert "abs-runtime-e020" in str(received), (
+        f"E020-UNIT-002: path identity must be preserved. Got: {received!r}"
+    )
+
+
+def test_shim_main_absolute_runtime_dir_is_absolute():
+    from atdd.coach.shim.__main__ import main
+
+    captured: list[Path] = []
+
+    class _CapturingShim:
+        def __init__(self, agent_id, spawn_command, runtime_dir, env_overrides=None):
+            captured.append(runtime_dir)
+
+        def run(self):
+            return 0
+
+    with patch("atdd.coach.shim.persona_shim.PersonaShim", _CapturingShim):
+        main(["--agent-id", "shim-860-abs2", "--runtime-dir", "/abs/path/runtime", "--", "echo", "ok"])
+
+    assert captured
+    received = captured[0]
+    assert received.is_absolute(), (
+        f"E020-UNIT-002: resolve() on absolute is idempotent — must still be absolute. "
+        f"Got: {received!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e021_smoke_001_live_process_alive_message_names_polled_path.py
+++ b/src/atdd/coach/commands/tests/test_e021_smoke_001_live_process_alive_message_names_polled_path.py
@@ -1,0 +1,89 @@
+# URN: test:spawn-agents:E021-SMOKE-001-live-process-alive-message-names-polled-path
+# Acceptance: acc:spawn-agents:E021-SMOKE-001-live-process-alive-message-names-polled-path
+# WMBT: wmbt:spawn-agents:E021
+# Phase: SMOKE
+# Layer: backend.smoke
+# Runtime: python
+# Assertion: behavioral
+"""E021-SMOKE-001 — the deployed _verify_process_alive produces a ProcessNotAlive
+message that includes the absolute path being polled; confirmed against the live
+installed package.
+
+Smoke gate: requires ATDD_RUN_SMOKE=1.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.smoke]
+
+
+class _AliveProc:
+    def poll(self):
+        return None
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ATDD_RUN_SMOKE"),
+    reason="E021-SMOKE-001 requires ATDD_RUN_SMOKE=1",
+)
+def test_deployed_verify_process_alive_names_polled_path_in_message(tmp_path):
+    from atdd.coach.commands.spawn import ProcessNotAlive, _verify_process_alive
+
+    agent_id = "smoke-e021-path-msg"
+    agent_dir = tmp_path / "agents" / agent_id
+    agent_dir.mkdir(parents=True)
+    # output.log does not exist
+
+    with pytest.raises(ProcessNotAlive) as exc_info:
+        _verify_process_alive(
+            proc=_AliveProc(),
+            agent_id=agent_id,
+            runtime_dir=agent_dir,
+            transport="cli-return",
+            timeout_s=0.1,
+        )
+
+    msg = str(exc_info.value)
+    expected_log_path = str(agent_dir / "output.log")
+
+    assert expected_log_path in msg, (
+        f"E021-SMOKE-001: ProcessNotAlive message must name the absolute polled path. "
+        f"Expected {expected_log_path!r} in message. Got: {msg!r}"
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ATDD_RUN_SMOKE"),
+    reason="E021-SMOKE-001 requires ATDD_RUN_SMOKE=1",
+)
+def test_deployed_verify_process_alive_message_is_actionable(tmp_path):
+    from atdd.coach.commands.spawn import ProcessNotAlive, _verify_process_alive
+
+    agent_id = "smoke-e021-actionable"
+    agent_dir = tmp_path / "agents" / agent_id
+    agent_dir.mkdir(parents=True)
+
+    with pytest.raises(ProcessNotAlive) as exc_info:
+        _verify_process_alive(
+            proc=_AliveProc(),
+            agent_id=agent_id,
+            runtime_dir=agent_dir,
+            transport="cli-return",
+            timeout_s=0.1,
+        )
+
+    msg = str(exc_info.value)
+    # Message must provide actionable path information, not just "crashed silently"
+    # without context. The path must appear in the message.
+    assert "/" in msg, (
+        f"E021-SMOKE-001: ProcessNotAlive message must contain a path (with '/') "
+        f"to be actionable. Got: {msg!r}"
+    )
+    # The agent_id should appear to identify which agent timed out.
+    assert agent_id in msg or "output.log" in msg, (
+        f"E021-SMOKE-001: message must identify the agent or log path. Got: {msg!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_e021_unit_001_timeout_message_names_polled_path_and_scan_outcome.py
+++ b/src/atdd/coach/commands/tests/test_e021_unit_001_timeout_message_names_polled_path_and_scan_outcome.py
@@ -1,0 +1,94 @@
+# URN: test:spawn-agents:E021-UNIT-001-timeout-message-names-polled-path-and-scan-outcome
+# Acceptance: acc:spawn-agents:E021-UNIT-001-timeout-message-names-polled-path-and-scan-outcome
+# WMBT: wmbt:spawn-agents:E021
+# Phase: GREEN
+# Assertion: behavioral
+"""E021-UNIT-001 — when _verify_process_alive times out (proc alive, output.log absent,
+no CWD-bleed candidate found), the ProcessNotAlive message:
+  1. names the absolute path being polled
+  2. includes a note indicating no alternate bleed candidate was located
+
+This turns a generic "crashed silently" message into an actionable diagnostic.
+
+RED: fails until _verify_process_alive scans for bleed candidates and includes a
+"no alternate" / "no candidate" note in the timeout message.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _AliveProc:
+    """Fake process that never exits."""
+
+    def poll(self):
+        return None
+
+
+def test_timeout_message_names_absolute_polled_path(tmp_path):
+    from atdd.coach.commands.spawn import ProcessNotAlive, _verify_process_alive
+
+    agent_id = "unit-e021-001-nopath"
+    agent_dir = tmp_path / "agents" / agent_id
+    agent_dir.mkdir(parents=True)
+    # output.log does NOT exist — shim never wrote a heartbeat
+
+    with pytest.raises(ProcessNotAlive) as exc_info:
+        _verify_process_alive(
+            proc=_AliveProc(),
+            agent_id=agent_id,
+            runtime_dir=agent_dir,
+            transport="cli-return",
+            timeout_s=0.05,
+        )
+
+    msg = str(exc_info.value)
+    expected_log_path = str(agent_dir / "output.log")
+
+    assert expected_log_path in msg, (
+        f"E021-UNIT-001: ProcessNotAlive message must name the absolute polled path "
+        f"{expected_log_path!r}. Got: {msg!r}"
+    )
+
+
+def test_timeout_message_includes_no_candidate_note_when_bleed_absent(tmp_path, monkeypatch):
+    from atdd.coach.commands.spawn import ProcessNotAlive, _verify_process_alive
+
+    agent_id = "unit-e021-001-nocandidate"
+    agent_dir = tmp_path / "agents" / agent_id
+    agent_dir.mkdir(parents=True)
+    # No output.log anywhere — no bleed candidate
+
+    # Change CWD so the scan has a defined location to check and finds nothing.
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ProcessNotAlive) as exc_info:
+        _verify_process_alive(
+            proc=_AliveProc(),
+            agent_id=agent_id,
+            runtime_dir=agent_dir,
+            transport="cli-return",
+            timeout_s=0.05,
+        )
+
+    msg = str(exc_info.value)
+    # The message must indicate that the bleed-candidate scan ran and found nothing.
+    # Acceptable phrases: "no alternate", "no candidate", "bleed candidate: none",
+    # "no bleed candidate", "not found at alternate", etc.
+    has_no_candidate_note = any(
+        phrase in msg.lower()
+        for phrase in [
+            "no alternate",
+            "no candidate",
+            "no bleed",
+            "candidate: none",
+            "not found at alternate",
+        ]
+    )
+    assert has_no_candidate_note, (
+        f"E021-UNIT-001: ProcessNotAlive message must include a note indicating the "
+        f"bleed-candidate scan found nothing. Got: {msg!r}. "
+        "Fix: add bleed-candidate scan to _verify_process_alive timeout handler."
+    )

--- a/src/atdd/coach/commands/tests/test_e021_unit_002_timeout_names_bleed_path_when_candidate_found.py
+++ b/src/atdd/coach/commands/tests/test_e021_unit_002_timeout_names_bleed_path_when_candidate_found.py
@@ -1,0 +1,119 @@
+# URN: test:spawn-agents:E021-UNIT-002-timeout-names-bleed-path-when-candidate-found
+# Acceptance: acc:spawn-agents:E021-UNIT-002-timeout-names-bleed-path-when-candidate-found
+# WMBT: wmbt:spawn-agents:E021
+# Phase: GREEN
+# Assertion: behavioral
+"""E021-UNIT-002 — when output.log is absent at the polled path but present at a
+CWD-bleed candidate, ProcessNotAlive message:
+  1. says "path-mismatch" or "found at" (makes the root cause explicit)
+  2. names BOTH the expected (polled) path and the found (alternate) path
+  3. does NOT say "shim may have crashed silently" (crash is ruled out)
+
+This is the diagnostic that turns a 45-minute false-crash investigation into a
+30-second read (reproduced 2026-05-26 on issue #860).
+
+RED: fails until _verify_process_alive scans CWD-relative bleed candidates and
+emits a "path-mismatch" message when a candidate is found.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+class _AliveProc:
+    def poll(self):
+        return None
+
+
+def test_timeout_emits_path_mismatch_when_bleed_candidate_found(tmp_path, monkeypatch):
+    from atdd.coach.commands.spawn import ProcessNotAlive, _verify_process_alive
+
+    agent_id = "unit-e021-002-bleed"
+
+    # Coach's expected location — output.log does NOT exist here.
+    polled_runtime_dir = tmp_path / "abs_runtime" / "agents" / agent_id
+    polled_runtime_dir.mkdir(parents=True)
+
+    # The CWD-bleed location — output.log DOES exist here (shim wrote to bled path).
+    # The bleed candidate follows the pattern: CWD / <common-runtime-suffix> / agents / id.
+    bleed_cwd = tmp_path / "worktree_cwd"
+    bleed_cwd.mkdir()
+    bleed_agent_dir = bleed_cwd / ".atdd" / "runtime" / "agents" / agent_id
+    bleed_agent_dir.mkdir(parents=True)
+    (bleed_agent_dir / "output.log").write_bytes(b"shim alive but bled\n")
+
+    # Set CWD to the worktree so the implementation can detect the candidate.
+    monkeypatch.chdir(bleed_cwd)
+
+    with pytest.raises(ProcessNotAlive) as exc_info:
+        _verify_process_alive(
+            proc=_AliveProc(),
+            agent_id=agent_id,
+            runtime_dir=polled_runtime_dir,
+            transport="cli-return",
+            timeout_s=0.05,
+        )
+
+    msg = str(exc_info.value)
+
+    # 1. "path-mismatch" or "found at" must appear.
+    has_mismatch_marker = any(
+        phrase in msg.lower()
+        for phrase in ["path-mismatch", "found at", "alternate path", "bleed candidate found"]
+    )
+    assert has_mismatch_marker, (
+        f"E021-UNIT-002: ProcessNotAlive must say 'path-mismatch' or 'found at' when a "
+        f"bleed candidate is detected. Got: {msg!r}"
+    )
+
+    # 2. The expected (polled) path must be named.
+    expected_log = str(polled_runtime_dir / "output.log")
+    assert expected_log in msg, (
+        f"E021-UNIT-002: message must name the polled (expected) path {expected_log!r}. "
+        f"Got: {msg!r}"
+    )
+
+    # 3. The found (alternate) bleed path must be named.
+    found_log = str(bleed_agent_dir / "output.log")
+    assert found_log in msg, (
+        f"E021-UNIT-002: message must name the found (alternate) path {found_log!r}. "
+        f"Got: {msg!r}"
+    )
+
+    # 4. "crashed silently" must NOT appear (crash is ruled out by the found candidate).
+    assert "crashed silently" not in msg, (
+        f"E021-UNIT-002: when a bleed candidate is found, the message must NOT say "
+        f"'crashed silently'. Got: {msg!r}"
+    )
+
+
+def test_path_mismatch_message_omits_crash_phrasing(tmp_path, monkeypatch):
+    from atdd.coach.commands.spawn import ProcessNotAlive, _verify_process_alive
+
+    agent_id = "unit-e021-002-nocrash"
+    polled_dir = tmp_path / "rt" / "agents" / agent_id
+    polled_dir.mkdir(parents=True)
+
+    bleed_cwd = tmp_path / "wt"
+    bleed_cwd.mkdir()
+    bleed_dir = bleed_cwd / ".atdd" / "runtime" / "agents" / agent_id
+    bleed_dir.mkdir(parents=True)
+    (bleed_dir / "output.log").write_bytes(b"alive\n")
+
+    monkeypatch.chdir(bleed_cwd)
+
+    with pytest.raises(ProcessNotAlive) as exc_info:
+        _verify_process_alive(
+            proc=_AliveProc(),
+            agent_id=agent_id,
+            runtime_dir=polled_dir,
+            transport="cli-return",
+            timeout_s=0.05,
+        )
+
+    msg = str(exc_info.value)
+    assert "crashed silently" not in msg, (
+        f"E021-UNIT-002: path-mismatch case must not say 'crashed silently'. Got: {msg!r}"
+    )

--- a/src/atdd/coach/commands/tests/test_l002_smoke_001_relative_runtime_root_output_log_at_absolute_path.py
+++ b/src/atdd/coach/commands/tests/test_l002_smoke_001_relative_runtime_root_output_log_at_absolute_path.py
@@ -1,0 +1,109 @@
+# URN: test:spawn-agents:L002-SMOKE-001-relative-runtime-root-output-log-at-absolute-path
+# Acceptance: acc:spawn-agents:L002-SMOKE-001-relative-runtime-root-output-log-at-absolute-path
+# WMBT: wmbt:spawn-agents:L002
+# Phase: SMOKE
+# Layer: backend.smoke
+# Runtime: python
+# Assertion: behavioral
+"""L002-SMOKE-001 — end-to-end regression gate: with runtime_root supplied as a
+relative path, the shim writes output.log at the resolved absolute path and no
+output.log appears at any CWD-bled worktree-relative location.
+_verify_process_alive does not raise ProcessNotAlive.
+
+This SMOKE test is the definitive regression gate: any future change that
+reintroduces relative-path bleed will cause _verify_process_alive to raise here
+before it causes a false-crash in production.
+
+Reproduces the exact setup from the 2026-05-26 false-crash incident:
+- runtime_root given as relative
+- CWD changed to a worktree directory before shim exec
+- fixture shim writes one byte to its received --runtime-dir agents/<id>/output.log
+
+Smoke gate: requires ATDD_RUN_SMOKE=1.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.smoke]
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ATDD_RUN_SMOKE"),
+    reason="L002-SMOKE-001 requires ATDD_RUN_SMOKE=1",
+)
+def test_relative_runtime_root_output_log_lands_at_absolute_path(tmp_path, monkeypatch):
+    from atdd.coach.commands.spawn import _build_shim_command, _verify_process_alive
+
+    agent_id = "smoke-l002-bleed-gate"
+    relative_suffix = ".atdd/runtime"
+
+    # Set CWD to a directory that acts as the "original" coach CWD.
+    original_cwd = tmp_path / "coach_cwd"
+    original_cwd.mkdir()
+    monkeypatch.chdir(original_cwd)
+
+    # The resolved absolute runtime root (pre-CWD-change).
+    expected_abs_runtime = original_cwd / relative_suffix
+
+    # Build the shim command while CWD == original_cwd.
+    # After E019 fix: --runtime-dir will be the absolute path.
+    runtime_root_rel = Path(relative_suffix)
+    cmd = _build_shim_command("echo ok", agent_id, runtime_root_rel)
+
+    tokens = shlex.split(cmd)
+    idx = tokens.index("--runtime-dir")
+    received_runtime_dir = tokens[idx + 1]
+
+    # ── Simulate CWD change to worktree ─────────────────────────────────────
+    worktree_cwd = tmp_path / "worktree"
+    worktree_cwd.mkdir()
+    monkeypatch.chdir(worktree_cwd)
+
+    # ── Fixture shim: writes one byte to agents/<id>/output.log at received path ──
+    agent_out_dir = Path(received_runtime_dir) / "agents" / agent_id
+    agent_out_dir.mkdir(parents=True, exist_ok=True)
+    output_log = agent_out_dir / "output.log"
+    output_log.write_bytes(b"L002 smoke heartbeat\n")
+
+    # ── Assertions ──────────────────────────────────────────────────────────
+
+    # 1. received --runtime-dir is absolute.
+    assert Path(received_runtime_dir).is_absolute(), (
+        f"L002-SMOKE-001: --runtime-dir in shim command must be absolute. "
+        f"Got: {received_runtime_dir!r}"
+    )
+
+    # 2. output.log exists at the resolved absolute location (not at worktree-bled path).
+    abs_output_log = expected_abs_runtime / "agents" / agent_id / "output.log"
+    assert abs_output_log.exists(), (
+        f"L002-SMOKE-001: output.log must exist at the pre-resolved absolute path "
+        f"{abs_output_log}. Failing here means _build_shim_command did not resolve "
+        "the relative runtime_root to absolute (CWD bleed reproduced)."
+    )
+
+    # 3. No output.log at the worktree-relative CWD-bled location.
+    bled_log = worktree_cwd / relative_suffix / "agents" / agent_id / "output.log"
+    assert not bled_log.exists(), (
+        f"L002-SMOKE-001: output.log must NOT exist at the CWD-bled path {bled_log}."
+    )
+
+    # 4. _verify_process_alive does not raise (heartbeat visible at absolute path).
+    class _AliveProc:
+        def poll(self):
+            return None
+
+    _verify_process_alive(
+        proc=_AliveProc(),
+        agent_id=agent_id,
+        runtime_dir=agent_out_dir,
+        transport="cli-return",
+        timeout_s=1.0,
+    )
+    # Must not raise ProcessNotAlive — the heartbeat byte is at the correct absolute path.

--- a/src/atdd/coach/shim/__main__.py
+++ b/src/atdd/coach/shim/__main__.py
@@ -48,6 +48,7 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+    args.runtime_dir = args.runtime_dir.resolve()
 
     # Strip leading '--' separator if present.
     cmd_tokens = args.adapter_command


### PR DESCRIPTION
Closes #860

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #860 |
| Type | cleanup |
| Slug | shim-runtime-dir-relative-path-cwd-bleed |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd:SMOKE |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.