### PR TITLE
chore(atdd): Move Rule Id Assertion From Template Test To Convention Reader (#921)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1469,3 +1469,12 @@ sessions:
   created: '2026-05-31'
   archived: null
   wagon: govern-lifecycle
+- id: '921'
+  slug: move-rule-id-assertion-from-template-test-to-convention-reader
+  file: null
+  issue_number: 921
+  type: tracking
+  status: INIT
+  created: '2026-05-31'
+  archived: null
+  wagon: govern-lifecycle

--- a/src/atdd/coach/commands/tests/test_e015_smoke_001_deployed_templates_contain_smoke_acceptance_checklist.py
+++ b/src/atdd/coach/commands/tests/test_e015_smoke_001_deployed_templates_contain_smoke_acceptance_checklist.py
@@ -1,12 +1,15 @@
 # Acceptance: acc:spawn-agents:E015-SMOKE-001-deployed-templates-contain-smoke-acceptance-checklist
 """
-E015 AC-SMOKE-001: The installed atdd package templates (SESSION-LAUNCH-TEMPLATE.md
-and CONDUCTOR.md) both contain the rule ID 'planner.wmbt.must-have-smoke-acceptance',
-confirming the checklist shipped in the installed distribution.
+E015 AC-SMOKE-001: The installed atdd package SESSION-LAUNCH-TEMPLATE.md ships
+the planner.wmbt.must-have-smoke-acceptance rule id surfaced for spawn-time
+agents, plus the validate command. CONDUCTOR.md no longer carries the rule id
+(removed per #919 / #921 — the rule's canonical home is wmbt.convention.yaml,
+and the installed-convention-ships-rule smoke check moved to
+src/atdd/planner/validators/test_wmbt_smoke_acceptance_rule_registered.py).
 
-This SMOKE test reads the templates from the actual installed package path (not the
-local source tree) so it verifies that the content survives the build-and-install
-pipeline that CI runs before executing the validate suite.
+This SMOKE test reads the templates from the actual installed package path
+(not the local source tree) so it verifies that the content survives the
+build-and-install pipeline that CI runs before executing the validate suite.
 
 Convention: src/atdd/planner/conventions/wmbt.convention.yaml
             (rule planner.wmbt.must-have-smoke-acceptance)
@@ -39,18 +42,6 @@ def test_installed_session_launch_template_has_rule_id() -> None:
     content = template_path.read_text()
     assert RULE_ID in content, (
         f"Installed SESSION-LAUNCH-TEMPLATE.md does not contain '{RULE_ID}'. "
-        "The fix did not ship into the installed distribution."
-    )
-
-
-def test_installed_atdd_md_has_rule_id() -> None:
-    """CONDUCTOR.md from installed package contains the rule ID."""
-    templates_dir = _installed_templates_dir()
-    template_path = templates_dir / "CONDUCTOR.md"
-    assert template_path.exists(), f"Installed CONDUCTOR.md not found: {template_path}"
-    content = template_path.read_text()
-    assert RULE_ID in content, (
-        f"Installed CONDUCTOR.md does not contain '{RULE_ID}'. "
         "The fix did not ship into the installed distribution."
     )
 

--- a/src/atdd/coach/commands/tests/test_e015_unit_002_atdd_md_init_phase_instructs_pre_commit_validate_planner.py
+++ b/src/atdd/coach/commands/tests/test_e015_unit_002_atdd_md_init_phase_instructs_pre_commit_validate_planner.py
@@ -1,16 +1,15 @@
 # Acceptance: acc:spawn-agents:E015-UNIT-002-atdd-md-init-phase-instructs-pre-commit-validate-planner
 """
-E015 AC-UNIT-002: CONDUCTOR.md template INIT phase block contains a pre_commit_gate
-key naming planner.wmbt.must-have-smoke-acceptance and the validate command with
-a 'BEFORE committing PLANNED' timing annotation.
+E015 AC-UNIT-002: CONDUCTOR.md template INIT phase block surfaces the
+pre-commit validate command and its 'BEFORE committing PLANNED' timing.
 
 CONDUCTOR.md is the persistent instruction file installed in every worktree via
-atdd sync. Augmenting the INIT phase with an explicit pre_commit_gate ensures
-any agent that reads the worktree CLAUDE.md sees the gate requirement, not just
-agents reading the spawn-time SESSION-LAUNCH-TEMPLATE.md.
-
-Convention: src/atdd/planner/conventions/wmbt.convention.yaml
-            (rule planner.wmbt.must-have-smoke-acceptance)
+atdd sync. The INIT phase block carries operator-facing instructions that
+belong in the template (the command name + the timing annotation). It does NOT
+carry the planner.wmbt.must-have-smoke-acceptance rule id itself — that rule's
+canonical home is src/atdd/planner/conventions/wmbt.convention.yaml, and the
+rule-registration assertion lives in src/atdd/planner/validators/
+test_wmbt_smoke_acceptance_rule_registered.py (#921).
 """
 from __future__ import annotations
 
@@ -26,7 +25,6 @@ _TEMPLATE_PATH = (
     / "CONDUCTOR.md"
 )
 
-RULE_ID = "planner.wmbt.must-have-smoke-acceptance"
 VALIDATE_CMD = "atdd validate planner --local --skip-api"
 
 
@@ -52,15 +50,6 @@ def _init_phase_section(content: str) -> str:
         if in_section:
             out.append(line)
     return "\n".join(out)
-
-
-def test_atdd_md_names_must_have_smoke_acceptance_rule() -> None:
-    """CONDUCTOR.md contains the rule ID 'planner.wmbt.must-have-smoke-acceptance'."""
-    content = _read_template()
-    assert RULE_ID in content, (
-        f"CONDUCTOR.md does not contain the rule ID '{RULE_ID}'. "
-        "Add a pre_commit_gate key to the INIT phase block in the atdd_cycle.phases section."
-    )
 
 
 def test_atdd_md_init_phase_includes_validate_planner_command() -> None:

--- a/src/atdd/planner/validators/test_wmbt_smoke_acceptance_rule_registered.py
+++ b/src/atdd/planner/validators/test_wmbt_smoke_acceptance_rule_registered.py
@@ -1,0 +1,74 @@
+# Acceptance: acc:govern-lifecycle:E921-UNIT-001-wmbt-smoke-acceptance-rule-registered-in-convention
+"""
+Asserts the rule ``planner.wmbt.must-have-smoke-acceptance`` is registered in
+its canonical home: ``src/atdd/planner/conventions/wmbt.convention.yaml``.
+
+Background (#921 — split from #919 Section A discussion): the prior
+template-reader test (``test_e015_unit_002::test_atdd_md_names_must_have_smoke_acceptance_rule``)
+asserted the rule id string appeared in ``CONDUCTOR.md``. That was the wrong
+substrate check — duplicating convention rule IDs into the agent-facing
+template re-introduced the dual-source-of-truth pattern the Coach
+Decomposition (#887) was actively removing (phase_machine was already excised
+from the template in #888 for the same reason).
+
+The rule lives in ``wmbt.convention.yaml``; this test asserts that fact
+directly. The companion installed-package smoke test asserts the rule survives
+the build-and-install pipeline.
+
+Convention: ``src/atdd/planner/conventions/wmbt.convention.yaml``
+"""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+RULE_ID = "planner.wmbt.must-have-smoke-acceptance"
+_CONVENTION_FILENAME = "wmbt.convention.yaml"
+
+
+def _load_convention(conv_path: Path) -> dict[str, Any]:
+    assert conv_path.exists(), f"Convention not found: {conv_path}"
+    return yaml.safe_load(conv_path.read_text())
+
+
+def _rule_ids(convention: dict[str, Any]) -> set[str]:
+    return {r["id"] for r in convention.get("rules", []) if isinstance(r, dict) and "id" in r}
+
+
+def test_wmbt_convention_registers_must_have_smoke_acceptance_rule() -> None:
+    """The local source-tree convention YAML registers the rule id."""
+    conv_path = (
+        Path(__file__).parent.parent  # src/atdd/planner
+        / "conventions"
+        / _CONVENTION_FILENAME
+    )
+    rule_ids = _rule_ids(_load_convention(conv_path))
+    assert RULE_ID in rule_ids, (
+        f"Rule '{RULE_ID}' is missing from {conv_path}. "
+        f"Rules currently registered: {sorted(rule_ids)}. "
+        "Add the rule to the convention's `rules:` block — "
+        "do NOT add it back to CONDUCTOR.md (that would re-introduce the "
+        "dual-source-of-truth pattern removed by the Coach Decomposition #887)."
+    )
+
+
+def test_installed_wmbt_convention_ships_must_have_smoke_acceptance_rule() -> None:
+    """SMOKE: the rule ships in the installed-package convention YAML.
+
+    This replaces the prior ``test_installed_atdd_md_has_rule_id`` (which read
+    ``CONDUCTOR.md`` from the installed package). The rule's canonical home is
+    the convention YAML; that's what should ship.
+    """
+    # ``atdd.planner.conventions`` is a namespace package, so __file__ is None
+    # and we resolve the directory via __path__.
+    conventions_module = importlib.import_module("atdd.planner.conventions")
+    conv_dir = Path(next(iter(conventions_module.__path__)))
+    conv_path = conv_dir / _CONVENTION_FILENAME
+    rule_ids = _rule_ids(_load_convention(conv_path))
+    assert RULE_ID in rule_ids, (
+        f"Installed package convention {conv_path} does not register '{RULE_ID}'. "
+        "The fix did not ship into the installed distribution."
+    )

--- a/src/atdd/planner/validators/test_wmbt_smoke_acceptance_rule_registered.py
+++ b/src/atdd/planner/validators/test_wmbt_smoke_acceptance_rule_registered.py
@@ -1,7 +1,13 @@
-# Acceptance: acc:govern-lifecycle:E921-UNIT-001-wmbt-smoke-acceptance-rule-registered-in-convention
 """
 Asserts the rule ``planner.wmbt.must-have-smoke-acceptance`` is registered in
 its canonical home: ``src/atdd/planner/conventions/wmbt.convention.yaml``.
+
+This validator-test is intentionally unanchored (no ``# Acceptance:`` URN
+header). #921 is a small test-repair tracking issue with no planned WMBT in
+``plan/govern_lifecycle/``, so a bidirectional acceptance binding would be
+artificial. The pattern mirrors ``test_hierarchy_coverage.py`` (also
+unanchored). If #919 Section B later wants to formalize this binding, it can
+file a WMBT and add the ``# Acceptance:`` line.
 
 Background (#921 — split from #919 Section A discussion): the prior
 template-reader test (``test_e015_unit_002::test_atdd_md_names_must_have_smoke_acceptance_rule``)


### PR DESCRIPTION
Closes #921
Refs #919

## Summary

Moves the `planner.wmbt.must-have-smoke-acceptance` rule-ID assertion from the template-reader tests to a convention-YAML-reader test, restoring the single-source-of-truth invariant that the Coach Decomposition (#887) has been enforcing.

The two deleted assertions were checking that `CONDUCTOR.md` (the agent-facing template) literally contained the rule-ID string. That was the wrong substrate check — the rule's canonical home is `src/atdd/planner/conventions/wmbt.convention.yaml:271`, where it has its full description, suppression syntax, and cross-link to tester.smoke.pres / #293. Duplicating the rule into agent-facing prose would re-introduce the dual-source-of-truth pattern (`phase_machine` was already removed from the template in #888 for the same reason).

## Changes

- **NEW** `src/atdd/planner/validators/test_wmbt_smoke_acceptance_rule_registered.py`
  - `test_wmbt_convention_registers_must_have_smoke_acceptance_rule` — reads the local source-tree convention YAML and asserts the rule is registered
  - `test_installed_wmbt_convention_ships_must_have_smoke_acceptance_rule` — smoke check: the rule survives the build-and-install pipeline (reads convention YAML from installed package)
- **DELETE** `test_atdd_md_names_must_have_smoke_acceptance_rule` (was in `test_e015_unit_002_*`)
- **DELETE** `test_installed_atdd_md_has_rule_id` (was in `test_e015_smoke_001_*`)
- **UPDATE** module docstrings + removed unused `RULE_ID` constant from `test_e015_unit_002`
- **Manifest:** backfilled #921 (`atdd issue reconcile` still broken per #580)

## Kept tests (still valid template-content checks)

- `test_atdd_md_init_phase_includes_validate_planner_command` — CONDUCTOR.md INIT phase has `atdd validate planner --local --skip-api` (operator-facing instruction, legitimately in template)
- `test_atdd_md_init_phase_has_before_committing_timing_annotation` — CONDUCTOR.md INIT phase has "before committing PLANNED" timing (same)
- `test_installed_session_launch_template_has_rule_id` — kept as-is; see "follow-up scope" below
- `test_installed_session_launch_template_has_validate_command`

## Follow-up scope (NOT in this PR per §12.3)

`SESSION-LAUNCH-TEMPLATE.md` (spawn-time agent instructions, distinct from CONDUCTOR.md) still has its own `test_installed_session_launch_template_has_rule_id` template-reader assertion. The same architectural principle would suggest moving that one too — but SESSION-LAUNCH-TEMPLATE.md's role and rule-id ergonomics are a separate question, deserving its own scoping decision. Not in #921's scope; could be filed as a follow-up if desired.

## Verification

| Test | Result |
|---|---|
| `test_wmbt_smoke_acceptance_rule_registered` (2 tests, new) | ✅ all pass |
| `test_e015_unit_002_atdd_md_init_phase_*` (2 kept tests) | ✅ all pass |
| `test_e015_smoke_001_deployed_templates_*` (2 kept tests) | ✅ all pass |
| Full `src/atdd/planner/validators/` suite (243 tests) | ✅ 243 passed (was 240 passed + 1 mine failing pre-namespace-package fix; now clean) |

## Unblocks

This PR **unblocks #919 Section B** (template streamline 221→~50 lines). Section B's planned deletion of the `audits:` block would have tripped the deleted template-reader assertions had they remained. With #921 landed, the surviving assertions only check operator-facing instructions that legitimately stay in CONDUCTOR.md.

## Test plan

- [ ] CI green (parity-test, import-discipline-test, incident-defense-test, validate-*)
- [ ] `test_wmbt_smoke_acceptance_rule_registered` appears in the planner validator suite and passes
- [ ] No template change in this PR (CONDUCTOR.md unchanged — the no-duplication invariant is preserved by what is NOT done here, not what is added)

🤖 Closes #921 (test repair, complete). `Refs #919` only — this PR unblocks Section B but does not deliver any of #919's scope.
