### PR TITLE
feat(atdd): Distinguish Real Control Root From Scratch Atdd (#1179)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -2780,7 +2780,7 @@ sessions:
   file: null
   issue_number: 1179
   type: implementation
-  status: INIT
+  status: PLANNED
   train: 0002-coach-drives-lifecycle
   created: '2026-06-22'
   archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -2780,7 +2780,7 @@ sessions:
   file: null
   issue_number: 1179
   type: implementation
-  status: RED
+  status: GREEN
   train: 0002-coach-drives-lifecycle
   created: '2026-06-22'
   archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -2780,7 +2780,7 @@ sessions:
   file: null
   issue_number: 1179
   type: implementation
-  status: SMOKE
+  status: REFACTOR
   train: 0002-coach-drives-lifecycle
   created: '2026-06-22'
   archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -2775,6 +2775,16 @@ sessions:
   created: '2026-06-22'
   archived: null
   branch: feat/state-store-control-root-resolver
+- id: '1179'
+  slug: distinguish-real-control-root-from-scratch-atdd
+  file: null
+  issue_number: 1179
+  type: implementation
+  status: INIT
+  train: 0002-coach-drives-lifecycle
+  created: '2026-06-22'
+  archived: null
+  branch: feat/distinguish-real-control-root-from-scratch-atdd
 - id: '1147'
   slug: wagon-separability-granularity
   file: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -2780,7 +2780,7 @@ sessions:
   file: null
   issue_number: 1179
   type: implementation
-  status: PLANNED
+  status: RED
   train: 0002-coach-drives-lifecycle
   created: '2026-06-22'
   archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -2780,7 +2780,7 @@ sessions:
   file: null
   issue_number: 1179
   type: implementation
-  status: GREEN
+  status: SMOKE
   train: 0002-coach-drives-lifecycle
   created: '2026-06-22'
   archived: null

--- a/docs/specs/state-store.md
+++ b/docs/specs/state-store.md
@@ -75,12 +75,23 @@ Implemented in `src/atdd/state/paths.py::resolve_control_root`. Order:
 
 1. `ATDD_CONTROL_ROOT` override (if set).
 2. Find the enclosing Git worktree root (nearest `.git` walking upward).
-3. worktree has `.atdd/` and parent does not → **single-repo**.
-4. parent has `.atdd/` and current is a child worktree → **sibling-worktree**.
-5. both parent and worktree `.atdd/` exist → **fail loudly** (`AmbiguousControlRootError`).
-6. otherwise walk upward for any `.atdd/`; if none → `ControlRootNotFoundError`.
+3. worktree is a Control Root and parent is not → **single-repo**.
+4. parent is a Control Root and current is a child worktree → **sibling-worktree**.
+5. both parent and worktree are Control Roots → **fail loudly** (`AmbiguousControlRootError`).
+6. otherwise walk upward for a Control Root; if none → `ControlRootNotFoundError`.
 
 Output: `control_root`, `git_worktree_root`, `layout_mode`, `state_store_path`.
+
+### What counts as a Control Root (#1179)
+
+"Control Root" means an **initialized** `.atdd/`, not merely a `.atdd/`
+directory. `is_control_root(dir)` is true only when the `.atdd/` carries an
+initialized-root signal — a marker file (`control-root.yaml` / `config.yaml` /
+`manifest.yaml`) or the `state/` directory. A **scratch-only** `.atdd/` holding
+just `cache/` / `runtime/` / `diagnostics/` (`is_scratch_atdd(dir)`) is ignored:
+it never shadows a real worktree Control Root and never triggers a false
+ambiguity. This is what lets the resolver work correctly in the flat
+sibling-worktree dev layout (see below).
 
 ## Commands (Phase 1)
 
@@ -93,13 +104,17 @@ Output: `control_root`, `git_worktree_root`, `layout_mode`, `state_store_path`.
 `atdd state init` / `migrate-layout` and the SQLite schema are deferred to
 #1168 Phase 2+.
 
-## Known field observation (#1177)
+## Field observation + resolution (#1177 → #1179)
 
 The standard ATDD development setup uses **flat sibling worktrees** under a
 common parent (`~/Github/atdd/main`, `~/Github/atdd/feat-*`, …). Tools that run
-with the parent as cwd can leave a **stray parent `.atdd/`** (e.g. only
-`cache/`, `diagnostics/`, `runtime/`). Because every git-tracked worktree also
-ships a full `.atdd/`, the resolver then reports this parent+child pair as
-*ambiguous* — which is correct per rule 5, and surfaces a real split-brain risk
-to clean up. A future refinement may distinguish a *real* Control Root (one with
-`state/` or `manifest.yaml`) from tool scratch; tracked as a #1168 follow-up.
+with the parent as cwd leave a **stray parent `.atdd/`** holding only `cache/`,
+`diagnostics/`, `runtime/`. Because every git-tracked worktree also ships a full
+`.atdd/` (with `manifest.yaml`, `config.yaml`), the original #1177 resolver
+reported this parent+child pair as *ambiguous*.
+
+**Resolved in #1179:** the stray parent is scratch (no Control Root marker), so
+the resolver now ignores it and resolves each worktree as **single-repo**.
+`atdd state doctor` prints a `Note: ignored scratch .atdd at …` diagnostic
+rather than failing. The genuine split-brain case (two *initialized* `.atdd/`)
+still fails loudly per rule 5.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.127.1"
+version = "3.128.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/state/__init__.py
+++ b/src/atdd/state/__init__.py
@@ -33,6 +33,8 @@ from atdd.state.paths import (
     ControlRootResolution,
     LayoutMode,
     check_layout,
+    is_control_root,
+    is_scratch_atdd,
     resolve_control_root,
 )
 
@@ -42,5 +44,7 @@ __all__ = [
     "ControlRootResolution",
     "LayoutMode",
     "check_layout",
+    "is_control_root",
+    "is_scratch_atdd",
     "resolve_control_root",
 ]

--- a/src/atdd/state/cli.py
+++ b/src/atdd/state/cli.py
@@ -22,6 +22,7 @@ from atdd.state.paths import (
     ControlRootNotFoundError,
     ControlRootResolution,
     check_layout,
+    is_scratch_atdd,
     resolve_control_root,
 )
 
@@ -79,6 +80,13 @@ def _cmd_doctor(root: Optional[str]) -> int:
     print(f"Git Worktree Root:  {gwr if gwr is not None else '(none — not in a git worktree)'}")
     print(f"Layout Mode:        {resolution.layout_mode.value}")
     print(f"State Store:        {resolution.state_store_path}")
+
+    # Diagnose (do not fail on) a scratch .atdd/ at the worktree parent that the
+    # resolver ignored — e.g. a flat-worktree parent tools filled with
+    # cache/runtime/diagnostics (#1179).
+    parent = resolution.control_root.parent
+    if is_scratch_atdd(parent):
+        print(f"Note:               ignored scratch .atdd at {parent / '.atdd'} (no Control Root marker)")
 
     violations = check_layout(resolution.control_root)
     if violations:

--- a/src/atdd/state/paths.py
+++ b/src/atdd/state/paths.py
@@ -33,6 +33,17 @@ STATE_STORE_RELATIVE = Path(ATDD_DIR) / "state" / "state.sqlite"
 #: Env override for the Control Root (resolver rule #1).
 CONTROL_ROOT_ENV = "ATDD_CONTROL_ROOT"
 
+#: Initialized-Control-Root signals inside a ``.atdd/`` (#1179). A ``.atdd/`` is
+#: a *real* Control Root only if it carries one of these — an explicit marker
+#: file, ``config.yaml``, ``manifest.yaml``, or the ``state/`` directory.
+#: Anything else (a ``.atdd/`` holding only scratch such as
+#: ``cache/`` / ``runtime/`` / ``diagnostics/``) is tool scratch, NOT a root,
+#: and must not be treated as a parent Control Root by the resolver.
+CONTROL_ROOT_MARKER_FILES = ("control-root.yaml", "config.yaml", "manifest.yaml")
+CONTROL_ROOT_MARKER_DIRS = ("state",)
+#: Subdirectories that, alone, mark a ``.atdd/`` as scratch-only (diagnostic).
+SCRATCH_ATDD_DIRS = ("cache", "runtime", "diagnostics")
+
 
 class LayoutMode(str, Enum):
     """How the Control Root relates to the Git worktree root."""
@@ -92,7 +103,33 @@ class ControlRootResolution:
 
 
 def _has_atdd(directory: Path) -> bool:
+    """A ``.atdd/`` directory exists here (presence only — may be scratch)."""
     return (directory / ATDD_DIR).is_dir()
+
+
+def is_control_root(directory: Path) -> bool:
+    """True if ``directory`` holds an *initialized* ``.atdd/`` Control Root (#1179).
+
+    A bare or scratch-only ``.atdd/`` (e.g. just ``cache/``/``runtime/``/
+    ``diagnostics/``, as tools leave at a flat-worktree parent) is NOT a Control
+    Root — it lacks any initialized-root signal. This is what keeps the resolver
+    from mistaking tool scratch for a parent Control Root.
+    """
+    atdd = directory / ATDD_DIR
+    if not atdd.is_dir():
+        return False
+    if any((atdd / name).is_dir() for name in CONTROL_ROOT_MARKER_DIRS):
+        return True
+    return any((atdd / name).is_file() for name in CONTROL_ROOT_MARKER_FILES)
+
+
+def is_scratch_atdd(directory: Path) -> bool:
+    """True if ``directory`` has a ``.atdd/`` that exists but is not a Control Root.
+
+    Used for diagnostics (``atdd state doctor`` reports an ignored scratch
+    ``.atdd/`` rather than failing on it).
+    """
+    return _has_atdd(directory) and not is_control_root(directory)
 
 
 def git_worktree_root(start: Path) -> Optional[Path]:
@@ -121,10 +158,16 @@ def resolve_control_root(
 
     1. ``ATDD_CONTROL_ROOT`` override, if set.
     2. Identify the enclosing Git worktree root.
-    3. worktree has ``.atdd/`` and parent does not → single-repo.
-    4. parent has ``.atdd/`` and current is a child worktree → sibling-worktree.
-    5. both parent and worktree ``.atdd/`` exist → fail loudly.
-    6. otherwise walk upward for any ``.atdd/`` (best-effort fallback) else raise.
+    3. worktree is a Control Root and parent is not → single-repo.
+    4. parent is a Control Root and current is a child worktree → sibling-worktree.
+    5. both parent and worktree are Control Roots → fail loudly.
+    6. otherwise walk upward for a Control Root (best-effort fallback) else raise.
+
+    "Control Root" here means an *initialized* ``.atdd/`` (see
+    :func:`is_control_root`), not merely a ``.atdd/`` directory: a scratch-only
+    ``.atdd/`` (e.g. a flat-worktree parent that tools filled with
+    ``cache/``/``runtime/``/``diagnostics/``) is ignored, so it never shadows a
+    real worktree Control Root nor triggers a false ambiguity (#1179).
     """
     env = os.environ if env is None else env
     start = Path(start).resolve()
@@ -148,23 +191,28 @@ def resolve_control_root(
     # Rule 2 — locate the enclosing Git worktree root.
     gwr = git_worktree_root(start)
     if gwr is not None:
-        worktree_has = _has_atdd(gwr)
+        worktree_root = is_control_root(gwr)
         parent = gwr.parent
-        parent_has = _has_atdd(parent)
+        parent_root = is_control_root(parent)
 
-        # Rule 5 — ambiguous parent + child .atdd/.
-        if worktree_has and parent_has:
+        # Rule 5 — ambiguous: BOTH parent and worktree are real Control Roots.
+        if worktree_root and parent_root:
             raise AmbiguousControlRootError(parent / ATDD_DIR, gwr / ATDD_DIR)
-        # Rule 3 — single-repo.
-        if worktree_has:
+        # Rule 3 — single-repo (a scratch parent .atdd/ is ignored, #1179).
+        if worktree_root:
+            if is_scratch_atdd(parent):
+                _log.debug(
+                    "ignoring scratch .atdd at worktree parent",
+                    extra={"scratch_atdd": str(parent / ATDD_DIR), "control_root": str(gwr)},
+                )
             return ControlRootResolution(gwr, gwr, LayoutMode.SINGLE_REPO)
         # Rule 4 — sibling-worktree (parent owns the Control Root).
-        if parent_has:
+        if parent_root:
             return ControlRootResolution(parent, gwr, LayoutMode.SIBLING_WORKTREE)
 
-    # Rule 6 — fallback: walk upward for any .atdd/.
+    # Rule 6 — fallback: walk upward for an initialized Control Root.
     for directory in (start, *start.parents):
-        if _has_atdd(directory):
+        if is_control_root(directory):
             mode = (
                 LayoutMode.SINGLE_REPO
                 if gwr is not None and gwr == directory

--- a/src/atdd/state/tests/test_control_root_scratch.py
+++ b/src/atdd/state/tests/test_control_root_scratch.py
@@ -1,0 +1,150 @@
+# URN: test:state-store:control-root-resolver:scratch-vs-real
+# Issue: #1179 (#1168 follow-up; refines #1177)
+# Phase: GREEN
+# Layer: unit
+# Assertion: behavioral
+"""#1179 — distinguish a real Control Root from a scratch ``.atdd/``.
+
+A ``.atdd/`` is a Control Root only if it carries an initialized-root signal
+(``config.yaml`` / ``manifest.yaml`` / ``state/`` / an explicit marker). A
+scratch-only ``.atdd/`` (just ``cache/`` / ``runtime/`` / ``diagnostics/``, as
+tools leave at a flat-worktree parent) must be ignored — it must NOT shadow a
+real worktree Control Root nor trigger a false ambiguity. This is the bug the
+#1177 resolver exposed on the real flat-sibling-worktree dev environment.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from atdd.state import cli as state_cli
+from atdd.state.paths import (
+    AmbiguousControlRootError,
+    ControlRootNotFoundError,
+    LayoutMode,
+    is_control_root,
+    is_scratch_atdd,
+    resolve_control_root,
+)
+
+_SRC = Path(__file__).resolve().parents[3]
+
+
+def _mk_worktree(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".git").mkdir(exist_ok=True)
+    return path
+
+
+def _scratch_atdd(path: Path) -> Path:
+    """A .atdd/ with only tool scratch — NOT a Control Root."""
+    for d in ("cache", "runtime", "diagnostics"):
+        (path / ".atdd" / d).mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _real_atdd(path: Path, marker: str = "manifest.yaml") -> Path:
+    """A .atdd/ carrying an initialized-root signal."""
+    (path / ".atdd").mkdir(parents=True, exist_ok=True)
+    if marker == "state":
+        (path / ".atdd" / "state").mkdir(exist_ok=True)
+    else:
+        (path / ".atdd" / marker).write_text("x\n", encoding="utf-8")
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# Predicates
+# --------------------------------------------------------------------------- #
+def test_scratch_only_atdd_is_not_a_control_root(tmp_path):
+    d = _scratch_atdd(tmp_path / "parent")
+    assert is_control_root(d) is False
+    assert is_scratch_atdd(d) is True
+
+
+@pytest.mark.parametrize("marker", ["config.yaml", "manifest.yaml", "state", "control-root.yaml"])
+def test_control_root_recognized_by_any_marker(tmp_path, marker):
+    d = _real_atdd(tmp_path / f"root-{marker}", marker=marker)
+    assert is_control_root(d) is True
+    assert is_scratch_atdd(d) is False
+
+
+def test_absent_atdd_is_neither(tmp_path):
+    d = tmp_path / "empty"
+    d.mkdir()
+    assert is_control_root(d) is False
+    assert is_scratch_atdd(d) is False
+
+
+# --------------------------------------------------------------------------- #
+# Resolver behavior (the #1177-exposed bug + preserved cases)
+# --------------------------------------------------------------------------- #
+def test_resolver_ignores_scratch_parent_and_picks_worktree(tmp_path):
+    """The real dev-env case: scratch parent .atdd/ beside a real worktree .atdd/.
+
+    Before #1179 this raised AmbiguousControlRootError; now the scratch parent is
+    ignored and the worktree resolves cleanly as single-repo.
+    """
+    project = _scratch_atdd(tmp_path / "project")        # parent: scratch only
+    main = _real_atdd(_mk_worktree(project / "main"))     # child worktree: real .atdd/
+
+    res = resolve_control_root(main, env={})
+
+    assert res.layout_mode is LayoutMode.SINGLE_REPO
+    assert res.control_root == main
+    assert res.git_worktree_root == main
+
+
+def test_resolver_still_sibling_when_parent_is_real_control_root(tmp_path):
+    project = _real_atdd(tmp_path / "project")            # parent: real Control Root
+    main = _mk_worktree(project / "main")                 # child worktree: no .atdd/
+
+    res = resolve_control_root(main, env={})
+
+    assert res.layout_mode is LayoutMode.SIBLING_WORKTREE
+    assert res.control_root == project
+
+
+def test_resolver_ambiguous_only_when_both_are_real(tmp_path):
+    project = _real_atdd(tmp_path / "project")
+    main = _real_atdd(_mk_worktree(project / "main"))     # BOTH real → still ambiguous
+
+    with pytest.raises(AmbiguousControlRootError):
+        resolve_control_root(main, env={})
+
+
+def test_resolver_not_found_when_only_scratch_anywhere(tmp_path):
+    project = _scratch_atdd(tmp_path / "project")
+    main = _scratch_atdd(_mk_worktree(project / "main"))  # scratch both → no real root
+
+    with pytest.raises(ControlRootNotFoundError):
+        resolve_control_root(main, env={})
+
+
+# --------------------------------------------------------------------------- #
+# Doctor diagnostic + live smoke
+# --------------------------------------------------------------------------- #
+def test_doctor_reports_ignored_scratch_parent(tmp_path, capsys):
+    project = _scratch_atdd(tmp_path / "project")
+    main = _real_atdd(_mk_worktree(project / "main"))
+
+    rc = state_cli.run(["doctor", "--root", str(main)])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "single-repo" in out
+    assert "ignored scratch .atdd" in out
+
+
+def test_doctor_ignores_scratch_parent_live(tmp_path):
+    project = _scratch_atdd(tmp_path / "project")
+    main = _real_atdd(_mk_worktree(project / "main"))
+    env = {"PYTHONPATH": str(_SRC), "PATH": __import__("os").environ.get("PATH", ""),
+           "HOME": str(project), "CI": "true"}
+    r = subprocess.run([sys.executable, "-m", "atdd", "state", "doctor", "--root", str(main)],
+                       cwd=str(main), env=env, capture_output=True, text=True, timeout=60)
+    assert r.returncode == 0, r.stderr
+    assert "single-repo" in (r.stdout + r.stderr)

--- a/src/atdd/state/tests/test_paths.py
+++ b/src/atdd/state/tests/test_paths.py
@@ -38,7 +38,10 @@ def _mk_worktree(path: Path) -> Path:
 
 
 def _mk_atdd(path: Path) -> Path:
+    # A real Control Root needs an initialized-root marker (#1179): a bare .atdd/
+    # is now treated as scratch and ignored by the resolver.
     (path / ".atdd").mkdir(parents=True, exist_ok=True)
+    (path / ".atdd" / "config.yaml").write_text("x\n", encoding="utf-8")
     return path
 
 

--- a/src/atdd/state/tests/test_state_cli_live.py
+++ b/src/atdd/state/tests/test_state_cli_live.py
@@ -36,7 +36,9 @@ def _mk_worktree(path: Path) -> Path:
 
 
 def _mk_atdd(path: Path) -> Path:
+    # Real Control Root needs an initialized-root marker (#1179).
     (path / ".atdd").mkdir(parents=True, exist_ok=True)
+    (path / ".atdd" / "config.yaml").write_text("x\n", encoding="utf-8")
     return path
 
 


### PR DESCRIPTION
Closes #1179

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #1179 |
| Type | implementation |
| Slug | distinguish-real-control-root-from-scratch-atdd |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd-issue, archetype:be, atdd:INIT, archetype:planner |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.