### PR TITLE
chore(atdd): Restore Interim Manual Version Bump (#1173)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1,6 +1,18 @@
 version: '2.0'
 created: '2026-05-13'
 sessions:
+- id: '1173'
+  slug: restore-interim-manual-version-bump
+  file: null
+  issue_number: 1173
+  type: cleanup
+  status: INIT
+  created: '2026-06-21'
+  archived: null
+  branch: chore/restore-interim-manual-version-bump
+  wagon: govern-lifecycle
+  feature: feature:govern-lifecycle:enforce-smoke-refactor-phase-substrate
+  train: 0001-self-compliance-validate
 - id: '1169'
   slug: stop-instructing-manual-version-bump
   file: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -6,7 +6,7 @@ sessions:
   file: null
   issue_number: 1173
   type: cleanup
-  status: PLANNED
+  status: REFACTOR
   created: '2026-06-21'
   archived: null
   branch: chore/restore-interim-manual-version-bump

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -6,7 +6,7 @@ sessions:
   file: null
   issue_number: 1173
   type: cleanup
-  status: INIT
+  status: PLANNED
   created: '2026-06-21'
   archived: null
   branch: chore/restore-interim-manual-version-bump

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,18 +61,20 @@ git:
 # Release Gate (MANDATORY) — to move to release.convention.yaml per #916
 release:
   mandatory: true
-  # Version + tag + publish are FULLY AUTOMATED on merge. Do NOT bump the
-  # version or create tags by hand — CI does it.
+  # INTERIM (see #1172): bump the version manually for now. The bump-on-merge
+  # automation (post-merge-lifecycle.yml) is currently NON-OPERATIONAL — its
+  # direct push to main is rejected by branch protection (GH006), so it has
+  # never successfully bumped. Until version handling moves to the State Store
+  # (#1168 / #1172), manual bumping is the working mechanism.
   change_class:
     PATCH: "bug fixes, docs, refactors, internal changes"
     MINOR: "new feature, new validator, new command, new convention (non-breaking)"
     MAJOR: "breaking API/CLI/schema/convention change or behavior removal"
-  automation:
-    bump_on_merge: "post-merge-lifecycle.yml bumps pyproject version on main from the branch prefix (feat/→MINOR, fix|chore|docs|refactor|devops/→PATCH, 'BREAKING CHANGE' or '<type>!:'→MAJOR), atomically with retries."
-    tag_and_publish: "publish.yml tags the new version and publishes to PyPI once the bump lands on main."
-  do_not:
-    - "Do NOT edit pyproject.toml::version — a manual bump SKIPS the auto-bump (legacy path) and causes version-line merge conflicts with parallel PRs."
-    - "Do NOT create or push git tags — CI tags on publish."
+  workflow:
+    - "Bump version in pyproject.toml based on branch prefix + change class"
+    - "Commit: 'Bump version to {version}'"
+    - "Merge PR; publish.yml tags + publishes from the version on main"
+  note: "Durable fix tracked in #1172 (State Store owns version source-of-truth); do not re-adopt the auto-bump until it is operational."
 
 # Issue Tracking (operator-facing CLI + the prohibition list — gh issue create /
 # gh pr create are forbidden because they bypass `atdd-issue` label-scoped

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -61,18 +61,20 @@ git:
 # Release Gate (MANDATORY) — to move to release.convention.yaml per #916
 release:
   mandatory: true
-  # Version + tag + publish are FULLY AUTOMATED on merge. Do NOT bump the
-  # version or create tags by hand — CI does it.
+  # INTERIM (see #1172): bump the version manually for now. The bump-on-merge
+  # automation (post-merge-lifecycle.yml) is currently NON-OPERATIONAL — its
+  # direct push to main is rejected by branch protection (GH006), so it has
+  # never successfully bumped. Until version handling moves to the State Store
+  # (#1168 / #1172), manual bumping is the working mechanism.
   change_class:
     PATCH: "bug fixes, docs, refactors, internal changes"
     MINOR: "new feature, new validator, new command, new convention (non-breaking)"
     MAJOR: "breaking API/CLI/schema/convention change or behavior removal"
-  automation:
-    bump_on_merge: "post-merge-lifecycle.yml bumps pyproject version on main from the branch prefix (feat/→MINOR, fix|chore|docs|refactor|devops/→PATCH, 'BREAKING CHANGE' or '<type>!:'→MAJOR), atomically with retries."
-    tag_and_publish: "publish.yml tags the new version and publishes to PyPI once the bump lands on main."
-  do_not:
-    - "Do NOT edit pyproject.toml::version — a manual bump SKIPS the auto-bump (legacy path) and causes version-line merge conflicts with parallel PRs."
-    - "Do NOT create or push git tags — CI tags on publish."
+  workflow:
+    - "Bump version in pyproject.toml based on branch prefix + change class"
+    - "Commit: 'Bump version to {version}'"
+    - "Merge PR; publish.yml tags + publishes from the version on main"
+  note: "Durable fix tracked in #1172 (State Store owns version source-of-truth); do not re-adopt the auto-bump until it is operational."
 
 # Issue Tracking (operator-facing CLI + the prohibition list — gh issue create /
 # gh pr create are forbidden because they bypass `atdd-issue` label-scoped

--- a/GLM.md
+++ b/GLM.md
@@ -61,18 +61,20 @@ git:
 # Release Gate (MANDATORY) — to move to release.convention.yaml per #916
 release:
   mandatory: true
-  # Version + tag + publish are FULLY AUTOMATED on merge. Do NOT bump the
-  # version or create tags by hand — CI does it.
+  # INTERIM (see #1172): bump the version manually for now. The bump-on-merge
+  # automation (post-merge-lifecycle.yml) is currently NON-OPERATIONAL — its
+  # direct push to main is rejected by branch protection (GH006), so it has
+  # never successfully bumped. Until version handling moves to the State Store
+  # (#1168 / #1172), manual bumping is the working mechanism.
   change_class:
     PATCH: "bug fixes, docs, refactors, internal changes"
     MINOR: "new feature, new validator, new command, new convention (non-breaking)"
     MAJOR: "breaking API/CLI/schema/convention change or behavior removal"
-  automation:
-    bump_on_merge: "post-merge-lifecycle.yml bumps pyproject version on main from the branch prefix (feat/→MINOR, fix|chore|docs|refactor|devops/→PATCH, 'BREAKING CHANGE' or '<type>!:'→MAJOR), atomically with retries."
-    tag_and_publish: "publish.yml tags the new version and publishes to PyPI once the bump lands on main."
-  do_not:
-    - "Do NOT edit pyproject.toml::version — a manual bump SKIPS the auto-bump (legacy path) and causes version-line merge conflicts with parallel PRs."
-    - "Do NOT create or push git tags — CI tags on publish."
+  workflow:
+    - "Bump version in pyproject.toml based on branch prefix + change class"
+    - "Commit: 'Bump version to {version}'"
+    - "Merge PR; publish.yml tags + publishes from the version on main"
+  note: "Durable fix tracked in #1172 (State Store owns version source-of-truth); do not re-adopt the auto-bump until it is operational."
 
 # Issue Tracking (operator-facing CLI + the prohibition list — gh issue create /
 # gh pr create are forbidden because they bypass `atdd-issue` label-scoped

--- a/src/atdd/coach/templates/ATDD-ISSUE-TEMPLATE.md
+++ b/src/atdd/coach/templates/ATDD-ISSUE-TEMPLATE.md
@@ -351,29 +351,24 @@ Reference: src/atdd/coach/conventions/issue.convention.yaml
 
 ---
 
-## Release Gate (AUTOMATED)
+## Release Gate (MANDATORY)
 
 <!--
-Version + tag + publish are FULLY AUTOMATED on merge. Do NOT bump the version
-or create tags by hand.
+INTERIM (see #1172): bump the version manually for now. The bump-on-merge automation
+(post-merge-lifecycle.yml) is currently NON-OPERATIONAL — its direct push to
+main is rejected by branch protection (GH006), so it has never successfully
+bumped. Until version handling moves to the State Store (#1168 / #1172), manual
+bumping is the working mechanism. Do NOT re-adopt the auto-bump until it works.
 
-- post-merge-lifecycle.yml bumps pyproject version on main from the branch
-  prefix (feat/→MINOR, fix|chore|docs|refactor|devops/→PATCH,
-  "BREAKING CHANGE" or "<type>!:"→MAJOR), atomically with retries.
-- publish.yml tags the new version and publishes to PyPI once the bump lands on main.
-
-A manual pyproject.toml::version edit SKIPS the auto-bump (legacy path) and
-causes version-line merge conflicts with parallel PRs.
-
-Change Class (what the branch prefix maps to — for reference only):
+Change Class (branch prefix → bump):
 - PATCH: bug fixes, docs, refactors, internal changes
 - MINOR: new feature, new validator, new command, new convention (non-breaking)
 - MAJOR: breaking API/CLI/schema/convention change or behavior removal
 -->
 
-- [ ] Do NOT edit pyproject.toml::version — CI bumps it on merge from the branch prefix
-- [ ] Do NOT create or push git tags — CI tags + publishes after the bump lands on main
-- [ ] Merge PR → confirm the `chore(release): bump version … [auto]` commit appears on main
+- [ ] Determine change class from branch prefix: PATCH / MINOR / MAJOR
+- [ ] Bump the version in pyproject.toml; commit "Bump version to X.Y.Z"
+- [ ] Merge PR → publish.yml tags + publishes from the version on main
 
 ---
 

--- a/src/atdd/coach/templates/CONDUCTOR.md
+++ b/src/atdd/coach/templates/CONDUCTOR.md
@@ -59,18 +59,20 @@ git:
 # Release Gate (MANDATORY) — to move to release.convention.yaml per #916
 release:
   mandatory: true
-  # Version + tag + publish are FULLY AUTOMATED on merge. Do NOT bump the
-  # version or create tags by hand — CI does it.
+  # INTERIM (see #1172): bump the version manually for now. The bump-on-merge
+  # automation (post-merge-lifecycle.yml) is currently NON-OPERATIONAL — its
+  # direct push to main is rejected by branch protection (GH006), so it has
+  # never successfully bumped. Until version handling moves to the State Store
+  # (#1168 / #1172), manual bumping is the working mechanism.
   change_class:
     PATCH: "bug fixes, docs, refactors, internal changes"
     MINOR: "new feature, new validator, new command, new convention (non-breaking)"
     MAJOR: "breaking API/CLI/schema/convention change or behavior removal"
-  automation:
-    bump_on_merge: "post-merge-lifecycle.yml bumps pyproject version on main from the branch prefix (feat/→MINOR, fix|chore|docs|refactor|devops/→PATCH, 'BREAKING CHANGE' or '<type>!:'→MAJOR), atomically with retries."
-    tag_and_publish: "publish.yml tags the new version and publishes to PyPI once the bump lands on main."
-  do_not:
-    - "Do NOT edit pyproject.toml::version — a manual bump SKIPS the auto-bump (legacy path) and causes version-line merge conflicts with parallel PRs."
-    - "Do NOT create or push git tags — CI tags on publish."
+  workflow:
+    - "Bump version in pyproject.toml based on branch prefix + change class"
+    - "Commit: 'Bump version to {version}'"
+    - "Merge PR; publish.yml tags + publishes from the version on main"
+  note: "Durable fix tracked in #1172 (State Store owns version source-of-truth); do not re-adopt the auto-bump until it is operational."
 
 # Issue Tracking (operator-facing CLI + the prohibition list — gh issue create /
 # gh pr create are forbidden because they bypass `atdd-issue` label-scoped

--- a/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
+++ b/src/atdd/coach/templates/PARENT-ISSUE-TEMPLATE.md
@@ -171,17 +171,18 @@
 
 ---
 
-## Release Gate (AUTOMATED)
+## Release Gate
 
-Version + tag + publish are fully automated on merge — do NOT bump the version
-or tag by hand. CI (`post-merge-lifecycle.yml`) bumps the pyproject version on
-main from the branch prefix (feat/→MINOR, fix|chore|docs|refactor|devops/→PATCH,
-BREAKING/!:→MAJOR), then `publish.yml` tags the new version and publishes to PyPI.
-A manual version edit SKIPS the auto-bump and causes version-line merge conflicts.
+INTERIM (see #1172): bump the version manually for now. The bump-on-merge
+automation (`post-merge-lifecycle.yml`) is currently NON-OPERATIONAL — its direct
+push to main is rejected by branch protection (GH006), so it has never
+successfully bumped. Until version handling moves to the State Store (#1168 /
+#1172), manual bumping is the working mechanism. `publish.yml` tags + publishes
+from the version on main.
 
-- [ ] Do NOT edit pyproject.toml::version — CI bumps it on merge from the branch prefix
-- [ ] Do NOT create or push git tags — CI tags + publishes after the bump lands on main
-- [ ] Merge PR → confirm the `chore(release): bump version … [auto]` commit appears on main
+- [ ] Rebase on main: `git pull origin main --rebase`
+- [ ] Bump version (feat/ → MINOR, fix|chore|docs/ → PATCH): edit pyproject.toml, commit "Bump version to X.Y.Z"
+- [ ] Merge PR → publish.yml tags + publishes from the version on main
 
 ---
 


### PR DESCRIPTION
Closes #1173

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #1173 |
| Type | cleanup |
| Slug | restore-interim-manual-version-bump |
| Train | 0001-self-compliance-validate |
| Labels | atdd-issue, atdd:INIT |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.