### PR TITLE
chore(atdd): Path Shim Leaks Via Atdd Validate During Rebase (#917)

### DIFF
--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -2752,6 +2752,17 @@ Phase descriptions:
 
 def cli() -> int:
     """CLI entry point with version and upgrade checks."""
+    # #917: self-heal a worktree falsely marked core.bare=true BEFORE doing any
+    # work. A stray unscoped `git config core.bare true` (SMOKE test in the
+    # wrong cwd, crashed run, xdist worker) bleeds into the shared .git/config
+    # and the next `git add -A` mass-deletes the working tree. Reset it here so
+    # no atdd command operates on a poisoned config. Never fatal.
+    try:
+        from atdd.coach.utils.repo import ensure_repo_not_falsely_bare
+        ensure_repo_not_falsely_bare()
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-11-16
+        pass
+
     # Check if repo needs sync after ATDD upgrade (at startup)
     # Skip if running 'atdd upgrade' — it handles its own messaging
     if not (len(sys.argv) > 1 and sys.argv[1] == "upgrade"):

--- a/src/atdd/coach/utils/repo.py
+++ b/src/atdd/coach/utils/repo.py
@@ -152,6 +152,86 @@ def detect_worktree_layout(start: Optional[Path] = None) -> str:
     return "no-git"
 
 
+def _read_core_bare(root: Path) -> Optional[str]:
+    """Return the effective ``core.bare`` value for *root*, or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "core.bare"],
+            cwd=root, capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-11-16
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def ensure_repo_not_falsely_bare(root: Optional[Path] = None) -> bool:
+    """Self-heal a working-tree checkout falsely marked ``core.bare=true`` (#917).
+
+    A normal checkout (``.git`` is a directory) and a linked worktree
+    (``.git`` is a *file*) both ALWAYS have a working tree and must carry
+    ``core.bare=false``. ``core.bare`` is a *shared/common* config key, so a
+    single stray unscoped ``git config core.bare true`` — from a SMOKE test
+    run in the wrong cwd, a crashed/killed run, or an xdist worker — bleeds
+    into the common ``.git/config`` and every linked worktree then reads
+    ``core.bare=true``. The next ``git add -A`` treats the checkout as bare
+    (no working tree) and stages the entire tree as deleted: the #629/#917
+    phantom-mass-deletion incident (Wave 12 shipped 220k-line deletions this
+    way; this session nearly shipped 323k-line deletions twice).
+
+    This guard runs at ATDD command entry: if it finds a working-tree
+    checkout reporting ``core.bare=true``, it resets it to ``false`` BEFORE
+    any later git operation can act on the poisoned value. Preventive and
+    harness-agnostic — unlike the test-only conftest guards, it protects the
+    production ``atdd`` flows (validate / pr / issue / coach).
+
+    Args:
+        root: checkout to inspect (defaults to cwd).
+
+    Returns:
+        True if it healed a contaminated config; False otherwise (no ``.git``,
+        legitimately not bare, or git unavailable). Never raises.
+    """
+    import logging
+
+    try:
+        root = (root or Path.cwd()).resolve()
+    except OSError:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-11-16
+        return False
+
+    git_path = root / ".git"
+    # A bare repo has no ``.git`` entry (it IS the git dir). If ``.git`` exists
+    # as a file or directory, this is a working-tree checkout that must never
+    # be bare. If it is absent, there is nothing here for us to protect.
+    if not git_path.exists():
+        return False
+
+    if _read_core_bare(root) != "true":
+        return False
+
+    # Working-tree checkout reporting bare=true → contamination. Reset it.
+    # ``core.bare`` is not worktree-scoped, so this writes the shared
+    # ``.git/config`` and heals every linked worktree at once.
+    try:
+        result = subprocess.run(
+            ["git", "config", "core.bare", "false"],
+            cwd=root, capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-11-16
+        return False
+    if result.returncode != 0:
+        return False
+
+    logging.getLogger(__name__).warning(
+        "atdd: healed core.bare=true on working-tree checkout %s — reset to "
+        "false to prevent phantom mass-deletion (#917).",
+        root,
+        extra={"root": str(root), "guard": "core-bare-self-heal", "issue": 917},
+    )
+    return True
+
+
 def require_repo_root(start: Optional[Path] = None) -> Path:
     """
     Find repo root, raising RuntimeError if no markers found.

--- a/src/atdd/coach/validators/test_core_bare_self_heal.py
+++ b/src/atdd/coach/validators/test_core_bare_self_heal.py
@@ -1,0 +1,88 @@
+# URN: component:govern-lifecycle:enforcement-substrate:test_core_bare_self_heal:backend:domain
+# Runtime: python
+# Purpose: atdd must self-heal a working-tree checkout falsely marked core.bare=true
+#          before any git op, preventing the #629/#917 phantom-mass-deletion.
+"""
+Tests for ``ensure_repo_not_falsely_bare`` (issue #917).
+
+``core.bare`` is a shared/common git config key. A single stray unscoped
+``git config core.bare true`` (a SMOKE test in the wrong cwd, a crashed run,
+an xdist worker) bleeds into ``.git/config``; the next ``git add -A`` then
+treats the checkout as bare and stages the whole tree as deleted — the
+phantom-mass-deletion incident (#629/#917). atdd must reset ``core.bare`` to
+false at command entry, BEFORE any git op acts on the poisoned value.
+
+These tests use a throwaway git repo under ``tmp_path`` — they never touch
+the live repo.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from atdd.coach.utils.repo import ensure_repo_not_falsely_bare
+
+pytestmark = [pytest.mark.coach]
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=root, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "t@t.t")
+    _git(root, "config", "user.name", "t")
+    (root / "f.txt").write_text("hello\n")
+    _git(root, "add", "f.txt")
+    _git(root, "-c", "core.hooksPath=/dev/null", "commit", "-q", "-m", "init")
+
+
+def test_heals_poisoned_core_bare(tmp_path: Path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    # Poison it exactly the way the incident does.
+    _git(repo, "config", "core.bare", "true")
+    assert _git(repo, "config", "--get", "core.bare") == "true"
+
+    healed = ensure_repo_not_falsely_bare(repo)
+
+    assert healed is True
+    assert _git(repo, "config", "--get", "core.bare") == "false"
+
+
+def test_noop_on_clean_repo(tmp_path: Path):
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    # A freshly-inited checkout is already non-bare.
+    assert ensure_repo_not_falsely_bare(repo) is False
+
+
+def test_noop_when_no_git_present(tmp_path: Path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert ensure_repo_not_falsely_bare(plain) is False
+
+
+def test_heals_linked_worktree_via_shared_config(tmp_path: Path):
+    """A linked worktree (.git is a FILE) inherits the poisoned shared config;
+    healing from the worktree must clear it (core.bare is a common key)."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    wt = tmp_path / "wt"
+    _git(repo, "worktree", "add", "-q", str(wt), "-b", "feat")
+    assert (wt / ".git").is_file()  # linked worktree gitfile
+
+    # Poison the shared config from the primary checkout.
+    _git(repo, "config", "core.bare", "true")
+    assert _git(wt, "config", "--get", "core.bare") == "true"  # bled into worktree
+
+    healed = ensure_repo_not_falsely_bare(wt)
+
+    assert healed is True
+    assert _git(wt, "config", "--get", "core.bare") == "false"


### PR DESCRIPTION
Closes #917

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #917 |
| Type | tracking |
| Slug | path-shim-leaks-via-atdd-validate-during-rebase |
| Labels | atdd-issue, atdd:COMPLETE, wagon:govern-lifecycle, tracking |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.

---

## Noted follow-up (decouple safety guard from blast-radius hook)

This PR's self-heal closes the bleed *source*, but a residual gap remains in the hook architecture:

- The **commit-msg hook** (#629 Layer 2) already BLOCKS any commit whose staged diff deletes >50 files / >10,000 lines — i.e. it would catch a phantom-deletion commit.
- But operators commit with **hooks off** (`git -c core.hooksPath=/dev/null commit`) — advised by the `feedback_rebase_hooks_disabled_avoids_phantom_delete` memory — to dodge the **post-commit blast-radius** hook (which runs `atdd validate` and historically bled `core.bare`). Disabling hooks to dodge the post-commit guard ALSO disables the protective commit-msg mass-delete guard. That is exactly how this session's two phantom-deletion commits slipped through.

**Follow-up:** stop coupling the (bleeding) post-commit blast-radius validation to the (protective) commit-msg mass-delete guard, so disabling one never disables the other. Options: move the mass-delete check to a layer that survives `core.hooksPath=/dev/null`, or make the post-commit blast-radius non-bleeding (this PR's self-heal is a step) so hooks-off is no longer needed and the commit-msg guard always runs. Once that lands, the `feedback_rebase_hooks_disabled_avoids_phantom_delete` memory should **invert** to "commit hooks-ON; the commit-msg guard is your net" rather than be deleted.

Tracked here as a follow-up to #917 (folded in per operator request).