### PR TITLE
fix(version_check): restore atdd init to upgrade banner (without --force)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1178,12 +1178,6 @@ sessions:
   archived: null
 - id: '851'
   slug: audit-and-retire-bypass-flag-proliferation
-  file: null
-  issue_number: 851
-  type: analysis
-  status: INIT
-  created: '2026-05-24'
-  archived: null
   file: plan/govern_lifecycle/E026.yaml
   issue_number: 851
   type: chore
@@ -1203,12 +1197,6 @@ sessions:
   archived: null
 - id: '855'
   slug: investigate-smoke-test-systemic-false-greens
-  file: null
-  issue_number: 855
-  type: analysis
-  status: INIT
-  created: '2026-05-25'
-  archived: null
   file: plan/govern_lifecycle/E027.yaml
   issue_number: 855
   type: chore
@@ -1258,3 +1246,11 @@ sessions:
   wagon: observe-and-correct
   feature: null
   train: 0002-coach-drives-lifecycle
+- id: '876'
+  slug: e023-split-managed-vs-consumer-budget
+  file: null
+  issue_number: 876
+  type: implementation
+  status: INIT
+  created: '2026-05-28'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1254,3 +1254,11 @@ sessions:
   status: INIT
   created: '2026-05-28'
   archived: null
+- id: '877'
+  slug: coach-api-milestone-rate-limiting
+  file: null
+  issue_number: 877
+  type: implementation
+  status: INIT
+  created: '2026-05-28'
+  archived: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.83.3"
+version = "3.83.4"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/version_check.py
+++ b/src/atdd/version_check.py
@@ -255,12 +255,12 @@ def check_upgrade_sync_needed() -> Optional[str]:
     if last_version is None:
         # First run or old config without toolkit.last_version
         # Treat as needing sync
-        return f"ATDD upgraded to {__version__}. Run: atdd sync"
+        return f"ATDD upgraded to {__version__}. Run: atdd sync && atdd init"
 
     # Compare versions
     if _is_newer(__version__, last_version):
         notes = get_upgrade_notes(last_version, __version__)
-        msg = f"ATDD upgraded ({last_version} → {__version__}). Run: atdd sync"
+        msg = f"ATDD upgraded ({last_version} → {__version__}). Run: atdd sync && atdd init"
         if notes:
             msg += "\n" + "\n".join(f"  → {v}: {note}" for v, note in notes)
         return msg


### PR DESCRIPTION
## Summary
- PR #874 intended to remove only `--force` from the upgrade banner, not `atdd init` entirely
- Corrects the overshoot: banner now reads `Run: atdd sync && atdd init` (no `--force`)
- Bumps version to 3.83.4 (PATCH)

## Before / After
```
# Before (3.83.1 — wrong, --force removed atdd init entirely)
Run: atdd sync && atdd init --force

# After 3.83.3 (wrong overshoot — atdd init dropped entirely)  
Run: atdd sync

# After 3.83.4 (correct intent)
Run: atdd sync && atdd init
```