### PR TITLE
feat(atdd): Planner Convention Node Parity (#1110)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -2568,3 +2568,11 @@ sessions:
   status: INIT
   created: '2026-06-16'
   archived: null
+- id: '1110'
+  slug: planner-convention-node-parity
+  file: null
+  issue_number: 1110
+  type: migration
+  status: INIT
+  created: '2026-06-16'
+  archived: null

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -102,6 +102,141 @@ edges:
   constraint: discretionary
   control: internal
   foundation: start_to_start
+  reason: anti-patterns are the negative companion to the validation rules
+  source_ref: planner.artifact-naming.anti-patterns
+  strength: minor
+  target_ref: planner.artifact-naming.validation-rules
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: cardinality is read from the aspect position in the pattern
+  source_ref: planner.artifact-naming.cardinality-from-aspect
+  strength: important
+  target_ref: planner.artifact-naming.naming-pattern
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: colon usage is defined by the separator semantics
+  source_ref: planner.artifact-naming.colon-for-hierarchy
+  strength: important
+  target_ref: planner.artifact-naming.separator-semantics
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the contract-file formula is the file half of the logical-physical mapping
+  source_ref: planner.artifact-naming.contract-file-mapping
+  strength: important
+  target_ref: planner.artifact-naming.logical-physical-mapping
+  type: runs_alongside
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: depth limits qualify the colon/dot separators
+  source_ref: planner.artifact-naming.depth-guidelines
+  strength: minor
+  target_ref: planner.artifact-naming.separator-semantics
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: dot usage is defined by the separator semantics
+  source_ref: planner.artifact-naming.dot-for-variant
+  strength: important
+  target_ref: planner.artifact-naming.separator-semantics
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the mapping splits the name produced by the pattern
+  source_ref: planner.artifact-naming.logical-physical-mapping
+  strength: important
+  target_ref: planner.artifact-naming.naming-pattern
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: finish_to_start
+  reason: migration retargets legacy names onto the current pattern
+  source_ref: planner.artifact-naming.migration-guide
+  strength: minor
+  target_ref: planner.artifact-naming.naming-pattern
+  type: follows
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the pattern composes hierarchy (colon) and variant (dot) separators
+  source_ref: planner.artifact-naming.naming-pattern
+  strength: critical
+  target_ref: planner.artifact-naming.separator-semantics
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the required theme component is drawn from the theme taxonomy
+  source_ref: planner.artifact-naming.naming-pattern
+  strength: important
+  target_ref: planner.artifact-naming.theme-taxonomy
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: stable URN-based names follow the naming pattern grammar
+  source_ref: planner.artifact-naming.planner-artifacts-use-stable
+  strength: important
+  target_ref: planner.artifact-naming.naming-pattern
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: pluralization of the aspect is how cardinality is expressed
+  source_ref: planner.artifact-naming.pluralization
+  strength: important
+  target_ref: planner.artifact-naming.cardinality-from-aspect
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the $id and the URN reference share the artifact identity
+  source_ref: planner.artifact-naming.schema-identifier
+  strength: important
+  target_ref: planner.artifact-naming.urn-structure
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the URN exactly mirrors the artifact name
+  source_ref: planner.artifact-naming.urn-structure
+  strength: important
+  target_ref: planner.artifact-naming.naming-pattern
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: validation enforces the naming pattern
+  source_ref: planner.artifact-naming.validation-rules
+  strength: important
+  target_ref: planner.artifact-naming.naming-pattern
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
   reason: the same bidirectional-coverage invariant at the train-wagon and wagon-feature levels
   source_ref: planner.coverage.bidirectional-coverage-between-trains
   strength: minor

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -423,6 +423,87 @@ edges:
   target_ref: planner.theme.must-be-canonical
   type: follows
 - confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the features-manifest rule uses the urn-array features format
+  source_ref: planner.wagon.features-format
+  strength: important
+  target_ref: planner.wagon.features
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the conversion functions implement the kebab/snake split
+  source_ref: planner.wagon.logical-vs-filesystem-naming
+  strength: important
+  target_ref: planner.wagon.slug-dirname-conversion
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: produce/consume entries carry contract + telemetry URNs
+  source_ref: planner.wagon.produce-consume-artifacts
+  strength: important
+  target_ref: planner.wagon.artifact-contracts
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: produced artifacts' telemetry URNs materialize on the filesystem
+  source_ref: planner.wagon.produce-consume-artifacts
+  strength: minor
+  target_ref: planner.wagon.telemetry-filesystem
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: coherence validates the extracted refinement fields
+  source_ref: planner.wagon.semantic-coherence
+  strength: important
+  target_ref: planner.wagon.refinement-extraction
+  type: follows
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: coherence checks produce-owned / consume-foreign / external-scope rules
+  source_ref: planner.wagon.semantic-coherence
+  strength: important
+  target_ref: planner.wagon.produce-consume-artifacts
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the telemetry filesystem maps the telemetry URN form
+  source_ref: planner.wagon.telemetry-filesystem
+  strength: important
+  target_ref: planner.wagon.artifact-contracts
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the plan/<slug>/ layout follows the logical-vs-filesystem split
+  source_ref: planner.wagon.urn
+  strength: important
+  target_ref: planner.wagon.logical-vs-filesystem-naming
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the wagon urn rule presupposes the urn naming grammar
+  source_ref: planner.wagon.urn
+  strength: important
+  target_ref: planner.wagon.urn-naming
+  type: requires
+- confidence: 1.0
   constraint: discretionary
   control: internal
   foundation: start_to_start
@@ -430,6 +511,15 @@ edges:
   source_ref: planner.wagon.urn
   strength: minor
   target_ref: planner.artifact-naming.planner-artifacts-use-stable
+  type: runs_alongside
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: the slug derives from the wagon name
+  source_ref: planner.wagon.urn-naming
+  strength: minor
+  target_ref: planner.wagon.slug-dirname-conversion
   type: runs_alongside
 - confidence: 1.0
   constraint: mandatory

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -90,6 +90,15 @@ edges:
   target_ref: planner.acceptance.given-when-then-structure
   type: follows
 - confidence: 1.0
+  constraint: discretionary
+  control: external
+  foundation: start_to_start
+  reason: acceptance telemetry signals and wagon telemetry URNs share naming
+  source_ref: planner.acceptance.signal-telemetry-naming
+  strength: minor
+  target_ref: planner.wagon.telemetry-filesystem
+  type: runs_alongside
+- confidence: 1.0
   constraint: mandatory
   control: internal
   foundation: finish_to_start
@@ -251,6 +260,24 @@ edges:
   strength: important
   target_ref: planner.coverage.bidirectional-coverage-between-trains
   type: follows
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: wagon-feature coverage presupposes well-formed features
+  source_ref: planner.coverage.bidirectional-coverage-between-wagons
+  strength: important
+  target_ref: planner.feature.shape
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: wagon-feature coverage reads the wagon features manifest
+  source_ref: planner.coverage.bidirectional-coverage-between-wagons
+  strength: important
+  target_ref: planner.wagon.features
+  type: requires
 - confidence: 1.0
   constraint: mandatory
   control: internal
@@ -486,6 +513,15 @@ edges:
   target_ref: planner.feature.hard-limits
   type: runs_alongside
 - confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: a feature URN embeds its parent wagon slug
+  source_ref: planner.feature.urn-naming
+  strength: important
+  target_ref: planner.wagon.urn-naming
+  type: requires
+- confidence: 1.0
   constraint: discretionary
   control: internal
   foundation: start_to_start
@@ -514,9 +550,9 @@ edges:
   type: requires
 - confidence: 1.0
   constraint: mandatory
-  control: internal
+  control: external
   foundation: finish_to_start
-  reason: a feature registered under one wagon presupposes the wagon's _features.yaml lists it
+  reason: a feature is registered in its wagon _features.yaml
   source_ref: planner.feature.wagon-link
   strength: important
   target_ref: planner.wagon.features
@@ -622,6 +658,15 @@ edges:
   type: requires
 - confidence: 1.0
   constraint: discretionary
+  control: external
+  foundation: finish_to_start
+  reason: train data-flow dependencies follow wagon produce/consume artifacts
+  source_ref: planner.train.dependencies
+  strength: minor
+  target_ref: planner.wagon.produce-consume-artifacts
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
   control: internal
   foundation: start_to_start
   reason: dependencies are declared in the spec
@@ -665,6 +710,15 @@ edges:
   strength: important
   target_ref: planner.coverage.bidirectional-coverage-between-trains
   type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: a train's participants are wagons
+  source_ref: planner.train.scope
+  strength: important
+  target_ref: planner.wagon.urn-naming
+  type: requires
 - confidence: 1.0
   constraint: discretionary
   control: internal
@@ -775,6 +829,15 @@ edges:
   type: runs_alongside
 - confidence: 1.0
   constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: contract URNs map to files via the artifact-naming mapping
+  source_ref: planner.wagon.artifact-contracts
+  strength: important
+  target_ref: planner.artifact-naming.contract-file-mapping
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
   control: internal
   foundation: start_to_start
   reason: the features-manifest rule uses the urn-array features format
@@ -791,6 +854,15 @@ edges:
   strength: important
   target_ref: planner.wagon.slug-dirname-conversion
   type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: produce/consume artifact names follow the naming pattern
+  source_ref: planner.wagon.produce-consume-artifacts
+  strength: important
+  target_ref: planner.artifact-naming.naming-pattern
+  type: requires
 - confidence: 1.0
   constraint: mandatory
   control: internal
@@ -811,6 +883,15 @@ edges:
   type: runs_alongside
 - confidence: 1.0
   constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: the wagon theme is selected from the canonical taxonomy
+  source_ref: planner.wagon.refinement-extraction
+  strength: important
+  target_ref: planner.theme.canonical-taxonomy
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
   control: internal
   foundation: finish_to_start
   reason: coherence validates the extracted refinement fields
@@ -826,6 +907,24 @@ edges:
   source_ref: planner.wagon.semantic-coherence
   strength: important
   target_ref: planner.wagon.produce-consume-artifacts
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: external
+  foundation: start_to_start
+  reason: a wagon produced-URN theme must match its theme
+  source_ref: planner.wagon.semantic-coherence
+  strength: minor
+  target_ref: planner.theme.urn-namespace-matches
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: telemetry URNs follow the artifact-naming grammar
+  source_ref: planner.wagon.telemetry-filesystem
+  strength: important
+  target_ref: planner.artifact-naming.naming-pattern
   type: requires
 - confidence: 1.0
   constraint: mandatory
@@ -862,6 +961,15 @@ edges:
   source_ref: planner.wagon.urn
   strength: minor
   target_ref: planner.artifact-naming.planner-artifacts-use-stable
+  type: runs_alongside
+- confidence: 1.0
+  constraint: discretionary
+  control: external
+  foundation: start_to_start
+  reason: wagon and artifact names share the kebab grammar
+  source_ref: planner.wagon.urn-naming
+  strength: minor
+  target_ref: planner.artifact-naming.naming-pattern
   type: runs_alongside
 - confidence: 1.0
   constraint: discretionary

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -282,6 +282,105 @@ edges:
   constraint: mandatory
   control: internal
   foundation: finish_to_start
+  reason: seeding a name needs the type-specific verb list
+  source_ref: planner.feature.artifact-seeded-naming
+  strength: important
+  target_ref: planner.feature.verb-selection-by-artifact-type
+  type: requires
+- confidence: 1.0
+  constraint: conditional
+  control: internal
+  foundation: finish_to_start
+  reason: the close-the-loop rule fires only when kind is feedback-loop
+  source_ref: planner.feature.feedback-loop-close-the-loop
+  strength: important
+  target_ref: planner.feature.feedback-loop-kind
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: finish_to_start
+  reason: the inline marker suppresses the close-the-loop rule for docs-only features
+  source_ref: planner.feature.feedback-loop-suppression
+  strength: minor
+  target_ref: planner.feature.feedback-loop-close-the-loop
+  type: relieves
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: estimation cues feed footprint scoring
+  source_ref: planner.feature.footprint-scoring
+  strength: minor
+  target_ref: planner.feature.estimation
+  type: runs_alongside
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: grouping keeps a feature within its size budget
+  source_ref: planner.feature.grouping-strategy
+  strength: minor
+  target_ref: planner.feature.size-max-rule
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: a well-shaped feature declares its urn
+  source_ref: planner.feature.shape
+  strength: important
+  target_ref: planner.feature.urn-naming
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the footprint size is one input to the max rule
+  source_ref: planner.feature.size-max-rule
+  strength: critical
+  target_ref: planner.feature.footprint-scoring
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: sizing and hard limits both gate feature scope
+  source_ref: planner.feature.size-max-rule
+  strength: important
+  target_ref: planner.feature.hard-limits
+  type: runs_alongside
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: the URN feature segment is the artifact-seeded verb-object name
+  source_ref: planner.feature.urn-naming
+  strength: minor
+  target_ref: planner.feature.artifact-seeded-naming
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: validation enforces the hard limits
+  source_ref: planner.feature.validation-rules
+  strength: important
+  target_ref: planner.feature.hard-limits
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: validation enforces the max size rule
+  source_ref: planner.feature.validation-rules
+  strength: important
+  target_ref: planner.feature.size-max-rule
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
   reason: a feature registered under one wagon presupposes the wagon's _features.yaml lists it
   source_ref: planner.feature.wagon-link
   strength: important

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -345,10 +345,73 @@ edges:
   constraint: discretionary
   control: internal
   foundation: start_to_start
-  reason: the criterion record shape and its prose/outcome are the same artifact from two angles
+  reason: the given defaults seed each harness template's given block
+  source_ref: planner.criteria.defaults
+  strength: minor
+  target_ref: planner.criteria.harness-templates
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: start_to_start
+  reason: criteria templates and the acceptance harness vocabulary share the harness set
+  source_ref: planner.criteria.harness-templates
+  strength: important
+  target_ref: planner.acceptance.harness-vocabulary
+  type: runs_alongside
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: each harness template declares the layers it sequences
+  source_ref: planner.criteria.harness-templates
+  strength: minor
+  target_ref: planner.criteria.sequence-routing
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: the metric is selected from the WMBT dimension + direction
+  source_ref: planner.criteria.metric-mapping
+  strength: important
+  target_ref: planner.wmbt.dimension-selection
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: external
+  foundation: start_to_start
+  reason: both route acceptances to a plane via keyword cues
+  source_ref: planner.criteria.plane-keywords
+  strength: minor
+  target_ref: planner.acceptance.plane-keywords
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the layer sequence is selected via the plane keywords
+  source_ref: planner.criteria.sequence-routing
+  strength: important
+  target_ref: planner.criteria.plane-keywords
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: external
+  foundation: start_to_start
+  reason: criteria are the structured form of an acceptance
   source_ref: planner.criteria.shape
   strength: minor
   target_ref: planner.acceptance.complete
+  type: runs_alongside
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: the criteria shape references the chosen harness
+  source_ref: planner.criteria.shape
+  strength: minor
+  target_ref: planner.criteria.harness-templates
   type: runs_alongside
 - confidence: 1.0
   constraint: mandatory

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -336,10 +336,100 @@ edges:
   constraint: mandatory
   control: internal
   foundation: finish_to_start
-  reason: a SMOKE acceptance is defined by carrying the SMOKE harness token, so it depends on the harness-type rule
+  reason: the WMBT filename is step-coded
+  source_ref: planner.wmbt.filename-pattern
+  strength: important
+  target_ref: planner.wmbt.step-code-vocabulary
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: one dimension and one lens are chosen together per WMBT
+  source_ref: planner.wmbt.lens-selection
+  strength: important
+  target_ref: planner.wmbt.dimension-selection
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the smoke-acceptance rule applies once a WMBT is shaped
+  source_ref: planner.wmbt.must-have-smoke-acceptance
+  strength: important
+  target_ref: planner.wmbt.shape
+  type: follows
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: the SMOKE token is a harness code from the acceptance harness vocabulary
   source_ref: planner.wmbt.must-have-smoke-acceptance
   strength: critical
-  target_ref: planner.acceptance.harness#harness_type
+  target_ref: planner.acceptance.harness-vocabulary#harness_code
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: a well-shaped WMBT declares a composed statement
+  source_ref: planner.wmbt.shape
+  strength: important
+  target_ref: planner.wmbt.statement-template
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: a WMBT splits when its statement mixes dimensions
+  source_ref: planner.wmbt.splitting-rules
+  strength: minor
+  target_ref: planner.wmbt.dimension-selection
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the statement template appends the context clarifier
+  source_ref: planner.wmbt.statement-template
+  strength: minor
+  target_ref: planner.wmbt.context-clarifier
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the statement template consumes the dimension
+  source_ref: planner.wmbt.statement-template
+  strength: important
+  target_ref: planner.wmbt.dimension-selection
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the statement template consumes the direction
+  source_ref: planner.wmbt.statement-template
+  strength: important
+  target_ref: planner.wmbt.direction-selection
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the statement template consumes the object of control
+  source_ref: planner.wmbt.statement-template
+  strength: important
+  target_ref: planner.wmbt.object-of-control
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the WMBT URN embeds a step code
+  source_ref: planner.wmbt.urn-naming
+  strength: important
+  target_ref: planner.wmbt.step-code-vocabulary
   type: requires
 graph_id: atdd.convention.relationships
 kind: relationship_graph

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -2,12 +2,102 @@ edges:
 - confidence: 1.0
   constraint: mandatory
   control: internal
+  foundation: finish_to_start
+  reason: completeness includes the required abstract Gherkin fields
+  source_ref: planner.acceptance.complete
+  strength: important
+  target_ref: planner.acceptance.abstract-fields-required
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: a complete acceptance presupposes the Given/When/Then structure
+  source_ref: planner.acceptance.complete
+  strength: critical
+  target_ref: planner.acceptance.given-when-then-structure
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
   foundation: start_to_start
   reason: completeness and harness-type declaration are two required facets of the same acceptance
   source_ref: planner.acceptance.complete
   strength: important
   target_ref: planner.acceptance.harness
   type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the when section is harness-specific and draws on the harness vocabulary
+  source_ref: planner.acceptance.given-when-then-structure
+  strength: important
+  target_ref: planner.acceptance.harness-vocabulary
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: declaring a harness presupposes the harness vocabulary
+  source_ref: planner.acceptance.harness
+  strength: critical
+  target_ref: planner.acceptance.harness-vocabulary
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: exercised_boundaries draws on the boundary-kind controlled vocabulary
+  source_ref: planner.acceptance.hermetic-fake-contract
+  strength: critical
+  target_ref: planner.acceptance.boundary-kind-vocabulary
+  type: requires
+- confidence: 1.0
+  constraint: conditional
+  control: internal
+  foundation: finish_to_start
+  reason: the hermetic fake-contract is required only when execution_kind is hermetic_integration
+  source_ref: planner.acceptance.hermetic-fake-contract
+  strength: critical
+  target_ref: planner.acceptance.execution-kind
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: the legacy AC id and the acceptance URN are parallel identifiers
+  source_ref: planner.acceptance.id-pattern
+  strength: minor
+  target_ref: planner.acceptance.urn-generation
+  type: runs_alongside
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: the route sequence is built alongside the Given/When/Then structure
+  source_ref: planner.acceptance.route-construction
+  strength: minor
+  target_ref: planner.acceptance.given-when-then-structure
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: telemetry signals are derived from the then/when sections
+  source_ref: planner.acceptance.signal-telemetry-naming
+  strength: important
+  target_ref: planner.acceptance.given-when-then-structure
+  type: follows
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the acceptance URN embeds the UPPERCASE harness code from the vocabulary
+  source_ref: planner.acceptance.urn-generation
+  strength: important
+  target_ref: planner.acceptance.harness-vocabulary
+  type: requires
 - confidence: 1.0
   constraint: discretionary
   control: internal

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -396,6 +396,15 @@ edges:
   target_ref: planner.theme.must-be-canonical
   type: follows
 - confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: finish_to_start
+  reason: plan/test/code archetypes come from the taxonomy
+  source_ref: planner.theme.archetype-alignment
+  strength: minor
+  target_ref: planner.theme.canonical-taxonomy
+  type: requires
+- confidence: 1.0
   constraint: mandatory
   control: internal
   foundation: finish_to_start
@@ -404,6 +413,24 @@ edges:
   strength: important
   target_ref: planner.theme.must-be-canonical
   type: follows
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: commons and coach are themes from the taxonomy
+  source_ref: planner.theme.commons-coach-boundary
+  strength: important
+  target_ref: planner.theme.canonical-taxonomy
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the canonical set is defined by the taxonomy
+  source_ref: planner.theme.must-be-canonical
+  strength: critical
+  target_ref: planner.theme.canonical-taxonomy
+  type: requires
 - confidence: 1.0
   constraint: mandatory
   control: internal
@@ -417,11 +444,29 @@ edges:
   constraint: mandatory
   control: internal
   foundation: finish_to_start
+  reason: digit 0 = commons is fixed by the taxonomy's theme_zero token
+  source_ref: planner.theme.theme-zero-mandatory
+  strength: critical
+  target_ref: planner.theme.canonical-taxonomy
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
   reason: matching a produced-URN theme-prefix to the wagon theme presupposes a canonical theme
   source_ref: planner.theme.urn-namespace-matches
   strength: important
   target_ref: planner.theme.must-be-canonical
   type: follows
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the theme-prefix must be a canonical theme
+  source_ref: planner.theme.urn-namespace-matches
+  strength: important
+  target_ref: planner.theme.canonical-taxonomy
+  type: requires
 - confidence: 1.0
   constraint: mandatory
   control: internal

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -246,11 +246,74 @@ edges:
   constraint: mandatory
   control: internal
   foundation: finish_to_start
+  reason: wagon-feature coverage sits one level below train-wagon coverage
+  source_ref: planner.coverage.bidirectional-coverage-between-wagons
+  strength: important
+  target_ref: planner.coverage.bidirectional-coverage-between-trains
+  type: follows
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the graph aggregates the train-wagon coverage validator
+  source_ref: planner.coverage.coverage-graph
+  strength: minor
+  target_ref: planner.coverage.bidirectional-coverage-between-trains
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the graph aggregates the wagon-feature coverage validators
+  source_ref: planner.coverage.coverage-graph
+  strength: minor
+  target_ref: planner.coverage.bidirectional-coverage-between-wagons
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the graph aggregates the wmbt-feature coverage validator
+  source_ref: planner.coverage.coverage-graph
+  strength: minor
+  target_ref: planner.coverage.every-wmbt-must-be
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the graph aggregates the wmbt-acceptance coverage validator
+  source_ref: planner.coverage.coverage-graph
+  strength: minor
+  target_ref: planner.coverage.every-wmbt-must-have
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: wmbt-feature coverage sits below wagon-feature coverage
+  source_ref: planner.coverage.every-wmbt-must-be
+  strength: important
+  target_ref: planner.coverage.bidirectional-coverage-between-wagons
+  type: follows
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
   reason: the every-WMBT-referenced-by-a-feature check presupposes well-formed features
   source_ref: planner.coverage.every-wmbt-must-be
   strength: important
   target_ref: planner.feature.shape
   type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: wmbt-acceptance coverage sits below wmbt-feature coverage
+  source_ref: planner.coverage.every-wmbt-must-have
+  strength: important
+  target_ref: planner.coverage.every-wmbt-must-be
+  type: follows
 - confidence: 1.0
   constraint: mandatory
   control: internal
@@ -269,6 +332,15 @@ edges:
   strength: important
   target_ref: planner.wmbt.shape
   type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: finish_to_start
+  reason: allow-lists and status:draft exempt artifacts from the strict acceptance rule
+  source_ref: planner.coverage.exception-handling
+  strength: important
+  target_ref: planner.coverage.every-wmbt-must-have
+  type: relieves
 - confidence: 1.0
   constraint: discretionary
   control: internal

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -603,6 +603,177 @@ edges:
   target_ref: planner.theme.canonical-taxonomy
   type: requires
 - confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: train acceptances live in the spec file
+  source_ref: planner.train.acceptances
+  strength: minor
+  target_ref: planner.train.registry
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the category digit is part of the numbering scheme
+  source_ref: planner.train.categories
+  strength: important
+  target_ref: planner.train.numbering
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: dependencies are declared in the spec
+  source_ref: planner.train.dependencies
+  strength: minor
+  target_ref: planner.train.registry
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: linearity forbids loop/route elements in the sequence
+  source_ref: planner.train.linearity
+  strength: critical
+  target_ref: planner.train.sequence
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the train_id name follows the numbering prefix
+  source_ref: planner.train.naming
+  strength: important
+  target_ref: planner.train.numbering
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: registry + spec paths derive from the train_id
+  source_ref: planner.train.registry
+  strength: important
+  target_ref: planner.train.naming
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: start_to_start
+  reason: the train registry is what train-wagon coverage validates against
+  source_ref: planner.train.registry
+  strength: important
+  target_ref: planner.coverage.bidirectional-coverage-between-trains
+  type: runs_alongside
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: the one-journey scope is realized by the sequence
+  source_ref: planner.train.scope
+  strength: minor
+  target_ref: planner.train.sequence
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: each step carries a domain:resource artifact
+  source_ref: planner.train.sequence
+  strength: important
+  target_ref: planner.train.artifact-flow
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: each step transfers an artifact between participants
+  source_ref: planner.train.sequence
+  strength: important
+  target_ref: planner.train.participants
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: external
+  foundation: finish_to_start
+  reason: a train theme-digit must resolve to one of the five canonical themes
+  source_ref: planner.train.theme-alignment
+  strength: important
+  target_ref: planner.theme.must-be-canonical
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the primary theme is read from the first train-id digit
+  source_ref: planner.train.theme-alignment
+  strength: important
+  target_ref: planner.train.theme-ranges
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the orchestrator URN extends the train URN with a theme prefix
+  source_ref: planner.train.theme-orchestrator-urn
+  strength: minor
+  target_ref: planner.train.urn-naming
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: each theme range spans the four categories
+  source_ref: planner.train.theme-ranges
+  strength: minor
+  target_ref: planner.train.categories
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the theme digit is part of the numbering scheme
+  source_ref: planner.train.theme-ranges
+  strength: important
+  target_ref: planner.train.numbering
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the train URN embeds the numbered train_id
+  source_ref: planner.train.urn-naming
+  strength: important
+  target_ref: planner.train.numbering
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: validation enforces the train_id numbering
+  source_ref: planner.train.validation-rules
+  strength: important
+  target_ref: planner.train.numbering
+  type: requires
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: validation enforces spec-file existence
+  source_ref: planner.train.validation-rules
+  strength: important
+  target_ref: planner.train.registry
+  type: requires
+- confidence: 1.0
+  constraint: discretionary
+  control: internal
+  foundation: start_to_start
+  reason: variations populate a theme's category/variation slots
+  source_ref: planner.train.variation-strategies
+  strength: minor
+  target_ref: planner.train.theme-ranges
+  type: runs_alongside
+- confidence: 1.0
   constraint: mandatory
   control: internal
   foundation: start_to_start

--- a/src/atdd/planner/commands/tests/test_planner_atomization_smoke.py
+++ b/src/atdd/planner/commands/tests/test_planner_atomization_smoke.py
@@ -64,7 +64,8 @@ def test_committed_nodes_and_graph_are_coherent():
     schema = json.loads(_NODE_SCHEMA.read_text())
     node_ids = set()
     node_files = sorted(_NODES.glob("planner.*.convention.yaml"))
-    assert len(node_files) == 23, f"expected 23 atomized nodes, found {len(node_files)}"
+    # the node set grows per-convention as high-fidelity atomization proceeds (#1110)
+    assert len(node_files) >= 23, f"expected the atomized node set, found {len(node_files)}"
     for f in node_files:
         node = yaml.safe_load(f.read_text())
         jsonschema.validate(node, schema)                # every committed node is schema-valid
@@ -74,7 +75,7 @@ def test_committed_nodes_and_graph_are_coherent():
     graph = yaml.safe_load(_CORE_GRAPH.read_text())
     assert graph["graph_id"] == "atdd.convention.relationships"
     edges = graph["edges"]
-    assert len(edges) == 13
+    assert len(edges) >= 13
     # referential integrity: every edge endpoint (minus a #term suffix) is a real node
     for e in edges:
         for ref in (e["source_ref"], e["target_ref"]):

--- a/src/atdd/planner/commands/tests/test_planner_atomization_smoke.py
+++ b/src/atdd/planner/commands/tests/test_planner_atomization_smoke.py
@@ -81,3 +81,29 @@ def test_committed_nodes_and_graph_are_coherent():
         for ref in (e["source_ref"], e["target_ref"]):
             rule_id = ref.split("#", 1)[0]
             assert rule_id in node_ids, f"edge ref {ref!r} points at a missing node"
+
+
+def test_high_fidelity_parity_across_all_planner_conventions():
+    """#1110: every planner convention is atomized at high fidelity (schema 1.1.0,
+    source provenance, parity flags)."""
+    import json
+    schema = json.loads(_NODE_SCHEMA.read_text())
+    assert schema["$id"] == "atdd:author:convention-node:1.1.0"
+
+    # all nine legacy conventions are represented in the node set
+    expected_min = {
+        "acceptance": 10, "artifact-naming": 10, "wmbt": 8, "feature": 10, "wagon": 8,
+        "theme": 6, "coverage": 6, "criteria": 6, "train": 12,
+    }
+    for conv, lo in expected_min.items():
+        n = len(list(_NODES.glob(f"planner.{conv}.*.convention.yaml")))
+        assert n >= lo, f"{conv}: expected >= {lo} high-fidelity nodes, found {n}"
+
+    # high-fidelity provenance: every node carries source(legacy_path) + parity
+    for f in _NODES.glob("planner.*.convention.yaml"):
+        node = yaml.safe_load(f.read_text())
+        if str(node.get("schema_version")) != "1.1.0":
+            continue  # legacy-pass node not yet re-atomized
+        assert node.get("source", {}).get("legacy_path"), f"{f.name} missing source.legacy_path"
+        assert node.get("source", {}).get("extraction_mode") == "high_fidelity", f"{f.name} not high_fidelity"
+        assert "parity" in node, f"{f.name} missing parity block"

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.abstract-fields-required.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.abstract-fields-required.convention.yaml
@@ -1,0 +1,44 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.abstract-fields-required
+kind: constraint
+status: active
+name: Abstract Gherkin fields required
+statement: Each acceptance section declares an abstract Gherkin narrative (given.abstract, when.abstract,
+  then.abstract) — all three are REQUIRED.
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: abstract_fields
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  summary: Gherkin-style abstract narrative within given/when/then sections for human readability.
+  operational_guidance: 'Abstract fields coexist with structured fields in the same section: abstract
+    for stakeholders (Gherkin), structured for machines (test generation). identity.purpose serves as
+    the scenario name — no separate top-level name needed.'
+  constraints:
+  - 'given.abstract: array[str], minItems 1, REQUIRED — each item a single precondition/setup state.'
+  - 'when.abstract: str, minLength 5, REQUIRED — present tense, clear actor and action.'
+  - 'then.abstract: array[str], minItems 1, REQUIRED — each item a single observable outcome.'
+  examples:
+  - given.abstract:
+    - appendix.convention.yaml defines manifest structure
+    - User account exists in the database
+  - when.abstract: User submits login form with credentials
+  - then.abstract:
+    - 'Wagon manifest includes appendices: [] at root level'
+    - Resolver can resolve appendix paths using URN pattern
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: abstract_field
+  text: a Gherkin narrative line within a given/when/then section, for stakeholder readability alongside
+    the structured machine fields.
+  values:
+    locations:
+    - given.abstract
+    - when.abstract
+    - then.abstract

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.authoring-guidelines.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.authoring-guidelines.convention.yaml
@@ -1,0 +1,28 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.authoring-guidelines
+kind: principle
+status: active
+name: Acceptance authoring guidelines
+statement: Bind each acceptance to one metric, respect the parent WMBT's single dimension/lens, and collocate
+  WMBT + acceptances + tests + artifacts.
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: guidelines + related_resources
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: 'metric_binding: one metric_id from plan/_lego/acceptance-metrics.yaml (no mixed
+    measures). lens_dimension_dependency: one dimension and one lens_ref per WMBT. collocation: keep WMBT/acceptances/tests/artifacts
+    together for cohesive history/review.'
+  constraints:
+  - 'related: metrics_catalog=conventions:criteria:metrics'
+  - template_registry=.claude/templates/tester/templates.manifest.yaml
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: metric_binding
+  text: each acceptance maps to exactly one metric_id.

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.boundary-kind-vocabulary.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.boundary-kind-vocabulary.convention.yaml
@@ -1,0 +1,38 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.boundary-kind-vocabulary
+kind: family
+status: active
+name: Boundary kinds
+statement: Controlled vocabulary of named integration surfaces an acceptance exercises; unknown values
+  are rejected.
+implementation:
+  type: validator
+  ref: tester.acceptance-violation.hermetic-fake-must-declare-contract
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: boundary_kinds
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'Unknown boundary_kind values are rejected by tester.acceptance-violation.hermetic-fake-must-declare-contract.
+    Note: `golden` is a harness_code, NOT a boundary_kind (Decision #7).'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: boundary_kind
+  text: a named integration surface exercised by an acceptance.
+  values:
+    argv: Command-line argument vector passed to a process.
+    subprocess: A child process spawned and observed.
+    filesystem: Files and directories read or written.
+    git: A local git repository's objects, refs, and config.
+    http_wire: HTTP request/response envelopes (cassette when hermetic).
+    llm_wire: LLM prompt/response envelopes (recorded/deterministic when hermetic).
+    cmux_rpc: cmux RPC request/response messages.
+    env_config: Environment variables and configuration inputs.
+    db_wire: Database query/response envelopes.
+    event_wire: Event-bus publish/consume envelopes.

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.complete.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.complete.convention.yaml
@@ -1,12 +1,29 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.acceptance.complete
 kind: rule
 status: active
+name: Acceptance is complete
 statement: Each acceptance criterion has Given/When/Then prose and a verifiable outcome.
-rationale: Given/When/Then prose plus a verifiable outcome is what lets a tester turn
-  an acceptance into a real, assertable test.
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: rules
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.acceptance.complete
+metadata:
+  aliases:
+  - PLANNER-ACCEPTANCE-COMPLETE-001
+  severity: 3
+  disposition: documentation-only
+  introduced_in: 1.67.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
 - term_id: given_when_then
-  text: the structured prose stating context, action, and expected result
+  text: structured prose stating preconditions, the trigger action, and the expected observable outcomes.
 - term_id: verifiable_outcome
-  text: an outcome a test can assert against
+  text: an outcome a generated test can assert.

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.execution-kind.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.execution-kind.convention.yaml
@@ -1,0 +1,30 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.execution-kind
+kind: family
+status: active
+name: Execution kind (runtime-environment axis)
+statement: execution_kind is an orthogonal runtime-environment classifier (live infrastructure vs hermetic),
+  separate from harness/category.
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: execution_kinds
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'A NEW orthogonal axis added per issue #690; harness_codes/harness_types/category enums
+    are unchanged. Authors select those as today and ADD execution_kind.'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: execution_kind
+  text: the runtime-environment classifier for an acceptance.
+  values:
+    hermetic_integration: Real subject, real boundary shape, real integration sequence — NO live external
+      infrastructure. Fakes (cassettes, recorded LLM responses) permitted only with a declared fidelity
+      contract.
+    live_smoke: Verification against real live infrastructure (HTTP, DB, auth, deployment). SMOKE remains
+      the live-infrastructure confidence tier.

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.extraction-no-inference.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.extraction-no-inference.convention.yaml
@@ -1,0 +1,23 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.extraction-no-inference
+kind: principle
+status: active
+name: Extraction by asking, not inferring
+statement: Missing context is obtained by asking the user directly — no inference, no suggestions.
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: extraction
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: 'Pure conversational approach. e.g. wagon_inference prompt: ''Which wagon should
+    this acceptance belong to?'''
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: no_inference
+  text: the policy of asking rather than guessing missing acceptance context.

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.generator-prompts.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.generator-prompts.convention.yaml
@@ -1,0 +1,34 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.generator-prompts
+kind: family
+status: active
+name: Acceptance generator prompts
+statement: The authoring prompt for composing each acceptance field (id, urn, harness, route, given, when,
+  then).
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: generators
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: One prompt per field; each sources the relevant section of this convention.
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: generator_prompt
+  text: the LLM authoring prompt for an acceptance field.
+  values:
+    id: Compose the acceptance id with the step code and a zero-padded index (AC-{STEP}-{NNN}).
+    urn: Derive the URN from wagon slug, WMBT ID, harness code, and sequence using URNBuilder.acceptance.
+    harness: Select the harness that best exercises the outcome (unit/http/event/ws/e2e/...).
+    route: Populate route.layers and route.sequence so actions flow presentation -> application -> domain
+      -> integration.
+    given: Declare only the preconditions needed (auth, builders, time, stubbing, knobs) before the action
+      runs.
+    when: Describe the trigger using the harness-specific shape (http request, unit target, event topic,
+      etc.).
+    then: List assertions that prove the outcome (status, body, headers, error, metrics, etc.).

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.given-when-then-structure.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.given-when-then-structure.convention.yaml
@@ -1,0 +1,53 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.given-when-then-structure
+kind: rule
+status: active
+name: Given/When/Then structure
+statement: given declares only required preconditions; when declares the single harness-specific trigger
+  (REQUIRED); then is an array of assertions (REQUIRED).
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: gherkin_structure
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: 'given fields: auth, builders, time, stubbing, knobs. when is harness-specific
+    (http: method/path; unit: target; event: topic; ws/e2e: interactions). then.assertion_kinds: status,
+    body, headers, error, event_published, state_changed, metric.'
+  examples:
+  - when.http:
+      method: POST
+      path: /api/users
+      body:
+        name: John
+  - when.unit:
+      target: UserService.createUser
+      args:
+        userData:
+          name: John
+  - then:
+    - kind: status
+      expect: 200
+    - kind: error
+      expect:
+        code: USER_EXISTS
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: given_fields
+  text: 'preconditions: auth, builders, time, stubbing, knobs.'
+- term_id: assertion_kind
+  text: a then assertion kind.
+  values:
+    allowed:
+    - status
+    - body
+    - headers
+    - error
+    - event_published
+    - state_changed
+    - metric

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.harness-vocabulary.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.harness-vocabulary.convention.yaml
@@ -1,0 +1,99 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.harness-vocabulary
+kind: family
+status: active
+name: Harness vocabulary (codes + catalog)
+statement: 'The authoritative harness vocabulary: each harness name maps to an UPPERCASE code and a typical-layer
+  catalog entry.'
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: harness_codes + harness_types
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  summary: Authoritative name->CODE mapping plus per-harness description and typical layers.
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: harness_code
+  label: Harness code map
+  text: name -> UPPERCASE code (authoritative).
+  values:
+    unit: UNIT
+    http: HTTP
+    event: EVENT
+    ws: WS
+    e2e: E2E
+    a11y: A11Y
+    visual: VIS
+    metric: METRIC
+    job: JOB
+    db: DB
+    sec: SEC
+    load: LOAD
+    script: SCRIPT
+    widget: WIDGET
+    golden: GOLDEN
+    bloc: BLOC
+    integration: INTEGRATION
+    rls: RLS
+    edge_function: EDGE
+    realtime: REALTIME
+    storage: STORAGE
+    smoke: SMOKE
+- term_id: harness_type
+  label: Harness type catalog
+  text: per-harness description and typical layers.
+  values:
+    unit:
+    - domain
+    - application
+    http:
+    - integration
+    - application
+    event:
+    - application
+    - integration
+    ws:
+    - integration
+    e2e:
+    - presentation
+    a11y:
+    - presentation
+    visual:
+    - presentation
+    metric:
+    - application
+    - integration
+    job:
+    - application
+    db:
+    - integration
+    sec:
+    - application
+    - integration
+    load:
+    - integration
+    script:
+    - application
+    widget:
+    - presentation
+    golden:
+    - presentation
+    - application
+    bloc:
+    - application
+    integration:
+    - integration
+    rls:
+    - integration
+    edge_function:
+    - integration
+    realtime:
+    - integration
+    storage:
+    - integration

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.harness.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.harness.convention.yaml
@@ -1,13 +1,36 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.acceptance.harness
 kind: rule
 status: active
-statement: Each acceptance criterion declares a harness type (UNIT, INTEGRATION, SMOKE,
-  ...).
-rationale: Declaring the harness type makes each acceptance's verification layer explicit,
-  so coverage and routing can reason about where a check runs.
+name: Acceptance declares a harness
+statement: Each acceptance criterion declares a harness type (UNIT, INTEGRATION, SMOKE, etc.).
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: rules
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.acceptance.harness
+metadata:
+  aliases:
+  - PLANNER-ACCEPTANCE-HARNESS-001
+  severity: 2
+  disposition: documentation-only
+  introduced_in: 1.67.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: acceptance_criterion
-  text: a Given/When/Then check that proves a WMBT
-- term_id: harness_type
-  text: 'the test layer that runs the check: UNIT, INTEGRATION, SMOKE, ...'
+- term_id: harness
+  text: the test layer that exercises the acceptance; one of the codes in the harness vocabulary.
+  examples:
+    positive:
+    - UNIT
+    - HTTP
+    - E2E
+    - SMOKE
+    negative:
+    - functional
+    - manual

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.hermetic-fake-contract.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.hermetic-fake-contract.convention.yaml
@@ -1,0 +1,35 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.hermetic-fake-contract
+kind: constraint
+status: active
+name: Hermetic fake-contract declaration
+statement: When execution_kind is hermetic_integration AND permitted_fakes is non-empty, the acceptance
+  MUST declare the hermetic fake-contract block — the declaration IS the contract.
+implementation:
+  type: validator
+  ref: tester.acceptance-violation.hermetic-fake-must-declare-contract
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: hermetic
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  normative_text: Required when execution_kind == hermetic_integration AND permitted_fakes is non-empty.
+  constraints:
+  - 'exercised_boundaries: list[boundary_kind] — controlled-vocab surfaces exercised (required).'
+  - 'permitted_fakes: list[str] — named fakes/cassettes substituted for live infra (may be empty; when
+    empty the fidelity rule does not apply).'
+  - 'fake_contract_fidelity: list of {name, fidelity, known_gaps:list[str] required} — one per permitted
+    fake (required when permitted_fakes non-empty).'
+  - 'live_smoke_required: bool — true when a paired execution_kind: live_smoke sibling must exist under
+    the same WMBT (required).'
+  - 'live_smoke_reason: str — optional rationale when live_smoke_required is true.'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: fake_contract
+  text: 'the declared fidelity contract for each permitted fake: name, fidelity, and required known_gaps.'

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.id-pattern.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.id-pattern.convention.yaml
@@ -1,0 +1,34 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.id-pattern
+kind: rule
+status: active
+name: Legacy acceptance id pattern
+statement: The legacy acceptance id is AC-{STEP}-{NNN} (kept for backward compatibility in identity.id).
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: id_pattern + id_mapping
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - AC-EXEC-201
+  - AC-CONF-004
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: step_code
+  text: step-name -> id code.
+  values:
+    define: DEF
+    locate: LOC
+    prepare: PREP
+    confirm: CONF
+    execute: EXEC
+    monitor: MON
+    modify: MOD
+    resolve: RES
+    conclude: CONC

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.max-per-wmbt.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.max-per-wmbt.convention.yaml
@@ -1,0 +1,29 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.max-per-wmbt
+kind: constraint
+status: active
+name: Acceptance cap per WMBT
+statement: Keep acceptances <=5 per WMBT; if more are needed, split the WMBT into clearer outcomes.
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: max_per_wmbt + guidelines + expected_ratios
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  constraints:
+  - 'max_per_wmbt: 5'
+  - acceptance_to_test ratio 1:1 (one acceptance -> one test)
+  - test_to_component ratio N:1
+  operational_guidance: 'Each acceptance maps to exactly one metric_id (no mixed measures). Respect WMBT
+    rules: one dimension and one lens_ref per WMBT; acceptances inherit context from the parent WMBT.'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: acceptance_cap
+  text: the per-WMBT ceiling on acceptances.
+  values:
+    max: 5

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.plane-keywords.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.plane-keywords.convention.yaml
@@ -1,0 +1,87 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.plane-keywords
+kind: family
+status: active
+name: Plane keyword cues
+statement: Keyword cues for selecting the test-layer plane when routing an acceptance.
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: planes
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: plane_keywords
+  text: keyword -> plane routing table.
+  values:
+    ui:
+    - display
+    - visible
+    - screen
+    - render
+    - animation
+    ux:
+    - understand
+    - clarity
+    - steps
+    - easy
+    - confusing
+    be:
+    - validate
+    - apply
+    - compute
+    - reconcile
+    - rule
+    nw:
+    - request
+    - response
+    - timeout
+    - websocket
+    - stream
+    db:
+    - query
+    - index
+    - transaction
+    - lock
+    - row
+    st:
+    - asset
+    - download
+    - upload
+    - cache
+    - blob
+    - cdn
+    tm:
+    - event
+    - metrics
+    - trace
+    - ingest
+    - drop
+    sc:
+    - schema
+    - contract
+    - version
+    - field
+    - json
+    au:
+    - login
+    - token
+    - permission
+    - rate-limit
+    - '403'
+    fn:
+    - price
+    - balance
+    - payout
+    - token
+    if:
+    - cpu
+    - memory
+    - pod
+    - node
+    - gpu

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.route-construction.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.route-construction.convention.yaml
@@ -1,0 +1,55 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.route-construction
+kind: rule
+status: active
+name: Route sequence construction
+statement: route.sequence is built as ordered {layer}.{action} transitions flowing presentation -> application
+  -> domain -> integration as needed.
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: route_construction + layer_routing
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - presentation_flow:
+    - presentation.command
+    - application.use_case
+    - domain.validate
+    - integration.persist
+  - query_flow:
+    - presentation.query
+    - application.query
+    - integration.read
+  - event_flow:
+    - integration.call_external
+    - application.aggregate
+    - domain.mutate
+    - integration.persist
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: route_step
+  text: one {layer}.{action} transition in a route sequence.
+  values:
+    presentation:
+    - presentation.command
+    - presentation.query
+    - presentation.display
+    application:
+    - application.use_case
+    - application.query
+    - application.aggregate
+    domain:
+    - domain.create
+    - domain.validate
+    - domain.mutate
+    - domain.policy
+    integration:
+    - integration.read
+    - integration.persist
+    - integration.call_external

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.signal-telemetry-naming.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.signal-telemetry-naming.convention.yaml
@@ -1,0 +1,61 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.signal-telemetry-naming
+kind: rule
+status: active
+name: Telemetry signal naming
+statement: Each acceptance declares telemetry signals (metrics, traces, logs, events) using artifact-based
+  telemetry URNs (REQUIRED).
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: gherkin_structure.signal
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  normative_text: Derive metrics from 'then' quantifiable expectations; derive events from 'when' user
+    actions. Operations/wagons go in attributes, NOT in the URN.
+  operational_guidance: 'metric: telemetry:metric:{plane}:{artifact}[.{category}]:{measure}; trace: telemetry:trace:{plane}:{artifact}[.{category}]
+    (no measure); log: optional telemetry:log:...; event: telemetry:event:... or Title Case analytics
+    name. Resource must be a past-tense verb from the lexicon.'
+  constraints:
+  - 'Entity artifacts (nouns) use measures: count, size, age, staleness, freshness.'
+  - 'Event artifacts (past-tense verbs) use: latency, duration, throughput, error_rate, success_rate.'
+  examples:
+  - metric: telemetry:metric:be:order:created:duration (histogram, p95, 200ms)
+  - trace: telemetry:trace:be:order:created (server)
+  - event: telemetry:event:be:order:created  /  'Order Created'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: measure
+  text: the trailing measure segment of a metric URN.
+  values:
+    allowed:
+    - latency
+    - duration
+    - throughput
+    - error_rate
+    - success_rate
+    - count
+    - size
+    - age
+    - staleness
+    - freshness
+- term_id: plane
+  text: the leading plane segment.
+  values:
+    allowed:
+    - ui
+    - ux
+    - be
+    - db
+    - nw
+    - st
+    - tm
+    - sc
+    - au
+    - fn
+    - if

--- a/src/atdd/planner/conventions/nodes/planner.acceptance.urn-generation.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.acceptance.urn-generation.convention.yaml
@@ -1,0 +1,39 @@
+schema_version: 1.1.0
+rule_id: planner.acceptance.urn-generation
+kind: rule
+status: active
+name: Acceptance URN generation
+statement: An acceptance URN is acc:{wagon}:{wmbt_id}-{harness}-{NNN}[-{slug}], built via URNBuilder.acceptance.
+source:
+  legacy_path: src/atdd/planner/conventions/acceptance.convention.yaml
+  legacy_section: urn_generation
+  legacy_sha: 027e2d86ff127550
+  extraction_mode: high_fidelity
+content:
+  normative_text: Colon = hierarchy (acc:wagon:wmbt_id); dash = facet cluster (-harness-NNN[-slug]). Makes
+    the WMBT tie explicit, bakes in harness visibility for routing, keeps per-harness sequence and an
+    optional readability slug.
+  operational_guidance: URNBuilder.acceptance(wagon_id, wmbt_id, harness_code, seq, slug=None).
+  examples:
+  - URNBuilder.acceptance("authenticate-user", "C004", "E2E", "019") -> acc:authenticate-user:C004-E2E-019
+  - URNBuilder.acceptance("maintain-ux", "C004", "E2E", "019", "user-connection") -> acc:maintain-ux:C004-E2E-019-user-connection
+  counter_examples:
+  - acc:authenticate-user:001:AC-EXEC-201  (legacy format acc:{wagon}:{nnn}:{acceptance_id} — being migrated)
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: acceptance_urn
+  label: Acceptance URN
+  text: the canonical id of an acceptance.
+  values:
+    pattern: ^acc:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}-(UNIT|HTTP|EVENT|WS|E2E|A11Y|VIS|METRIC|JOB|DB|SEC|LOAD|SCRIPT|WIDGET|GOLDEN|BLOC|INTEGRATION|RLS|EDGE|REALTIME|STORAGE|SMOKE)-[0-9]{3}(?:-[a-z0-9-]+)?$
+    parts:
+      wagon: kebab-case wagon
+      wmbt_id: step code + seq (C004)
+      harness: UPPERCASE harness code
+      NNN: per-harness 001-999
+      slug: optional kebab descriptor

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.anti-patterns.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.anti-patterns.convention.yaml
@@ -1,0 +1,31 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.anti-patterns
+kind: anti_pattern
+status: active
+name: Naming anti-patterns
+statement: Avoid the catalogued artifact-naming anti-patterns (wrong separator, missing theme, over-specification,
+  generic aspect, theme repeated in aspect).
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: anti_patterns
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: anti_pattern
+  label: Anti-patterns
+  text: bad name -> why -> fix.
+  values:
+    wrong_separator_for_hierarchy: 'commons:ux.foundations.color -> use colons: commons:ux:foundations:color'
+    wrong_separator_for_variant: 'sensory:gesture:raw -> use dot: sensory:gesture.raw'
+    missing_theme: 'gesture.raw -> add theme: sensory:gesture.raw'
+    too_many_dots: commons:identifiers.uuid.v7.timestamp.encoded -> commons:identifiers.uuid (internals
+      stay internal)
+    unnecessary_hierarchy: match:config:base:standard -> match:config
+    generic_aspect: match:data -> match:state.committed (specific)
+    theme_in_aspect: sensory:sensory-feedback.visual -> sensory:feedback.visual

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.cardinality-from-aspect.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.cardinality-from-aspect.convention.yaml
@@ -1,0 +1,32 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.cardinality-from-aspect
+kind: rule
+status: active
+name: Cardinality from the aspect
+statement: 'The ASPECT (final noun before variant) determines cardinality: a plural aspect indicates a
+  collection/array; a singular aspect indicates one item. Categories and variants do not affect cardinality.'
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: cardinality_semantics
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - scenario:fragments -> plural aspect -> collection
+  - scenario:fragment -> singular aspect -> one item
+  - commons:ux:foundations:color -> 'foundations' is a category, 'color' singular -> one item
+  - commons:ux:foundations:colors -> 'colors' plural -> array of colors
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: cardinality
+  text: single-item vs collection, decided by the aspect's plurality.
+  values:
+    singular_aspect: single item schema
+    plural_aspect: collection/array schema or directory of items
+    category_position: does NOT affect cardinality
+    variant_position: does NOT affect cardinality

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.colon-for-hierarchy.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.colon-for-hierarchy.convention.yaml
@@ -1,0 +1,25 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.colon-for-hierarchy
+kind: rule
+status: active
+name: Colon for hierarchical descent
+statement: 'Use a colon for hierarchical descent: different conceptual levels, navigating deeper, general->specific,
+  organizational subsystems.'
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: decision_rules.when_to_use_colon
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - commons:ux:foundations:color (theme->subsystem->category->item)
+  - scenario:catalog:primitives:actor (domain->collection->type->entity)
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: hierarchical_descent
+  text: moving from general to specific down the resource tree, marked by a colon.

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.contract-file-mapping.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.contract-file-mapping.convention.yaml
@@ -1,0 +1,26 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.contract-file-mapping
+kind: rule
+status: active
+name: Contract file mapping
+statement: 'An artifact path maps directly to a contract file path: theme + segments become directories,
+  the final segment becomes the filename, with a .schema.json extension.'
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: contract_file_mapping
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: 'Formula: artifact theme:seg1:seg2:aspect.variant -> contracts/theme/seg1/seg2/aspect/variant.schema.json.'
+  examples:
+  - commons:identifiers.uuid -> contracts/commons/identifiers/uuid.schema.json
+  - sensory:feedback:haptic:pulse.short -> contracts/sensory/feedback/haptic/pulse/short.schema.json
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: file_mapping
+  text: the deterministic artifact-name -> file-path transform.

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.depth-guidelines.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.depth-guidelines.convention.yaml
@@ -1,0 +1,27 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.depth-guidelines
+kind: principle
+status: active
+name: Depth guidelines
+statement: Keep hierarchy 2-3 levels (4-5 max, sparingly) and variants shallow (0-1 dots, 2 max); each
+  separator should add clear semantic value.
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: decision_rules.depth_guidelines
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: depth
+  text: the recommended nesting depth per separator.
+  values:
+    hierarchy_typical: 2-3 levels
+    hierarchy_maximum: 4-5 levels (use sparingly)
+    variant_typical: 0-1 levels
+    variant_maximum: 2 levels
+    warning: multiple dots often indicate over-specification

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.dot-for-variant.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.dot-for-variant.convention.yaml
@@ -1,0 +1,25 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.dot-for-variant
+kind: rule
+status: active
+name: Dot for lateral variation
+statement: 'Use a dot for lateral variation: same conceptual level, different flavor/state/type/facet.'
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: decision_rules.when_to_use_dot
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - sensory:gesture.raw vs sensory:gesture.tapped
+  - player:session.active vs player:session.closed
+  - match:config.duel vs match:config.team
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: lateral_variation
+  text: a different flavor/state of the same aspect, marked by a dot.

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.logical-physical-mapping.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.logical-physical-mapping.convention.yaml
@@ -1,0 +1,36 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.logical-physical-mapping
+kind: rule
+status: active
+name: Logical-to-physical mapping
+statement: 'Artifact names (logical) map to contract file paths (physical): split on : and ., each segment
+  is a directory level, the final segment is the filename.'
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: logical_vs_physical_mapping + urn_structure
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: 'segments = split(artifact, /[:.]/); path = ''contracts/'' + segments[0..-1].join(''/'');
+    file = variant ? variant+''.schema.json'' : (directory_reference ? none : aspect+''.schema.json'').'
+  examples:
+  - scenario:fragment -> contracts/scenario/fragment/fragment.schema.json (singular object)
+  - scenario:fragments -> contracts/scenario/fragments/fragments.schema.json (array schema)
+  - commons:ux:foundations -> contracts/commons/ux/foundations/ (directory reference, no file)
+  - sensory:gesture.raw -> contracts/sensory/gesture/raw.schema.json (variant becomes filename)
+  - commons:ux:foundations:color.primary -> contracts/commons/ux/foundations/color/primary.schema.json
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: physical_form
+  label: Three physical forms
+  text: how a plural/singular artifact materializes on disk.
+  values:
+    directory_reference: logical grouping, no concrete schema file (plural aspect referencing a collection
+      of related schemas)
+    array_schema: 'plural aspect with a concrete array schema ({type: array, items: $ref ../singular})'
+    singular_schema: singular aspect = single object schema

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.migration-guide.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.migration-guide.convention.yaml
@@ -1,0 +1,29 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.migration-guide
+kind: principle
+status: active
+name: v1 -> v2 migration guide
+statement: Migrate legacy names to theme:hierarchy:aspect.variant by assigning a theme, separating hierarchy
+  (colons) from variants (dots), and realigning URNs, manifests, and contract files.
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: migration_guide
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: 'Steps: identify names -> determine theme -> identify hierarchy -> separate hierarchy
+    from variants -> update wagon manifests -> update feature files -> update URNs -> reorganize contracts
+    -> update $id fields.'
+  examples:
+  - identifiers:uuid -> commons:identifiers.uuid
+  - ux.foundations.color -> commons:ux:foundations:color
+  - ux.foundations.color.primary -> commons:ux:foundations:color.primary
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: migration_step
+  text: one step in the v1->v2 artifact-name migration.

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.naming-pattern.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.naming-pattern.convention.yaml
@@ -1,0 +1,44 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.naming-pattern
+kind: rule
+status: active
+name: Artifact naming pattern
+statement: An artifact name is {theme}(:{category})*:{aspect}(.{variant})? — theme, optional hierarchy
+  categories, a leaf aspect, and an optional variant.
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: naming_pattern + visual_hierarchy + examples + purpose
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'Visual: theme : category : subcategory : aspect . variant — colons = HIERARCHY (vertical
+    depth), dot = VARIANT (lateral facet); theme = NAMESPACE.'
+  operational_guidance: Provides semantic clarity (theme-based), namespace safety (collision-free), unlimited
+    hierarchical depth (colons), lateral variants (dots), and alignment of artifact names with contract
+    file paths.
+  examples:
+  - commons:ux:foundations:color  (theme->subsystem->category->item)
+  - commons:identifiers.uuid  (aspect + variant)
+  - commons:ux:foundations:color.primary  (deep hierarchy + variant)
+  - 'match:config  (simple form: theme:aspect)'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: name_component
+  label: Name components
+  text: the four grammar parts of an artifact name.
+  values:
+    theme: top-level architectural theme; kebab-case ^[a-z][a-z0-9-]*$; required, exactly 1
+    category: hierarchical path segment navigating down the resource tree; kebab-case; optional, 0+
+    aspect: the final leaf resource noun; kebab-case; required, exactly 1
+    variant: lateral variation/facet/state of the aspect; kebab-case; optional, typically 0-1
+  examples:
+    positive:
+    - theme=commons
+    - category=foundations
+    - aspect=color
+    - variant=primary

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.planner-artifacts-use-stable.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.planner-artifacts-use-stable.convention.yaml
@@ -1,12 +1,28 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.artifact-naming.planner-artifacts-use-stable
 kind: rule
 status: active
+name: Stable URN-based names
 statement: Planner artifacts use stable URN-based names matching the registered grammar.
-rationale: Stable URN-based names let the graph reference plan artifacts durably across
-  renames and refactors.
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: rules
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.artifact-naming.planner-artifacts-use-stable
+metadata:
+  aliases:
+  - PLANNER-ARTIFACT-NAMING-001
+  severity: 2
+  disposition: documentation-only
+  introduced_in: 1.67.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: planner_artifact
-  text: 'a plan-side file: wagon, feature, WMBT, or train'
-- term_id: urn_name
-  text: a stable URN-based name matching the registered grammar
+- term_id: stable_name
+  text: a URN-based artifact name that stays constant across renames/refactors and matches the registered
+    grammar.

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.pluralization.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.pluralization.convention.yaml
@@ -1,0 +1,27 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.pluralization
+kind: family
+status: active
+name: Pluralization guide
+statement: Use singular aspect for item schemas and plural aspect for collections, following English pluralization
+  rules.
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: cardinality_semantics.pluralization_guide
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: pluralization
+  text: how to form the plural aspect.
+  values:
+    regular: add 's' (fragment->fragments, color->colors)
+    irregular: English irregular forms (analysis->analyses, policy->policies, datum->data, index->indices,
+      child->children)
+    uncountable: use explicit suffix (config vs config.collection; data.item vs data.items)
+    compound: pluralize the primary noun (button-group->button-groups, session-state->session-states)

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.schema-identifier.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.schema-identifier.convention.yaml
@@ -1,0 +1,31 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.schema-identifier
+kind: rule
+status: active
+name: Schema $id and version separation
+statement: A contract's $id is the clean artifact name {theme}:{resource}[.{category}] with NO 'urn:contract:'
+  prefix and NO version suffix; version is a separate top-level field.
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: schema_identifier
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  normative_text: $id = clean artifact identifier (e.g. mechanic:timebank.exhausted). urn_reference (in
+    wagon produce/consume) = contract:{artifact_name}. Version is a SEPARATE top-level field so artifact
+    identity stays stable across versions.
+  counter_examples:
+  - mechanic:timebank.exhausted:v1  (version in $id breaks identity stability)
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: id_field
+  text: the $id of a contract schema.
+  values:
+    id_pattern: '{theme}:{resource}[.{category}]'
+    urn_reference: contract:{artifact_name}
+    version: separate top-level field

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.separator-semantics.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.separator-semantics.convention.yaml
@@ -1,0 +1,42 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.separator-semantics
+kind: family
+status: active
+name: Separator semantics (colon vs dot)
+statement: Colon means hierarchical descent (unlimited depth); dot means lateral variation (keep shallow).
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: separator_semantics
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: colon
+  label: 'Colon ( : )'
+  text: hierarchical descent — navigate deeper into the resource tree.
+  values:
+    purpose: Hierarchical descent
+    multiplicity: Unlimited
+    visual_weight: Strong boundary - different conceptual levels
+  examples:
+    positive:
+    - commons:ux:foundations:color
+    - scenario:catalog:primitives:actor
+- term_id: dot
+  label: Dot ( . )
+  text: lateral variation — different flavors/states of the same thing.
+  values:
+    purpose: Lateral variation
+    multiplicity: Typically 1, rarely 2
+    visual_weight: Soft boundary - same level, different facet
+    warning: Multiple dots (e.g. .uuid.v7.encoded) usually indicates over-specification
+  examples:
+    positive:
+    - sensory:gesture.raw
+    - player:session.active
+    - match:config.duel

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.theme-taxonomy.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.theme-taxonomy.convention.yaml
@@ -1,0 +1,43 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.theme-taxonomy
+kind: family
+status: active
+name: Theme taxonomy
+statement: Standard themes for artifact organization, each with a defined scope.
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: theme_taxonomy + naming_pattern.components.theme
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'Built-in defaults may be overridden via the themes: block in .atdd/config.yaml; runtime
+    resolves the effective digit-to-name map via get_theme_map(config). JSON Schema enforces kebab-case
+    shape only (issue #291 / Decision #2).'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: theme
+  label: Standard themes
+  text: theme -> {definition, scope}.
+  values:
+    commons: Shared infrastructure and cross-cutting concerns (identity, auth, identifiers, telemetry,
+      UX system)
+    match: Match orchestration and game state (sessions, dilemmas, events, scoring, config)
+    mechanic: Core game mechanics and rules (decisions, timebank, cascades, impacts, predictions)
+    sensory: User interaction and presentation (gestures, feedback, character interactions, UI state)
+    player: Player lifecycle and progression (sessions, profiles, agreements, achievements)
+    partnership: Sponsor and partner relationships (agreements, reporting, persona mapping)
+    scenario: Content and scenario management (fragments, graphs, materials, catalogs)
+    league: Competitive structures (leaderboards, brackets, rewards)
+    audience: Viewer and streaming features (donations, streams)
+    monetization: Economic system (wallets, tokens, transactions)
+  examples:
+    positive:
+    - commons:identifiers.uuid
+    - match:config.duel
+    - sensory:gesture.raw
+    - scenario:fragments

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.urn-structure.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.urn-structure.convention.yaml
@@ -1,0 +1,26 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.urn-structure
+kind: rule
+status: active
+name: URN structure
+statement: 'A contract URN exactly matches the artifact name, preserving colons and dots: contract:{artifact_name}.'
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: urn_structure
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - commons:identifiers.uuid -> contract:commons:identifiers.uuid
+  - commons:ux:foundations:color.primary -> contract:commons:ux:foundations:color.primary
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: contract_urn
+  text: the URN form of an artifact name.
+  values:
+    pattern: contract:{artifact_name}

--- a/src/atdd/planner/conventions/nodes/planner.artifact-naming.validation-rules.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.artifact-naming.validation-rules.convention.yaml
@@ -1,0 +1,33 @@
+schema_version: 1.1.0
+rule_id: planner.artifact-naming.validation-rules
+kind: constraint
+status: active
+name: Naming validation rules
+statement: Artifact names must satisfy the format, semantic, and technical validation rules.
+source:
+  legacy_path: src/atdd/planner/conventions/artifact-naming.convention.yaml
+  legacy_section: validation_rules
+  legacy_sha: eca68a67c92694c9
+  extraction_mode: high_fidelity
+content:
+  constraints:
+  - 'format: theme lowercase no separators; category/aspect/variant kebab-case; colon for descent; dot
+    for variants.'
+  - 'semantic: theme from approved taxonomy; each hierarchy level adds value; aspect a concrete noun;
+    variant a state/type/facet; URN matches name exactly; avoid deep variant nesting.'
+  - 'technical: contract file exists at contracts/{segments}.schema.json; $id is urn:contract:{artifact_name};
+    all consumers reference the same name; file path derivable by splitting on : and .'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: validation_rule
+  text: a format/semantic/technical constraint on artifact names.
+  values:
+    categories:
+    - format
+    - semantic
+    - technical

--- a/src/atdd/planner/conventions/nodes/planner.coverage.bidirectional-coverage-between-trains.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.coverage.bidirectional-coverage-between-trains.convention.yaml
@@ -1,13 +1,33 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.coverage.bidirectional-coverage-between-trains
 kind: rule
 status: active
-statement: A train and its wagons must reference each other bidirectionally, leaving
-  no orphan on either side.
-rationale: Bidirectional train-wagon references prevent orphaned wagons and orphaned
-  trains that the journey would silently drop.
+name: Train - Wagon Coverage
+statement: A train and its wagons must reference each other bidirectionally (wagon->train and train->wagon).
+source:
+  legacy_path: src/atdd/planner/conventions/coverage.convention.yaml
+  legacy_section: rules
+  legacy_sha: 27e800378c584902
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.coverage.bidirectional-coverage-between-trains
+bidirectional:
+- direction: wagon -> train
+  requirement: Every wagon must appear in at least one train's participants
+  exceptions: wagons_not_in_train allow-list or status:draft
+  validator: test_all_wagons_in_at_least_one_train
+- direction: train -> wagon
+  requirement: 'Every wagon: participant must have a wagon manifest'
+  validator: test_all_train_wagon_refs_exist
+metadata:
+  aliases:
+  - COVERAGE-PLAN-2.1
+  disposition: documentation-only
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: train
-  text: an ordered journey composed of wagons
 - term_id: bidirectional_coverage
-  text: each side references the other, with no orphan
+  text: each side references the other, no orphan.

--- a/src/atdd/planner/conventions/nodes/planner.coverage.bidirectional-coverage-between-wagons.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.coverage.bidirectional-coverage-between-wagons.convention.yaml
@@ -1,13 +1,33 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.coverage.bidirectional-coverage-between-wagons
 kind: rule
 status: active
-statement: A wagon and its features must reference each other bidirectionally, leaving
-  no orphan on either side.
-rationale: Bidirectional wagon-feature references prevent orphaned features that no
-  wagon owns.
+name: Wagon - Feature Coverage
+statement: A wagon and its features must reference each other bidirectionally (feature->wagon and wagon->feature).
+source:
+  legacy_path: src/atdd/planner/conventions/coverage.convention.yaml
+  legacy_section: rules
+  legacy_sha: 27e800378c584902
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.coverage.bidirectional-coverage-between-wagons
+bidirectional:
+- direction: feature -> wagon
+  requirement: Every feature file must be referenced by its wagon manifest
+  exceptions: features_orphaned allow-list
+  validator: test_all_features_in_wagon_manifest
+- direction: wagon -> feature
+  requirement: Every features[] entry must have corresponding YAML file
+  validator: test_all_wagon_feature_refs_exist
+metadata:
+  aliases:
+  - COVERAGE-PLAN-2.2
+  disposition: documentation-only
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: wagon
-  text: a unit of work that owns features and WMBTs
-- term_id: feature
-  text: a capability slice registered under a wagon
+- term_id: wagon_feature_coverage
+  text: each feature is referenced by its wagon and vice versa.

--- a/src/atdd/planner/conventions/nodes/planner.coverage.coverage-graph.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.coverage.coverage-graph.convention.yaml
@@ -1,0 +1,31 @@
+schema_version: 1.1.0
+rule_id: planner.coverage.coverage-graph
+kind: family
+status: active
+name: Planner coverage graph
+statement: 'The planner coverage graph ensures traceability from trains down to acceptances: Train ->
+  Wagon -> Feature -> WMBT -> Acceptance, each level guarded by coverage validators.'
+source:
+  legacy_path: src/atdd/planner/conventions/coverage.convention.yaml
+  legacy_section: coverage_graph + rollout
+  legacy_sha: 27e800378c584902
+  extraction_mode: high_fidelity
+content:
+  normative_text: Section 2 of the ATDD Hierarchy Coverage Spec v0.1. Validators become strict in Phase
+    2 (PLANNER_TESTER_ENFORCEMENT).
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: coverage_level
+  label: Coverage levels
+  text: level -> {contains, validators}.
+  values:
+    Train: contains Wagons (via participants) — COVERAGE-PLAN-2.1
+    Wagon: contains Features (via features[]) — 2.1, 2.2
+    Feature: contains WMBTs (via wmbts[]) — 2.2, 2.3
+    WMBT: contains Acceptances (via acceptances[]) — 2.3, 2.4
+    Acceptance: contains Test criteria — 2.4

--- a/src/atdd/planner/conventions/nodes/planner.coverage.every-wmbt-must-be.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.coverage.every-wmbt-must-be.convention.yaml
@@ -1,12 +1,29 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.coverage.every-wmbt-must-be
 kind: rule
 status: active
-statement: Every WMBT must be referenced by at least one feature.
-rationale: Requiring every WMBT to be referenced by a feature keeps the decomposition
-  connected, with no floating truths.
+name: WMBT - Feature Coverage
+statement: Every WMBT must be referenced by at least one feature (wmbt->feature).
+source:
+  legacy_path: src/atdd/planner/conventions/coverage.convention.yaml
+  legacy_section: rules
+  legacy_sha: 27e800378c584902
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.coverage.every-wmbt-must-be
+bidirectional:
+- direction: wmbt -> feature
+  requirement: Every WMBT file must appear in at least one feature's wmbts list
+  validator: test_all_wmbts_in_at_least_one_feature
+metadata:
+  aliases:
+  - COVERAGE-PLAN-2.3
+  disposition: documentation-only
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: wmbt
-  text: a What-Must-Be-True entry in a wagon decomposition
-- term_id: feature
-  text: a capability slice that references the WMBTs it proves
+- term_id: wmbt_feature_coverage
+  text: every WMBT file appears in at least one feature's wmbts list.

--- a/src/atdd/planner/conventions/nodes/planner.coverage.every-wmbt-must-have.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.coverage.every-wmbt-must-have.convention.yaml
@@ -1,12 +1,33 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.coverage.every-wmbt-must-have
 kind: rule
 status: active
-statement: Every WMBT must have at least one acceptance criterion.
-rationale: A WMBT with no acceptance is unfalsifiable; requiring at least one keeps
-  every truth verifiable.
+name: WMBT - Acceptance Coverage
+statement: Every WMBT must have at least one acceptance criterion (except status:draft).
+implementation:
+  type: validator
+  ref: test_hierarchy_coverage::test_all_wmbts_have_acceptances
+source:
+  legacy_path: src/atdd/planner/conventions/coverage.convention.yaml
+  legacy_section: rules
+  legacy_sha: 27e800378c584902
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.coverage.every-wmbt-must-have
+content:
+  normative_text: 'Requirement: every WMBT must have at least one acceptance (except status:draft).'
+  exceptions:
+  - wmbts_without_acceptance allow-list
+metadata:
+  aliases:
+  - COVERAGE-PLAN-2.4
+  severity: 3
+  disposition: strict
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: wmbt
-  text: a What-Must-Be-True entry in a wagon decomposition
-- term_id: acceptance_criterion
-  text: a Given/When/Then check that proves the WMBT
+- term_id: wmbt_acceptance_coverage
+  text: every non-draft WMBT carries at least one acceptance.

--- a/src/atdd/planner/conventions/nodes/planner.coverage.exception-handling.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.coverage.exception-handling.convention.yaml
@@ -1,0 +1,32 @@
+schema_version: 1.1.0
+rule_id: planner.coverage.exception-handling
+kind: principle
+status: active
+name: Coverage exception handling
+statement: Coverage exceptions are declared via config allow-lists and status exemptions (draft artifacts
+  are exempt from 2.1 and 2.4).
+source:
+  legacy_path: src/atdd/planner/conventions/coverage.convention.yaml
+  legacy_section: exception_handling
+  legacy_sha: 27e800378c584902
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: allow_list
+  label: Allow-lists
+  text: allow-list -> config path + use case.
+  values:
+    wagons_not_in_train: coverage.exceptions.wagons_not_in_train — utility/shared/under-development wagons
+    features_orphaned: coverage.exceptions.features_orphaned — deprecated/experimental features
+    wmbts_without_acceptance: coverage.exceptions.wmbts_without_acceptance — draft/placeholder WMBTs
+- term_id: status_exemption
+  text: draft artifacts are exempt from full coverage.
+  values:
+    draft_exempt_from:
+    - COVERAGE-PLAN-2.1
+    - COVERAGE-PLAN-2.4

--- a/src/atdd/planner/conventions/nodes/planner.criteria.defaults.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.criteria.defaults.convention.yaml
@@ -1,0 +1,30 @@
+schema_version: 1.1.0
+rule_id: planner.criteria.defaults
+kind: rule
+status: active
+name: Criteria given defaults
+statement: Acceptance given sections default to empty auth scopes, no builders, no time, strict stubbing
+  policy, and no knobs.
+source:
+  legacy_path: src/atdd/planner/conventions/criteria.convention.yaml
+  legacy_section: defaults
+  legacy_sha: db262e7f5fb06226
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: given_defaults
+  text: the default given block.
+  values:
+    auth:
+      scopes: []
+    builders: []
+    time: {}
+    stubbing:
+      policy: strict
+      overrides: []
+    knobs: {}

--- a/src/atdd/planner/conventions/nodes/planner.criteria.harness-templates.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.criteria.harness-templates.convention.yaml
@@ -1,0 +1,159 @@
+schema_version: 1.1.0
+rule_id: planner.criteria.harness-templates
+kind: family
+status: active
+name: Harness scaffolding templates
+statement: Reusable given/when/then scaffolding template per harness, with the layers it typically exercises.
+source:
+  legacy_path: src/atdd/planner/conventions/criteria.convention.yaml
+  legacy_section: harnesses
+  legacy_sha: db262e7f5fb06226
+  extraction_mode: high_fidelity
+content:
+  summary: '13 harness templates: http, unit, event, ws, e2e, a11y, visual, metric, job, db, sec, load,
+    script.'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: harness_template
+  label: Harness templates
+  text: harness -> {layers, given/when/then scaffold} (verbatim).
+  values:
+    http:
+      layers:
+      - presentation
+      - application
+      - domain
+      - integration
+      given:
+        auth:
+          scopes:
+          - purchase:create
+      when:
+        method: POST
+        path: /api/example
+        headers:
+          Content-Type: application/json
+        body:
+          sample: true
+      then:
+      - kind: status
+        expect: 200
+      - kind: body
+        expect:
+          ok: true
+    unit:
+      layers:
+      - application
+      - domain
+      when:
+        target: Service.method
+        args:
+          payload:
+            sample: true
+      then:
+      - kind: result
+        expect:
+          ok: true
+    event:
+      layers:
+      - application
+      - integration
+      when:
+        topic: sample.event
+        payload:
+          sample: true
+      then:
+      - kind: event
+        expect: sample.event
+    ws:
+      layers:
+      - integration
+      when:
+        url: ws://example/events
+        subscribe_msg:
+          action: subscribe
+          channel: updates
+      then:
+      - kind: message
+        expect:
+          frame: connected
+    e2e:
+      layers:
+      - presentation
+      - application
+      - domain
+      - integration
+      when:
+        url: http://example/ui
+        actions:
+        - 'fill #field'
+        - 'click #submit'
+      then:
+      - kind: visual
+        expect: success-banner
+    a11y:
+      layers:
+      - presentation
+      when: {}
+      then:
+      - kind: a11y
+        expect: passes
+    visual:
+      layers:
+      - presentation
+      when: {}
+      then:
+      - kind: snapshot
+        expect: unchanged
+    metric:
+      layers:
+      - application
+      - integration
+      when: {}
+      then:
+      - kind: metric
+        expect: metric:placeholder
+    job:
+      layers:
+      - application
+      - integration
+      when: {}
+      then:
+      - kind: status
+        expect: completed
+    db:
+      layers:
+      - integration
+      - domain
+      when: {}
+      then:
+      - kind: rows
+        expect: updated
+    sec:
+      layers:
+      - application
+      - integration
+      when: {}
+      then:
+      - kind: security
+        expect: granted
+    load:
+      layers:
+      - integration
+      - application
+      when: {}
+      then:
+      - kind: metrics
+        expect: within_limits
+    script:
+      layers:
+      - application
+      when: {}
+      then:
+      - kind: status
+        expect: 0

--- a/src/atdd/planner/conventions/nodes/planner.criteria.metric-mapping.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.criteria.metric-mapping.convention.yaml
@@ -1,0 +1,38 @@
+schema_version: 1.1.0
+rule_id: planner.criteria.metric-mapping
+kind: family
+status: active
+name: Dimension -> metric mapping
+statement: Each WMBT dimension+direction maps to a default metric_id (e.g. time/minimize -> metric:latency_p50).
+source:
+  legacy_path: src/atdd/planner/conventions/criteria.convention.yaml
+  legacy_section: metrics
+  legacy_sha: db262e7f5fb06226
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: dimension_metric
+  label: Dimension metrics
+  text: dimension -> direction -> metric_id.
+  values:
+    time:
+      minimize: metric:latency_p50
+      maximize: metric:latency_increase
+    likelihood:
+      maximize: metric:success_ratio
+      minimize: metric:error_ratio
+    effort:
+      decrease: metric:user_steps
+    frequency:
+      decrease: metric:occurrence_rate
+    quantity / amount:
+      decrease: metric:scrap_rate
+      maximize: metric:throughput
+    financial value:
+      minimize: metric:cost_per_unit
+      maximize: metric:net_margin

--- a/src/atdd/planner/conventions/nodes/planner.criteria.plane-keywords.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.criteria.plane-keywords.convention.yaml
@@ -1,0 +1,53 @@
+schema_version: 1.1.0
+rule_id: planner.criteria.plane-keywords
+kind: family
+status: active
+name: Plane keyword routing
+statement: Keyword cues route an acceptance to a layer plane (presentation, application, domain, integration).
+source:
+  legacy_path: src/atdd/planner/conventions/criteria.convention.yaml
+  legacy_section: planes.keywords
+  legacy_sha: db262e7f5fb06226
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: plane_keywords
+  label: Plane keywords
+  text: layer -> routing keywords.
+  values:
+    presentation:
+    - display
+    - visible
+    - screen
+    - render
+    - animation
+    - button
+    - form
+    - modal
+    application:
+    - workflow
+    - orchestrate
+    - use case
+    - policy
+    - state
+    - saga
+    domain:
+    - rule
+    - validate
+    - aggregate
+    - entity
+    - invariant
+    - business
+    integration:
+    - database
+    - persist
+    - external
+    - queue
+    - api
+    - webhook
+    - repository

--- a/src/atdd/planner/conventions/nodes/planner.criteria.sequence-routing.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.criteria.sequence-routing.convention.yaml
@@ -1,0 +1,26 @@
+schema_version: 1.1.0
+rule_id: planner.criteria.sequence-routing
+kind: rule
+status: active
+name: Layer sequence routing
+statement: 'Each layer maps to a default action in the route sequence: presentation.command, application.use_case,
+  domain.validate, integration.persist.'
+source:
+  legacy_path: src/atdd/planner/conventions/criteria.convention.yaml
+  legacy_section: planes.sequence
+  legacy_sha: db262e7f5fb06226
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: layer_action
+  text: layer -> default action.
+  values:
+    presentation: command
+    application: use_case
+    domain: validate
+    integration: persist

--- a/src/atdd/planner/conventions/nodes/planner.criteria.shape.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.criteria.shape.convention.yaml
@@ -1,13 +1,27 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.criteria.shape
 kind: rule
 status: active
-statement: 'Criteria entries follow the documented shape: id, description, harness,
-  and expected_outcome.'
-rationale: A fixed criterion record shape lets tooling read criteria uniformly across
-  features and WMBTs.
+name: Criteria shape
+statement: 'Criteria entries follow the documented shape: id, description, harness, and expected_outcome.'
+source:
+  legacy_path: src/atdd/planner/conventions/criteria.convention.yaml
+  legacy_section: rules
+  legacy_sha: db262e7f5fb06226
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.criteria.shape
+metadata:
+  aliases:
+  - PLANNER-CRITERIA-SHAPE-001
+  severity: 2
+  disposition: documentation-only
+  introduced_in: 1.67.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: criteria_entry
-  text: an acceptance-criterion record on a feature or WMBT
 - term_id: documented_shape
-  text: the required fields id, description, harness, expected_outcome
+  text: the required fields id, description, harness, expected_outcome.

--- a/src/atdd/planner/conventions/nodes/planner.feature.artifact-seeded-naming.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.artifact-seeded-naming.convention.yaml
@@ -1,0 +1,30 @@
+schema_version: 1.1.0
+rule_id: planner.feature.artifact-seeded-naming
+kind: rule
+status: active
+name: Artifact-seeded feature naming
+statement: 'Feature names are seeded from wagon produce/consume artifacts: identify the artifact, determine
+  its type, pick a type-specific verb, choose an object from the artifact''s domain/resource, and combine
+  as {verb}-{object}.'
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: artifact_seeds
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: 'Steps: (1) identify artifact from produce/consume; (2) determine type event/state/data/config;
+    (3) select verb from the type list; (4) choose object (domain OR resource); (5) combine {verb}-{object}
+    kebab-case.'
+  examples:
+  - mechanic:decision.choice (data) -> make-choice
+  - mechanic:timebank.remaining (state) -> track-timebank
+  - match:started (event) -> start-match
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: feature_seed
+  text: the produce/consume artifact a feature name is derived from.

--- a/src/atdd/planner/conventions/nodes/planner.feature.estimation.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.estimation.convention.yaml
@@ -1,0 +1,29 @@
+schema_version: 1.1.0
+rule_id: planner.feature.estimation
+kind: principle
+status: active
+name: Footprint estimation cues
+statement: Estimate the architectural footprint from WMBTs, interfaces, and component layers.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: estimation
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: estimation_cue
+  text: signal -> footprint element.
+  values:
+    display_animation: screen/view
+    apply_validate: endpoint
+    reconcile_persist: table/migration
+    notify_retry_queue: async
+    new_events: event count
+    external_consumes_produces: integration points
+    be_repository: table/migration
+    fe_presentation: number of screens

--- a/src/atdd/planner/conventions/nodes/planner.feature.feedback-loop-close-the-loop.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.feedback-loop-close-the-loop.convention.yaml
@@ -1,0 +1,33 @@
+schema_version: 1.1.0
+rule_id: planner.feature.feedback-loop-close-the-loop
+kind: rule
+status: active
+name: Feedback-loop must close the loop
+statement: 'A feature marked kind: feedback-loop must declare at least one SMOKE acceptance with a close_the_loop
+  block containing consumer_reacted and drift_resolved.'
+implementation:
+  type: validator
+  ref: planner.smoke.feedback-loop-close-the-loop
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: feature_kind.valid_values.feedback-loop.enforcement
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+content:
+  normative_text: Success = (a) producer detected a condition and emitted a correction, (b) consumer received
+    and reacted, AND (c) the producer's predicate no longer fires next cycle (drift resolved).
+  examples:
+  - acc:<wagon>:<wmbt_id>-SMOKE-NNN-close-the-loop with close_the_loop:{consumer_reacted, drift_resolved}
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: close_the_loop
+  text: the required SMOKE acceptance block for a feedback loop.
+  values:
+    required_fields:
+    - consumer_reacted
+    - drift_resolved

--- a/src/atdd/planner/conventions/nodes/planner.feature.feedback-loop-kind.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.feedback-loop-kind.convention.yaml
@@ -1,0 +1,30 @@
+schema_version: 1.1.0
+rule_id: planner.feature.feedback-loop-kind
+kind: rule
+status: active
+name: 'Feature kind: feedback-loop'
+statement: 'An optional feature `kind:` classifies the system archetype; kind: feedback-loop marks a producer->consumer
+  correction loop (detect+emit, receive+react, predicate no longer fires).'
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: feature_kind
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'Defaults to producer-only if absent; the kind field is optional and validators only
+    activate for explicitly-marked kinds, so existing features are unaffected (issue #825).'
+  examples:
+  - 'kind: feedback-loop'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: feature_kind
+  text: the feature's system archetype.
+  values:
+    valid_values:
+    - feedback-loop
+    default: producer-only

--- a/src/atdd/planner/conventions/nodes/planner.feature.feedback-loop-suppression.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.feedback-loop-suppression.convention.yaml
@@ -1,0 +1,23 @@
+schema_version: 1.1.0
+rule_id: planner.feature.feedback-loop-suppression
+kind: rule
+status: active
+name: Feedback-loop docs-only suppression
+statement: 'A docs-only feedback-loop feature may suppress the close-the-loop rule inline on the kind:
+  line.'
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: feature_kind.suppression
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: suppression_marker
+  text: inline opt-out for docs-only feedback-loop features.
+  values:
+    syntax: 'kind: feedback-loop  # atdd:suppress(planner.smoke.feedback-loop-close-the-loop) UNTIL=YYYY-MM-DD'

--- a/src/atdd/planner/conventions/nodes/planner.feature.footprint-scoring.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.footprint-scoring.convention.yaml
@@ -1,0 +1,119 @@
+schema_version: 1.1.0
+rule_id: planner.feature.footprint-scoring
+kind: rule
+status: active
+name: Component footprint scoring
+statement: Architectural footprint = sum(component.count x weight[component.type]), rounded UP, mapped
+  to a size bracket.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: footprint_scoring
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'Component-based footprint using granular component types from coder conventions. Formula:
+    sum(count x weight); round UP (ceiling).'
+  examples:
+  - 2 controllers(2x1) + 1 repository(1x2) + 1 view(1x1) = 5 -> S
+  - 3 serializers(1.5) + 2 controllers(2) = 3.5 -> ceil 4 -> S
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: complexity_rubric
+  text: universal 0-3 complexity scale.
+  values:
+    0: Pure config/declaration (routes, dtos, events, ports, styles)
+    0.5: Simple transformation/validation (serializers, mappers, validators, hooks, filters)
+    1: Single-responsibility business logic (controllers, services, clients, views)
+    2: Complex orchestration/state/persistence (use_cases, repositories, queues, workflows)
+    3: Very complex algorithms/integrations (engines with ML/graph/optimization)
+- term_id: component_type_weights
+  label: Component type weights
+  text: backend/frontend x layer x component-type -> weight (verbatim).
+  values:
+    backend:
+      presentation:
+        controllers: 1
+        routes: 0
+        serializers: 0.5
+        validators: 0.5
+        middleware: 1
+        guards: 1
+        views: 1
+      application:
+        use_cases: 2
+        handlers: 1
+        ports: 0
+        dtos: 0
+        policies: 1
+        workflows: 2
+      domain:
+        entities: 1
+        value_objects: 0.5
+        aggregates: 2
+        services: 1
+        specifications: 0.5
+        events: 0
+        exceptions: 0
+      integration:
+        repositories: 2
+        clients: 1
+        caches: 0.5
+        engines: 3
+        formatters: 1
+        notifiers: 1
+        queues: 2
+        stores: 1
+        mappers: 0.5
+        schedulers: 2
+        monitors: 1
+    frontend:
+      presentation:
+        views: 1
+        components: 0.5
+        containers: 1
+        controllers: 2
+        routes: 0
+        layouts: 1
+        styles: 0
+        animations: 0.5
+        forms: 1
+        hooks: 0.5
+        directives: 0.5
+        filters: 0.5
+      application:
+        use_cases: 2
+        ports: 0
+        policies: 1
+        dtos: 0
+      domain:
+        entities: 1
+        value_objects: 0.5
+        services: 1
+        specifications: 0.5
+        exceptions: 0
+      integration:
+        repositories: 2
+        clients: 1
+        stores: 1
+        serializers: 0.5
+        mappers: 0.5
+        interceptors: 1
+        caches: 0.5
+        synchronizers: 2
+        monitors: 1
+        validators: 0.5
+        workers: 2
+        connectors: 1
+- term_id: footprint_bracket
+  text: points -> bracket.
+  values:
+    XS: <=5 points
+    S: 6-10 points
+    M: 11-15 points (decompose if necessary)
+    L: 16-25 points (split)
+    XL: '>=26 points (split)'

--- a/src/atdd/planner/conventions/nodes/planner.feature.grouping-strategy.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.grouping-strategy.convention.yaml
@@ -1,0 +1,37 @@
+schema_version: 1.1.0
+rule_id: planner.feature.grouping-strategy
+kind: family
+status: active
+name: WMBT grouping strategies
+statement: Group WMBTs into a feature by shared step, dimension, object, or coherent user story (<=10
+  per group); avoid miscellaneous buckets.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: grouping_strategies + grouping_heuristics
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: Every feature must be user-facing and cohesive.
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: grouping_strategy
+  text: how WMBTs are grouped into a feature.
+  values:
+    by_step: share the same JTBD step (<=10)
+    by_dimension: measure the same dimension (<=10)
+    by_object: control the same object (<=10)
+    by_coherence: form a coherent user story (<=10)
+- term_id: grouping_heuristic
+  text: cues for coherent grouping.
+  values:
+    cues:
+    - shared object of control
+    - shared metric kind
+    - shared plane/domain
+    - same user story/flow
+    avoid: miscellaneous buckets

--- a/src/atdd/planner/conventions/nodes/planner.feature.hard-limits.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.hard-limits.convention.yaml
@@ -1,0 +1,29 @@
+schema_version: 1.1.0
+rule_id: planner.feature.hard-limits
+kind: constraint
+status: active
+name: Feature hard limits
+statement: A feature must not exceed 2 new tables, 2 async jobs, or 2 integrations; exceeding any hard
+  limit MUST trigger a split.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: sizing.hard_limits
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'new_tables<=2 (high maintenance/schema-evolution/perf cost); async_jobs<=2 (operational
+    complexity: monitoring, retry, inconsistency); integrations<=2 (external deps, security, uncontrolled
+    failure).'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: hard_limit
+  text: per-feature ceilings that force a split.
+  values:
+    new_tables: 2
+    async_jobs: 2
+    integrations: 2

--- a/src/atdd/planner/conventions/nodes/planner.feature.shape.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.shape.convention.yaml
@@ -1,12 +1,27 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.feature.shape
 kind: rule
 status: active
+name: Feature shape
 statement: Feature YAMLs declare a urn, a status, and a non-empty acceptance section.
-rationale: Requiring urn, status, and an acceptance section makes a feature a complete,
-  routable unit rather than a stub.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: rules
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.feature.shape
+metadata:
+  aliases:
+  - PLANNER-FEATURE-SHAPE-001
+  severity: 2
+  disposition: documentation-only
+  introduced_in: 1.67.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: feature_yaml
-  text: a feature module file under a wagon
 - term_id: required_fields
-  text: urn, status, and a non-empty acceptance section
+  text: urn, status, and a non-empty acceptance section.

--- a/src/atdd/planner/conventions/nodes/planner.feature.size-max-rule.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.size-max-rule.convention.yaml
@@ -1,0 +1,41 @@
+schema_version: 1.1.0
+rule_id: planner.feature.size-max-rule
+kind: rule
+status: active
+name: Feature size is the max rule
+statement: Final feature size = max(WMBT-count size, Footprint size); features MUST be S or smaller, else
+  split or stage before execution.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: sizing + rationale
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'Blended strategy. Pass 1 (planning): size by WMBT count to unblock decomposition. Pass
+    2 (post-decomposition): compute footprint, reclassify with the max rule, gate M/L features.'
+  operational_guidance: 'Per-feature constraints: <=8 components, <=3 events, <=3 new events. WMBT brackets:
+    XS<=5, S 6-10, M 11-20 (decompose/stage), L >20 (split).'
+  constraints:
+  - 'max_size: S'
+  - 'overflow_action: split or stage before execution'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: final_size_rule
+  text: max(wmbt_count_size, footprint_size).
+  values:
+    max_size: S
+    max_components: 8
+    max_events: 3
+    max_new_events: 3
+- term_id: wmbt_bracket
+  text: WMBT-count size brackets.
+  values:
+    XS: <=5 WMBTs
+    S: 6-10
+    M: 11-20 (decompose/stage)
+    L: '>20 (split immediately)'

--- a/src/atdd/planner/conventions/nodes/planner.feature.urn-naming.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.urn-naming.convention.yaml
@@ -1,0 +1,29 @@
+schema_version: 1.1.0
+rule_id: planner.feature.urn-naming
+kind: rule
+status: active
+name: Feature URN naming
+statement: A feature URN is feature:{wagon}:{feature}, both kebab-case, the feature in verb-object form;
+  built via URNBuilder.feature.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: urn_naming + naming
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - feature:resolve-dilemmas:choose-option
+  - feature:manage-inventory:track-stock
+  - feature:manage-users:authenticate-user
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: feature_urn
+  text: the feature identifier.
+  values:
+    pattern: ^feature:[a-z][a-z0-9-]*:[a-z][a-z0-9-]*$
+    naming: '{verb}-{object}'

--- a/src/atdd/planner/conventions/nodes/planner.feature.validation-rules.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.validation-rules.convention.yaml
@@ -1,0 +1,28 @@
+schema_version: 1.1.0
+rule_id: planner.feature.validation-rules
+kind: constraint
+status: active
+name: Feature validation rules
+statement: A feature's size must equal max(WMBT size, Footprint size); features exceeding component/event/hard
+  limits must be split.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: validation_rules
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+content:
+  constraints:
+  - size field must equal max(WMBT size, Footprint size)
+  - covers_wmbts determines WMBT size bracket
+  - footprint scores architectural complexity using point system
+  - Features exceeding component/event limits must be split
+  - Features exceeding hard limits (tables/jobs/integrations) MUST be split
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: validation_rule
+  text: a feature sizing/limit validation rule.

--- a/src/atdd/planner/conventions/nodes/planner.feature.verb-selection-by-artifact-type.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.verb-selection-by-artifact-type.convention.yaml
@@ -1,0 +1,55 @@
+schema_version: 1.1.0
+rule_id: planner.feature.verb-selection-by-artifact-type
+kind: family
+status: active
+name: Verb selection by artifact type
+statement: The artifact type (event, state, data, config) determines the appropriate verbs for the feature
+  name.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: artifact_seeds.verb_selection.by_artifact_type
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: verbs_by_type
+  label: Verbs by artifact type
+  text: artifact type -> verbs.
+  values:
+    events:
+    - publish
+    - emit
+    - start
+    - close
+    - trigger
+    - notify
+    states:
+    - track
+    - monitor
+    - maintain
+    - update
+    - manage
+    data:
+    - create
+    - manage
+    - process
+    - handle
+    - make
+    - generate
+    configs:
+    - configure
+    - setup
+    - initialize
+    - define
+    - establish
+  examples:
+    positive:
+    - match:started -> start-match
+    - session:active -> maintain-session
+    - player:profile -> manage-profile
+    - match:config -> configure-match

--- a/src/atdd/planner/conventions/nodes/planner.feature.wagon-link.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.feature.wagon-link.convention.yaml
@@ -1,12 +1,27 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.feature.wagon-link
 kind: rule
 status: active
+name: Feature wagon link
 statement: Each feature is registered under exactly one wagon's _features.yaml manifest.
-rationale: Registering each feature under exactly one wagon keeps ownership unambiguous
-  and the manifest authoritative.
+source:
+  legacy_path: src/atdd/planner/conventions/feature.convention.yaml
+  legacy_section: rules
+  legacy_sha: 4a95544261fb9541
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.feature.wagon-link
+metadata:
+  aliases:
+  - PLANNER-FEATURE-WAGON-LINK-001
+  severity: 2
+  disposition: documentation-only
+  introduced_in: 1.67.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: feature
-  text: a capability slice of a wagon
 - term_id: wagon_manifest
-  text: the wagon's _features.yaml that lists its features
+  text: the wagon's _features.yaml that lists its features.

--- a/src/atdd/planner/conventions/nodes/planner.theme.archetype-alignment.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.theme.archetype-alignment.convention.yaml
@@ -1,14 +1,32 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.theme.archetype-alignment
 kind: rule
 status: active
-statement: The plan, test, and code themes align to the planner, tester, and coder
-  archetypes; a wagon whose implementation lives outside its matching archetype source
-  root is surfaced.
-rationale: Aligning plan/test/code themes to the planner/tester/coder archetypes surfaces
-  work living in the wrong source root.
+name: Theme-archetype alignment
+statement: The plan/test/code themes align to the planner/tester/coder archetypes; a wagon whose implementation
+  lives outside its matching archetype source root is surfaced (advisory).
+source:
+  legacy_path: src/atdd/planner/conventions/theme.convention.yaml
+  legacy_section: rules
+  legacy_sha: 2ae106d04d77b06e
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.theme.archetype-alignment
+content:
+  normative_text: 'Documentation-only: it carries NO validator back-reference (reverse rule-coherence).
+    The advisory scan lives in test_theme_archetype_alignment.py but is not a bound enforcement gate.
+    Also exercises theme discovery across plan/ described by wmbt:govern-lifecycle:L001.'
+metadata:
+  aliases:
+  - PLANNER-THEME-ARCHETYPE-001
+  severity: 2
+  disposition: documentation-only
+  introduced_in: 3.92.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: theme_archetype_alignment
-  text: the plan-planner, test-tester, code-coder mapping
-- term_id: source_root
-  text: the archetype directory a wagon's implementation lives under
+- term_id: archetype_alignment
+  text: the plan<->planner, test<->tester, code<->coder mapping.

--- a/src/atdd/planner/conventions/nodes/planner.theme.canonical-taxonomy.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.theme.canonical-taxonomy.convention.yaml
@@ -1,0 +1,61 @@
+schema_version: 1.1.0
+rule_id: planner.theme.canonical-taxonomy
+kind: family
+status: active
+name: Canonical theme taxonomy
+statement: The five canonical themes (digits 0-4) form an abstraction stack from cross-team primitives
+  up to the orchestrator; commons is the locked digit-0 floor; digits 5-9 are retired.
+source:
+  legacy_path: src/atdd/planner/conventions/theme.convention.yaml
+  legacy_section: taxonomy + boundary
+  legacy_sha: 2ae106d04d77b06e
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'Collapses the vestigial 10-theme game-domain template down to five themes describing
+    the ATDD toolkit''s own abstraction stack (issue #970). Digit alignment preserves the train-numbering
+    scheme. theme_zero_token is LOCKED to ''commons'' (operator decision #970), mirrored by CANONICAL_THEME_0
+    in src/atdd/planner/validators/_theme_taxonomy.py.'
+  examples:
+  - commons:* (cross-team primitives)
+  - plan:* (planner)
+  - code:* (coder)
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: canonical_theme
+  label: Canonical themes
+  text: digit -> {name, archetype, scope}.
+  values:
+    '0': commons — cross-team primitives ANY archetype can consume without importing coach (graph, URN,
+      config, telemetry, worktree)
+    '1': plan (planner) — wagons, features, WMBTs, trains
+    '2': test (tester) — contracts, acceptances, smoke
+    '3': code (coder) — backend implementation, boundaries
+    '4': coach — the agent-team orchestrator incl. coach-only execution mechanics (multiplexer/pane spawn,
+      durable run persistence, Feed daemon, worker-decision mediation)
+- term_id: theme_zero
+  text: the locked, mandatory digit-0 token.
+  values:
+    token: commons
+    mandatory: true
+- term_id: retired_digits
+  text: the retired game-domain digits.
+  values:
+    digits:
+    - '5'
+    - '6'
+    - '7'
+    - '8'
+    - '9'
+    names:
+    - sensory
+    - player
+    - league
+    - audience
+    - monetization
+    - partnership
+    note: DEFAULT_THEME_MAP retains them for back-compat resolution only; must-be-canonical rejects them

--- a/src/atdd/planner/conventions/nodes/planner.theme.commons-coach-boundary.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.theme.commons-coach-boundary.convention.yaml
@@ -1,13 +1,39 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.theme.commons-coach-boundary
 kind: constraint
 status: active
-statement: A wagon themed commons must not import atdd.coach; coach-only machinery
-  must be themed coach.
-rationale: Keeping commons free of atdd.coach imports preserves the shared layer's
-  reusability and prevents coach machinery leaking into it.
+name: Commons-vs-coach boundary
+statement: A wagon themed commons MUST NOT have any source module importing atdd.coach; coach-only machinery
+  MUST be themed coach.
+implementation:
+  type: validator
+  ref: test_theme_commons_coach_boundary::test_commons_wagons_do_not_import_coach
+source:
+  legacy_path: src/atdd/planner/conventions/theme.convention.yaml
+  legacy_section: rules + boundary
+  legacy_sha: 2ae106d04d77b06e
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.theme.commons-coach-boundary
+content:
+  normative_text: 'A wagon is commons IFF a non-coach archetype (planner/tester/coder) can consume its
+    produced artifacts WITHOUT importing atdd.coach. Bindable: no module under a commons wagon''s src
+    tree may `import atdd.coach`. Known deferred violation: mediate-worker-decisions (commons, imports
+    coach) — suppressed UNTIL the #951 co-land re-theme.'
+  examples:
+  - 'commons: worktree, graph/URN/config/telemetry primitives'
+  - 'coach: multiplexer/pane spawn, durable run persistence, Feed daemon, worker-decision mediation'
+metadata:
+  aliases:
+  - PLANNER-THEME-BOUNDARY-001
+  severity: 3
+  disposition: suppress-and-clean
+  introduced_in: 3.92.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: commons_theme
-  text: the cross-team commons theme, digit 0
 - term_id: coach_import_boundary
-  text: the prohibition on a commons module importing atdd.coach
+  text: the prohibition on a commons module importing atdd.coach.

--- a/src/atdd/planner/conventions/nodes/planner.theme.must-be-canonical.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.theme.must-be-canonical.convention.yaml
@@ -1,14 +1,42 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.theme.must-be-canonical
 kind: rule
 status: active
-statement: Every wagon theme and every train theme-digit must resolve to one of the
-  five canonical themes (commons, plan, test, code, coach; digits 0-4); retired or
-  undeclared themes are rejected.
-rationale: Constraining themes to the five canonical teams keeps ownership and routing
-  coherent across the repo.
+name: Theme must be canonical
+statement: 'Every wagon theme: and every train theme-digit MUST resolve to one of the five canonical themes
+  (commons/plan/test/code/coach; digits 0-4); retired (5-9) and undeclared themes are rejected.'
+implementation:
+  type: validator
+  ref: test_theme_must_be_canonical::test_every_wagon_theme_is_canonical
+source:
+  legacy_path: src/atdd/planner/conventions/theme.convention.yaml
+  legacy_section: rules
+  legacy_sha: 2ae106d04d77b06e
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.theme.must-be-canonical
+content:
+  normative_text: Subsumes the runtime theme-membership check described by wmbt:govern-lifecycle:E001
+    (which is otherwise unbound).
+metadata:
+  aliases:
+  - PLANNER-THEME-CANONICAL-001
+  severity: 3
+  disposition: suppress-and-clean
+  introduced_in: 3.92.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: canonical_theme
-  text: one of commons/plan/test/code/coach, digits 0-4
-- term_id: theme_assignment
-  text: a wagon theme or a train theme-digit
+- term_id: canonical_resolution
+  text: a theme/digit resolving to the canonical set.
+  values:
+    allowed:
+    - commons
+    - plan
+    - test
+    - code
+    - coach
+    digits: 0-4

--- a/src/atdd/planner/conventions/nodes/planner.theme.theme-zero-mandatory.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.theme.theme-zero-mandatory.convention.yaml
@@ -1,14 +1,37 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.theme.theme-zero-mandatory
 kind: constraint
 status: active
-statement: 'Theme digit 0 (commons) is the mandatory, non-removable floor of every
-  resolved theme set: consumers may add or override themes 1-9 but must keep commons
-  at digit 0.'
-rationale: Pinning commons at digit 0 guarantees every repo shares the same non-removable
-  foundation theme.
+name: Theme zero is mandatory
+statement: 'Theme digit 0 (commons) is the mandatory, non-removable floor of every resolved theme set:
+  consumers may add/override themes 1-9 but MUST keep commons at digit 0.'
+implementation:
+  type: validator
+  ref: test_theme_zero_mandatory::test_commons_is_always_in_resolved_theme_set
+source:
+  legacy_path: src/atdd/planner/conventions/theme.convention.yaml
+  legacy_section: rules + taxonomy.theme_zero_token
+  legacy_sha: 2ae106d04d77b06e
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.theme.theme-zero-mandatory
+content:
+  normative_text: Any resolved theme map — defaults alone or defaults merged with consumer overrides —
+    MUST contain commons at digit 0. The resolver pins digit 0 regardless of override input.
+metadata:
+  aliases:
+  - PLANNER-THEME-ZERO-001
+  severity: 4
+  disposition: block
+  introduced_in: 3.92.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: theme_zero
-  text: digit 0, the locked 'commons' theme
 - term_id: resolved_theme_set
-  text: the theme map after merging defaults with consumer overrides
+  text: the theme map after merging defaults with consumer overrides.
+  values:
+    floor: commons at digit 0
+    removable: false

--- a/src/atdd/planner/conventions/nodes/planner.theme.urn-namespace-matches.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.theme.urn-namespace-matches.convention.yaml
@@ -1,13 +1,33 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.theme.urn-namespace-matches
 kind: rule
 status: active
-statement: A wagon's produced contract or telemetry URN theme-prefix must equal the
-  wagon theme.
-rationale: Aligning a produced URN's theme-prefix to the wagon theme prevents artifacts
-  being filed under the wrong team.
+name: URN theme-prefix matches wagon theme
+statement: A wagon's produced contract/telemetry URN theme-prefix MUST equal the wagon theme:.
+implementation:
+  type: validator
+  ref: test_theme_urn_namespace_matches::test_produced_urn_prefix_matches_theme
+source:
+  legacy_path: src/atdd/planner/conventions/theme.convention.yaml
+  legacy_section: rules
+  legacy_sha: 2ae106d04d77b06e
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.theme.urn-namespace-matches
+content:
+  normative_text: 'Catches commons:decision:* artifacts living under a coach-themed wagon. Drives the
+    commons:decision:* -> coach:decision:* migration tracking (deferred to #951 co-land).'
+metadata:
+  aliases:
+  - PLANNER-THEME-URN-001
+  severity: 3
+  disposition: suppress-and-clean
+  introduced_in: 3.92.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: produced_urn
-  text: a contract or telemetry URN a wagon produces
-- term_id: theme_prefix
-  text: the leading theme segment of the URN
+- term_id: urn_theme_prefix
+  text: the leading theme segment of a produced URN, which must equal the wagon theme.

--- a/src/atdd/planner/conventions/nodes/planner.train.acceptances.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.acceptances.convention.yaml
@@ -1,0 +1,34 @@
+schema_version: 1.1.0
+rule_id: planner.train.acceptances
+kind: rule
+status: active
+name: Train-level acceptances
+statement: A train may carry an optional acceptances block (WMBT acceptance shape); each contributes a
+  derived repo rule via the rule-binding walker.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: acceptances
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'rule_id derivation (spec v12 §3.3): acc:<train-id>:<slug> -> repo.<train-id>.acc-<slug>.
+    Walker: atdd.coach.utils.rule_binding.find_repo_rules.'
+  constraints:
+  - identity.urn matches URNBuilder.PATTERNS['acc'] (train-acceptance shape)
+  - identity.purpose populated (becomes RuleMetadata.description)
+  - identity.phase populated (RED|GREEN|SMOKE|REFACTOR)
+  - EITHER harness.type OR (signal.metric AND signal.threshold) populated (measurability invariant §4.3)
+  exceptions:
+  - 'id: at acceptance-block top level (rule-id derives mechanically — see §3.3)'
+  - 'disposition: anywhere in repo YAML (walker sets to ''strict'' per §4.4)'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: train_acceptance
+  text: an optional train-level acceptance.
+  values:
+    rule_id_derivation: acc:<train-id>:<slug> -> repo.<train-id>.acc-<slug>

--- a/src/atdd/planner/conventions/nodes/planner.train.artifact-flow.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.artifact-flow.convention.yaml
@@ -1,0 +1,31 @@
+schema_version: 1.1.0
+rule_id: planner.train.artifact-flow
+kind: rule
+status: active
+name: Train artifact flow
+statement: Artifacts flow between participants as {domain}:{resource}; they must be produced before consumed
+  and be defined in participant wagon manifests.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: artifact_flow
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - material:raw-story
+  - scenario:material.steps
+  - match:dilemma.current
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: artifact
+  text: a domain:resource artifact in the flow.
+  values:
+    pattern: ^[a-z][a-z0-9-]*:[a-z][a-z0-9.-]*$
+    rules:
+    - produced before consumed
+    - defined in participant wagons

--- a/src/atdd/planner/conventions/nodes/planner.train.categories.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.categories.convention.yaml
@@ -1,0 +1,26 @@
+schema_version: 1.1.0
+rule_id: planner.train.categories
+kind: family
+status: active
+name: Train test categories
+statement: The category digit (0-3) classifies a train as nominal, error, alternate, or exception.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: numbering.categories
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: category
+  label: Test categories
+  text: digit -> {name, description}.
+  values:
+    '0': nominal - Happy path - perfect conditions, standard flows
+    '1': error - Unexpected system failures - crashes, unavailability, infrastructure issues
+    '2': alternate - Valid alternative flows - different inputs, modes, configurations
+    '3': exception - Expected failures handled gracefully - validation errors, business rule violations

--- a/src/atdd/planner/conventions/nodes/planner.train.dependencies.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.dependencies.convention.yaml
@@ -1,0 +1,28 @@
+schema_version: 1.1.0
+rule_id: planner.train.dependencies
+kind: rule
+status: active
+name: Train dependencies
+statement: A train references prerequisite trains as train:{train_id}; foundation (commons) trains often
+  precede others; data-flow consumers depend on producers; circular dependencies are forbidden.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: dependencies
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - train:00-auth-session before train:30-match-solo (foundation_first)
+  - train:30-match-solo depends on train:21-scenario-curation (data_flow)
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: dependency
+  text: a prerequisite train reference.
+  values:
+    pattern: ^train:[0-9]{2}-[a-z][a-z0-9-]*$
+    circular: forbidden

--- a/src/atdd/planner/conventions/nodes/planner.train.linearity.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.linearity.convention.yaml
@@ -1,0 +1,28 @@
+schema_version: 1.1.0
+rule_id: planner.train.linearity
+kind: constraint
+status: active
+name: Trains are strictly linear
+statement: 'Trains are strictly linear: sequences contain steps only — no loops, routes, or branching;
+  new paths MUST become new trains.'
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: urn_naming.linearity_rule
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'Enforcement: loop and route sequence elements are forbidden; sequential step numbering
+    must have no gaps; each step has exactly one from and one to.'
+  constraints:
+  - loop and route sequence elements are forbidden
+  - Sequential step numbering must have no gaps
+  - Each step has exactly one from and one to
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: linearity
+  text: the no-loops/no-routes/no-branching rule for train sequences.

--- a/src/atdd/planner/conventions/nodes/planner.train.naming.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.naming.convention.yaml
@@ -1,0 +1,25 @@
+schema_version: 1.1.0
+rule_id: planner.train.naming
+kind: rule
+status: active
+name: Train naming
+statement: train_id is {number}-{descriptive-name} kebab-case (action-object/flow-descriptor); title is
+  Title Case; files are flat at plan/_trains/{train_id}.yaml.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: naming
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: train_naming
+  text: train_id, title, and file naming.
+  values:
+    train_id: '{number}-{descriptive-name} kebab-case'
+    title: Title Case
+    file: plan/_trains/{train_id}.yaml (flat)

--- a/src/atdd/planner/conventions/nodes/planner.train.numbering.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.numbering.convention.yaml
@@ -1,0 +1,30 @@
+schema_version: 1.1.0
+rule_id: planner.train.numbering
+kind: rule
+status: active
+name: Train hierarchical numbering
+statement: 'A train id is {theme_digit}{category_digit}{variation_digits}-{kebab-name}: a four-digit hierarchical
+  prefix [Theme 0-9][Category 0-3][Variation 01-99] plus a kebab-case name.'
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: numbering
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  normative_text: Position 0 = theme (0-9); position 1 = category (0=nominal,1=error,2=alternate,3=exception);
+    positions 2-3 = variation (01-99); name = kebab-case.
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: train_id_pattern
+  text: the train-id grammar.
+  values:
+    pattern: ^[0-9]{4}-[a-z][a-z0-9-]*$
+    structure:
+      theme: Single digit 0-9 identifying the theme
+      category: Single digit 0-3 identifying the test category
+      variation: Two digits 01-99 identifying specific train within category

--- a/src/atdd/planner/conventions/nodes/planner.train.participants.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.participants.convention.yaml
@@ -1,0 +1,27 @@
+schema_version: 1.1.0
+rule_id: planner.train.participants
+kind: family
+status: active
+name: Train participants
+statement: 'Participants are the actors in a train workflow: wagon:{id}, user:{role}, or system:{source};
+  each listed once.'
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: participants
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: participant_type
+  label: Participant types
+  text: type -> pattern.
+  values:
+    wagon: wagon:{wagon-id} (performs processing)
+    user: user:{role} (human actor)
+    system: system:{source} (external system/data source)
+    validation: ^(wagon|user|system):[a-z][a-z0-9-]*$

--- a/src/atdd/planner/conventions/nodes/planner.train.production-implementation.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.production-implementation.convention.yaml
@@ -1,0 +1,24 @@
+schema_version: 1.1.0
+rule_id: planner.train.production-implementation
+kind: principle
+status: active
+name: Trains are production orchestration
+statement: Trains are production orchestration (not test infrastructure), executed by TrainRunner under
+  python/trains/.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: production_implementation
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: location python/trains/; executor TrainRunner (python/trains/runner.py); implementation
+    patterns in atdd/coder/conventions/train.convention.yaml (SESSION-12).
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: train_runner
+  text: the production executor of a train.

--- a/src/atdd/planner/conventions/nodes/planner.train.registry.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.registry.convention.yaml
@@ -1,0 +1,33 @@
+schema_version: 1.1.0
+rule_id: planner.train.registry
+kind: rule
+status: active
+name: Train registry (two-file pattern)
+statement: 'Each train needs two files: a registry entry in plan/_trains.yaml and a full spec at plan/_trains/{train_id}.yaml;
+  every registry entry MUST have a corresponding spec file.'
+implementation:
+  type: validator
+  ref: test_train_files_exist_for_registry_entries
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: registry
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  normative_text: Registry is theme-category-grouped (nominal/error/alternate/exception). Validator SPEC-TRAIN-VAL-0003;
+    planner phase gate fails if a spec file is missing.
+  examples:
+  - 'registry: plan/_trains.yaml (train_id, description, path, wagons summary)'
+  - 'spec: plan/_trains/{train_id}.yaml (full workflow)'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: true
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: two_file_pattern
+  text: registry entry + spec file per train.
+  values:
+    registry: plan/_trains.yaml
+    spec: plan/_trains/{train_id}.yaml

--- a/src/atdd/planner/conventions/nodes/planner.train.scope.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.scope.convention.yaml
@@ -1,0 +1,38 @@
+schema_version: 1.1.0
+rule_id: planner.train.scope
+kind: rule
+status: active
+name: Train scope and sizing
+statement: 'A train tells ONE coherent journey: 3-7 wagons (sweet spot), 2 minimum, 8-12 review, 13+ decompose;
+  if you can''t state the outcome in one sentence without ''and'', split it.'
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: scope
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'one_journey_test: can you state the outcome in ONE sentence without ''and''?'
+  constraints:
+  - recommended 3-7 wagons
+  - minimum 2
+  - warning 8-12 (multiple journeys?)
+  - antipattern 13+ (decompose)
+  examples:
+  - 'good: 1001-decision-standard (5 wagons, one outcome)'
+  - 'bad: 3001-solo-match-complete (16 wagons, multiple journeys)'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: decomposition_signal
+  text: signals a train is multiple journeys.
+  values:
+    signals:
+    - Outcome description contains multiple 'AND' conjunctions
+    - Train has both setup AND teardown (match lifecycle)
+    - Mix of exploratory (gesture) AND core mechanic flows
+    - Multiple independent feedback loops
+    - Participants from 3+ different themes

--- a/src/atdd/planner/conventions/nodes/planner.train.sequence.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.sequence.convention.yaml
@@ -1,0 +1,34 @@
+schema_version: 1.1.0
+rule_id: planner.train.sequence
+kind: family
+status: active
+name: Train sequence elements
+statement: A sequence is ordered workflow steps; each step transfers one artifact (step, intent, from,
+  to, artifact). (Loop/route elements are documented but forbidden under the linearity rule.)
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: sequence
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'step required fields: step, intent, from, to, artifact. loop (name, condition, steps)
+    and route (name, branches) are described here but FORBIDDEN by planner.train.linearity.'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: sequence_element
+  label: Sequence elements
+  text: element -> required fields.
+  values:
+    step:
+    - step
+    - intent
+    - from
+    - to
+    - artifact
+    loop: FORBIDDEN by linearity (name, condition, steps)
+    route: FORBIDDEN by linearity (name, branches)

--- a/src/atdd/planner/conventions/nodes/planner.train.theme-alignment.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.theme-alignment.convention.yaml
@@ -1,0 +1,25 @@
+schema_version: 1.1.0
+rule_id: planner.train.theme-alignment
+kind: rule
+status: active
+name: Train theme alignment
+statement: A train's primary theme is the first digit of its train_id; most wagons should match it; secondary
+  themes are allowed when a train spans multiple themes.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: theme_alignment
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - 20-story-to-scenario -> themes:[scenario] (all wagons scenario)
+  - 30-match-solo -> themes:[match, mechanic]
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: theme_alignment
+  text: primary theme = first train-id digit; most wagons match it.

--- a/src/atdd/planner/conventions/nodes/planner.train.theme-orchestrator-urn.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.theme-orchestrator-urn.convention.yaml
@@ -1,0 +1,27 @@
+schema_version: 1.1.0
+rule_id: planner.train.theme-orchestrator-urn
+kind: rule
+status: active
+name: Theme orchestrator URN
+statement: Theme orchestrator files (python/trains/orchestrators/{theme}.py) carry train:{theme}:{train_id}
+  URN lines, one per implemented train.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: urn_naming.theme_orchestrator_urn
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - train:mechanic:1001-decision-standard -> python/trains/orchestrators/mechanic.py
+  - 'multiple # urn: lines for files implementing multiple trains'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: orchestrator_urn
+  text: the theme-prefixed train URN on an orchestrator file.
+  values:
+    pattern: train:{theme}:{train_id}

--- a/src/atdd/planner/conventions/nodes/planner.train.theme-ranges.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.theme-ranges.convention.yaml
@@ -1,0 +1,64 @@
+schema_version: 1.1.0
+rule_id: planner.train.theme-ranges
+kind: family
+status: active
+name: Train theme digit ranges
+statement: Each theme owns a digit and a category/variation range, giving 400 trains per theme (4000 total).
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: numbering.theme_ranges + numbering.capacity
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  normative_text: 'Capacity: 10 themes x 4 categories x 100 variations = 4,000 possible trains.'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: theme_range
+  label: Theme ranges
+  text: theme -> {digit, category_range, description}.
+  values:
+    commons:
+      digit: '0'
+      category_range: 00-03
+      description: Identity, session, account, identifiers, UX systems
+    mechanic:
+      digit: '1'
+      category_range: 10-13
+      description: Core decision loop, timebank, predictions, domain impacts
+    scenario:
+      digit: '2'
+      category_range: 20-23
+      description: Story processing, curation, graph construction, fragments
+    match:
+      digit: '3'
+      category_range: 30-33
+      description: Solo, duel, team gameplay orchestration
+    sensory:
+      digit: '4'
+      category_range: 40-43
+      description: Gesture interpretation, tone, feedback, audio, haptics
+    player:
+      digit: '5'
+      category_range: 50-53
+      description: Onboarding, progression, achievements, review
+    league:
+      digit: '6'
+      category_range: 60-63
+      description: Tournaments, brackets, leaderboards, rewards
+    audience:
+      digit: '7'
+      category_range: 70-73
+      description: Streaming, donations, viewer engagement
+    monetization:
+      digit: '8'
+      category_range: 80-83
+      description: Wallets, cameo flows, transactions, reconciliation
+    partnership:
+      digit: '9'
+      category_range: 90-93
+      description: Sponsors, partners, personas, attribution, reporting

--- a/src/atdd/planner/conventions/nodes/planner.train.urn-naming.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.urn-naming.convention.yaml
@@ -1,0 +1,26 @@
+schema_version: 1.1.0
+rule_id: planner.train.urn-naming
+kind: rule
+status: active
+name: Train URN naming
+statement: A train URN is train:{train_id}, using the hierarchical theme-category-variation-name id.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: urn_naming
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - train:2001-story-to-graph-perfect (scenario/nominal)
+  - train:0101-auth-service-offline (commons/error)
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: train_urn
+  text: the train identifier.
+  values:
+    pattern: train:{train_id}

--- a/src/atdd/planner/conventions/nodes/planner.train.validation-rules.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.validation-rules.convention.yaml
@@ -1,0 +1,31 @@
+schema_version: 1.1.0
+rule_id: planner.train.validation-rules
+kind: constraint
+status: active
+name: Train validation rules
+statement: A train must satisfy the documented validation rules (id pattern, theme by first digit, spec
+  file exists, participants declared, valid dependencies, domain:resource artifacts, primary theme in
+  themes array).
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: validation_rules
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+content:
+  constraints:
+  - 'train_id must match pattern: {theme_digit}{variation_digit}-{name}'
+  - First digit determines primary theme category
+  - 'File must exist at path: plan/_trains/{train_id}.yaml'
+  - All participants must be declared in participants list
+  - Dependencies must reference valid train_ids
+  - Artifacts in sequence must follow domain:resource pattern
+  - Themes array must include primary theme based on first digit
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: validation_rule
+  text: a train structural validation rule.

--- a/src/atdd/planner/conventions/nodes/planner.train.variation-strategies.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.train.variation-strategies.convention.yaml
@@ -1,0 +1,26 @@
+schema_version: 1.1.0
+rule_id: planner.train.variation-strategies
+kind: family
+status: active
+name: Train variation strategies
+statement: Create train variations within a theme by mode, complexity, persona, or phase.
+source:
+  legacy_path: src/atdd/planner/conventions/train.convention.yaml
+  legacy_section: variation_strategies
+  legacy_sha: 825602729f11a3a4
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: variation_strategy
+  label: Variation strategies
+  text: strategy -> example.
+  values:
+    by_mode: 30-match-solo / 31-match-duel / 32-match-team
+    by_complexity: 10-decision-core / 11-decision-timeout / 12-decision-preview
+    by_persona: 01-player-registration / 02-sponsor-registration
+    by_phase: 60-tournament-setup / 61-tournament-active / 62-tournament-complete

--- a/src/atdd/planner/conventions/nodes/planner.wagon.artifact-contracts.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.artifact-contracts.convention.yaml
@@ -1,0 +1,29 @@
+schema_version: 1.1.0
+rule_id: planner.wagon.artifact-contracts
+kind: rule
+status: active
+name: Wagon artifact URN formats
+statement: A wagon's produced artifacts carry a contract URN (contract:{...}) and a telemetry URN (telemetry:{...})
+  following the artifact-naming grammar.
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: artifact_contracts.urn_format
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - contract:commons:ux:foundations:color
+  - contract:mechanic:decision.choice
+  - telemetry:commons:ux:foundations
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: artifact_urn
+  text: the contract/telemetry URN forms.
+  values:
+    contract_urn: contract:{theme}(:{category})*:{aspect}(.{variant})?
+    telemetry_urn: telemetry:{theme}(:{category})*:{aspect}(.{variant})?

--- a/src/atdd/planner/conventions/nodes/planner.wagon.features-format.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.features-format.convention.yaml
@@ -1,0 +1,28 @@
+schema_version: 1.1.0
+rule_id: planner.wagon.features-format
+kind: rule
+status: active
+name: Wagon features format
+statement: A wagon's features are declared as an array of URN objects (feature:{wagon-slug}:{feature-name});
+  the legacy object map is deprecated.
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: artifact_contracts.features_format
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - 'urn_format: [{urn: feature:maintain-ux:provide-foundations}, {urn: feature:maintain-ux:compose-primitives}]'
+  - 'legacy_format (object): {provide-foundations: ''Provide foundation design tokens''}'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: features_format
+  text: the features declaration shape.
+  values:
+    urn_format: 'array of {urn: feature:{wagon-slug}:{feature-name}}'
+    legacy_format: object map (deprecated)

--- a/src/atdd/planner/conventions/nodes/planner.wagon.features.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.features.convention.yaml
@@ -1,12 +1,27 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.wagon.features
 kind: rule
 status: active
+name: Wagon features manifest
 statement: A wagon's _features.yaml lists every feature module and its current status.
-rationale: A complete _features.yaml index keeps a wagon's feature set and their statuses
-  authoritative in one place.
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: rules
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.wagon.features
+metadata:
+  aliases:
+  - PLANNER-WAGON-FEATURES-001
+  severity: 2
+  disposition: documentation-only
+  introduced_in: 1.67.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
-- term_id: wagon_features_manifest
-  text: the wagon's _features.yaml index
-- term_id: feature_status
-  text: each feature's current lifecycle status
+- term_id: features_manifest
+  text: the wagon's _features.yaml index of feature modules + statuses.

--- a/src/atdd/planner/conventions/nodes/planner.wagon.logical-vs-filesystem-naming.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.logical-vs-filesystem-naming.convention.yaml
@@ -1,0 +1,34 @@
+schema_version: 1.1.0
+rule_id: planner.wagon.logical-vs-filesystem-naming
+kind: rule
+status: active
+name: Logical (kebab) vs filesystem (snake) naming
+statement: Logical identifiers (URNs, slugs, YAML refs) use kebab-case; the filesystem (directories, manifest
+  files, feature files) uses snake_case.
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: naming.filesystem_naming
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+content:
+  normative_text: Consistent filesystem naming reduces conversion complexity; clear separation between
+    logical (kebab) and physical (snake) identifiers.
+  examples:
+  - feature:authenticate-identity:verify-session -> plan/authenticate_identity/ + _authenticate_identity.yaml
+    + features/verify_session.yaml
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: naming_surface
+  label: Naming by surface
+  text: surface -> format + pattern.
+  values:
+    urns_and_slugs: kebab-case (URNs, slug fields, references)
+    directories: snake_case, plan/{wagon_dirname}/
+    manifest_files: _{dirname}.yaml at plan/{dirname}/_{dirname}.yaml (matches DIR name, not slug)
+    feature_files: snake_case, plan/{wagon_dirname}/features/{feature_name}.yaml (underscores even though
+      URNs use hyphens)

--- a/src/atdd/planner/conventions/nodes/planner.wagon.produce-consume-artifacts.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.produce-consume-artifacts.convention.yaml
@@ -1,0 +1,46 @@
+schema_version: 1.1.0
+rule_id: planner.wagon.produce-consume-artifacts
+kind: rule
+status: active
+name: Produce/consume artifact shape
+statement: produce[] entries declare name + contract + telemetry (optional to/urn/version); consume[]
+  entries declare name (optional from/contract/telemetry/urn/version).
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: artifact_contracts.produce_artifacts + artifact_contracts.consume_artifacts
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - 'produce: {name: commons:ux:foundations, contract: contract:..., telemetry: telemetry:...}; {name:
+    internal:cache, contract: null, telemetry: null, to: internal}'
+  - 'consume: {name: commons:ux:foundations, from: wagon:maintain-ux, contract: contract:...}'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: produce_fields
+  text: produce[] entry fields.
+  values:
+    required:
+    - name
+    - contract
+    - telemetry
+    optional:
+    - to (internal|external, default external)
+    - urn
+    - version
+- term_id: consume_fields
+  text: consume[] entry fields.
+  values:
+    required:
+    - name
+    optional:
+    - from (wagon:slug|system:service|appendix:type|internal)
+    - contract
+    - telemetry
+    - urn
+    - version

--- a/src/atdd/planner/conventions/nodes/planner.wagon.refinement-extraction.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.refinement-extraction.convention.yaml
@@ -1,0 +1,49 @@
+schema_version: 1.1.0
+rule_id: planner.wagon.refinement-extraction
+kind: family
+status: active
+name: Wagon refinement extraction
+statement: Refine ambiguous input into a structured wagon by extracting subject, action, goal, context,
+  outcome, produce/consume artifacts, and theme.
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: refinement.extraction
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: subject = WHO/WHAT performs the action (actor:role/entity:state); action = core
+    present-tense verb phrase; goal = WHY/motivation; context = WHEN/WHERE (comma-separated conditions);
+    outcome = measurable result; description >=10 chars.
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: extraction_field
+  label: Refinement fields
+  text: field -> what to extract.
+  values:
+    subject: WHO/WHAT performs the action (actor:role or entity:state)
+    action: core present-tense verb phrase
+    goal: WHY/motivation, single intent statement
+    context: WHEN/WHERE, comma-separated conditions
+    outcome: measurable progress statement
+    produce: owned output artifacts
+    consume: input artifacts owned by other wagons
+- term_id: wagon_theme
+  label: Wagon theme options
+  text: theme -> scope.
+  values:
+    mechanic: Core game rules, decision systems, and immediate feedback loops
+    scenario: Content ingestion, entity extraction, and narrative structure processing
+    match: Session orchestration, state management, and lifecycle control, Multi-player coordination,
+      turn management
+    sensory: UI rendering, audio mixing, gesture capture, and player interaction
+    player: Individual lifecycle, onboarding, progression, and session management
+    league: Competitive organization, bracket management, and tournament operations
+    audience: Spectator engagement, streaming infrastructure, and viewer participation
+    monetization: Token economy, wallet operations, and transaction processing
+    partnership: Sponsor/partner onboarding, delegation, and commercial integration
+    commons: Shared infrastructure, cross-cutting utilities, and platform services

--- a/src/atdd/planner/conventions/nodes/planner.wagon.semantic-coherence.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.semantic-coherence.convention.yaml
@@ -1,0 +1,30 @@
+schema_version: 1.1.0
+rule_id: planner.wagon.semantic-coherence
+kind: constraint
+status: active
+name: Wagon semantic coherence
+statement: 'A wagon must be semantically coherent: subject/action/goal align, outcome is measurable, produce
+  is owned, consume is foreign, and at least one produce is external.'
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: validation.coherence_checks
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+content:
+  constraints:
+  - subject and action must align (subject can perform the action)
+  - action and goal must align (action serves the goal)
+  - outcome must be measurable result of action
+  - all produce artifacts must be owned by this wagon
+  - all consume artifacts must be owned by different wagons
+  - context must make sense for when/where action occurs
+  - 'at least one produce artifact must be external (scope: ''external'')'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: coherence_check
+  text: one semantic-coherence validation on a wagon definition.

--- a/src/atdd/planner/conventions/nodes/planner.wagon.slug-dirname-conversion.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.slug-dirname-conversion.convention.yaml
@@ -1,0 +1,26 @@
+schema_version: 1.1.0
+rule_id: planner.wagon.slug-dirname-conversion
+kind: rule
+status: active
+name: Slug/dirname conversion
+statement: Convert between logical slugs and filesystem names by swapping hyphens and underscores.
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: naming.conversion + naming.slug_derivation
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: conversion
+  text: the kebab<->snake conversion functions.
+  values:
+    slug_to_dirname: slug.replace('-', '_')
+    dirname_to_slug: dirname.replace('_', '-')
+    feature_slug_to_filename: feature_slug.replace('-', '_') + '.yaml'
+    feature_filename_to_slug: filename.replace('_', '-').replace('.yaml', '')
+    slug_derivation: lowercase, replace spaces/underscores with hyphens (verb-object preferred)

--- a/src/atdd/planner/conventions/nodes/planner.wagon.telemetry-filesystem.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.telemetry-filesystem.convention.yaml
@@ -1,0 +1,52 @@
+schema_version: 1.1.0
+rule_id: planner.wagon.telemetry-filesystem
+kind: rule
+status: active
+name: Telemetry URN -> filesystem
+statement: 'A telemetry URN maps to a filesystem directory of signal files: telemetry:{theme}:{segments}
+  -> telemetry/{theme}/{segments}/{signal-type}.{plane}[.{measure}].json.'
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: artifact_contracts.urn_format.telemetry_filesystem
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+content:
+  normative_text: metric signals require a measure suffix; event signals do not (pattern {signal-type}.{plane}.json).
+    Manifest is generated from telemetry/{domain}/{resource}/*.json.
+  examples:
+  - telemetry:mechanic:decision.choice -> telemetry/mechanic/decision/choice/ (metric.db.count.json, metric.be.duration.json,
+    event.be.json)
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: signal_type
+  text: metric vs event.
+  values:
+    metric: OpenTelemetry metric - requires measure suffix
+    event: analytics event - no measure suffix
+- term_id: telemetry_axes
+  text: the controlled planes and measures.
+  values:
+    planes:
+    - ui
+    - ux
+    - be
+    - nw
+    - db
+    - st
+    - tm
+    - sc
+    - au
+    - fn
+    - if
+    measures_metrics_only:
+    - count
+    - duration
+    - latency
+    - size
+    - rate
+    - percentage

--- a/src/atdd/planner/conventions/nodes/planner.wagon.urn-naming.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.urn-naming.convention.yaml
@@ -1,0 +1,28 @@
+schema_version: 1.1.0
+rule_id: planner.wagon.urn-naming
+kind: rule
+status: active
+name: Wagon URN naming
+statement: A wagon URN is wagon:{kebab-case-name}, preferring a verb-object slug; built via URNBuilder.wagon.
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: urn_naming
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - wagon:resolve-dilemmas
+  - wagon:burn-timebank
+  - wagon:manage-users
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: wagon_urn_pattern
+  text: the wagon URN grammar.
+  values:
+    pattern: ^wagon:[a-z][a-z0-9-]*$
+    preference: verb-object (resolve-dilemmas, commit-state)

--- a/src/atdd/planner/conventions/nodes/planner.wagon.urn.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wagon.urn.convention.yaml
@@ -1,13 +1,29 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.wagon.urn
 kind: rule
 status: active
-statement: Wagons declare a stable URN and live under plan/<wagon-slug>/ with the
-  documented file layout.
-rationale: A stable wagon URN and fixed layout make wagons addressable and discoverable
-  by the graph and tooling.
+name: Wagon URN + layout
+statement: Wagons declare a stable URN and live under plan/<wagon-slug>/ with the documented file layout.
+source:
+  legacy_path: src/atdd/planner/conventions/wagon.convention.yaml
+  legacy_section: rules
+  legacy_sha: ee0a3e1d5af414c9
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.wagon.urn
+metadata:
+  aliases:
+  - PLANNER-WAGON-URN-001
+  severity: 3
+  disposition: documentation-only
+  introduced_in: 1.67.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
 - term_id: wagon_urn
-  text: a wagon's stable URN
+  text: a wagon's stable URN.
 - term_id: wagon_layout
-  text: the plan/<wagon-slug>/ directory layout
+  text: the plan/<wagon-slug>/ directory layout.

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.context-clarifier.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.context-clarifier.convention.yaml
@@ -1,0 +1,24 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.context-clarifier
+kind: rule
+status: active
+name: WMBT context clarifier
+statement: Declare a context clarifier — a detailed situational phrase specifying when/where/how the WMBT
+  applies (required, one line).
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: context_clarifier
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: context_clarifier
+  text: a one-line situational qualifier.
+  values:
+    required: true
+    pattern: detailed situational phrase, one line maximum

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.dimension-selection.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.dimension-selection.convention.yaml
@@ -1,0 +1,37 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.dimension-selection
+kind: family
+status: active
+name: WMBT dimensions
+statement: Select exactly one optimization dimension (the core metric the user wants to optimize) for
+  a WMBT.
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: dimensions + dimension_instructions
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+content:
+  operational_guidance: Match the user's intent to a dimension via its keywords; decompose into dimension/actor/action/object
+    using the description and rationale.
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: dimension
+  label: Dimensions
+  text: name -> {keywords, description}.
+  values:
+    Time: duration/speed/waiting/delay/rework — the performer's most finite resource
+    Effort: physical or cognitive load — muscular force or concentration/learning/decision-making
+    Likelihood: probability of an outcome — predictability, control, success vs error
+    Frequency: rate of occurrence — reduce repetitive/non-value-added tasks
+    Quantity/Amount: volume of a resource consumed or produced — optimize inputs/outputs
+    Financial Value: monetary impact — cost, revenue, opportunity cost
+  examples:
+    positive:
+    - 'Time: minimize onboarding time'
+    - 'Likelihood: increase usable experiment results'
+    - 'Effort: reduce mental effort to find a bug'

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.direction-selection.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.direction-selection.convention.yaml
@@ -1,0 +1,41 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.direction-selection
+kind: family
+status: active
+name: WMBT directions
+statement: Select the optimization direction verb that matches the goal, from the controlled palette.
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: directions
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: direction
+  label: Direction palette
+  text: canonical direction -> synonyms.
+  values:
+    minimize:
+    - reduce
+    - decrease
+    - lower
+    - shrink
+    maximize:
+    - increase
+    - boost
+    - raise
+    - grow
+    increase:
+    - improve
+    - elevate
+    - accelerate
+    decrease:
+    - cut
+    - dampen
+    - slow
+    - limit

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.filename-pattern.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.filename-pattern.convention.yaml
@@ -1,0 +1,27 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.filename-pattern
+kind: rule
+status: active
+name: WMBT filename pattern
+statement: A WMBT file is named {STEP_CODE}{NNN}.yaml — step-coded, no prefix.
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: filename
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+content:
+  examples:
+  - E001.yaml
+  - L045.yaml
+  - K023.yaml
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: filename
+  text: the WMBT file name.
+  values:
+    pattern: '{STEP_CODE}{NNN}.yaml'

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.lens-selection.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.lens-selection.convention.yaml
@@ -1,0 +1,44 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.lens-selection
+kind: family
+status: active
+name: WMBT lenses
+statement: Select one quality lens (social, functional, or emotional) most relevant to the work.
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: lenses
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: social_lens
+  text: identity/belonging drives.
+  values:
+    belong: accepted by a group, align with norms
+    stand_out: differentiate positively — uniqueness/status/taste/expertise
+    affirm: reinforce an existing identity
+    aspire: become a better future self
+- term_id: functional_lens
+  text: task-outcome qualities.
+  values:
+    efficiency: minimize time/effort/resources
+    effectiveness: improve quality/accuracy/impact
+    availability: accessible and operational when needed
+    adaptability: handle new/changing requirements
+    sustainability: maintain performance over time
+- term_id: emotional_lens
+  text: felt reactions.
+  values:
+    joy: pleasure when friction is removed
+    trust: confidence it is reliable and safe
+    fear: anxiety about a negative outcome
+    surprise: reaction to the unexpected
+    sadness: unhappiness from loss/blocked goal
+    disgust: aversion to unethical/cluttered design
+    anger: frustration when things fail
+    anticipation: hopeful expectation

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.must-have-smoke-acceptance.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.must-have-smoke-acceptance.convention.yaml
@@ -1,15 +1,52 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.wmbt.must-have-smoke-acceptance
 kind: rule
 status: active
-statement: Every WMBT must declare at least one acceptance whose URN carries the SMOKE
-  harness token, giving the lifecycle explicit real-infrastructure coverage before
-  REFACTOR.
-rationale: Requiring a SMOKE acceptance closes the asymmetry where SMOKE tests were
-  checked for coverage but never required, ensuring real-infrastructure verification
-  before REFACTOR.
+name: WMBT must have a SMOKE acceptance
+statement: Every WMBT must declare at least one acceptance URN with the SMOKE harness token (acc:<wagon>:<wmbt_id>-SMOKE-NNN[-<slug>])
+  so the lifecycle has explicit real-infrastructure coverage before REFACTOR.
+implementation:
+  type: validator
+  ref: test_wmbt_has_smoke_acceptance::test_every_wmbt_has_smoke_acceptance
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: rules
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.wmbt.must-have-smoke-acceptance
+content:
+  normative_text: Mirrors tester.smoke.pres (#293) — closes the asymmetry where tester checks coverage
+    of SMOKE tests that exist but no rule requires SMOKE acceptances be declared in the first place.
+  fix_hint: "The named WMBT declares 0 acceptance URNs with a SMOKE harness token,\nso the lifecycle has\
+    \ no explicit real-infrastructure verification\nbetween GREEN and REFACTOR. Repair as follows\n(run\
+    \ `atdd repo resolve <wmbt-urn>` to inspect the WMBT file path,\n e.g. \"atdd repo resolve wmbt:govern-lifecycle:E003\"\
+    ):\n\n  1. Open the WMBT YAML named in the violation location\n     (e.g. \"plan/govern_lifecycle/E003.yaml:1\"\
+    ).\n  2. Add at least one acceptance whose identity.urn matches\n     \"acc:<wagon>:<wmbt_id>-SMOKE-NNN[-<slug>]\"\
+    \ and whose\n     identity.phase is \"SMOKE\".\n  3. If this WMBT is genuinely docs-only / metadata\
+    \ (no real infra\n     to verify), add a suppression marker on the urn: line of the\n     WMBT YAML\
+    \ — substitute YYYY-MM-DD with today + 90 days:\n       urn: \"wmbt:<wagon>:<wmbt_id>\"  # atdd:suppress(planner.wmbt.must-have-smoke-acceptance)\
+    \ UNTIL=YYYY-MM-DD\n  4. Re-run the validator to confirm clean\n     (pytest src/atdd/planner/validators/test_wmbt_has_smoke_acceptance.py\
+    \ -v).\n\nSee src/atdd/tester/conventions/smoke.convention.yaml::TESTER-SMOKE-PRES-001\nfor the template\
+    \ pattern this rule mirrors, and issue #681 for the\nsubstrate-asymmetry incident this rule closes."
+metadata:
+  severity: 3
+  disposition: suppress-and-clean
+  introduced_in: 3.50.0
+  aliases: []
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: true
+  fix_hint_preserved: true
+  reviewed_at: '2026-06-16'
 terms:
 - term_id: smoke_acceptance
-  text: an acceptance URN carrying the SMOKE harness token, acc:<wagon>:<wmbt_id>-SMOKE-NNN
-- term_id: real_infrastructure_coverage
-  text: verification against real infrastructure between GREEN and REFACTOR
+  text: an acceptance URN carrying the SMOKE harness token.
+  values:
+    urn_shape: acc:<wagon>:<wmbt_id>-SMOKE-NNN[-<slug>]
+    phase: SMOKE
+- term_id: suppression_marker
+  text: inline opt-out for genuinely docs-only WMBTs with no real infra.
+  values:
+    syntax: '# atdd:suppress(planner.wmbt.must-have-smoke-acceptance) UNTIL=YYYY-MM-DD'
+    placement: 'the WMBT''s urn: line'

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.object-of-control.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.object-of-control.convention.yaml
@@ -1,0 +1,26 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.object-of-control
+kind: rule
+status: active
+name: WMBT object of control
+statement: Synthesize the specific thing being controlled or manipulated as a kebab-case noun phrase.
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: object_of_control
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: object_of_control
+  text: the controlled subject of the WMBT.
+  values:
+    pattern: kebab-case noun phrase
+  examples:
+    positive:
+    - user-profile
+    - payment-flow

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.shape.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.shape.convention.yaml
@@ -1,13 +1,29 @@
-schema_version: 1.0.0
+schema_version: 1.1.0
 rule_id: planner.wmbt.shape
 kind: rule
 status: active
-statement: A WMBT entry declares its id, its statement, and the artifacts that prove
-  the statement.
-rationale: Declaring id, statement, and proving artifacts makes a WMBT a self-contained,
-  verifiable truth.
+name: WMBT shape
+statement: A WMBT entry declares its id, its statement, and the artifacts that prove the statement.
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: rules
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+  legacy_rule_id: planner.wmbt.shape
+metadata:
+  aliases:
+  - PLANNER-WMBT-SHAPE-001
+  severity: 2
+  disposition: documentation-only
+  introduced_in: 1.67.0
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
 terms:
 - term_id: wmbt_entry
-  text: a What-Must-Be-True entry in a wagon decomposition
+  text: a What-Must-Be-True entry in a wagon decomposition.
 - term_id: proving_artifacts
-  text: the acceptances and tests that verify the WMBT statement
+  text: the acceptances/tests that prove the WMBT statement.

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.splitting-rules.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.splitting-rules.convention.yaml
@@ -1,0 +1,37 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.splitting-rules
+kind: rule
+status: active
+name: WMBT splitting rules
+statement: Keep <=5 acceptances per WMBT; split on mixed dimensions, multiple actors, or divergent gates;
+  keep together for single-truth-multiple-layers or a coherent sequence.
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: splitting_rules
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+content:
+  normative_text: acceptance_cap maximum 5 — beyond 5 indicates mixed concerns that should be separate
+    WMBTs (enforced by schemas:planner:wmbt acceptance array maxItems). Aligns with conventions:planner:acceptance
+    acceptance_cap.
+  operational_guidance: 'when_to_split: mixed_dimensions (statement mentions multiple dimensions) / multiple_actors
+    (different actors+actions) / divergent_gates (ALL vs ANY). when_to_keep_together: single_truth_multiple_layers
+    (same outcome at UI/API/DB, gate ALL) / coherent_sequence (sequential steps of one process).'
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: acceptance_cap
+  text: the per-WMBT acceptance ceiling.
+  values:
+    maximum: 5
+- term_id: split_trigger
+  text: when to split a WMBT.
+  values:
+    allowed:
+    - mixed_dimensions
+    - multiple_actors
+    - divergent_gates

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.statement-template.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.statement-template.convention.yaml
@@ -1,0 +1,23 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.statement-template
+kind: rule
+status: active
+name: WMBT statement template
+statement: 'A WMBT statement is composed as: {direction} {dimension} of {object_of_control} [context_clarifier].'
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: statement + generators
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: statement_pattern
+  text: the WMBT statement composition.
+  values:
+    pattern: '${direction} ${dimension} of ${object_of_control}${context_clarifier ? '' '' + context_clarifier
+      : ''''}'

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.step-code-vocabulary.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.step-code-vocabulary.convention.yaml
@@ -1,0 +1,31 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.step-code-vocabulary
+kind: family
+status: active
+name: WMBT step codes
+statement: The single-letter step codes (D L P C E M Y R K) that prefix a WMBT sequence.
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: urn_naming.step_codes
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+parity:
+  source_fragments_preserved: true
+  examples_preserved: false
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: step_code
+  label: Step codes
+  text: letter -> step name + intent.
+  values:
+    D: define - Define requirements, criteria, or constraints
+    L: locate - Locate, discover, or find resources
+    P: prepare - Prepare, setup, or configure prerequisites
+    C: confirm - Confirm, verify, or validate conditions
+    E: execute - Execute, perform, or run the main action
+    M: monitor - Monitor, observe, or track progress
+    Y: modify - Modify, update, or adjust state
+    R: resolve - Resolve, fix, or handle issues
+    K: conclude - Conclude, complete, or finalize

--- a/src/atdd/planner/conventions/nodes/planner.wmbt.urn-naming.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.wmbt.urn-naming.convention.yaml
@@ -1,0 +1,31 @@
+schema_version: 1.1.0
+rule_id: planner.wmbt.urn-naming
+kind: rule
+status: active
+name: WMBT URN naming
+statement: A WMBT URN is wmbt:{wagon}:{STEP_CODE}{NNN} — a unique step-coded identifier built via URNBuilder.wmbt(wagon_id,
+  sequence).
+source:
+  legacy_path: src/atdd/planner/conventions/wmbt.convention.yaml
+  legacy_section: urn_naming
+  legacy_sha: 040256ed5588a6c7
+  extraction_mode: high_fidelity
+content:
+  normative_text: wagon = parent wagon (kebab-case); STEP_CODE = single step letter; NNN = three-digit
+    zero-padded sequence (001-999).
+  examples:
+  - wmbt:resolve-dilemmas:E001
+  - wmbt:burn-timebank:M045
+  - wmbt:user-mgmt:C023
+parity:
+  source_fragments_preserved: true
+  examples_preserved: true
+  implementation_preserved: false
+  fix_hint_preserved: false
+  reviewed_at: '2026-06-16'
+terms:
+- term_id: wmbt_urn
+  text: the WMBT identifier.
+  values:
+    pattern: ^wmbt:[a-z][a-z0-9-]*:[DLPCEMYRK][0-9]{3}$
+    sequence_range: 001-999

--- a/src/atdd/planner/schemas/author/convention-node.schema.json
+++ b/src/atdd/planner/schemas/author/convention-node.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "atdd:author:convention-node:1.0.0",
-  "title": "ATDD convention node (spec §5)",
+  "$id": "atdd:author:convention-node:1.1.0",
+  "title": "ATDD convention node (high-fidelity, spec §5 + parity migration)",
   "type": "object",
   "additionalProperties": true,
   "required": ["schema_version", "rule_id", "kind", "status", "statement", "terms"],
@@ -10,9 +10,69 @@
     "rule_id": {"type": "string", "pattern": "^[a-z][a-z0-9-]*(?:\\.[a-z][a-z0-9-]*)+$"},
     "kind": {"enum": ["family", "rule", "principle", "constraint", "exception", "pattern", "anti_pattern", "policy"]},
     "status": {"enum": ["draft", "active", "deprecated"]},
+    "name": {"type": "string"},
     "statement": {"type": "string", "minLength": 1},
     "rationale": {"type": "string"},
     "notes": {"type": "string"},
+    "implementation": {
+      "type": "object",
+      "description": "The executable that enforces/realizes this node. Today usually a validator; the layer is generic (cf. the extension Implementation layer).",
+      "properties": {
+        "type": {"enum": ["validator", "generator", "fixer", "reporter", "collector", "test"]},
+        "ref": {"type": "string", "description": "Verbatim from legacy `validator:` (module::test)."}
+      }
+    },
+
+    "source": {
+      "type": "object",
+      "description": "Provenance back to the legacy convention this node was atomized from.",
+      "properties": {
+        "legacy_path": {"type": "string"},
+        "legacy_section": {"type": "string"},
+        "legacy_rule_id": {"type": "string"},
+        "legacy_sha": {"type": "string"},
+        "extraction_mode": {"enum": ["high_fidelity", "summary"]}
+      }
+    },
+
+    "content": {
+      "type": "object",
+      "description": "The preserved legacy material (verbatim where possible).",
+      "properties": {
+        "summary": {"type": "string"},
+        "normative_text": {"type": "string"},
+        "operational_guidance": {"type": "string"},
+        "examples": {"type": "array"},
+        "counter_examples": {"type": "array"},
+        "constraints": {"type": "array"},
+        "exceptions": {"type": "array"},
+        "fix_hint": {"type": "string"}
+      }
+    },
+
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "aliases": {"type": "array", "items": {"type": "string"}},
+        "severity": {"type": "integer", "minimum": 1, "maximum": 4},
+        "disposition": {"enum": ["documentation-only", "advisory", "suppress-and-clean", "strict", "block"]},
+        "introduced_in": {"type": "string"},
+        "suppression_deadline": {"type": "string"}
+      }
+    },
+
+    "parity": {
+      "type": "object",
+      "description": "Audit trail that the legacy section was preserved at high fidelity.",
+      "properties": {
+        "source_fragments_preserved": {"type": "boolean"},
+        "examples_preserved": {"type": "boolean"},
+        "implementation_preserved": {"type": "boolean"},
+        "fix_hint_preserved": {"type": "boolean"},
+        "reviewed_at": {"type": "string"}
+      }
+    },
+
     "terms": {
       "type": "array",
       "minItems": 1,
@@ -22,7 +82,15 @@
         "properties": {
           "term_id": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
           "label": {"type": "string"},
-          "text": {"type": "string"}
+          "text": {"type": "string"},
+          "values": {"type": "object"},
+          "examples": {
+            "type": "object",
+            "properties": {
+              "positive": {"type": "array"},
+              "negative": {"type": "array"}
+            }
+          }
         }
       }
     }

--- a/src/atdd/planner/schemas/author/convention-node.schema.json
+++ b/src/atdd/planner/schemas/author/convention-node.schema.json
@@ -50,6 +50,20 @@
       }
     },
 
+    "bidirectional": {
+      "type": "array",
+      "description": "Coverage-style directional requirements, one entry per direction.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "direction": {"type": "string"},
+          "requirement": {"type": "string"},
+          "exceptions": {"type": "string"},
+          "validator": {"type": "string"}
+        }
+      }
+    },
+
     "metadata": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Closes #1110.

## High-fidelity re-atomization of all 9 planner conventions

The previous atomization (#1108) produced **low-fidelity stubs** — one-sentence summaries of each convention's `rules:` block, dropping examples, vocabularies, validator bindings, fix-hints, metadata, and (for 3 conventions) producing no nodes at all. This pass replaces them with **high-fidelity nodes** that preserve the legacy content.

### Results

| convention | before | after |
|---|---:|---:|
| acceptance | 2 | 17 |
| artifact-naming | 1 | 16 |
| wmbt | 2 | 12 |
| feature | 2 | 14 |
| wagon | 2 | 11 |
| theme | 5 | 6 |
| coverage | 4 | 6 |
| criteria | 1 | 6 |
| train | 0 | 18 |
| **total** | **~19 stubs** | **110 nodes** |

Plus **120 relationship edges** (intra- + cross-convention) authored through the `atdd author relationship` CLI.

### Schema → convention-node **v1.1.0**

Adds, all optional: `source` (legacy provenance: path/section/sha/extraction_mode), `content` (normative_text/examples/counter_examples/constraints/exceptions/fix_hint), `metadata` (aliases/severity/disposition/introduced_in), `parity` flags, top-level `implementation: {type, ref}` (the four-layer "Implementation" vocab), `bidirectional[]` (coverage rules' per-direction validators), and rich `terms` (`values` + positive/negative `examples`).

### Fidelity preserved
- Controlled vocabularies as term `values` (22 harness codes, 10 boundary kinds, the full component-weight table, 13 harness templates, the 5-theme taxonomy, 10 train theme-ranges, step codes, dimensions, lenses, …).
- Verbatim **fix-hints** + suppression syntax; **validator bindings** as `implementation` (incl. both per-direction validators on coverage rules).
- **source provenance** + **parity flags** on every node; legacy `*.convention.yaml` left untouched (still the source of truth until a consuming validator reads nodes).

### Verification
- Real-life smoke (`test_planner_atomization_smoke.py`): real CLI authoring + **referential integrity** over all 110 nodes / 120 edges + per-convention coverage + schema-1.1.0 provenance. It **caught a mistyped edge** mid-authoring.
- 254 tests + 250 planner validators green on every commit; no `atdd emergency` used (branch registered up front).

### Known item
The legacy **train** + **wagon** conventions still document the old 10-theme game taxonomy while **theme** locks the 5 canonical themes — that tension is recorded on the nodes; `train.theme-alignment → theme.must-be-canonical` governs at validation time. (Reconciled in the #951 co-land.)