### PR TITLE
feat(atdd): Define Validator Report And Persistence Materialization Contract (#890)

### DIFF
--- a/.atdd/baselines/validation/planner.yaml
+++ b/.atdd/baselines/validation/planner.yaml
@@ -1,5 +1,5 @@
 phase: planner
-passed_at: '2026-05-30T21:26:36.560190+00:00'
+passed_at: '2026-05-31T02:37:53.752292+00:00'
 source_hash: 56eee38c8c1f1b7326bb2266723a863a1528c1db0e3bec543321333f6dc04162
 atdd_version: 3.84.0
 skipped_api: true

--- a/docs/smoke-audit.md
+++ b/docs/smoke-audit.md
@@ -108,6 +108,7 @@ of bypass patterns.
 | acc:govern-lifecycle:E033-SMOKE-001-real-commit-rejects-staged-create | real (git commit with pre-commit hook) | pre-commit rejects staged gh issue create | N/A (single component) | #816 |
 | acc:govern-lifecycle:E034-SMOKE-001-real-init-installs-and-warns | real (atdd init) | init installs shim + envrc entry | N/A (single component) | #816 |
 | acc:govern-lifecycle:E035-SMOKE-001-real-import-purity-and-yaml-load | real (child interpreter subprocess imports atdd.coach.core + on-disk YAML load) | fresh import leaks no subprocess; phase_machine.convention.yaml parses to 9 phases | N/A (single component) | #888 |
+| acc:govern-lifecycle:E037-SMOKE-001-real-collect-reports-emission | real (child interpreter subprocess runs the disposition-gate emit adapter writing an on-disk JSONL sink) | emitted ValidatorReport row carries the violation rule_id with disposition=block | N/A (single component) | #890 |
 | acc:govern-lifecycle:L002-SMOKE-001-meta-walker-zero-hits-on-post-retrofit-repo | real (walk_all_smoke_acceptances_for_anti_patterns) | anti-pattern hits list | N/A (meta-validator) | #855 |
 | acc:govern-lifecycle:R004-SMOKE-001-real-linked-worktree-recognized-worktree-ready | real (git worktree) | worktree detection | N/A (single component) | — |
 | acc:govern-lifecycle:Y004-SMOKE-001-pre-commit-template-has-drift-notice | real (template file) | file content | N/A (single component) | — |

--- a/plan/govern_lifecycle/E037.yaml
+++ b/plan/govern_lifecycle/E037.yaml
@@ -1,0 +1,96 @@
+urn: "wmbt:govern-lifecycle:E037"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "validator-report-and-persistence-contracts-drifting-or-being-defined-ad-hoc-across-the-coach-decomposition-layers"
+context_clarifier: "when the Coach decomposition (docs/coach-decomposition.md, umbrella #887) freezes the validator-emission and persistence contracts as Child 3 — re-exporting the frozen §4.2 ValidatorReport from atdd.validators, shipping atdd.validators.emit.emit_reports that appends run-scoped JSONL, migrating the per-persona disposition gate to emit ValidatorReport rows, and defining the §4.6 PersistenceStore Protocol, the §4.4 load_conventions signature, and the §5.2 events.jsonl schema (schema_version 1.0) as the typed seam Children 7 and 8 build against"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of validator-report-and-persistence-contracts-drifting-or-being-defined-ad-hoc-across-the-coach-decomposition-layers by re-exporting the §4.2 ValidatorReport from atdd.validators, shipping atdd.validators.emit.emit_reports (run-scoped JSONL, best-effort), routing the disposition gate through it, and freezing the §4.6 PersistenceStore Protocol, the §4.4 load_conventions signature, and the §5.2 events.jsonl schema as signatures-only contracts for Children 7 and 8 (#890)"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:E037-UNIT-001-validator-report-emit-contract"
+      id: "AC-UNIT-001"
+      purpose: "The frozen §4.2 ValidatorReport is re-exported from atdd.validators, and atdd.validators.emit.emit_reports appends one JSONL row per report to the active run sink while staying a safe no-op when no run context is configured"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd.coach.core.types.ValidatorReport is a frozen dataclass carrying the §4.2 fields (validator_id, rule_id, severity, disposition, unsuppressed_count, location, detail, fix_hint_ref)"
+        - "atdd.validators re-exports ValidatorReport and emit_reports as the stable validator-emission import location"
+        - "A temporary reports sink is selected via the ATDD_VALIDATOR_REPORTS_PATH environment variable"
+    when:
+      abstract: "emit_reports is called once with a tuple of ValidatorReport rows while the sink env var is set, and once while no run-context env var is set"
+    then:
+      abstract:
+        - "with the sink configured, the file contains exactly one JSON object per emitted report, each round-tripping every §4.2 field"
+        - "with no run context configured, emit_reports is a no-op and writes nothing"
+        - "ValidatorReport is frozen — attempting to mutate a field raises"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-31"
+  - identity:
+      urn: "acc:govern-lifecycle:E037-UNIT-002-persistence-store-protocol"
+      id: "AC-UNIT-002"
+      purpose: "atdd.train.persistence exposes the §4.6 PersistenceStore Protocol with every method, the §4.4 load_conventions signature, and IssueRecord, and atdd.train.types exposes the §4.7 run/event value types — the typed seam Children 7 and 8 import"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd.train.persistence defines PersistenceStore (a typing.Protocol), IssueRecord, and load_conventions"
+        - "atdd.train.types defines RunId, RunStatus, RunSummary, RunState, WaveResult, and TrainEvent"
+    when:
+      abstract: "the PersistenceStore Protocol members are introspected and load_conventions is invoked"
+    then:
+      abstract:
+        - "from atdd.train.persistence import PersistenceStore, load_conventions succeeds"
+        - "PersistenceStore declares every §4.6 method: create_run, load_run, list_runs, append_event, replay_events, append_decision, get_issue, upsert_issue, materialize_evidence"
+        - "load_conventions raises NotImplementedError (signature only; the body ships in Child 7) and the §4.7 train value types are importable"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-31"
+  - identity:
+      urn: "acc:govern-lifecycle:E037-UNIT-003-events-jsonl-schema"
+      id: "AC-UNIT-003"
+      purpose: "atdd.train.events freezes the §5.2 events.jsonl schema at schema_version 1.0, enumerates the initial event types with their required payload keys, and validates event dicts purely"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd.train.events exposes SCHEMA_VERSION, REQUIRED_EVENT_FIELDS, EVENT_TYPES, and validate_event_dict"
+    when:
+      abstract: "the constants are inspected and validate_event_dict is called with a well-formed event and with malformed events"
+    then:
+      abstract:
+        - "SCHEMA_VERSION == '1.0' and REQUIRED_EVENT_FIELDS includes schema_version, ts, run_id, issue_number, type, payload, seq"
+        - "EVENT_TYPES contains the §5.2 initial set (RunStarted, EvidenceMaterialized, DecisionMade, DispatchEmitted, AgentSpawned, AgentReady, AgentEventReceived, AgentDone, PhaseAdvanced, PrOpened, PrMerged, RunBlocked, RunEscalated, RunCompleted, RunResumed)"
+        - "validate_event_dict returns an empty tuple for a valid event and a non-empty tuple naming the problem for a missing field, an unknown type, or an unsupported schema major"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-31"
+  - identity:
+      urn: "acc:govern-lifecycle:E037-SMOKE-001-real-collect-reports-emission"
+      id: "AC-SMOKE-001"
+      purpose: "A real disposition-gate invocation in a real process, with a real run sink on disk, emits a real ValidatorReport row — exercising the actual gate adapter and filesystem, not an in-memory stub"
+      phase: "SMOKE"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "The atdd package is importable from local source and runnable as a subprocess"
+        - "ATDD_VALIDATOR_REPORTS_PATH points at a real temp file the subprocess may write"
+    when:
+      abstract: "a subprocess imports atdd.coach.utils.disposition_gate and calls assert_disposition_satisfied with a structured violation for an unknown rule_id (strict tier)"
+    then:
+      abstract:
+        - "the on-disk validator-reports.jsonl contains at least one ValidatorReport row whose rule_id matches the violation and whose disposition is 'block' (strict gate tier mapped to the §4.2 vocabulary)"
+        - "emission occurs whether or not the gate ultimately fails, and never alters the gate verdict"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-31"

--- a/plan/govern_lifecycle/_govern_lifecycle.yaml
+++ b/plan/govern_lifecycle/_govern_lifecycle.yaml
@@ -62,7 +62,7 @@ features:
   - urn: "feature:govern-lifecycle:freeze-coach-core-typed-api-and-phase-machine"
 
 wmbt:
-  total: 64
+  total: 65
   R001: "minimize stale local manifest status after a successful GitHub transition"
   R002: "minimize misleading layout errors during post-transition re-enter"
   R003: "minimize stale hierarchy_coverage_features ratchet baseline carrying tactical baseline bumps"
@@ -127,3 +127,4 @@ wmbt:
   E033: "minimize quantity of committed-scripts-that-bake-in-gh-issue-create-calls by installing a pre-commit hook that greps the staged diff for added gh issue create lines, rejects with an educational error, and exempts *.md docs (#816)"
   E034: "minimize likelihood of fresh-worktrees-missing-the-gh-shim-envrc-and-precommit-hook-after-atdd-init by making atdd init install .atdd/bin/gh, .envrc, and the pre-commit hook idempotently with a direnv soft-fail notice (#816)"
   E035: "minimize likelihood of coach-core-policy-surface-and-phase-machine-drifting-or-duplicating-across-modules by freezing the typed contracts in atdd.coach.core.types, the five pure policy functions in atdd.coach.core, and the phase machine in phase_machine.convention.yaml while removing the duplicate transition table from the CLAUDE.md managed block (#888)"
+  E037: "minimize likelihood of validator-report-and-persistence-contracts-drifting-or-being-defined-ad-hoc-across-the-coach-decomposition-layers by re-exporting the ValidatorReport from atdd.validators, shipping atdd.validators.emit.emit_reports, routing the disposition gate through it, and freezing the PersistenceStore Protocol, the load_conventions signature, and the events.jsonl schema as signatures-only contracts for Children 7 and 8 (#890)"

--- a/plan/govern_lifecycle/features/define_validator_report_and_persistence_materialization_contract.yaml
+++ b/plan/govern_lifecycle/features/define_validator_report_and_persistence_materialization_contract.yaml
@@ -1,0 +1,7 @@
+feature: define-validator-report-and-persistence-materialization-contract
+wagon: govern-lifecycle
+urn: "feature:govern-lifecycle:define-validator-report-and-persistence-materialization-contract"
+wmbts:
+  - "wmbt:govern-lifecycle:E037"
+references:
+  - "docs/coach-decomposition.md"

--- a/src/atdd/coach/utils/disposition_gate.py
+++ b/src/atdd/coach/utils/disposition_gate.py
@@ -278,6 +278,77 @@ def _suggest_marker_for(rule_id: str) -> str:
     )
 
 
+# Map the gate's disposition tiers onto the ValidatorReport disposition
+# vocabulary (docs/coach-decomposition.md §4.2). The two vocabularies differ:
+# the gate speaks strict/advisory/suppress-and-clean; ValidatorReport speaks
+# block/warn-and-log/suppress-and-clean.
+_GATE_TO_REPORT_DISPOSITION = {
+    "strict": "block",
+    "advisory": "warn-and-log",
+    "suppress-and-clean": "suppress-and-clean",
+}
+
+
+def _coerce_severity(value: Any) -> int:
+    """Best-effort coerce a Violation severity to the ValidatorReport int (0-5)."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    return {
+        "info": 1,
+        "low": 2,
+        "warn": 3,
+        "warning": 3,
+        "error": 4,
+        "high": 4,
+        "critical": 5,
+    }.get(str(value).strip().lower(), 0)
+
+
+def _emit_validator_reports(
+    validator_id: str,
+    structured: "Dict[str, List[Any]]",
+    registry: "Dict[str, RuleMetadata]",
+) -> None:
+    """Emit one ``ValidatorReport`` per rule_id to the active run (§4.11).
+
+    Best-effort: a no-op when no run context is configured (see
+    ``atdd.validators.emit.emit_reports``) and never raises into the gate. This
+    is the migration adapter (Child 3 / #890) that makes every validator routing
+    through this gate emit uniform reports the train persistence layer reads back
+    into ``Evidence.validator_reports``.
+    """
+    try:
+        from atdd.coach.core.types import ValidatorReport
+        from atdd.validators.emit import emit_reports
+
+        reports: List[ValidatorReport] = []
+        for rule_id, vs in structured.items():
+            meta = registry.get(rule_id)
+            gate_disp = meta.disposition if meta and meta.disposition else _DEFAULT_DISPOSITION
+            if gate_disp not in _LEGAL_DISPOSITIONS:
+                gate_disp = _DEFAULT_DISPOSITION
+            severities = [_coerce_severity(getattr(v, "severity", 0)) for v in vs]
+            first = vs[0] if vs else None
+            reports.append(
+                ValidatorReport(
+                    validator_id=validator_id,
+                    rule_id=rule_id,
+                    severity=max(severities) if severities else 0,
+                    disposition=_GATE_TO_REPORT_DISPOSITION.get(gate_disp, "block"),
+                    unsuppressed_count=len(vs),
+                    location=getattr(first, "location", None) if first else None,
+                    detail=getattr(first, "detail", None) if first else None,
+                )
+            )
+        if reports:
+            emit_reports(tuple(reports))
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        # Emission is best-effort; never let it perturb the gate verdict.
+        return
+
+
 def assert_disposition_satisfied(
     validator_id: str,
     violations: Sequence[Any],
@@ -337,6 +408,11 @@ def assert_disposition_satisfied(
             structured[v.rule_id].append(v)
         else:
             opaque.append(v)
+
+    # Child 3 (#890): emit a ValidatorReport per rule so the train persistence
+    # layer can read violations back into Evidence (§4.11). Best-effort; the
+    # call is a no-op outside a configured run and never affects the verdict.
+    _emit_validator_reports(validator_id, structured, registry)
 
     # Substrate spec v12 §4.5 / issue #422: record per-rule outcomes on the
     # active pytest session BEFORE we route through the gate. The security

--- a/src/atdd/train/__init__.py
+++ b/src/atdd/train/__init__.py
@@ -1,0 +1,12 @@
+"""``atdd.train`` — stateful train-runner orchestration layer.
+
+This package owns runs, events, persistence, resume, and wave concurrency
+(docs/coach-decomposition.md §3.1, §3.2). It depends inward on ``atdd.coach.core``
+(pure policy) and on the runtime/integration adapters; it MUST NOT be imported by
+``atdd.coach.core`` (enforced by the import-discipline test, §3.3 / §10.2).
+
+Child 3 (#890) lands the *contract* surface only — the ``PersistenceStore``
+Protocol, the run/event types, and the events.jsonl schema constants. Concrete
+implementations (``JsonlPersistenceStore``, ``materialize_evidence``) ship in
+Child 7 (#894).
+"""

--- a/src/atdd/train/events.py
+++ b/src/atdd/train/events.py
@@ -1,0 +1,97 @@
+"""events.jsonl schema contract (docs/coach-decomposition.md §5.2).
+
+The train runner is the *single writer* to ``runs/<run_id>/events.jsonl``. Every
+line is a JSON object with the required top-level fields below plus a
+type-specific ``payload``. This module freezes the schema version and the initial
+event-type registry; it contains only pure data + pure validation helpers (no
+I/O) so it is safe to import from anywhere.
+
+Concrete appending/replay ships with ``JsonlPersistenceStore`` in Child 7
+(#894). See :class:`atdd.train.types.TrainEvent` for the in-memory shape.
+"""
+from __future__ import annotations
+
+# Schema-version rule (§5.2): any new ``type`` or payload-shape change increments
+# the minor; a breaking format change increments the major. Replay refuses
+# unknown major versions and migrates minor versions in-memory at read time.
+SCHEMA_VERSION = "1.0"
+
+# Required top-level keys on every events.jsonl line (§5.2 + TrainEvent §4.7).
+REQUIRED_EVENT_FIELDS: tuple[str, ...] = (
+    "schema_version",
+    "ts",
+    "run_id",
+    "issue_number",
+    "type",
+    "payload",
+    "seq",
+)
+
+# Initial event-type set (§5.2). Maps event ``type`` → required ``payload`` keys.
+# Sourced-from / single-writer notes live in the spec; this is the machine copy.
+EVENT_TYPES: dict[str, tuple[str, ...]] = {
+    "RunStarted": ("conventions_hash", "conventions_snapshot_ref", "policy_handle_id"),
+    "EvidenceMaterialized": ("evidence_hash", "current_phase"),
+    "DecisionMade": ("verdict_kind", "from_phase", "to_phase", "persona", "rule_ids"),
+    "DispatchEmitted": ("dispatch_spec",),
+    "AgentSpawned": ("agent_id", "transport", "surface_ref"),
+    "AgentReady": ("agent_id", "transport_signal", "elapsed_seconds"),
+    "AgentEventReceived": ("agent_id", "agent_event"),
+    "AgentDone": ("agent_id", "summary", "exit_code"),
+    "PhaseAdvanced": ("from_phase", "to_phase", "commit_sha"),
+    "PrOpened": ("pr_number", "branch"),
+    "PrMerged": ("pr_number", "merge_commit_sha"),
+    "RunBlocked": ("verdict",),
+    "RunEscalated": ("verdict", "notification_channel"),
+    "RunCompleted": ("final_phase", "total_duration_seconds"),
+    "RunResumed": ("from_event_seq", "resume_reason"),
+}
+
+
+def schema_major(version: str) -> int:
+    """Major component of a ``"major.minor"`` schema version string. Pure."""
+    return int(version.split(".", 1)[0])
+
+
+def validate_event_dict(event: dict) -> tuple[str, ...]:
+    """Return a tuple of human-readable problems with ``event``; empty == valid.
+
+    Pure: no I/O, no clock. Checks required top-level fields, a known ``type``,
+    and the required payload keys for that type. Does not assert payload value
+    shapes beyond presence (those are owned by the producing layer).
+    """
+    problems: list[str] = []
+
+    for field in REQUIRED_EVENT_FIELDS:
+        if field not in event:
+            problems.append(f"missing required field {field!r}")
+
+    version = event.get("schema_version")
+    if version is not None and schema_major(str(version)) != schema_major(SCHEMA_VERSION):
+        problems.append(
+            f"unsupported schema major: {version!r} (reader supports {SCHEMA_VERSION!r})"
+        )
+
+    etype = event.get("type")
+    if etype is not None:
+        if etype not in EVENT_TYPES:
+            problems.append(f"unknown event type {etype!r}")
+        else:
+            payload = event.get("payload")
+            if not isinstance(payload, dict):
+                problems.append("payload must be an object")
+            else:
+                for key in EVENT_TYPES[etype]:
+                    if key not in payload:
+                        problems.append(f"{etype} payload missing {key!r}")
+
+    return tuple(problems)
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "REQUIRED_EVENT_FIELDS",
+    "EVENT_TYPES",
+    "schema_major",
+    "validate_event_dict",
+]

--- a/src/atdd/train/persistence.py
+++ b/src/atdd/train/persistence.py
@@ -1,0 +1,114 @@
+"""Persistence contract for the train runner (docs/coach-decomposition.md §4.6).
+
+Child 3 (#890) ships the *contract surface only*:
+
+- the :class:`PersistenceStore` ``Protocol`` (every method from §4.6),
+- :class:`IssueRecord` (manifest row shape, §4.7),
+- the :func:`load_conventions` signature (§4.4) — first impl in Child 7.
+
+Concrete implementations ship later:
+
+- ``InMemoryPersistenceStore`` — Child 2 (#889), parity-test fixture.
+- ``JsonlPersistenceStore`` + ``materialize_evidence`` body — Child 7 (#894).
+
+This module is a typed seam; it performs no I/O at import time.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Protocol, runtime_checkable
+
+from atdd.coach.core.types import (
+    Conventions,
+    Evidence,
+    IssueType,
+    Phase,
+    TransitionDecision,
+)
+from atdd.train.types import (
+    RunId,
+    RunState,
+    RunStatus,
+    RunSummary,
+    TrainEvent,
+)
+
+
+@dataclass(frozen=True)
+class IssueRecord:
+    """Manifest row shape — read/written by persistence (§4.7)."""
+
+    id: str
+    slug: str
+    issue_number: int
+    type: IssueType
+    status: Phase
+    train: str | None
+    created: str
+    archived: str | None
+
+
+@runtime_checkable
+class PersistenceStore(Protocol):
+    """The bridge between the train runner and durable run state (§4.6).
+
+    Method signatures are frozen here; the JSONL-backed implementation ships in
+    Child 7. The single-writer invariant (only the train-runner layer calls
+    :meth:`append_event`) is what makes replay deterministic (§5.2).
+    """
+
+    # --- run lifecycle ---
+    def create_run(self, issue_number: int, *, conventions: Conventions) -> RunId: ...
+
+    def load_run(self, run_id: RunId) -> RunState: ...
+
+    def list_runs(self, *, status: RunStatus | None = None) -> list[RunSummary]: ...
+
+    # --- events (single-writer: train runner) ---
+    def append_event(self, run_id: RunId, event: TrainEvent) -> None: ...
+
+    def replay_events(self, run_id: RunId) -> Iterator[TrainEvent]: ...
+
+    # --- decisions (audit trail for every Coach Verdict) ---
+    def append_decision(
+        self, run_id: RunId, decision: TransitionDecision, *, evidence_hash: str
+    ) -> None: ...
+
+    # --- manifest (issue registry) ---
+    def get_issue(self, n: int) -> IssueRecord: ...
+
+    def upsert_issue(self, rec: IssueRecord) -> None: ...
+
+    # --- evidence materialization (THE bridge to Coach-core) ---
+    def materialize_evidence(self, issue_number: int) -> Evidence:
+        """Aggregate from manifest, GitHub adapter, validators, filesystem into a
+        frozen :class:`~atdd.coach.core.types.Evidence` snapshot. The conventions
+        hash MUST match the active :class:`~atdd.coach.core.types.Conventions`.
+
+        Body implemented in Child 7 (#894).
+        """
+        ...
+
+
+def load_conventions(repo_root: Path) -> Conventions:
+    """Load + normalize the convention YAML files, compute the snapshot hash, and
+    freeze them into a :class:`~atdd.coach.core.types.Conventions` bundle (§4.4).
+
+    Conventions are loaded once per run and frozen for the run's duration; the
+    snapshot hash is recorded in the run's first event so replay is deterministic.
+    Hot-reload mid-run is explicitly unsupported.
+
+    Concrete implementation ships in Child 7 (#894).
+    """
+    raise NotImplementedError(
+        "load_conventions ships in Child 7 (#894); "
+        "see docs/coach-decomposition.md §4.4"
+    )
+
+
+__all__ = [
+    "PersistenceStore",
+    "IssueRecord",
+    "load_conventions",
+]

--- a/src/atdd/train/types.py
+++ b/src/atdd/train/types.py
@@ -1,0 +1,86 @@
+"""Train-runner supporting types (docs/coach-decomposition.md §4.7).
+
+These are the run/event value types the ``PersistenceStore`` Protocol (§4.6) and
+the ``TrainRunner`` Protocol (§4.7, Child 8) bind to. They are plain frozen
+dataclasses / ``NewType`` aliases — no behaviour, no I/O — so both the
+persistence layer (Child 3/7) and the runner layer (Child 8) can import them
+without a dependency cycle.
+
+Physical-location note (§4.7): ``RunId``, ``RunStatus``, ``RunSummary``,
+``RunState``, ``WaveResult`` and ``TrainEvent`` live here in ``atdd.train.types``.
+``IssueRecord`` lives in ``atdd.train.persistence``. ``MergeResult`` lives in
+``atdd.integrations.github.types`` (Child 4).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, NewType
+
+from atdd.coach.core.types import Phase, TransitionDecision
+
+# Opaque run identifier, e.g. "run-816-2026-05-30-a81b0d90" (§4.7).
+RunId = NewType("RunId", str)
+
+# Lifecycle state of a run, shared by RunStatus / RunSummary (§4.7).
+RunLifecycle = Literal["RUNNING", "BLOCKED", "ESCALATED", "COMPLETED", "CANCELLED"]
+
+
+@dataclass(frozen=True)
+class RunStatus:
+    run_id: RunId
+    issue_number: int
+    current_phase: Phase
+    state: RunLifecycle
+    last_event_seq: int
+    started_at: str
+    last_event_at: str
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    run_id: RunId
+    issue_number: int
+    state: RunLifecycle
+
+
+@dataclass(frozen=True)
+class RunState:
+    """Materialized in-memory state reconstructed from event replay (§4.7)."""
+
+    run_id: RunId
+    issue_number: int
+    current_phase: Phase
+    conventions_hash: str
+    decisions: tuple[TransitionDecision, ...]
+    last_event_seq: int
+
+
+@dataclass(frozen=True)
+class WaveResult:
+    started: tuple[RunId, ...]
+    blocked: tuple[RunId, ...]
+    failed_to_start: tuple[tuple[int, str], ...]  # (issue_number, reason)
+
+
+@dataclass(frozen=True)
+class TrainEvent:
+    """Unified shape for events appended to events.jsonl (§5.2)."""
+
+    schema_version: str
+    ts: str
+    run_id: RunId
+    issue_number: int
+    type: str
+    payload: dict
+    seq: int  # monotonic per run
+
+
+__all__ = [
+    "RunId",
+    "RunLifecycle",
+    "RunStatus",
+    "RunSummary",
+    "RunState",
+    "WaveResult",
+    "TrainEvent",
+]

--- a/src/atdd/validators/__init__.py
+++ b/src/atdd/validators/__init__.py
@@ -1,0 +1,21 @@
+"""``atdd.validators`` — validation layer (docs/coach-decomposition.md §4.11).
+
+Validators run checks against repo state and emit :class:`ValidatorReport` rows;
+they do not decide what to do with violations (that is Coach-core's job, §3.2).
+
+The existing per-persona validator suites stay where they are
+(``src/atdd/{planner,tester,coder,coach}/validators/``); this top-level package
+holds the *emission* infrastructure they call.
+
+``ValidatorReport`` is *defined* in the pure-policy module ``atdd.coach.core.types``
+(so the dependency direction points inward, §4.2). It is re-exported here as the
+stable import location for validator emission::
+
+    from atdd.validators import ValidatorReport, emit_reports
+"""
+from __future__ import annotations
+
+from atdd.coach.core.types import ValidatorReport
+from atdd.validators.emit import emit_reports
+
+__all__ = ["ValidatorReport", "emit_reports"]

--- a/src/atdd/validators/emit.py
+++ b/src/atdd/validators/emit.py
@@ -21,11 +21,14 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Iterable
 
 from atdd.coach.core.types import ValidatorReport
+
+_log = logging.getLogger(__name__)
 
 ENV_REPORTS_PATH = "ATDD_VALIDATOR_REPORTS_PATH"
 ENV_RUN_DIR = "ATDD_RUN_DIR"
@@ -76,7 +79,10 @@ def emit_reports(reports: Iterable[ValidatorReport]) -> None:
             for report in rows:
                 handle.write(json.dumps(dataclasses.asdict(report), sort_keys=True))
                 handle.write("\n")
-    except OSError:
+    except OSError as exc:
+        # Emission is best-effort and env-gated: never break a validator gate,
+        # but surface why the sink write failed instead of swallowing silently.
+        _log.warning("validator-report emission failed: %s", exc)
         return
 
 

--- a/src/atdd/validators/emit.py
+++ b/src/atdd/validators/emit.py
@@ -1,0 +1,91 @@
+"""Validator emission (docs/coach-decomposition.md §4.11).
+
+Every validator emits :class:`ValidatorReport` rows via :func:`emit_reports`,
+which appends them to the active run's persistence store so
+``materialize_evidence()`` can read them back into ``Evidence.validator_reports``.
+
+Run resolution is environment-driven so a validator stays oblivious to *where*
+it runs:
+
+1. ``ATDD_VALIDATOR_REPORTS_PATH`` — explicit sink file (set by
+   ``atdd validate --collect-reports``).
+2. ``ATDD_RUN_DIR`` — a run directory; reports go to ``<dir>/validator-reports.jsonl``.
+3. ``ATDD_RUN_ID`` (+ optional ``ATDD_REPO_ROOT``) — reports go to
+   ``<repo_root>/.atdd/runtime/runs/<run_id>/validator-reports.jsonl`` (§5.1).
+
+When no run context is set (a plain ``pytest`` / ``atdd validate`` run),
+:func:`emit_reports` is a safe no-op so ordinary runs never litter the tree.
+Emission is always best-effort: an I/O error never propagates into the gate.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+
+from atdd.coach.core.types import ValidatorReport
+
+ENV_REPORTS_PATH = "ATDD_VALIDATOR_REPORTS_PATH"
+ENV_RUN_DIR = "ATDD_RUN_DIR"
+ENV_RUN_ID = "ATDD_RUN_ID"
+ENV_REPO_ROOT = "ATDD_REPO_ROOT"
+
+REPORTS_FILENAME = "validator-reports.jsonl"
+
+
+def resolve_reports_path() -> Path | None:
+    """Return the active run's reports file, or ``None`` when no run context.
+
+    Reads environment only; does not create anything.
+    """
+    explicit = os.environ.get(ENV_REPORTS_PATH)
+    if explicit:
+        return Path(explicit)
+
+    run_dir = os.environ.get(ENV_RUN_DIR)
+    if run_dir:
+        return Path(run_dir) / REPORTS_FILENAME
+
+    run_id = os.environ.get(ENV_RUN_ID)
+    if run_id:
+        repo_root = Path(os.environ.get(ENV_REPO_ROOT, ".")).resolve()
+        return repo_root / ".atdd" / "runtime" / "runs" / run_id / REPORTS_FILENAME
+
+    return None
+
+
+def emit_reports(reports: Iterable[ValidatorReport]) -> None:
+    """Append ``reports`` to the active run's ``validator-reports.jsonl``.
+
+    No-op when there are no reports or no run context is configured. Best-effort:
+    filesystem errors are swallowed so emission never breaks a validator gate.
+    """
+    rows = list(reports)
+    if not rows:
+        return
+
+    path = resolve_reports_path()
+    if path is None:
+        return
+
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            for report in rows:
+                handle.write(json.dumps(dataclasses.asdict(report), sort_keys=True))
+                handle.write("\n")
+    except OSError:
+        return
+
+
+__all__ = [
+    "emit_reports",
+    "resolve_reports_path",
+    "ENV_REPORTS_PATH",
+    "ENV_RUN_DIR",
+    "ENV_RUN_ID",
+    "ENV_REPO_ROOT",
+    "REPORTS_FILENAME",
+]

--- a/src/atdd/validators/emit.py
+++ b/src/atdd/validators/emit.py
@@ -82,7 +82,10 @@ def emit_reports(reports: Iterable[ValidatorReport]) -> None:
     except OSError as exc:
         # Emission is best-effort and env-gated: never break a validator gate,
         # but surface why the sink write failed instead of swallowing silently.
-        _log.warning("validator-report emission failed: %s", exc)
+        _log.warning(
+            "validator-report emission failed",
+            extra={"error": str(exc), "error_type": type(exc).__name__},
+        )
         return
 
 

--- a/tests/coach/test_e037_smoke_001_real_collect_reports_emission.py
+++ b/tests/coach/test_e037_smoke_001_real_collect_reports_emission.py
@@ -1,0 +1,66 @@
+# URN: test:govern-lifecycle:define-validator-report-and-persistence-materialization-contract:E037-SMOKE-001-real-collect-reports-emission
+# Acceptance: acc:govern-lifecycle:E037-SMOKE-001-real-collect-reports-emission
+# WMBT: wmbt:govern-lifecycle:E037
+# Phase: RED
+# Layer: backend.integration
+"""SMOKE test for E037-SMOKE-001 (docs/coach-decomposition.md §4.11).
+
+Exercises the real disposition-gate emission adapter in a real interpreter
+subprocess writing to a real on-disk run sink — not an in-memory stub. Proves
+that a per-persona validator routing through ``assert_disposition_satisfied``
+emits a ``ValidatorReport`` row the train persistence layer can read back.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = pytest.mark.atdd_validator
+
+_REPO_SRC = pathlib.Path(__file__).resolve().parents[2] / "src"
+
+
+def test_real_disposition_gate_emits_validator_report_to_disk(tmp_path):
+    sink = tmp_path / "validator-reports.jsonl"
+    script = textwrap.dedent(
+        f"""
+        import os, types
+        os.environ["ATDD_VALIDATOR_REPORTS_PATH"] = {str(sink)!r}
+        import atdd.coach.utils.disposition_gate as dg
+        violation = types.SimpleNamespace(
+            rule_id="demo.e037.smoke",
+            severity=4,
+            location="src/x.py:1",
+            detail="smoke violation",
+        )
+        try:
+            # Unknown rule -> strict tier -> gate fails AFTER emission happens.
+            dg.assert_disposition_satisfied("e037_smoke_validator", [violation])
+        except BaseException:
+            pass
+        """
+    )
+    # Ensure the subprocess imports THIS worktree's source (with the emit adapter),
+    # not an unrelated installed build.
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join(
+            [str(_REPO_SRC), os.environ.get("PYTHONPATH", "")]
+        ),
+    }
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, env=env
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    rows = [json.loads(line) for line in sink.read_text().splitlines() if line.strip()]
+    assert any(
+        row["rule_id"] == "demo.e037.smoke" and row["disposition"] == "block"
+        for row in rows
+    ), f"no matching ValidatorReport row emitted; got {rows!r}"

--- a/tests/coach/test_e037_unit_001_validator_report_emit_contract.py
+++ b/tests/coach/test_e037_unit_001_validator_report_emit_contract.py
@@ -1,0 +1,73 @@
+# URN: test:govern-lifecycle:define-validator-report-and-persistence-materialization-contract:E037-UNIT-001-validator-report-emit-contract
+# Acceptance: acc:govern-lifecycle:E037-UNIT-001-validator-report-emit-contract
+"""Unit test for E037-UNIT-001 (docs/coach-decomposition.md §4.2, §4.11).
+
+``ValidatorReport`` is the frozen §4.2 contract, re-exported from
+``atdd.validators`` as the stable validator-emission location, and
+``emit_reports`` appends one run-scoped JSONL row per report while staying a safe
+no-op when no run context is configured.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from atdd.coach.core.types import ValidatorReport as CoreValidatorReport
+from atdd.validators import ValidatorReport, emit_reports
+from atdd.validators import emit as emit_mod
+
+pytestmark = pytest.mark.atdd_validator
+
+_FIELDS = {
+    "validator_id",
+    "rule_id",
+    "severity",
+    "disposition",
+    "unsuppressed_count",
+    "location",
+    "detail",
+    "fix_hint_ref",
+}
+
+
+def _sample(**overrides) -> ValidatorReport:
+    base = dict(
+        validator_id="demo_validator",
+        rule_id="demo.rule",
+        severity=3,
+        disposition="warn-and-log",
+        unsuppressed_count=2,
+        location="src/x.py:7",
+        detail="demo violation",
+    )
+    base.update(overrides)
+    return ValidatorReport(**base)
+
+
+def test_validator_report_is_the_frozen_core_type():
+    # Re-export must be the very same object defined in pure policy (§4.2).
+    assert ValidatorReport is CoreValidatorReport
+    fields = {f.name for f in dataclasses.fields(ValidatorReport)}
+    assert _FIELDS <= fields
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        _sample().severity = 5  # type: ignore[misc]
+
+
+def test_emit_reports_writes_one_jsonl_row_per_report(tmp_path, monkeypatch):
+    sink = tmp_path / "validator-reports.jsonl"
+    monkeypatch.setenv(emit_mod.ENV_REPORTS_PATH, str(sink))
+    emit_reports((_sample(rule_id="a"), _sample(rule_id="b", disposition="block")))
+    rows = [json.loads(line) for line in sink.read_text().splitlines() if line.strip()]
+    assert len(rows) == 2
+    assert {row["rule_id"] for row in rows} == {"a", "b"}
+    assert set(rows[0]) == _FIELDS  # every §4.2 field round-trips
+
+
+def test_emit_reports_is_noop_without_run_context(tmp_path, monkeypatch):
+    for var in (emit_mod.ENV_REPORTS_PATH, emit_mod.ENV_RUN_DIR, emit_mod.ENV_RUN_ID):
+        monkeypatch.delenv(var, raising=False)
+    assert emit_mod.resolve_reports_path() is None
+    # Must not raise and must not create anything when there is no run context.
+    emit_reports((_sample(),))

--- a/tests/coach/test_e037_unit_002_persistence_store_protocol.py
+++ b/tests/coach/test_e037_unit_002_persistence_store_protocol.py
@@ -1,0 +1,50 @@
+# URN: test:govern-lifecycle:define-validator-report-and-persistence-materialization-contract:E037-UNIT-002-persistence-store-protocol
+# Acceptance: acc:govern-lifecycle:E037-UNIT-002-persistence-store-protocol
+"""Unit test for E037-UNIT-002 (docs/coach-decomposition.md §4.6, §4.7, §4.4).
+
+``atdd.train.persistence`` exposes the §4.6 ``PersistenceStore`` Protocol (every
+method), the §4.4 ``load_conventions`` signature, and ``IssueRecord``; the §4.7
+run/event value types live in ``atdd.train.types``. Concrete bodies ship in
+Child 7 — here the *contract surface* is asserted.
+"""
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from atdd.train import types as train_types
+from atdd.train.persistence import IssueRecord, PersistenceStore, load_conventions
+
+pytestmark = pytest.mark.atdd_validator
+
+# Every method from docs/coach-decomposition.md §4.6.
+_REQUIRED_METHODS = {
+    "create_run",
+    "load_run",
+    "list_runs",
+    "append_event",
+    "replay_events",
+    "append_decision",
+    "get_issue",
+    "upsert_issue",
+    "materialize_evidence",
+}
+
+
+def test_persistence_store_protocol_has_every_4_6_method():
+    members = set(dir(PersistenceStore))
+    missing = _REQUIRED_METHODS - members
+    assert not missing, f"PersistenceStore missing §4.6 methods: {sorted(missing)}"
+
+
+def test_load_conventions_is_signature_only():
+    # Importable (acceptance) but unimplemented until Child 7 (§4.4).
+    with pytest.raises(NotImplementedError):
+        load_conventions(pathlib.Path("."))
+
+
+def test_train_value_types_are_importable():
+    for name in ("RunId", "RunStatus", "RunSummary", "RunState", "WaveResult", "TrainEvent"):
+        assert hasattr(train_types, name), f"missing §4.7 type {name}"
+    assert hasattr(IssueRecord, "__dataclass_fields__")

--- a/tests/coach/test_e037_unit_003_events_jsonl_schema.py
+++ b/tests/coach/test_e037_unit_003_events_jsonl_schema.py
@@ -1,0 +1,82 @@
+# URN: test:govern-lifecycle:define-validator-report-and-persistence-materialization-contract:E037-UNIT-003-events-jsonl-schema
+# Acceptance: acc:govern-lifecycle:E037-UNIT-003-events-jsonl-schema
+"""Unit test for E037-UNIT-003 (docs/coach-decomposition.md §5.2).
+
+``atdd.train.events`` freezes the events.jsonl schema at ``schema_version 1.0``,
+enumerates the §5.2 initial event types with their required payload keys, and
+validates event dicts purely (no I/O).
+"""
+from __future__ import annotations
+
+import pytest
+
+from atdd.train.events import (
+    EVENT_TYPES,
+    REQUIRED_EVENT_FIELDS,
+    SCHEMA_VERSION,
+    validate_event_dict,
+)
+
+pytestmark = pytest.mark.atdd_validator
+
+# The initial event-type set from docs/coach-decomposition.md §5.2.
+_INITIAL_EVENT_TYPES = {
+    "RunStarted",
+    "EvidenceMaterialized",
+    "DecisionMade",
+    "DispatchEmitted",
+    "AgentSpawned",
+    "AgentReady",
+    "AgentEventReceived",
+    "AgentDone",
+    "PhaseAdvanced",
+    "PrOpened",
+    "PrMerged",
+    "RunBlocked",
+    "RunEscalated",
+    "RunCompleted",
+    "RunResumed",
+}
+
+
+def test_schema_version_is_1_0_with_required_top_level_fields():
+    assert SCHEMA_VERSION == "1.0"
+    assert {
+        "schema_version",
+        "ts",
+        "run_id",
+        "issue_number",
+        "type",
+        "payload",
+        "seq",
+    } <= set(REQUIRED_EVENT_FIELDS)
+
+
+def test_event_types_cover_the_5_2_initial_set():
+    missing = _INITIAL_EVENT_TYPES - set(EVENT_TYPES)
+    assert not missing, f"events schema missing §5.2 types: {sorted(missing)}"
+
+
+def test_validate_event_dict_accepts_valid_and_flags_invalid():
+    valid = {
+        "schema_version": "1.0",
+        "ts": "2026-05-31T00:00:00Z",
+        "run_id": "run-890",
+        "issue_number": 890,
+        "type": "DecisionMade",
+        "seq": 1,
+        "payload": {
+            "verdict_kind": "proceed",
+            "from_phase": "RED",
+            "to_phase": "GREEN",
+            "persona": "coder",
+            "rule_ids": [],
+        },
+    }
+    assert validate_event_dict(valid) == ()
+    assert validate_event_dict({}) != ()  # missing every required field
+    assert validate_event_dict(dict(valid, type="NotARealType")) != ()
+    assert validate_event_dict(dict(valid, schema_version="2.0")) != ()  # major mismatch
+    no_payload_key = dict(valid)
+    no_payload_key["payload"] = {}  # DecisionMade requires payload keys
+    assert validate_event_dict(no_payload_key) != ()


### PR DESCRIPTION
Closes #890

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #890 |
| Labels | atdd-issue, atdd:PLANNED |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.

---

## Incident defenses preserved (per-PR requirement, doc §9)

This PR is **purely additive** — new contract modules (`atdd.train.*`,
`atdd.validators.*`) plus a **best-effort** emission adapter on the disposition
gate. It touches **no** incident-defense layer (worktree I-1/I-2/I-9,
agent_control I-4/I-10, train I-3/I-7/I-8/I-12, emergency I-11, pre-push I-13).

- `_emit_validator_reports()` runs **after** violation bucketing inside
  `assert_disposition_satisfied` and is wrapped in `try/except`, so it can never
  alter the gate verdict — strict/suppress-and-clean/advisory behavior is
  unchanged.
- `emit_reports()` is a no-op unless a run-sink env var is set, so ordinary
  `atdd validate` / `pytest` runs write nothing (no new I/O side effects).

## Acceptance mapping — WMBT `wmbt:govern-lifecycle:E037`

| Acceptance | Test |
|---|---|
| E037-UNIT-001 ValidatorReport re-export + emit | `tests/coach/test_e037_unit_001_validator_report_emit_contract.py` |
| E037-UNIT-002 PersistenceStore Protocol + load_conventions | `tests/coach/test_e037_unit_002_persistence_store_protocol.py` |
| E037-UNIT-003 events.jsonl schema (v1.0, §5.2) | `tests/coach/test_e037_unit_003_events_jsonl_schema.py` |
| E037-SMOKE-001 real disposition-gate emission | `tests/coach/test_e037_smoke_001_real_collect_reports_emission.py` |

## Scope note

Validator migration is via the adapter on `assert_disposition_satisfied` (every
validator routing through the gate now emits). The `atdd validate
--collect-reports` operator flag is a small deferred follow-up; the emission
mechanism is fully delivered and env-addressable (`ATDD_VALIDATOR_REPORTS_PATH`).
