### PR TITLE
feat(atdd): Smoke Token Missing From Acceptance Urn Enum (#959)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1780,7 +1780,7 @@ sessions:
   file: null
   issue_number: 959
   type: cleanup
-  status: GREEN
+  status: SMOKE
   created: '2026-06-08'
   archived: null
   wagon: govern-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1780,7 +1780,7 @@ sessions:
   file: null
   issue_number: 959
   type: cleanup
-  status: RED
+  status: GREEN
   created: '2026-06-08'
   archived: null
   wagon: govern-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1775,3 +1775,16 @@ sessions:
   train: null
   branch: feat/daemon-scope-excludes-worktree-launched-worker-decision
   worktree: /Users/alecfokapu/Github/atdd/feat-daemon-scope-excludes-worktree-launched-worker-decision
+- id: '959'
+  slug: smoke-token-missing-from-acceptance-urn-enum
+  file: null
+  issue_number: 959
+  type: cleanup
+  status: PLANNED
+  created: '2026-06-08'
+  archived: null
+  wagon: govern-lifecycle
+  feature: null
+  train: null
+  branch: feat/smoke-token-missing-from-acceptance-urn-enum
+  worktree: /Users/alecfokapu/Github/atdd/feat-smoke-token-missing-from-acceptance-urn-enum

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1780,7 +1780,7 @@ sessions:
   file: null
   issue_number: 959
   type: cleanup
-  status: SMOKE
+  status: REFACTOR
   created: '2026-06-08'
   archived: null
   wagon: govern-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1780,7 +1780,7 @@ sessions:
   file: null
   issue_number: 959
   type: cleanup
-  status: PLANNED
+  status: RED
   created: '2026-06-08'
   archived: null
   wagon: govern-lifecycle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.106.1"
+version = "3.106.2"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/conventions/naming.convention.yaml
+++ b/src/atdd/coach/conventions/naming.convention.yaml
@@ -182,7 +182,7 @@ patterns:
     description: "Acceptance criteria URN for test traceability"
     semantic_pattern: "acc:{wagon}:{wmbt}-{harness}-{NNN}[-{slug}]"
     format: "Structured URN with step code, harness, and sequence"
-    regex: "^acc:[a-z][a-z0-9_-]+:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
+    regex: "^acc:[a-z][a-z0-9_-]+:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
     components:
       wagon: "Parent wagon (kebab-case)"
       wmbt_id: "Step code [DLPCEMYRK] + 3-digit sequence (e.g., C004)"

--- a/src/atdd/coach/utils/graph/tests/test_urn_smoke_harness_token.py
+++ b/src/atdd/coach/utils/graph/tests/test_urn_smoke_harness_token.py
@@ -1,0 +1,98 @@
+# URN: test:coach:urn:smoke_harness_token
+"""
+Issue #959 — SMOKE is missing from the acceptance-URN family enum.
+
+``planner.wmbt.must-have-smoke-acceptance`` REQUIRES the ``-SMOKE-NNN`` token
+on every SMOKE acceptance, yet the acceptance-URN family pattern enumerated
+``UNIT|HTTP|EVENT|…|INTEGRATION|…|STORAGE`` but NOT ``SMOKE``. The result: every
+SMOKE acceptance was simultaneously required and flagged as a broken URN — the
+broken-URN scanner (``atdd repo broken``) resolves ``acc:`` URNs through
+``URNBuilder.PATTERNS['acc']`` (see resolver.py::_validate_format) and reported
+~500 ``acc:*-SMOKE-*`` URNs as broken.
+
+These tests pin that ``SMOKE`` is a first-class harness token in the
+acceptance-URN grammar so ``-SMOKE-NNN`` URNs validate as well-formed, and stay
+coherent with ``_SMOKE_URN_RE`` in
+``src/atdd/planner/validators/test_wmbt_has_smoke_acceptance.py``.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from atdd.coach.utils.graph.urn import URNBuilder
+
+# Mirror of _SMOKE_URN_RE in
+# src/atdd/planner/validators/test_wmbt_has_smoke_acceptance.py — the two MUST
+# stay coherent: anything the SMOKE-acceptance validator demands must validate
+# as a well-formed acc URN.
+_SMOKE_URN_RE = re.compile(
+    r"^acc:[a-z][a-z0-9-]*:[DLPCEMYRK]\d{3}-SMOKE-\d{3}(?:-[a-z0-9-]+)?$"
+)
+
+
+# ---------------------------------------------------------------------------
+# Family enum includes SMOKE
+# ---------------------------------------------------------------------------
+
+
+class TestSmokeHarnessCode:
+    def test_harness_codes_maps_smoke(self):
+        """URNBuilder.HARNESS_CODES exposes the canonical SMOKE token."""
+        assert URNBuilder.HARNESS_CODES.get("smoke") == "SMOKE"
+
+    def test_acceptance_builder_emits_smoke_urn(self):
+        """The builder accepts SMOKE and produces a well-formed acc URN."""
+        urn = URNBuilder.acceptance(
+            "mediate-worker-decisions", "E007", "SMOKE", "001", "live-all-answered"
+        )
+        assert urn == (
+            "acc:mediate-worker-decisions:E007-SMOKE-001-live-all-answered"
+        )
+
+
+# ---------------------------------------------------------------------------
+# -SMOKE-NNN URNs validate as well-formed (not broken)
+# ---------------------------------------------------------------------------
+
+
+class TestSmokeUrnValidates:
+    @pytest.mark.parametrize(
+        "good_urn",
+        [
+            "acc:mediate-worker-decisions:E007-SMOKE-001-live-multi-question-all-answered",
+            "acc:integration-hardening:E001-SMOKE-002",
+            "acc:auth:C004-SMOKE-019-session-management",
+            "acc:a:D001-SMOKE-999",
+        ],
+    )
+    def test_smoke_acc_urn_passes_validate_urn(self, good_urn):
+        # validate_urn(...,"acc") is exactly the path resolver.py::_validate_format
+        # uses (URNBuilder.PATTERNS['acc']) to decide is_broken for the scanner.
+        assert URNBuilder.validate_urn(good_urn, "acc") is True
+
+    def test_smoke_acc_urn_passes_validate_grammar(self):
+        """The auto-detect public entry point accepts SMOKE acc URNs."""
+        assert URNBuilder.validate_grammar(
+            "acc:integration-hardening:E001-SMOKE-002-self-compliance"
+        ) is True
+
+
+# ---------------------------------------------------------------------------
+# Regression: the ~500 false-broken SMOKE URNs are no longer reported
+# ---------------------------------------------------------------------------
+
+
+class TestSmokeBrokenRegression:
+    def test_representative_real_smoke_urn_not_broken(self):
+        """A representative live URN from plan/ resolves as well-formed."""
+        urn = "acc:mediate-worker-decisions:E007-SMOKE-001-live-multi-question-all-answered"
+        assert URNBuilder.validate_urn(urn, "acc") is True
+
+    def test_coherent_with_smoke_acceptance_validator_regex(self):
+        """Anything _SMOKE_URN_RE accepts must validate as an acc URN."""
+        sample = "acc:integration-hardening:E001-SMOKE-001-some-live-check"
+        assert _SMOKE_URN_RE.match(sample), "fixture must match the validator regex"
+        assert URNBuilder.validate_urn(sample, "acc") is True

--- a/src/atdd/coach/utils/graph/urn.py
+++ b/src/atdd/coach/utils/graph/urn.py
@@ -138,7 +138,8 @@ class URNBuilder:
         'rls': 'RLS',
         'edge_function': 'EDGE',
         'realtime': 'REALTIME',
-        'storage': 'STORAGE'
+        'storage': 'STORAGE',
+        'smoke': 'SMOKE'
     }
 
     _MANIFEST_STATE = {}
@@ -155,10 +156,10 @@ class URNBuilder:
         'test': (
             r'^test:('
             # V3 acceptance: test:{wagon}:{feature}:{WMBT_ID}-{HARNESS}-{NNN}-{slug}
-            r'[a-z][a-z0-9-]*:[a-z][a-z0-9-]*:[A-Z]\d{3}-(?:UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-\d{3}-[a-z0-9][a-z0-9-]*'
+            r'[a-z][a-z0-9-]*:[a-z][a-z0-9-]*:[A-Z]\d{3}-(?:UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-\d{3}-[a-z0-9][a-z0-9-]*'
             r'|'
             # V3 journey: test:train:{train_id}:{HARNESS}-{NNN}-{slug}
-            r'train:\d{4}-[a-z0-9][a-z0-9-]*:(?:UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-\d{3}-[a-z0-9][a-z0-9-]*'
+            r'train:\d{4}-[a-z0-9][a-z0-9-]*:(?:UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-\d{3}-[a-z0-9][a-z0-9-]*'
             r'|'
             # Legacy dot format (migration support)
             r'[a-z0-9]+(?:-[a-z0-9]+)*(?::[a-z0-9]+(?:-[a-z0-9]+)*)*(?:\.[a-z0-9-]+)?'
@@ -179,7 +180,7 @@ class URNBuilder:
         # `[DLPCEMYRK]\d{3}-<HARNESS>-\d{3}` greedily before the train branch).
         'acc': (
             r'^acc:[a-z0-9][a-z0-9-]*:('
-            r'[DLPCEMYRK][0-9]{3}-(?:UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?'
+            r'[DLPCEMYRK][0-9]{3}-(?:UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-[0-9]{3}(?:-[a-z0-9-]+)?'
             r'|'
             r'[a-z][a-z0-9-]*'
             r')$'

--- a/src/atdd/coach/utils/rule_binding.py
+++ b/src/atdd/coach/utils/rule_binding.py
@@ -285,7 +285,7 @@ def find_convention_files(
 _WMBT_ACC_BODY_RE = re.compile(
     r"^([DLPCEMYRK][0-9]{3})-"
     r"(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|"
-    r"WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-"
+    r"WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-"
     r"([0-9]{3})(?:-([a-z0-9-]+))?$"
 )
 
@@ -311,7 +311,7 @@ _RULE_ID_PATTERN = re.compile(
 #           v12 §5.4) — derived from a feature.yaml abuse_case.
 _REPO_RULE_ID_PATTERN = re.compile(
     r"^repo\.[a-z0-9][a-z0-9-]*\.("
-    r"[DLPCEMYRK][0-9]{3}-acc-(?:unit|http|event|ws|e2e|a11y|vis|metric|job|db|sec|load|script|widget|golden|bloc|integration|rls|edge|realtime|storage)-[0-9]{3}"
+    r"[DLPCEMYRK][0-9]{3}-acc-(?:unit|http|event|ws|e2e|a11y|vis|metric|job|db|sec|load|script|widget|golden|bloc|integration|rls|edge|realtime|storage|smoke)-[0-9]{3}"
     r"|"
     r"acc-[a-z][a-z0-9-]*"
     r"|"

--- a/src/atdd/planner/conventions/acceptance.convention.yaml
+++ b/src/atdd/planner/conventions/acceptance.convention.yaml
@@ -90,7 +90,7 @@ urn_generation:
     - Enforces colon = hierarchy, dash = facet cluster
 
   validation:
-    pattern: "^acc:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?$"
+    pattern: "^acc:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-[0-9]{3}(?:-[a-z0-9-]+)?$"
     description: "Enforces colon for hierarchy (acc:wagon:wmbt_id) and dash-joined facet cluster (-harness-NNN[-slug])"
 
   legacy_format:
@@ -121,6 +121,7 @@ harness_codes:
   edge_function: EDGE
   realtime: REALTIME
   storage: STORAGE
+  smoke: SMOKE
 
 # -----------------------------------------------------------------------------
 # execution_kind — orthogonal runtime-environment classifier (issue #690)

--- a/src/atdd/planner/schemas/acceptance.schema.json
+++ b/src/atdd/planner/schemas/acceptance.schema.json
@@ -13,12 +13,12 @@
       "properties": {
         "urn": {
           "type": "string",
-          "pattern": "^acc:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?$",
+          "pattern": "^acc:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-[0-9]{3}(?:-[a-z0-9-]+)?$",
           "description": "Acceptance URN format: acc:{wagon}:{wmbt_id}-{harness}-{NNN}[-{slug}]"
         },
         "id": {
           "type": "string",
-          "pattern": "^AC-(HTTP|UNIT|EVENT|WS|E2E|A11Y|VISUAL|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE_FUNCTION|REALTIME|STORAGE)-[0-9]{3}$"
+          "pattern": "^AC-(HTTP|UNIT|EVENT|WS|E2E|A11Y|VISUAL|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE_FUNCTION|REALTIME|STORAGE|SMOKE)-[0-9]{3}$"
         },
         "purpose": {
           "type": "string",

--- a/src/atdd/tester/schemas/contract.schema.json
+++ b/src/atdd/tester/schemas/contract.schema.json
@@ -344,7 +344,7 @@
               "type": "array",
               "items": {
                 "type": "string",
-                "pattern": "^acc:[a-z][a-z0-9_-]*:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
+                "pattern": "^acc:[a-z][a-z0-9_-]*:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
               },
               "description": "Acceptance URNs that validate this contract (optional)"
             }

--- a/src/atdd/tester/schemas/telemetry.schema.json
+++ b/src/atdd/tester/schemas/telemetry.schema.json
@@ -77,7 +77,7 @@
       "minItems": 0,
       "items": {
         "type": "string",
-        "pattern": "^acc:[a-z][a-z0-9_-]*:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
+        "pattern": "^acc:[a-z][a-z0-9_-]*:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
       },
       "description": "Array of acceptance criteria URNs that validate this signal"
     },

--- a/src/atdd/tester/validators/test_contract_schema_compliance.py
+++ b/src/atdd/tester/validators/test_contract_schema_compliance.py
@@ -282,7 +282,7 @@ def test_contract_acceptance_references_exist():
         pytest.skip("No acceptance URNs found in plan/")
 
     urn_pattern = re.compile(
-        r"^acc:[a-z][a-z0-9_-]*:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
+        r"^acc:[a-z][a-z0-9_-]*:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
     )
 
     missing = []

--- a/src/atdd/tester/validators/test_telemetry_structure.py
+++ b/src/atdd/tester/validators/test_telemetry_structure.py
@@ -507,7 +507,7 @@ def test_telemetry_acceptance_references_exist():
         pytest.skip("No acceptance URNs found in plan/")
 
     urn_pattern = re.compile(
-        r"^acc:[a-z][a-z0-9_-]*:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
+        r"^acc:[a-z][a-z0-9_-]*:([DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-[0-9]{3}(?:-[a-z0-9-]+)?|[A-Z][0-9]{3})$"
     )
 
     missing = []


### PR DESCRIPTION
## Summary

`SMOKE` was missing from the acceptance-URN harness enum, yet
`planner.wmbt.must-have-smoke-acceptance` **requires** the `-SMOKE-NNN` token on
every SMOKE acceptance. So every SMOKE acceptance was simultaneously **required**
and flagged as a **broken URN** — `atdd repo broken` reported ~500
`acc:*-SMOKE-*` references as broken.

This PR adds `SMOKE` to every copy of the acceptance-URN harness alternation and
to the `smoke: SMOKE` harness-code maps, so `acc:<wagon>:<WMBT>-SMOKE-NNN[-slug]`
URNs validate as well-formed.

### Graph Context

This is a toolkit-grammar fix in shared URN substrate, not a wagon/feature
deliverable. The broken-URN scanner (`atdd repo broken`) resolves `acc:` URNs
through `URNBuilder.PATTERNS['acc']` in `src/atdd/coach/utils/graph/urn.py`
(`resolver.py::_validate_format`). The harness alternation is hand-duplicated
across coach (`urn.py`, `naming.convention.yaml`, `rule_binding.py`), planner
(`acceptance.convention.yaml`, `acceptance.schema.json`), and tester
(contract/telemetry validators + schemas). `SMOKE` had already been promoted to a
first-class harness token in the SMOKE-acceptance validator (`_SMOKE_URN_RE`) and
is in active use across `plan/`, but was never added to the canonical grammar —
the two drifted out of coherence. This change re-aligns them.

Once `acc:*-SMOKE-*` URNs resolve, the repo-rule walker derives rule-ids of the
form `repo.<wagon>.<WMBT>-acc-smoke-<NNN>`, so `_REPO_RULE_ID_PATTERN` in
`rule_binding.py` was extended with the lowercase `smoke` harness in lockstep.

### Verification

- `atdd repo broken`: total broken references dropped 472 → 199; **zero**
  `acc:*-SMOKE-*` remain broken (the ~500 false-broken SMOKE family is gone).
  The residual entries are `test:` family URNs with pre-existing structural
  issues (missing feature segment) — independent of the SMOKE enum and out of
  scope for this issue.
- New `test_urn_smoke_harness_token.py`: 9 tests, RED → GREEN.
- Full archetype validator suite: 1271 passed, 0 failed.
- `atdd repo validate`: PASS (substrate conformance PASS).

## Release notes

**Why**: SMOKE acceptances were required by the planner but rejected by the
URN traceability grammar, producing a ~500-entry false-broken baseline that
masked real traceability breaks.

**What**: Added `SMOKE` to the acceptance-URN harness enum across all duplicated
grammar definitions (URNBuilder, planner/tester conventions + schemas,
naming/rule-binding patterns), added the `smoke: SMOKE` harness-code mappings,
and extended the repo-rule-id grammar with the lowercase `smoke` harness.

**Impact**: `acc:*-SMOKE-NNN` URNs now validate as well-formed; the false-broken
SMOKE family is eliminated from `atdd repo broken`. PATCH (3.106.1 → 3.106.2);
no breaking changes — the enum is widened, not altered.

Closes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)
