### PR TITLE
docs: add ATDD manifesto and market comparison

### DIFF
--- a/ATDD_Manifesto.md
+++ b/ATDD_Manifesto.md
@@ -1,0 +1,419 @@
+# ATDD Manifesto
+
+**Working draft**  
+**Purpose:** Position ATDD as a software delivery protocol for agentic and human software work.
+
+---
+
+## 1. The thesis
+
+**ATDD does not make agents smarter. ATDD makes software delivery more deterministic.**
+
+The market is racing toward smarter agents: better reasoning, larger context, stronger planning, better tool use, more autonomy. That is useful, but it is not enough.
+
+Software delivery should not depend on whether the current agent is brilliant, lucky, or context-rich enough to infer every hidden convention of a project.
+
+ATDD starts from a different premise:
+
+> Do not trust the agent's cognition. Trust the delivery system.
+
+ATDD defines the protocol by which software work becomes explicit, checkable, repeatable, and deliverable.
+
+---
+
+## 2. The problem
+
+Modern software delivery still depends on too much invisible human cognition.
+
+Humans know the unwritten rules:
+
+- where files should go;
+- what naming conventions mean;
+- which architectural boundaries matter;
+- which tests are expected;
+- what “done” really means;
+- which changes are safe;
+- which delivery gates must pass;
+- when a change is incomplete even if the code compiles.
+
+Agents do not reliably know those things unless they are encoded somewhere.
+
+When those rules live in someone’s head, an agent must guess. When an agent guesses, delivery quality depends on model intelligence. That is fragile.
+
+ATDD exists to move delivery knowledge out of human memory and into a machine-readable delivery protocol.
+
+---
+
+## 3. The core idea
+
+**Less trust in cognition. More trust in executable conventions.**
+
+ATDD turns software delivery into a closed loop:
+
+```txt
+Convention → Scope → Gate → Workspace Provider → Implementation → Violation/Evidence
+```
+
+The agent, human, or CI system does not need to infer the delivery contract from vibes.
+
+It can ask:
+
+```txt
+What conventions apply?
+Where do they apply?
+When must they run?
+What executes them?
+What result shape is expected?
+What violation points back to which rule?
+What evidence proves the gate passed?
+```
+
+That is the protocol layer ATDD wants to standardize.
+
+---
+
+## 4. Strong positioning statements
+
+### ATDD is a protocol, not a platform.
+
+ATDD should not become a replacement for CI engines, policy engines, static analyzers, agent frameworks, developer portals, or supply-chain systems.
+
+ATDD should define the delivery contract that those tools can execute, enforce, observe, or report.
+
+### ATDD is contracts, not vibes.
+
+A delivery rule should not be a vague instruction like:
+
+```txt
+Make sure this follows our architecture.
+```
+
+It should become:
+
+```txt
+rule_id: coder.source.component-header-required
+scope: source files matching X
+gate: pre-push, ci
+validator: component-header implementation
+output: Violation(rule_id=..., file=..., line=..., severity=...)
+```
+
+### ATDD is evidence, not confidence.
+
+An agent saying “I think this is done” is not enough.
+
+ATDD should produce machine-readable evidence:
+
+```txt
+which gate ran
+which convention set applied
+which workspace provider executed
+which implementation produced the result
+which violations remain
+which artifacts were checked
+```
+
+### ATDD standardizes the definition of done.
+
+The point is not only to run tests. The point is to define what “done” means for a delivery unit.
+
+Done means the relevant conventions were applied, the relevant gates ran, violations were resolved or accepted according to policy, and evidence was produced.
+
+### ATDD gives weaker agents stronger rails.
+
+A very smart agent may infer many project conventions. A weaker agent may not.
+
+ATDD reduces the gap by making the delivery environment explicit.
+
+The goal is not to eliminate intelligence. The goal is to reduce the amount of intelligence required to deliver correctly.
+
+### ATDD makes the system smarter, not only the agent.
+
+The current market often asks: “How do we build smarter agents?”
+
+ATDD asks: “How do we build a smarter delivery system so agents do not need to guess?”
+
+---
+
+## 5. What ATDD is
+
+ATDD is a software delivery protocol that binds together:
+
+- **intent** — what the delivery unit is trying to achieve;
+- **conventions** — the explicit rules and expectations;
+- **scopes** — where rules apply;
+- **gates** — when rules run;
+- **extensions** — installable use-case/rule packages;
+- **workspace providers** — reusable runtime contracts;
+- **workspace instances** — materialized execution environments;
+- **implementations** — executable units that realize convention behavior;
+- **violations** — machine-readable failures tied to rule IDs;
+- **evidence** — machine-readable proof that delivery gates ran and what they produced.
+
+ATDD is the connective protocol between human intent, agent execution, validator feedback, and delivery evidence.
+
+---
+
+## 6. What ATDD is not
+
+ATDD should not become:
+
+- a new CI/CD engine;
+- a new static analyzer;
+- a new policy language;
+- a new agent framework;
+- a new package manager;
+- a new developer portal;
+- a new supply-chain attestation framework.
+
+Those categories already exist and should be reused.
+
+ATDD should define how they plug into a common delivery protocol.
+
+---
+
+## 7. The architectural spine
+
+### Extension
+
+An **extension** is the installable use-case package.
+
+It owns:
+
+- conventions;
+- scopes;
+- gates;
+- rule IDs;
+- ownership boundaries;
+- implementation references.
+
+An extension answers:
+
+```txt
+What delivery behavior are we adding?
+What rules does this package own?
+Where do they apply?
+When do they run?
+```
+
+### Convention
+
+A **convention** is a declarative rule or expectation.
+
+It is not necessarily executable by itself. It is the normative delivery statement.
+
+### Scope
+
+A **scope** defines where a convention applies.
+
+Examples:
+
+```txt
+all source files
+all public API files
+all migration files
+all test files
+all files in a component boundary
+```
+
+### Gate
+
+A **gate** defines when a convention is enforced.
+
+Examples:
+
+```txt
+pre-commit
+pre-push
+pull request
+ci
+release
+migration
+agent handoff
+```
+
+### Workspace Provider
+
+A **workspace provider** is a reusable runtime contract.
+
+Examples:
+
+```txt
+atdd.workspace.python-pytest
+atdd.workspace.node-vitest
+atdd.workspace.go-test
+atdd.workspace.opa
+atdd.workspace.semgrep
+```
+
+The provider owns how executable units run, not why they matter.
+
+### Workspace Instance
+
+A **workspace instance** is the resolved/materialized runtime used during execution.
+
+It is the concrete local execution environment created from a workspace provider.
+
+### Implementation
+
+An **implementation** is the executable unit that realizes a convention.
+
+Today, most implementations may be validators.
+
+But the layer should remain generic:
+
+```yaml
+kind: implementation
+type: validator
+```
+
+Future implementation types may include:
+
+```txt
+validator
+fixer
+generator
+reporter
+migrator
+collector
+test
+```
+
+### Violation
+
+A **violation** is a machine-readable failure tied to a rule ID.
+
+It should point back to the convention that was broken.
+
+### Evidence
+
+**Evidence** is the machine-readable proof of execution and result.
+
+It should answer:
+
+```txt
+What ran?
+Against what?
+Under which convention set?
+Using which runtime?
+With what result?
+```
+
+---
+
+## 8. The first-class workspace provider decision
+
+Reusable runtimes should be first-class from the beginning.
+
+ATDD should not encourage every extension to copy its own `python-pytest` runtime folder.
+
+That would create:
+
+- duplicated runtimes;
+- version drift;
+- inconsistent commands;
+- inconsistent discovery behavior;
+- painful migration once extensions proliferate.
+
+The recommended model is:
+
+```txt
+Extension
+  owns the use case and rule IDs
+
+Workspace Provider
+  owns the reusable runtime contract
+
+Workspace Instance
+  is materialized during execution
+
+Implementation
+  targets a workspace provider and emits violations/evidence
+```
+
+Embedded workspaces may remain allowed for private or unusual runtimes, but official/common runtimes should be shared providers by default.
+
+---
+
+## 9. Relationship to agents
+
+ATDD is agent-compatible, but not agent-dependent.
+
+A human can use ATDD. A CI system can use ATDD. A coding agent can use ATDD. A coach/worker multi-agent system can use ATDD.
+
+The protocol is the stable part.
+
+The intelligence of the actor is variable.
+
+That is the point.
+
+ATDD makes delivery behavior portable across actors.
+
+---
+
+## 10. The delivery loop
+
+The ATDD loop is:
+
+```txt
+1. Extension declares conventions, scopes, and gates.
+2. Implementation declares which rule IDs it enforces.
+3. Workspace provider supplies the runtime contract.
+4. Workspace instance executes the implementation.
+5. Implementation emits violations or evidence.
+6. Agent/human/system uses feedback to repair or accept the delivery state.
+7. Gate result becomes part of the delivery record.
+```
+
+This is the closed loop:
+
+```txt
+Declarative rule + executable implementation + reusable runtime + evidence = delivery protocol
+```
+
+---
+
+## 11. The non-negotiables
+
+ATDD should be:
+
+- explicit;
+- machine-readable;
+- composable;
+- runtime-agnostic;
+- agent-agnostic;
+- CI-agnostic;
+- evidence-producing;
+- convention-centered;
+- implementation-backed;
+- strict about ownership boundaries.
+
+ATDD should avoid:
+
+- hidden rules;
+- unversioned runtime behavior;
+- ambiguous “done” states;
+- agent-only assumptions;
+- duplicated workspace runtimes;
+- vague validation output;
+- tool lock-in.
+
+---
+
+## 12. Final manifesto statement
+
+ATDD is the missing software delivery protocol for a world where humans, agents, and automation all contribute to software production.
+
+It does not bet everything on smarter agents.
+
+It bets on a smarter delivery system.
+
+It replaces invisible expectations with explicit conventions.
+
+It replaces informal confidence with executable gates.
+
+It replaces vibes with violations and evidence.
+
+It lets weaker agents deliver stronger software because the system carries more of the delivery intelligence.
+
+**Protocol, not platform. Contracts, not vibes. Evidence, not confidence.**

--- a/ATDD_Market_Comparison.md
+++ b/ATDD_Market_Comparison.md
@@ -1,0 +1,556 @@
+# ATDD Market Comparison and Non-Reinvention Analysis
+
+**Working draft**  
+**Purpose:** Compare ATDD with adjacent market categories and clarify where ATDD should integrate instead of competing.
+
+---
+
+## 1. Executive verdict
+
+ATDD does not appear to be a direct reinvention of a single existing product category.
+
+The market already has many strong pieces:
+
+- agent frameworks;
+- agent/tool interoperability protocols;
+- policy-as-code engines;
+- static analyzers;
+- CI/CD systems;
+- supply-chain integrity frameworks;
+- developer portals;
+- test frameworks.
+
+But these tools do not usually define a complete software delivery protocol that binds together:
+
+```txt
+conventions
+scopes
+gates
+extensions
+workspace providers
+implementations
+violations
+evidence
+agent/human/CI execution loops
+```
+
+That is the ATDD opportunity.
+
+The risk is not that ATDD duplicates one product. The risk is that ATDD accidentally tries to become all of them.
+
+The discipline should be:
+
+> ATDD should be the contract layer, not the execution engine for every category.
+
+---
+
+## 2. Comparison table
+
+| Category | Examples | What they already solve | Where ATDD overlaps | Where ATDD should differ |
+|---|---|---|---|---|
+| Agent frameworks | OpenAI Agents SDK, Microsoft Agent Framework / AutoGen, CrewAI | Build and orchestrate agents, tools, handoffs, memory, sessions, workflows | Agents may execute ATDD tasks or respond to ATDD violations | ATDD should not be an agent framework. It should define the delivery contract agents follow. |
+| Agent/tool protocols | MCP, A2A-style protocols | Tool discovery, tool invocation, agent communication | ATDD capabilities can be exposed as tools or agent messages | ATDD should not replace tool/agent protocols. It should define software delivery semantics carried through them. |
+| Policy-as-code | OPA/Rego, Conftest, Kyverno | Declarative policy decisions and enforcement | ATDD conventions may be enforced by policy engines | ATDD should not invent a general policy language. It should map policies to delivery conventions, gates, and evidence. |
+| Static analysis / code scanning | Semgrep, CodeQL, ESLint, Ruff, mypy | Detect code findings, style issues, security issues, type errors | ATDD implementations may wrap or normalize scanner outputs | ATDD should not become a scanner. It should normalize violations and tie them to delivery rule IDs. |
+| Test frameworks | pytest, Vitest, Jest, Go test, Cargo test | Execute tests in language ecosystems | ATDD workspace providers may define how these runtimes execute implementations | ATDD should not replace test runners. It should standardize how test-backed implementations map to conventions and evidence. |
+| CI/CD systems | GitHub Actions, GitLab CI, Buildkite, Dagger, Tekton, Argo | Run workflows, jobs, builds, tests, deployments | ATDD gates can run in CI/CD systems | ATDD should not become CI. It should define what must run, when, and what output means. |
+| CD event standards | CDEvents | Standardize continuous delivery event data for interoperability | ATDD evidence can map into delivery events | ATDD should not replace CD events. It should generate delivery evidence that can be emitted through event standards. |
+| Supply-chain integrity | SLSA, in-toto, Sigstore, SBOM tooling | Provenance, artifact integrity, tamper resistance, supply-chain verification | ATDD evidence can feed attestations and provenance | ATDD should not replace supply-chain frameworks. It should provide higher-level delivery-rule evidence. |
+| Developer portals / golden paths | Backstage | Catalog software, scaffold templates, unify developer tooling | ATDD extensions can encode golden path rules and delivery conventions | ATDD should not become the portal. It should provide enforceable delivery contracts behind the portal. |
+
+---
+
+## 3. Agent frameworks
+
+### What exists
+
+Agent frameworks focus on creating and orchestrating AI agents.
+
+Examples include:
+
+- OpenAI Agents SDK;
+- Microsoft Agent Framework / AutoGen lineage;
+- CrewAI.
+
+OpenAI describes agents as applications that plan, call tools, collaborate across specialists, and keep state for multi-step work.[^openai-agents] Microsoft describes its Agent Framework as a successor combining AutoGen-style abstractions for single- and multi-agent patterns with enterprise features such as state management, type safety, telemetry, and model support.[^ms-agent-framework] CrewAI positions itself around production-ready multi-agent systems, crews, flows, guardrails, memory, knowledge, and observability.[^crewai]
+
+### Overlap with ATDD
+
+Agents can be actors inside ATDD.
+
+An agent might:
+
+- inspect conventions;
+- run gates;
+- fix violations;
+- ask another agent to repair a failing implementation;
+- produce evidence for a delivery step.
+
+### Difference
+
+Agent frameworks ask:
+
+```txt
+How do we create, coordinate, and run agents?
+```
+
+ATDD asks:
+
+```txt
+What software delivery contract must any actor satisfy?
+```
+
+ATDD should not compete with agent frameworks.
+
+ATDD should define the protocol that agents follow.
+
+---
+
+## 4. Agent/tool interoperability protocols
+
+### What exists
+
+MCP standardizes how LLM applications integrate with external data sources and tools, and its tool specification allows servers to expose named tools with schemas that models can invoke.[^mcp-spec][^mcp-tools]
+
+### Overlap with ATDD
+
+ATDD could expose capabilities through MCP-style tools:
+
+```txt
+atdd.list_conventions
+atdd.resolve_gate
+atdd.validate
+atdd.explain_violation
+atdd.apply_fix
+atdd.emit_evidence
+```
+
+### Difference
+
+MCP answers:
+
+```txt
+How does a model discover and call tools?
+```
+
+ATDD answers:
+
+```txt
+What does correct software delivery mean, and how is that checked?
+```
+
+MCP can carry ATDD operations. It does not define ATDD’s delivery semantics.
+
+---
+
+## 5. Policy-as-code
+
+### What exists
+
+OPA is a general-purpose policy engine that provides a declarative language and APIs to offload policy decision-making from software systems.[^opa-docs]
+
+Policy-as-code is mature and should not be reinvented.
+
+### Overlap with ATDD
+
+Some ATDD conventions can be implemented by policy engines.
+
+Example:
+
+```txt
+ATDD convention:
+  container image must not run as root
+
+Possible implementation:
+  OPA/Rego policy
+```
+
+### Difference
+
+OPA answers:
+
+```txt
+Given this input, does this policy allow or deny it?
+```
+
+ATDD answers:
+
+```txt
+Which convention owns this rule?
+Where does it apply?
+Which gate enforces it?
+Which implementation executes it?
+Which violation maps back to which rule_id?
+What evidence proves the gate ran?
+```
+
+ATDD should integrate policy engines as implementation backends, not replace them.
+
+---
+
+## 6. Static analysis and code scanning
+
+### What exists
+
+Semgrep is a static analysis tool that searches code, finds bugs, and enforces secure guardrails and coding standards; it supports many languages and can run in IDE, pre-commit, and CI/CD workflows.[^semgrep-github]
+
+Other tools in this category include CodeQL, ESLint, Ruff, mypy, and language-specific linters.
+
+### Overlap with ATDD
+
+ATDD implementations may wrap scanners.
+
+Example:
+
+```txt
+ATDD convention:
+  source files must declare a component header
+
+Possible implementations:
+  custom pytest validator
+  Semgrep rule
+  AST parser
+  language server rule
+```
+
+### Difference
+
+Scanners produce findings.
+
+ATDD should normalize those findings into delivery violations:
+
+```txt
+Violation(
+  rule_id="coder.source.component-header-required",
+  file="src/foo.py",
+  line=12,
+  severity="error",
+  gate="pre-push"
+)
+```
+
+The scanner can vary. The delivery contract should not.
+
+---
+
+## 7. Test frameworks and workspace providers
+
+### What exists
+
+Language ecosystems already have mature test runners:
+
+```txt
+pytest
+Vitest
+Jest
+Go test
+Cargo test
+```
+
+### Overlap with ATDD
+
+ATDD workspace providers can standardize how implementations run on those runtimes.
+
+Example:
+
+```txt
+atdd.workspace.python-pytest
+  owns pytest runtime contract
+  owns test discovery behavior
+  owns command shape
+  owns shared runtime files
+```
+
+### Difference
+
+pytest answers:
+
+```txt
+How do I run Python tests?
+```
+
+ATDD answers:
+
+```txt
+Which delivery convention does this test-backed implementation enforce?
+Which rule_id does a failure map to?
+Which gate does this affect?
+What evidence should be emitted?
+```
+
+Workspace providers should be first-class in ATDD because common runtimes are shared by default.
+
+---
+
+## 8. CI/CD systems
+
+### What exists
+
+GitHub Actions is a CI/CD platform for automating build, test, and deployment pipelines.[^github-actions] Dagger positions itself as a way to build, test, and deploy codebases repeatably, running locally, in CI, or in the cloud.[^dagger]
+
+### Overlap with ATDD
+
+ATDD gates can run inside CI/CD systems.
+
+Example:
+
+```yaml
+- name: ATDD CI Gate
+  run: atdd validate --gate ci
+```
+
+### Difference
+
+CI/CD answers:
+
+```txt
+How do I run jobs?
+```
+
+ATDD answers:
+
+```txt
+What delivery contract must this job enforce?
+What conventions apply?
+What violations block the gate?
+What evidence is produced?
+```
+
+ATDD should not be a CI engine.
+
+ATDD should be portable across CI engines.
+
+---
+
+## 9. Continuous delivery event standards
+
+### What exists
+
+CDEvents is a common specification for Continuous Delivery events intended to enable interoperability across the software production ecosystem.[^cdevents]
+
+### Overlap with ATDD
+
+ATDD evidence could be emitted as or attached to continuous delivery events.
+
+Example:
+
+```txt
+ATDD gate result → CDEvents-compatible event
+```
+
+### Difference
+
+CDEvents standardizes event shapes.
+
+ATDD should define what delivery semantics produced the event.
+
+---
+
+## 10. Supply-chain integrity
+
+### What exists
+
+SLSA is a software supply-chain security framework with standards and controls to prevent tampering, improve integrity, and secure packages and infrastructure.[^slsa]
+
+in-toto protects software supply-chain integrity by verifying that expected tasks were performed as planned, by authorized actors, and that products were not tampered with in transit.[^intoto-github]
+
+### Overlap with ATDD
+
+ATDD evidence can feed provenance and attestation systems.
+
+Example:
+
+```txt
+ATDD evidence:
+  convention_set: v1.4.0
+  workspace_provider: atdd.workspace.python-pytest@1.0.0
+  implementation: component-header-validator@1.2.0
+  gate: ci
+  result: pass
+  artifact_digest: sha256:...
+```
+
+### Difference
+
+Supply-chain frameworks focus on integrity, provenance, authorization, and tamper resistance.
+
+ATDD focuses on delivery conventions, gate semantics, violations, and executable feedback loops.
+
+ATDD should feed supply-chain systems, not replace them.
+
+---
+
+## 11. Developer portals and golden paths
+
+### What exists
+
+Backstage is an open source developer portal framework that centralizes software catalogs, infrastructure tools, and developer workflows.[^backstage]
+
+### Overlap with ATDD
+
+Backstage can scaffold repositories and expose golden paths. ATDD can encode the enforceable delivery contract behind those golden paths.
+
+Example:
+
+```txt
+Backstage template creates service repo
+ATDD extension declares delivery conventions
+ATDD validators enforce them
+CI emits ATDD evidence
+```
+
+### Difference
+
+Backstage answers:
+
+```txt
+How do developers discover, scaffold, and operate software through a portal?
+```
+
+ATDD answers:
+
+```txt
+What machine-readable delivery rules must this software satisfy?
+```
+
+---
+
+## 12. The ATDD gap
+
+The market has engines.
+
+ATDD should be the protocol that coordinates them.
+
+Existing tools are strong at:
+
+```txt
+running agents
+calling tools
+scanning code
+running policies
+executing CI jobs
+building artifacts
+emitting supply-chain attestations
+scaffolding developer workflows
+```
+
+ATDD’s gap is:
+
+```txt
+standardizing software delivery expectations as explicit, executable, agent-readable contracts
+```
+
+That includes:
+
+```txt
+what rules exist
+where they apply
+when they run
+what executes them
+how violations are shaped
+how evidence is produced
+how agents/humans/CI systems close the loop
+```
+
+---
+
+## 13. Reinvention boundaries
+
+ATDD should not build the following unless absolutely necessary:
+
+| Do not reinvent | Use instead |
+|---|---|
+| General policy language | OPA/Rego or existing policy engines |
+| Static analysis engine | Semgrep, CodeQL, linters, custom adapters |
+| CI engine | GitHub Actions, GitLab CI, Dagger, Buildkite, Tekton, Argo |
+| Agent orchestration framework | OpenAI Agents SDK, Microsoft Agent Framework, CrewAI, LangGraph-style systems |
+| Tool invocation protocol | MCP or similar protocols |
+| Supply-chain attestation framework | SLSA, in-toto, Sigstore, SBOM/provenance tooling |
+| Developer portal | Backstage or similar portals |
+
+ATDD should define adapters and contracts around these tools.
+
+---
+
+## 14. What ATDD should own directly
+
+ATDD should own the protocol spine:
+
+```txt
+Extension
+Convention
+Scope
+Gate
+Workspace Provider
+Workspace Instance
+Implementation
+Violation
+Evidence
+```
+
+This spine is the part that no adjacent tool cleanly owns for agentic software delivery.
+
+---
+
+## 15. Over-engineering risks
+
+ATDD becomes over-engineered if it tries to become a platform too early.
+
+Avoid building:
+
+- a remote marketplace before local resolution works;
+- a complex semantic version solver before exact versions work;
+- a custom policy language before adapters are exhausted;
+- a custom static analysis engine before wrappers are proven insufficient;
+- a full CI runtime before existing CI integration is stable;
+- a custom agent protocol before MCP/A2A-style integration is tested;
+- a full supply-chain attestation system before ATDD evidence has a stable shape.
+
+The right sequence is:
+
+```txt
+1. Define the protocol spine.
+2. Define violation and evidence formats.
+3. Define first-class workspace providers.
+4. Provide a small official provider set.
+5. Integrate with existing tools through adapters.
+6. Add ecosystem machinery only when usage forces it.
+```
+
+---
+
+## 16. Strategic positioning
+
+The clearest market position is:
+
+> ATDD is a software delivery protocol for humans, agents, and automation.
+
+It is not trying to make agents smarter.
+
+It is trying to make delivery more deterministic.
+
+It makes project conventions explicit, executable, and portable across actors.
+
+That is why ATDD can coexist with agent frameworks, CI/CD systems, policy engines, static analyzers, and supply-chain frameworks.
+
+ATDD is not the engine.
+
+ATDD is the delivery contract those engines can execute.
+
+---
+
+## References
+
+[^openai-agents]: OpenAI, “Agents SDK,” https://developers.openai.com/api/docs/guides/agents
+[^ms-agent-framework]: Microsoft, “Microsoft Agent Framework Overview,” https://learn.microsoft.com/en-us/agent-framework/overview/
+[^crewai]: CrewAI, “CrewAI Documentation,” https://docs.crewai.com/
+[^mcp-spec]: Model Context Protocol, “Specification,” https://modelcontextprotocol.io/specification/2025-06-18
+[^mcp-tools]: Model Context Protocol, “Tools,” https://modelcontextprotocol.io/specification/draft/server/tools
+[^opa-docs]: Open Policy Agent, “OPA Documentation,” https://openpolicyagent.org/docs
+[^semgrep-github]: Semgrep GitHub repository, https://github.com/semgrep/semgrep
+[^github-actions]: GitHub Docs, “Understanding GitHub Actions,” https://docs.github.com/articles/getting-started-with-github-actions
+[^dagger]: Dagger, “A better way to ship,” https://dagger.io/
+[^cdevents]: CDEvents, “CDEvents,” https://cdevents.dev/
+[^slsa]: SLSA, “Supply-chain Levels for Software Artifacts,” https://slsa.dev/
+[^intoto-github]: in-toto GitHub repository, https://github.com/in-toto/in-toto
+[^backstage]: Backstage, “Software Catalog and Developer Platform,” https://backstage.io/


### PR DESCRIPTION
## Summary

Adds two root-level Markdown documents:

- `ATDD_Manifesto.md` — positioning ATDD as a software delivery protocol for humans, agents, and automation.
- `ATDD_Market_Comparison.md` — comparison against adjacent categories and reinvention boundaries.

## Notes

These are editable Markdown drafts intended to be refined and exported later.