### PR TITLE
feat(atdd): Extract Runtime Worktree Preserving Incident Defenses (#892)

### DIFF
--- a/.atdd/baselines/validation/planner.yaml
+++ b/.atdd/baselines/validation/planner.yaml
@@ -1,5 +1,5 @@
 phase: planner
-passed_at: '2026-05-31T02:37:53.752292+00:00'
+passed_at: '2026-05-31T03:24:06.001795+00:00'
 source_hash: 56eee38c8c1f1b7326bb2266723a863a1528c1db0e3bec543321333f6dc04162
 atdd_version: 3.84.0
 skipped_api: true

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1348,7 +1348,7 @@ sessions:
   file: null
   issue_number: 892
   type: implementation
-  status: SMOKE
+  status: REFACTOR
   train: 0001-self-compliance-validate
   created: '2026-05-31'
   archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1348,7 +1348,7 @@ sessions:
   file: null
   issue_number: 892
   type: implementation
-  status: RED
+  status: SMOKE
   train: 0001-self-compliance-validate
   created: '2026-05-31'
   archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1343,3 +1343,12 @@ sessions:
   train: 0001-self-compliance-validate
   created: '2026-05-31'
   archived: null
+- id: '892'
+  slug: extract-runtime-worktree-preserving-incident-defenses
+  file: null
+  issue_number: 892
+  type: implementation
+  status: INIT
+  train: 0001-self-compliance-validate
+  created: '2026-05-31'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1348,7 +1348,7 @@ sessions:
   file: null
   issue_number: 892
   type: implementation
-  status: INIT
+  status: PLANNED
   train: 0001-self-compliance-validate
   created: '2026-05-31'
   archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1348,7 +1348,7 @@ sessions:
   file: null
   issue_number: 892
   type: implementation
-  status: PLANNED
+  status: RED
   train: 0001-self-compliance-validate
   created: '2026-05-31'
   archived: null

--- a/.github/workflows/atdd-validate.yml
+++ b/.github/workflows/atdd-validate.yml
@@ -224,6 +224,42 @@ jobs:
       - name: Run lifecycle parity test (§10.1)
         run: PYTHONPATH=src python3 -m pytest tests/lifecycle/test_full_issue_parity.py -v --tb=short
 
+  # Incident-defense suite (docs/coach-decomposition.md §9, §12.1 item 7).
+  # Each migration child that touches a layer adds explicit tests under
+  # tests/incident_defenses/ proving the defenses it preserves. Child 5 (#892)
+  # ships the worktree defenses (I-1 bare dispatch, I-2 protected main, I-9
+  # core.bare=false). Failing blocks merge via the validate-gate fan-in.
+  incident-defense-test:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'issues' ||
+      contains(github.event.issue.labels.*.name, 'atdd-issue') ||
+      contains(github.event.issue.labels.*.name, 'atdd-wmbt')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-atdd-toolkit
+
+      - name: Install dependencies
+        run: pip3 install pytest pyyaml
+
+      - name: Configure git identity (real-git worktree tests)
+        run: |
+          git config --global user.email "atdd-ci@example.com"
+          git config --global user.name "ATDD CI"
+
+      - name: Run incident-defense suite (§9)
+        run: PYTHONPATH=src python3 -m pytest tests/incident_defenses/ -v --tb=short
+
   # Note: the pre-merge `version-bump` PR check was removed in #462 phase 2.
   # Version is now bumped automatically on main by the bump-on-merge step in
   # `.github/workflows/post-merge-lifecycle.yml` (branch-prefix → semver
@@ -232,7 +268,7 @@ jobs:
   # check that no longer reports.
 
   validate-gate:
-    needs: [validate-planner, validate-tester, validate-coder, validate-coach, validate-smoke, import-discipline-test, parity-test]
+    needs: [validate-planner, validate-tester, validate-coder, validate-coach, validate-smoke, import-discipline-test, parity-test, incident-defense-test]
     runs-on: ubuntu-latest
     if: always()
     permissions:
@@ -246,7 +282,8 @@ jobs:
                         "coach:${{ needs.validate-coach.result }}" \
                         "smoke:${{ needs.validate-smoke.result }}" \
                         "import-discipline:${{ needs.import-discipline-test.result }}" \
-                        "parity:${{ needs.parity-test.result }}"; do
+                        "parity:${{ needs.parity-test.result }}" \
+                        "incident-defense:${{ needs.incident-defense-test.result }}"; do
             phase="${result%%:*}"
             status="${result##*:}"
             if [ "$status" != "success" ] && [ "$status" != "skipped" ]; then

--- a/docs/smoke-audit.md
+++ b/docs/smoke-audit.md
@@ -109,6 +109,7 @@ of bypass patterns.
 | acc:govern-lifecycle:E034-SMOKE-001-real-init-installs-and-warns | real (atdd init) | init installs shim + envrc entry | N/A (single component) | #816 |
 | acc:govern-lifecycle:E035-SMOKE-001-real-import-purity-and-yaml-load | real (child interpreter subprocess imports atdd.coach.core + on-disk YAML load) | fresh import leaks no subprocess; phase_machine.convention.yaml parses to 9 phases | N/A (single component) | #888 |
 | acc:govern-lifecycle:E037-SMOKE-001-real-collect-reports-emission | real (child interpreter subprocess runs the disposition-gate emit adapter writing an on-disk JSONL sink) | emitted ValidatorReport row carries the violation rule_id with disposition=block | N/A (single component) | #890 |
+| acc:govern-lifecycle:E038-SMOKE-001-real-worktree-core-bare-false-on-disk | real (atdd.runtime.worktree.ensure_issue_worktree against a real on-disk git repo + real git CLI) | new worktree's per-worktree core.bare override reads false (I-9 canonical fix); shared config not left bare | N/A (single component) | #892 |
 | acc:govern-lifecycle:L002-SMOKE-001-meta-walker-zero-hits-on-post-retrofit-repo | real (walk_all_smoke_acceptances_for_anti_patterns) | anti-pattern hits list | N/A (meta-validator) | #855 |
 | acc:govern-lifecycle:R004-SMOKE-001-real-linked-worktree-recognized-worktree-ready | real (git worktree) | worktree detection | N/A (single component) | — |
 | acc:govern-lifecycle:Y004-SMOKE-001-pre-commit-template-has-drift-notice | real (template file) | file content | N/A (single component) | — |

--- a/plan/_wagons.yaml
+++ b/plan/_wagons.yaml
@@ -621,7 +621,7 @@ wagons:
   - name: commons:code:implementation
     from: wagon:implement-code
   wmbt:
-    total: 64
+    total: 66
     R001: minimize stale local manifest status after a successful GitHub transition
     R002: minimize misleading layout errors during post-transition re-enter
     R003: minimize stale hierarchy_coverage_features ratchet baseline carrying tactical
@@ -782,6 +782,17 @@ wagons:
       functions in atdd.coach.core, and the phase machine in phase_machine.convention.yaml
       while removing the duplicate transition table from the CLAUDE.md managed block
       (#888)
+    E037: minimize likelihood of validator-report-and-persistence-contracts-drifting-or-being-defined-ad-hoc-across-the-coach-decomposition-layers
+      by re-exporting the ValidatorReport from atdd.validators, shipping atdd.validators.emit.emit_reports,
+      routing the disposition gate through it, and freezing the PersistenceStore Protocol,
+      the load_conventions signature, and the events.jsonl schema as signatures-only
+      contracts for Children 7 and 8 (#890)
+    E038: minimize likelihood of worktree-creation-and-its-incident-defenses-being-duplicated-or-bypassed-across-coach-command-modules
+      by extracting ensure_issue_worktree, remove_worktree, and branch-safety helpers
+      into the pure atdd.runtime.worktree layer that sets git config --worktree core.bare
+      false on creation (I-9), refuses bare/foreign-directory dispatch (I-1), and
+      blocks protected-main worktrees (I-2), and routing every coach worktree call
+      site through it via compatibility shims (#892)
   total: 0
   manifest: plan/govern_lifecycle/_govern_lifecycle.yaml
   path: plan/govern_lifecycle/

--- a/plan/govern_lifecycle/E038.yaml
+++ b/plan/govern_lifecycle/E038.yaml
@@ -1,0 +1,99 @@
+urn: "wmbt:govern-lifecycle:E038"
+step: "execute"
+direction: "minimize"
+dimension: "likelihood"
+object_of_control: "worktree-creation-and-its-incident-defenses-being-duplicated-or-bypassed-across-coach-command-modules"
+context_clarifier: "when the Coach decomposition (docs/coach-decomposition.md, umbrella #887) extracts the runtime worktree layer as Child 5 (#892, §13.5) — moving ensure_issue_worktree, remove_worktree, and the branch-safety helpers out of the coach command modules into a pure atdd.runtime.worktree module that may import only stdlib + subprocess + pathlib (§3.3), routing coach.commands.coach, coach.commands.branch, and coach.commands.issue_lifecycle through it via shims so there is exactly one worktree-creation path and the three worktree incident defenses (I-1 no bare-directory dispatch, I-2 no protected-main commits, I-9 git config --worktree core.bare false on creation) live in one place"
+lens: "functional.effectiveness"
+statement: "minimize likelihood of worktree-creation-and-its-incident-defenses-being-duplicated-or-bypassed-across-coach-command-modules by extracting ensure_issue_worktree, remove_worktree, and branch-safety helpers into the pure atdd.runtime.worktree layer that sets git config --worktree core.bare false on creation (I-9), refuses bare/foreign-directory dispatch (I-1), and blocks protected-main worktrees (I-2), and routing every coach worktree call site through it via compatibility shims (#892)"
+acceptances:
+  - identity:
+      urn: "acc:govern-lifecycle:E038-UNIT-001-ensure-issue-worktree-creates-idempotent-core-bare"
+      id: "AC-UNIT-001"
+      purpose: "atdd.runtime.worktree.ensure_issue_worktree creates a real git worktree, is idempotent on re-call, and sets git config --worktree core.bare false on every new worktree (incident defense I-9 — the canonical fix for the bare-mode config bleed)"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A real git repository with one seed commit on its default branch"
+        - "atdd.runtime.worktree exposes ensure_issue_worktree(worktree_path, branch, repo_root)"
+        - "The target worktree path does not yet exist"
+    when:
+      abstract: "ensure_issue_worktree is called once to create the worktree, then a second time with identical arguments"
+    then:
+      abstract:
+        - "the first call returns the worktree path and the path is a real git worktree (its .git link exists and git worktree list includes it)"
+        - "the new worktree's per-worktree config reports core.bare == false (git config --worktree core.bare resolves to false) — I-9"
+        - "the second call is idempotent: it returns the same path without raising and without creating a duplicate worktree"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-31"
+  - identity:
+      urn: "acc:govern-lifecycle:E038-UNIT-002-incident-defenses-bare-dispatch-and-protected-main"
+      id: "AC-UNIT-002"
+      purpose: "ensure_issue_worktree preserves incident defense I-1 (refuses to dispatch into a path that exists but is not a valid git working tree) and I-2 (refuses to create a worktree on a protected branch such as main/master, which would land commits on protected main)"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "A real git repository with one seed commit"
+        - "A target path that already exists and contains foreign (non-atdd) content"
+        - "atdd.runtime.worktree exposes a branch-safety predicate (is_protected_branch) and ensure_issue_worktree"
+    when:
+      abstract: "ensure_issue_worktree is invoked against the foreign-content path, and separately invoked with branch='main'"
+    then:
+      abstract:
+        - "the foreign-content path is refused (returns None, never silently overwritten) and no git worktree is registered for it — I-1"
+        - "is_protected_branch('main') and is_protected_branch('master') are True while is_protected_branch('feat/x') is False"
+        - "invoking ensure_issue_worktree with a protected branch raises ProtectedBranchError before any git worktree add runs — I-2"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-31"
+  - identity:
+      urn: "acc:govern-lifecycle:E038-UNIT-003-import-discipline-and-call-site-routing"
+      id: "AC-UNIT-003"
+      purpose: "atdd.runtime.worktree obeys the §3.3 dependency rules (imports no orchestration/integration/sibling-runtime layer) and the three coach worktree call sites route through it so no second worktree-creation path exists"
+      phase: "GREEN"
+    harness:
+      type: "unit"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd.runtime.worktree source parsed for its import set"
+        - "atdd.coach.commands.coach._ensure_issue_worktree, atdd.coach.commands.branch, and atdd.coach.commands.issue_lifecycle source modules"
+    when:
+      abstract: "the runtime.worktree import set is checked against the forbidden set and the coach call-site sources are inspected for raw git-worktree-add invocations"
+    then:
+      abstract:
+        - "atdd.runtime.worktree imports none of: atdd.coach, atdd.train, atdd.integrations, atdd.runtime.agent_control, atdd.runtime.multiplexer (§3.3)"
+        - "coach._ensure_issue_worktree delegates the git worktree creation to atdd.runtime.worktree.ensure_issue_worktree"
+        - "the migrated coach call sites perform no raw 'git worktree add' subprocess of their own — creation is owned by atdd.runtime.worktree"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-31"
+  - identity:
+      urn: "acc:govern-lifecycle:E038-SMOKE-001-real-worktree-core-bare-false-on-disk"
+      id: "AC-SMOKE-001"
+      purpose: "In a real process against a real on-disk git repository, a worktree created through atdd.runtime.worktree carries a per-worktree core.bare=false override — exercising the real git CLI and filesystem, the canonical I-9 fix proof, not an in-memory stub"
+      phase: "SMOKE"
+    harness:
+      type: "integration"
+      category: "backend"
+    given:
+      abstract:
+        - "atdd is importable from local source and a real git repository exists on disk with a seed commit"
+        - "extensions.worktreeConfig is not assumed pre-enabled on the repository"
+    when:
+      abstract: "a real (non-mocked) call to atdd.runtime.worktree.ensure_issue_worktree creates a new worktree on a feature branch, then git config --worktree core.bare is read from inside the created worktree via the real git CLI"
+    then:
+      abstract:
+        - "the created worktree exists on disk and is listed by git worktree list"
+        - "reading git config --worktree core.bare from the new worktree returns false (the per-worktree override is materialized in the on-disk config.worktree, not merely the shared config)"
+        - "the shared repository config is not left as core.bare=true by the creation path"
+    metadata:
+      author: "atdd:self-compliance"
+      created: "2026-05-31"

--- a/plan/govern_lifecycle/_govern_lifecycle.yaml
+++ b/plan/govern_lifecycle/_govern_lifecycle.yaml
@@ -60,9 +60,10 @@ features:
   - urn: "feature:govern-lifecycle:smoke-false-green-prevention"
   - urn: "feature:govern-lifecycle:gh-issue-create-block-l3"
   - urn: "feature:govern-lifecycle:freeze-coach-core-typed-api-and-phase-machine"
+  - urn: "feature:govern-lifecycle:extract-runtime-worktree-preserving-incident-defenses"
 
 wmbt:
-  total: 65
+  total: 66
   R001: "minimize stale local manifest status after a successful GitHub transition"
   R002: "minimize misleading layout errors during post-transition re-enter"
   R003: "minimize stale hierarchy_coverage_features ratchet baseline carrying tactical baseline bumps"
@@ -128,3 +129,4 @@ wmbt:
   E034: "minimize likelihood of fresh-worktrees-missing-the-gh-shim-envrc-and-precommit-hook-after-atdd-init by making atdd init install .atdd/bin/gh, .envrc, and the pre-commit hook idempotently with a direnv soft-fail notice (#816)"
   E035: "minimize likelihood of coach-core-policy-surface-and-phase-machine-drifting-or-duplicating-across-modules by freezing the typed contracts in atdd.coach.core.types, the five pure policy functions in atdd.coach.core, and the phase machine in phase_machine.convention.yaml while removing the duplicate transition table from the CLAUDE.md managed block (#888)"
   E037: "minimize likelihood of validator-report-and-persistence-contracts-drifting-or-being-defined-ad-hoc-across-the-coach-decomposition-layers by re-exporting the ValidatorReport from atdd.validators, shipping atdd.validators.emit.emit_reports, routing the disposition gate through it, and freezing the PersistenceStore Protocol, the load_conventions signature, and the events.jsonl schema as signatures-only contracts for Children 7 and 8 (#890)"
+  E038: "minimize likelihood of worktree-creation-and-its-incident-defenses-being-duplicated-or-bypassed-across-coach-command-modules by extracting ensure_issue_worktree, remove_worktree, and branch-safety helpers into the pure atdd.runtime.worktree layer that sets git config --worktree core.bare false on creation (I-9), refuses bare/foreign-directory dispatch (I-1), and blocks protected-main worktrees (I-2), and routing every coach worktree call site through it via compatibility shims (#892)"

--- a/plan/govern_lifecycle/features/extract_runtime_worktree_preserving_incident_defenses.yaml
+++ b/plan/govern_lifecycle/features/extract_runtime_worktree_preserving_incident_defenses.yaml
@@ -1,0 +1,7 @@
+feature: extract-runtime-worktree-preserving-incident-defenses
+wagon: govern-lifecycle
+urn: "feature:govern-lifecycle:extract-runtime-worktree-preserving-incident-defenses"
+wmbts:
+  - "wmbt:govern-lifecycle:E038"
+references:
+  - "docs/coach-decomposition.md"

--- a/src/atdd/coach/commands/branch.py
+++ b/src/atdd/coach/commands/branch.py
@@ -302,32 +302,28 @@ class BranchManager:
         )
         remote_exists = bool(result.stdout.strip())
 
-        # Create worktree
+        # Create worktree. Creation, the existing-path triage, and the
+        # I-1/I-2/I-9 incident defenses (incl. `core.bare=false` per-worktree)
+        # are owned by the runtime layer (docs/coach-decomposition.md §13.5).
+        # New branches start from origin/<default_branch> so they begin at the
+        # latest remote commit regardless of local-main staleness.
+        from atdd.runtime import worktree as runtime_worktree
         if remote_exists:
-            cmd = [
-                "git", "worktree", "add",
-                str(worktree_path),
-                f"origin/{branch_name}",
-            ]
             print(f"Attaching to existing remote branch: {branch_name}")
         else:
-            # Start the new branch from origin/<default_branch> so it begins
-            # at the latest remote commit regardless of local-main staleness.
-            cmd = [
-                "git", "worktree", "add",
-                str(worktree_path),
-                "-b", branch_name,
-                f"origin/{default_branch}",
-            ]
             print(f"Creating new branch: {branch_name}")
 
-        result = subprocess.run(
-            cmd,
-            capture_output=True, text=True, timeout=30,
-            cwd=self.target_dir,
-        )
-        if result.returncode != 0:
-            print(f"Error: git worktree add failed:\n{result.stderr.strip()}")
+        try:
+            created = runtime_worktree.ensure_issue_worktree(
+                worktree_path, branch_name, self.target_dir,
+                issue_number=issue_number,
+                start_point=f"origin/{default_branch}",
+            )
+        except runtime_worktree.ProtectedBranchError as exc:
+            print(f"Error: {exc}")
+            return 1
+        if created is None:
+            print("Error: git worktree add failed")
             return 1
 
         print(f"  Worktree: {worktree_path}")

--- a/src/atdd/coach/commands/branch.py
+++ b/src/atdd/coach/commands/branch.py
@@ -320,6 +320,10 @@ class BranchManager:
                 start_point=f"origin/{default_branch}",
             )
         except runtime_worktree.ProtectedBranchError as exc:
+            logger.warning(
+                "refused worktree on protected branch",
+                extra={"issue": issue_number, "error": str(exc)},
+            )
             print(f"Error: {exc}")
             return 1
         if created is None:

--- a/src/atdd/coach/commands/coach.py
+++ b/src/atdd/coach/commands/coach.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import shutil
 import subprocess
 import sys
 import threading
@@ -780,6 +779,7 @@ def _ensure_issue_worktree(ctx) -> Optional[Path]:
     """
     from atdd.coach.commands import session_template
     from atdd.coach.handlers.spawn import _resolve_worktree
+    from atdd.runtime import worktree as runtime_worktree
 
     worktree = _resolve_worktree(ctx)
 
@@ -802,55 +802,20 @@ def _ensure_issue_worktree(ctx) -> Optional[Path]:
     if not branch or branch == "TBD":
         branch = f"feat/issue-{ctx.issue_number}"
 
-    # A path that exists but is not a git worktree needs triage before
-    # `git worktree add` (which accepts only a missing or empty directory):
-    #  - empty            → fine, git accepts it as-is.
-    #  - atdd-only residue → stale debris from the pre-fix bug; safe to clear.
-    #  - anything else     → hard failure, never silently clobbered.
-    if worktree.exists():
-        entries = {p.name for p in worktree.iterdir()}
-        if not entries:
-            pass  # empty dir — git worktree add accepts it
-        elif entries <= {".atdd", ".launch_prompt.txt", ".DS_Store"}:
-            shutil.rmtree(worktree)
-        else:
-            print(
-                f"❌ #{ctx.issue_number}: worktree path {worktree} exists and is "
-                f"not a git worktree; refusing to overwrite",
-                file=sys.stderr,
-            )
-            return None
-
-    # Attach to an existing remote branch if present, else create a new one.
-    remote = subprocess.run(
-        ["git", "branch", "-r", "--list", f"origin/{branch}"],
-        cwd=str(repo_root), capture_output=True, text=True,
-    )
-    if remote.stdout.strip():
-        add_cmd = ["git", "worktree", "add", str(worktree), f"origin/{branch}"]
-    else:
-        add_cmd = ["git", "worktree", "add", str(worktree), "-b", branch]
-
-    result = subprocess.run(
-        add_cmd, cwd=str(repo_root), capture_output=True, text=True,
-    )
-    if result.returncode != 0:
+    # Worktree creation (triage of an existing non-git path, remote/new-branch
+    # selection, and the I-1/I-2/I-9 incident defenses) is owned by the runtime
+    # layer (docs/coach-decomposition.md §13.5). Coach only resolves the path
+    # and branch, then delegates.
+    try:
+        return runtime_worktree.ensure_issue_worktree(
+            worktree, branch, repo_root, issue_number=ctx.issue_number,
+        )
+    except runtime_worktree.ProtectedBranchError as exc:
         print(
-            f"❌ #{ctx.issue_number}: git worktree add failed: "
-            f"{result.stderr.strip()}",
+            f"❌ #{ctx.issue_number}: {exc}",
             file=sys.stderr,
         )
         return None
-
-    _logger.info(
-        "coach cold-start worktree created",
-        extra={
-            "issue": ctx.issue_number,
-            "worktree": str(worktree),
-            "branch": branch,
-        },
-    )
-    return worktree
 
 
 def _make_coach_context(

--- a/src/atdd/coach/commands/coach.py
+++ b/src/atdd/coach/commands/coach.py
@@ -811,6 +811,10 @@ def _ensure_issue_worktree(ctx) -> Optional[Path]:
             worktree, branch, repo_root, issue_number=ctx.issue_number,
         )
     except runtime_worktree.ProtectedBranchError as exc:
+        _logger.warning(
+            "coach cold-start refused worktree on protected branch",
+            extra={"issue": ctx.issue_number, "error": str(exc)},
+        )
         print(
             f"❌ #{ctx.issue_number}: {exc}",
             file=sys.stderr,

--- a/src/atdd/coach/commands/issue_lifecycle.py
+++ b/src/atdd/coach/commands/issue_lifecycle.py
@@ -227,19 +227,24 @@ class IssueLifecycle:
         )
         remote_exists = bool(result.stdout.strip())
 
+        # Creation + I-1/I-2/I-9 incident defenses are owned by the runtime
+        # layer (docs/coach-decomposition.md §13.5).
+        from atdd.runtime import worktree as runtime_worktree
         if remote_exists:
-            cmd = ["git", "worktree", "add", str(worktree_path), f"origin/{branch_name}"]
             print(f"Attaching to existing remote branch: {branch_name}")
         else:
-            cmd = ["git", "worktree", "add", str(worktree_path), "-b", branch_name]
             print(f"Creating new branch: {branch_name}")
 
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=30,
-            cwd=self.target_dir,
-        )
-        if result.returncode != 0:
-            print(f"Error: git worktree add failed:\n{result.stderr.strip()}")
+        try:
+            created = runtime_worktree.ensure_issue_worktree(
+                worktree_path, branch_name, self.target_dir,
+                issue_number=issue_number,
+            )
+        except runtime_worktree.ProtectedBranchError as exc:
+            print(f"Error: {exc}")
+            return None
+        if created is None:
+            print("Error: git worktree add failed")
             return None
 
         print(f"  Worktree: {worktree_path}")

--- a/src/atdd/coach/commands/issue_lifecycle.py
+++ b/src/atdd/coach/commands/issue_lifecycle.py
@@ -241,6 +241,10 @@ class IssueLifecycle:
                 issue_number=issue_number,
             )
         except runtime_worktree.ProtectedBranchError as exc:
+            logger.warning(
+                "refused worktree on protected branch",
+                extra={"issue": issue_number, "error": str(exc)},
+            )
             print(f"Error: {exc}")
             return None
         if created is None:

--- a/src/atdd/runtime/__init__.py
+++ b/src/atdd/runtime/__init__.py
@@ -1,0 +1,8 @@
+"""ATDD runtime layer — execution adapters (worktree, multiplexer, agent_control).
+
+Per docs/coach-decomposition.md §3.2 / §3.3 the runtime layer owns git worktree
+creation, multiplexer surfaces (view-only), and agent control. Each submodule
+obeys the dependency rules in §3.3: it may import stdlib + subprocess + pathlib
+but MUST NOT import the orchestration (``atdd.train``), policy
+(``atdd.coach``), or integration (``atdd.integrations``) layers.
+"""

--- a/src/atdd/runtime/worktree.py
+++ b/src/atdd/runtime/worktree.py
@@ -1,0 +1,263 @@
+"""Git worktree creation/removal and branch safety for the ATDD runtime layer.
+
+Coach decomposition Child 5 (docs/coach-decomposition.md §13.5, umbrella #887).
+
+This module is the **single** worktree-creation path. It preserves three
+incident defenses from §9 at this layer:
+
+- **I-1** — no bare-directory worktree dispatch. A path that exists but is not a
+  valid git working tree (and is not safe-to-clear atdd residue) is refused
+  rather than silently dispatched into / overwritten.
+- **I-2** — no protected-main commits. Creating a worktree on a protected
+  branch (``main`` / ``master``) is refused up front, because an agent
+  dispatched there would land commits on protected ``main``
+  (2026-05-16 incident).
+- **I-9** — ``git config --worktree core.bare false`` on every new worktree.
+  This is the canonical fix for the recurring ``core.bare=true`` shared-config
+  bleed: the per-worktree override neutralises a contaminated shared config for
+  the worktree's lifetime.
+
+Dependency discipline (§3.3): this module imports only stdlib + ``subprocess``
++ ``pathlib``. It MUST NOT import ``atdd.coach.*``, ``atdd.train.*``,
+``atdd.integrations.*``, ``atdd.runtime.agent_control`` or
+``atdd.runtime.multiplexer``. Callers in the coach layer translate their own
+context (issue body, manifest) into the primitive arguments below and route
+through this module.
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional, Sequence
+
+_log = logging.getLogger(__name__)
+
+#: Branches an issue worktree must never be created on (I-2). Committing on these
+#: from a dispatched agent would land changes on protected ``main``.
+DEFAULT_PROTECTED_BRANCHES: tuple[str, ...] = ("main", "master")
+
+#: Entries that mark a path as safe-to-clear atdd residue (pre-fix debris) rather
+#: than a foreign directory that must be preserved (I-1).
+_ATDD_RESIDUE: frozenset[str] = frozenset({".atdd", ".launch_prompt.txt", ".DS_Store"})
+
+
+class WorktreeError(Exception):
+    """Base class for worktree-layer errors."""
+
+
+class ProtectedBranchError(WorktreeError):
+    """Raised when a worktree would be created on a protected branch (I-2)."""
+
+
+def is_protected_branch(
+    branch: str,
+    protected: Sequence[str] = DEFAULT_PROTECTED_BRANCHES,
+) -> bool:
+    """Return True when ``branch`` is a protected branch (exact match).
+
+    Matching is exact: ``main`` is protected but ``fix/main-thing`` is not.
+    """
+    return branch.strip() in set(protected)
+
+
+def assert_safe_branch(
+    branch: str,
+    protected: Sequence[str] = DEFAULT_PROTECTED_BRANCHES,
+) -> None:
+    """Raise :class:`ProtectedBranchError` when ``branch`` is protected (I-2)."""
+    if is_protected_branch(branch, protected):
+        raise ProtectedBranchError(
+            f"refusing to create a worktree on protected branch {branch!r}: "
+            f"commits from a dispatched agent would land on protected main (I-2)"
+        )
+
+
+def ensure_per_worktree_core_bare_false(
+    worktree_path: Path,
+    repo_root: Optional[Path] = None,
+) -> None:
+    """Set ``core.bare=false`` as a per-worktree override on ``worktree_path`` (I-9).
+
+    Enables ``extensions.worktreeConfig`` on the repository first (idempotent;
+    required before ``git config --worktree`` writes land in the worktree-local
+    ``config.worktree`` file), then writes ``core.bare false`` scoped to this
+    worktree only. The ``--worktree`` flag is mandatory for any ``core.*`` write
+    so the value never bleeds into the shared config (#884).
+    """
+    worktree_path = Path(worktree_path)
+    config_cwd = Path(repo_root) if repo_root is not None else worktree_path
+
+    try:
+        check = subprocess.run(
+            ["git", "config", "--get", "extensions.worktreeConfig"],
+            cwd=str(config_cwd), capture_output=True, text=True, timeout=10,
+        )
+        if not (check.returncode == 0 and check.stdout.strip().lower() == "true"):
+            subprocess.run(
+                ["git", "config", "extensions.worktreeConfig", "true"],
+                cwd=str(config_cwd), capture_output=True, text=True, timeout=10,
+            )
+        subprocess.run(
+            ["git", "config", "--worktree", "core.bare", "false"],
+            cwd=str(worktree_path), capture_output=True, text=True, timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        _log.warning(
+            "could not set per-worktree core.bare=false",
+            extra={"worktree": str(worktree_path), "error": str(exc)},
+        )
+
+
+def _remote_branch_exists(repo_root: Path, branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "branch", "-r", "--list", f"origin/{branch}"],
+        cwd=str(repo_root), capture_output=True, text=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def ensure_issue_worktree(
+    worktree_path: Path,
+    branch: str,
+    repo_root: Path,
+    *,
+    issue_number: Optional[int] = None,
+    start_point: Optional[str] = None,
+    protected_branches: Sequence[str] = DEFAULT_PROTECTED_BRANCHES,
+) -> Optional[Path]:
+    """Ensure a git worktree for ``branch`` exists at ``worktree_path``.
+
+    Idempotent: an existing git worktree at ``worktree_path`` is returned
+    unchanged (with its per-worktree ``core.bare=false`` override re-asserted).
+
+    Incident defenses:
+
+    - **I-2** — raises :class:`ProtectedBranchError` before touching the
+      filesystem when ``branch`` is protected.
+    - **I-1** — refuses (returns ``None``) when ``worktree_path`` exists with
+      foreign content; only an empty directory or atdd residue is cleared.
+    - **I-9** — sets ``git config --worktree core.bare false`` on creation.
+
+    Args:
+        worktree_path: Absolute target path for the worktree (a flat sibling of
+            ``repo_root`` by convention).
+        branch: Branch to attach to (existing remote) or create (new ``-b``).
+        repo_root: Root of the main checkout the worktree links to.
+        issue_number: Optional, for log context only.
+        start_point: Optional start ref for a NEW branch (e.g.
+            ``origin/main``). Ignored when attaching to an existing remote
+            branch.
+        protected_branches: Branches treated as protected (I-2).
+
+    Returns:
+        The worktree ``Path`` on success, or ``None`` when creation was refused
+        or failed (caller surfaces BLOCKED).
+    """
+    worktree_path = Path(worktree_path)
+    repo_root = Path(repo_root)
+
+    # I-2: protected-branch pre-flight, before any filesystem mutation.
+    assert_safe_branch(branch, protected_branches)
+
+    # Idempotent: an existing git worktree is reused unchanged.
+    if (worktree_path / ".git").exists():
+        ensure_per_worktree_core_bare_false(worktree_path, repo_root)
+        return worktree_path
+
+    # I-1: triage a path that exists but is not a git worktree. `git worktree
+    # add` accepts only a missing or empty directory.
+    #   - empty            → git accepts it as-is.
+    #   - atdd-only residue → stale debris from the pre-fix bug; safe to clear.
+    #   - anything else     → refuse; never silently clobber foreign content.
+    if worktree_path.exists():
+        entries = {p.name for p in worktree_path.iterdir()}
+        if not entries:
+            pass  # empty dir
+        elif entries <= _ATDD_RESIDUE:
+            shutil.rmtree(worktree_path)
+        else:
+            _log.warning(
+                "refusing bare-directory worktree dispatch: path exists and is "
+                "not a git worktree",
+                extra={
+                    "issue": issue_number,
+                    "worktree": str(worktree_path),
+                },
+            )
+            return None
+
+    # Attach to an existing remote branch if present, else create a new one.
+    if _remote_branch_exists(repo_root, branch):
+        add_cmd = [
+            "git", "worktree", "add", str(worktree_path), f"origin/{branch}",
+        ]
+    else:
+        add_cmd = ["git", "worktree", "add", str(worktree_path), "-b", branch]
+        if start_point:
+            add_cmd.append(start_point)
+
+    result = subprocess.run(
+        add_cmd, cwd=str(repo_root), capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        _log.warning(
+            "git worktree add failed",
+            extra={
+                "issue": issue_number,
+                "worktree": str(worktree_path),
+                "branch": branch,
+                "error": result.stderr.strip(),
+            },
+        )
+        return None
+
+    # I-9: neutralise any contaminated shared core.bare for this worktree.
+    ensure_per_worktree_core_bare_false(worktree_path, repo_root)
+
+    _log.info(
+        "worktree created",
+        extra={
+            "issue": issue_number,
+            "worktree": str(worktree_path),
+            "branch": branch,
+        },
+    )
+    return worktree_path
+
+
+def remove_worktree(
+    worktree_path: Path,
+    repo_root: Path,
+    *,
+    force: bool = False,
+) -> bool:
+    """Remove the git worktree at ``worktree_path`` and prune stale metadata.
+
+    Returns ``True`` when the worktree is no longer registered/present after the
+    call, ``False`` when removal failed.
+    """
+    worktree_path = Path(worktree_path)
+    repo_root = Path(repo_root)
+
+    cmd = ["git", "worktree", "remove", str(worktree_path)]
+    if force:
+        cmd.append("--force")
+
+    result = subprocess.run(
+        cmd, cwd=str(repo_root), capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        _log.warning(
+            "git worktree remove failed",
+            extra={"worktree": str(worktree_path), "error": result.stderr.strip()},
+        )
+        return False
+
+    # Prune any dangling administrative entries left behind.
+    subprocess.run(
+        ["git", "worktree", "prune"],
+        cwd=str(repo_root), capture_output=True, text=True,
+    )
+    return not worktree_path.exists()

--- a/tests/incident_defenses/test_e038_smoke_001_real_worktree_core_bare.py
+++ b/tests/incident_defenses/test_e038_smoke_001_real_worktree_core_bare.py
@@ -1,0 +1,88 @@
+# URN: test:govern-lifecycle:extract-runtime-worktree-preserving-incident-defenses:E038-SMOKE-001-real-worktree-core-bare-false-on-disk
+# Acceptance: acc:govern-lifecycle:E038-SMOKE-001-real-worktree-core-bare-false-on-disk
+# WMBT: wmbt:govern-lifecycle:E038
+# Phase: SMOKE
+# Layer: backend.application
+"""SMOKE — real on-disk proof of incident defense I-9.
+
+Coach decomposition Child 5 (docs/coach-decomposition.md §13.5, §9). In a real
+child interpreter process, against a real on-disk git repository, a worktree
+created through the production ``atdd.runtime.worktree.ensure_issue_worktree``
+must carry a per-worktree ``core.bare=false`` override — the canonical fix for
+the recurring ``core.bare=true`` shared-config bleed.
+
+This drives the real production wiring (the actual installed/importable module,
+a real ``git worktree add``, and a real ``git config --worktree`` read) rather
+than any synthetic fixture, per smoke.convention.yaml.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+
+
+def test_real_worktree_has_per_worktree_core_bare_false(tmp_path):
+    repo = tmp_path / "main"
+    repo.mkdir()
+    _git("init", cwd=repo)
+    _git("config", "user.email", "smoke@example.com", cwd=repo)
+    _git("config", "user.name", "ATDD Smoke", cwd=repo)
+    (repo / "README.md").write_text("seed\n")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "seed", cwd=repo)
+
+    target = tmp_path / "feat-smoke"
+
+    # Real, fresh process exercising the production module end-to-end.
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    program = textwrap.dedent(
+        f"""
+        import sys
+        sys.path.insert(0, {str(src_dir)!r})
+        from atdd.runtime import worktree as wt
+        result = wt.ensure_issue_worktree(
+            {str(target)!r}, "feat/smoke", {str(repo)!r}, issue_number=892
+        )
+        assert result is not None, "ensure_issue_worktree returned None"
+        print("CREATED", result)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", program],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, f"child failed:\n{proc.stdout}\n{proc.stderr}"
+
+    # The worktree is real and registered.
+    listed = subprocess.run(
+        ["git", "worktree", "list"], cwd=str(repo), capture_output=True, text=True
+    ).stdout
+    assert str(target) in listed, f"git does not list {target}:\n{listed}"
+
+    # I-9: the per-worktree override is materialized on disk and reads false.
+    core_bare = subprocess.run(
+        ["git", "config", "--worktree", "core.bare"],
+        cwd=str(target), capture_output=True, text=True,
+    ).stdout.strip()
+    assert core_bare == "false", (
+        f"expected per-worktree core.bare=false on disk, got {core_bare!r}"
+    )
+
+    # The shared config must not be left bare by the creation path.
+    shared = subprocess.run(
+        ["git", "config", "--local", "core.bare"],
+        cwd=str(repo), capture_output=True, text=True,
+    ).stdout.strip()
+    assert shared in ("", "false"), f"shared config left core.bare={shared!r}"

--- a/tests/incident_defenses/test_worktree_safety.py
+++ b/tests/incident_defenses/test_worktree_safety.py
@@ -1,0 +1,274 @@
+# URN: test:govern-lifecycle:extract-runtime-worktree-preserving-incident-defenses:E038-UNIT-001-ensure-issue-worktree-creates-idempotent-core-bare
+# Acceptance: acc:govern-lifecycle:E038-UNIT-001-ensure-issue-worktree-creates-idempotent-core-bare
+# Acceptance: acc:govern-lifecycle:E038-UNIT-002-incident-defenses-bare-dispatch-and-protected-main
+# Acceptance: acc:govern-lifecycle:E038-UNIT-003-import-discipline-and-call-site-routing
+# WMBT: wmbt:govern-lifecycle:E038
+# Phase: RED
+# Layer: backend.application
+"""Incident-defense suite for the extracted ``atdd.runtime.worktree`` layer.
+
+Coach decomposition Child 5 (docs/coach-decomposition.md §13.5, §9, umbrella
+#887). This is the canonical home for the three worktree incident defenses
+named in §9:
+
+- **I-1** — no bare-directory worktree dispatch
+  (``test_refuses_bare_dispatch``)
+- **I-2** — no protected-main commits
+  (``test_blocks_main_commit``)
+- **I-9** — ``git config --worktree core.bare false`` on creation
+  (``test_sets_per_worktree_core_bare``) — the canonical fix for the recurring
+  ``core.bare=true`` shared-config bleed.
+
+RED until ``src/atdd/runtime/worktree.py`` exists and the coach call sites
+delegate to it.
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.platform]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _git(*args: str, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+
+
+def _make_repo(root: Path) -> Path:
+    """Create a minimal git repo at ``root/main`` with one seed commit."""
+    repo = root / "main"
+    repo.mkdir()
+    _git("init", cwd=repo)
+    _git("config", "user.email", "test@example.com", cwd=repo)
+    _git("config", "user.name", "ATDD Test", cwd=repo)
+    (repo / "README.md").write_text("seed\n")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-m", "seed", cwd=repo)
+    return repo
+
+
+def _worktree_listed(repo: Path, path: Path) -> bool:
+    out = subprocess.run(
+        ["git", "worktree", "list"], cwd=str(repo), capture_output=True, text=True
+    ).stdout
+    return str(path) in out
+
+
+def _read_worktree_core_bare(worktree: Path) -> str:
+    """Read ``git config --worktree core.bare`` from inside ``worktree``."""
+    res = subprocess.run(
+        ["git", "config", "--worktree", "core.bare"],
+        cwd=str(worktree), capture_output=True, text=True,
+    )
+    return res.stdout.strip()
+
+
+# --------------------------------------------------------------------------- #
+# AC-UNIT-001 — create / idempotent / I-9 core.bare=false
+# --------------------------------------------------------------------------- #
+def test_ensure_issue_worktree_creates_real_git_worktree(tmp_path):
+    from atdd.runtime import worktree as wt
+
+    repo = _make_repo(tmp_path)
+    target = tmp_path / "feat-thing"
+
+    result = wt.ensure_issue_worktree(target, "feat/thing", repo)
+
+    assert result == target
+    assert (target / ".git").exists(), f"{target} is not a git worktree"
+    assert _worktree_listed(repo, target)
+
+
+def test_ensure_issue_worktree_is_idempotent(tmp_path):
+    from atdd.runtime import worktree as wt
+
+    repo = _make_repo(tmp_path)
+    target = tmp_path / "feat-thing"
+
+    first = wt.ensure_issue_worktree(target, "feat/thing", repo)
+    second = wt.ensure_issue_worktree(target, "feat/thing", repo)
+
+    assert first == second == target
+    # exactly one linked worktree registered for this path
+    porcelain = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],
+        cwd=str(repo), capture_output=True, text=True,
+    ).stdout
+    assert porcelain.count(f"worktree {target}") == 1
+
+
+def test_sets_per_worktree_core_bare(tmp_path):
+    """I-9: every new worktree carries a per-worktree ``core.bare=false``."""
+    from atdd.runtime import worktree as wt
+
+    repo = _make_repo(tmp_path)
+    target = tmp_path / "feat-bare"
+
+    wt.ensure_issue_worktree(target, "feat/bare", repo)
+
+    assert _read_worktree_core_bare(target) == "false", (
+        "ensure_issue_worktree must set `git config --worktree core.bare false` "
+        "on the new worktree (incident defense I-9)"
+    )
+
+
+def test_creation_does_not_leave_shared_config_bare(tmp_path):
+    """The creation path must not leave the SHARED repo config as core.bare=true."""
+    from atdd.runtime import worktree as wt
+
+    repo = _make_repo(tmp_path)
+    target = tmp_path / "feat-shared"
+
+    wt.ensure_issue_worktree(target, "feat/shared", repo)
+
+    shared = subprocess.run(
+        ["git", "config", "--local", "core.bare"],
+        cwd=str(repo), capture_output=True, text=True,
+    ).stdout.strip()
+    assert shared in ("", "false"), f"shared config left core.bare={shared!r}"
+
+
+# --------------------------------------------------------------------------- #
+# AC-UNIT-002 — I-1 bare/foreign dispatch + I-2 protected main
+# --------------------------------------------------------------------------- #
+def test_refuses_bare_dispatch(tmp_path):
+    """I-1: a path that exists with foreign content is refused, never clobbered."""
+    from atdd.runtime import worktree as wt
+
+    repo = _make_repo(tmp_path)
+    target = tmp_path / "feat-foreign"
+    target.mkdir()
+    (target / "important.txt").write_text("do not delete me\n")
+
+    result = wt.ensure_issue_worktree(target, "feat/foreign", repo)
+
+    assert result is None, "foreign-content path must be refused (I-1)"
+    assert (target / "important.txt").exists(), "must not clobber foreign content"
+    assert not _worktree_listed(repo, target), "no worktree should be registered"
+
+
+def test_clears_atdd_only_residue(tmp_path):
+    """A path containing only atdd residue is safe to clear and create over."""
+    from atdd.runtime import worktree as wt
+
+    repo = _make_repo(tmp_path)
+    target = tmp_path / "feat-residue"
+    target.mkdir()
+    (target / ".launch_prompt.txt").write_text("stale\n")
+
+    result = wt.ensure_issue_worktree(target, "feat/residue", repo)
+
+    assert result == target
+    assert (target / ".git").exists()
+
+
+def test_is_protected_branch():
+    from atdd.runtime import worktree as wt
+
+    assert wt.is_protected_branch("main") is True
+    assert wt.is_protected_branch("master") is True
+    assert wt.is_protected_branch("feat/x") is False
+    assert wt.is_protected_branch("fix/main-thing") is False
+
+
+def test_blocks_main_commit(tmp_path):
+    """I-2: refuses to create a worktree on a protected branch (would commit to main)."""
+    from atdd.runtime import worktree as wt
+
+    repo = _make_repo(tmp_path)
+    target = tmp_path / "on-main"
+
+    with pytest.raises(wt.ProtectedBranchError):
+        wt.ensure_issue_worktree(target, "main", repo)
+
+    assert not target.exists(), "no worktree must be created on a protected branch"
+    assert not _worktree_listed(repo, target)
+
+
+# --------------------------------------------------------------------------- #
+# AC-UNIT-003 — import discipline + call-site routing
+# --------------------------------------------------------------------------- #
+def test_runtime_worktree_has_no_forbidden_imports():
+    """§3.3: atdd.runtime.worktree imports no orchestration/integration layer."""
+    src = REPO_ROOT / "src" / "atdd" / "runtime" / "worktree.py"
+    tree = ast.parse(src.read_text())
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(n.name for n in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+
+    forbidden = {
+        "atdd.coach", "atdd.train", "atdd.integrations",
+        "atdd.runtime.agent_control", "atdd.runtime.multiplexer",
+    }
+    leaked = {
+        imp for imp in imports
+        for fb in forbidden
+        if imp == fb or imp.startswith(fb + ".")
+    }
+    assert not leaked, f"runtime.worktree leaked forbidden imports: {leaked}"
+
+
+def test_coach_ensure_issue_worktree_delegates_to_runtime(tmp_path, monkeypatch):
+    """The coach cold-start shim routes creation through atdd.runtime.worktree."""
+    from atdd.coach.commands import coach as coach_mod
+    from atdd.coach.commands import session_template
+    from atdd.runtime import worktree as wt
+    from atdd.coach.handlers.state_machine import CoachContext
+
+    repo = _make_repo(tmp_path)
+    monkeypatch.chdir(repo)
+    body = (
+        "## Issue Metadata\n\n| Field | Value |\n|-------|-------|\n"
+        "| Branch | `feat/delegated` |\n\n## Summary\nx\n"
+    )
+    monkeypatch.setattr(
+        session_template, "fetch_issue",
+        lambda n: {"number": n, "title": "t", "body": body},
+    )
+
+    calls: list[tuple] = []
+    real = wt.ensure_issue_worktree
+
+    def _spy(worktree_path, branch, repo_root, **kw):
+        calls.append((Path(worktree_path), branch))
+        return real(worktree_path, branch, repo_root, **kw)
+
+    monkeypatch.setattr(wt, "ensure_issue_worktree", _spy)
+
+    ctx = CoachContext(issue_number=4242)
+    result = coach_mod._ensure_issue_worktree(ctx)
+
+    assert calls, "coach._ensure_issue_worktree must call runtime.worktree.ensure_issue_worktree"
+    assert result is not None and (result / ".git").exists()
+    assert calls[0][1] == "feat/delegated"
+
+
+# --------------------------------------------------------------------------- #
+# remove_worktree
+# --------------------------------------------------------------------------- #
+def test_remove_worktree_unregisters_and_deletes(tmp_path):
+    from atdd.runtime import worktree as wt
+
+    repo = _make_repo(tmp_path)
+    target = tmp_path / "feat-remove"
+    wt.ensure_issue_worktree(target, "feat/remove", repo)
+    assert _worktree_listed(repo, target)
+
+    ok = wt.remove_worktree(target, repo, force=True)
+
+    assert ok is True
+    assert not _worktree_listed(repo, target)
+    assert not target.exists()


### PR DESCRIPTION
Closes #892

Child 5 of the Coach decomposition (`docs/coach-decomposition.md` §13.5). Refs umbrella #887.

## What

Extracts the git-worktree lifecycle out of the coach command modules into a new, pure runtime layer `atdd.runtime.worktree`, the **single** worktree-creation path.

- `src/atdd/runtime/worktree.py` — `ensure_issue_worktree`, `remove_worktree`, and branch-safety helpers (`is_protected_branch`, `assert_safe_branch`, `ProtectedBranchError`).
- Call sites migrated to route through it (shims keep their surrounding UX): `coach.commands.coach._ensure_issue_worktree`, `coach.commands.branch.BranchManager.branch`, `coach.commands.issue_lifecycle._create_branch`.
- New required-CI job `incident-defense-test` runs `tests/incident_defenses/` and is wired into the `validate-gate` fan-in.

## Incident defenses preserved (§9)

This PR is the canonical home for the three **worktree** defenses. Each has an explicit test in `tests/incident_defenses/test_worktree_safety.py`:

| Defense | Behavior | Test |
|---|---|---|
| **I-1** — no bare-directory worktree dispatch | A path that exists but is not a valid git working tree (and is not safe-to-clear atdd residue) is refused (`None`), never clobbered. | `test_refuses_bare_dispatch` |
| **I-2** — no protected-main commits | Creating a worktree on a protected branch (`main`/`master`) raises `ProtectedBranchError` before any filesystem mutation. | `test_blocks_main_commit`, `test_is_protected_branch` |
| **I-9** — `core.bare=false` per-worktree on creation | `ensure_issue_worktree` sets `git config --worktree core.bare false` (enabling `extensions.worktreeConfig` first) on every new worktree — the canonical fix for the recurring `core.bare=true` shared-config bleed. | `test_sets_per_worktree_core_bare`, `test_creation_does_not_leave_shared_config_bare`, `test_e038_smoke_001_real_worktree_core_bare.py` (real subprocess + real git, on disk) |

This PR **ships** the I-9 defense as the canonical fix for the bare-mode bleed.

## Per-PR requirements (§12.3)

- ✅ Lifecycle parity test green (`tests/lifecycle/test_full_issue_parity.py`).
- ✅ Import-discipline test green (`tests/architecture/test_layer_imports.py`) — `atdd.runtime.worktree` imports stdlib + `subprocess` + `pathlib` only; no `atdd.coach/train/integrations/agent_control/multiplexer` (§3.3).
- ✅ No new I/O imports under `atdd.coach.core` (untouched).
- ✅ New module under the right layer; old call sites shimmed (delegate), not duplicated.
- ✅ Doc unchanged — no contract changed; this PR implements the §13.5 scope as written.

## ATDD lifecycle

WMBT `wmbt:govern-lifecycle:E038` + feature `extract-runtime-worktree-preserving-incident-defenses`. Full INIT → PLANNED → RED → GREEN → SMOKE → REFACTOR. `docs/smoke-audit.md` row added for `E038-SMOKE-001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
