### PR TITLE
feat(atdd): State Store Github Provider Sync (#1184)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -2815,6 +2815,16 @@ sessions:
   created: '2026-06-22'
   archived: null
   branch: feat/state-store-manifest-import-and-compatibility
+- id: '1184'
+  slug: state-store-github-provider-sync
+  file: null
+  issue_number: 1184
+  type: implementation
+  status: INIT
+  train: 0002-coach-drives-lifecycle
+  created: '2026-06-22'
+  archived: null
+  branch: feat/state-store-github-provider-sync
 - id: '1147'
   slug: wagon-separability-granularity
   file: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -2820,7 +2820,7 @@ sessions:
   file: null
   issue_number: 1184
   type: implementation
-  status: INIT
+  status: REFACTOR
   train: 0002-coach-drives-lifecycle
   created: '2026-06-22'
   archived: null

--- a/docs/specs/state-store.md
+++ b/docs/specs/state-store.md
@@ -152,6 +152,27 @@ Read-side **projections** (`src/atdd/state/projections.py`) are pure reads
 
 GitHub sync (Phase 5, #1184) builds on these APIs.
 
+## GitHub provider sync (Phase 5, #1184)
+
+`atdd state sync` bridges the State Store (operational truth) and GitHub
+(external side-effect truth) through the `outbox` / `inbox` queues and
+`external_refs` — implemented in `src/atdd/integrations/github/state_sync.py`
+(the integrations layer imports `atdd.state`; never the reverse — enforced by
+the `atdd.state` entry added to the layer-imports architecture gate).
+
+- **push** (`--push`) drains the `outbox` (local → GitHub): `create_issue` /
+  `add_label` / `comment`, each dispatched to a `GitHubClient`. A created issue
+  is recorded back as an `external_ref`. A failed op leaves its message
+  **pending** (retryable); failures are isolated per message.
+- **apply** (default) drains the `inbox` (GitHub → local): `issue_state` folds a
+  remote state change onto the linked work item (resolved via its
+  `external_ref`); `issue_imported` upserts a new work item + ref.
+
+The `GitHubClient` is a Protocol so tests inject a fake (no live `gh` in CI); the
+real `GhCliClient` shells to `gh`. `atdd state sync` applies the inbox and
+reports pending outbox by default; `--push` performs the real GitHub writes;
+`--dry-run` reports without mutating.
+
 ## Manifest import (Phase 4, #1183)
 
 `atdd state import-manifest` reads the `.atdd/manifest.yaml` `sessions` ledger and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.131.0"
+version = "3.132.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/cli.py
+++ b/src/atdd/cli.py
@@ -2597,10 +2597,17 @@ Phase descriptions:
         from atdd.planner.commands.author import run as run_author
         return run_author(list(getattr(args, "author_argv", []) or []))
 
-    # atdd state <doctor|layout --check> ...  (#1168 Phase 1 — #1177)
+    # atdd state <doctor|layout|init|import-manifest|sync> ...  (#1168)
     elif args.command == "state":
+        state_argv = list(getattr(args, "state_argv", []) or [])
+        # `state sync` bridges to GitHub, so it lives in the integrations layer and
+        # is routed here (the composition root) — keeping atdd.state itself free of
+        # any atdd.integrations import (foundational-layer discipline, #1184).
+        if state_argv and state_argv[0] == "sync":
+            from atdd.integrations.github.state_sync import run_sync_cli
+            return run_sync_cli(state_argv[1:])
         from atdd.state.cli import run as run_state
-        return run_state(list(getattr(args, "state_argv", []) or []))
+        return run_state(state_argv)
 
     # atdd plan <source> ... (PLAN-1 — #758)
     elif args.command == "plan":

--- a/src/atdd/integrations/github/state_sync.py
+++ b/src/atdd/integrations/github/state_sync.py
@@ -1,0 +1,197 @@
+"""State Store ⇄ GitHub provider sync (#1168 Phase 5, #1184).
+
+Bridges the local State Store (operational truth) with GitHub (external
+side-effect truth) through the `outbox` / `inbox` queues and `external_refs`:
+
+- **push** drains the `outbox` (local → GitHub): create issue / add label /
+  comment, each dispatched to a :class:`GitHubClient`; a created issue is
+  recorded back as an `external_ref`.
+- **apply** drains the `inbox` (GitHub → local): apply imported issue state to
+  the linked work item via its `external_ref`.
+
+The client is a Protocol so tests inject a fake — no live GitHub in CI. The real
+:class:`GhCliClient` shells to ``gh`` via :func:`atdd.integrations.github._gh.run_gh`.
+
+Layer direction: this module lives in ``atdd.integrations.github`` and imports
+``atdd.state`` (allowed). ``atdd.state`` never imports back (foundational layer).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Protocol, Sequence
+
+from atdd.integrations.github._gh import run_gh
+from atdd.state.db import connect, init_state_store
+from atdd.state.paths import resolve_control_root
+from atdd.state.store import StateStore
+
+_log = logging.getLogger(__name__)
+
+GITHUB_PROVIDER = "github"
+
+
+class GitHubClient(Protocol):
+    """Minimal GitHub operations the outbox dispatches to."""
+
+    def create_issue(self, title: str, body: str, labels: Sequence[str]) -> str:
+        """Create an issue; return its number as a string."""
+
+    def add_label(self, issue_number: str, label: str) -> None: ...
+
+    def add_comment(self, issue_number: str, body: str) -> None: ...
+
+
+class GhCliClient:
+    """Real :class:`GitHubClient` backed by the ``gh`` CLI (not used in tests)."""
+
+    def create_issue(self, title: str, body: str, labels: Sequence[str]) -> str:
+        args = ["issue", "create", "--title", title, "--body", body]
+        for label in labels:
+            args += ["--label", label]
+        url = run_gh(args)
+        return url.rstrip("/").rsplit("/", 1)[-1]  # trailing path segment = issue number
+
+    def add_label(self, issue_number: str, label: str) -> None:
+        run_gh(["issue", "edit", str(issue_number), "--add-label", label])
+
+    def add_comment(self, issue_number: str, body: str) -> None:
+        run_gh(["issue", "comment", str(issue_number), "--body", body])
+
+
+@dataclass
+class PushResult:
+    pending: int
+    pushed: int
+    failed: int
+    errors: List[str] = field(default_factory=list)
+
+
+@dataclass
+class ApplyResult:
+    pending: int
+    applied: int
+    skipped: int
+    notes: List[str] = field(default_factory=list)
+
+
+def push_outbox(store: StateStore, client: GitHubClient, *, dry_run: bool = False) -> PushResult:
+    """Drain the outbox to GitHub. A message stays pending if its op fails."""
+    pending = store.sync.pending_outbox()
+    pushed = failed = 0
+    errors: List[str] = []
+    for msg in pending:
+        if dry_run:
+            continue
+        try:
+            _dispatch_outbox(store, client, msg)
+            store.sync.mark_sent(msg.id)  # noqa: N+1 — one provider op per queued message
+            pushed += 1
+        except Exception as exc:  # noqa: BLE001 — per-message isolation; one failure must not abort the drain
+            failed += 1
+            errors.append(f"outbox#{msg.id} {msg.operation}: {exc}")
+            _log.warning("outbox push failed",
+                         extra={"outbox_id": msg.id, "operation": msg.operation, "error": str(exc)})
+    return PushResult(pending=len(pending), pushed=pushed, failed=failed, errors=errors)
+
+
+def _dispatch_outbox(store: StateStore, client: GitHubClient, msg) -> None:
+    op, p = msg.operation, msg.payload
+    if op == "create_issue":
+        number = client.create_issue(p.get("title", ""), p.get("body", ""), p.get("labels", []) or [])
+        object_uid = p.get("object_uid")
+        if object_uid:
+            store.external_refs.link(object_uid, GITHUB_PROVIDER, "issue", str(number),
+                                     data={"source": "outbox-create"})
+    elif op == "add_label":
+        client.add_label(str(p["issue_number"]), p["label"])
+    elif op == "comment":
+        client.add_comment(str(p["issue_number"]), p.get("body", ""))
+    else:
+        raise ValueError(f"unknown outbox operation: {op!r}")
+
+
+def apply_inbox(store: StateStore, *, dry_run: bool = False) -> ApplyResult:
+    """Drain the inbox (GitHub → local), applying each event to local state."""
+    pending = store.sync.pending_inbox()
+    applied = skipped = 0
+    notes: List[str] = []
+    for msg in pending:
+        kind = msg.payload.get("kind")
+        try:
+            handled = _apply_inbox_message(store, msg)
+        except Exception as exc:  # noqa: BLE001 — per-message isolation
+            skipped += 1
+            notes.append(f"inbox#{msg.id} {kind}: {exc}")
+            continue
+        if handled:
+            applied += 1
+        else:
+            skipped += 1
+            notes.append(f"inbox#{msg.id}: {kind} not applicable (no local object?)")
+        if not dry_run:
+            store.sync.mark_processed(msg.id)  # noqa: N+1 — one event per queued message
+    return ApplyResult(pending=len(pending), applied=applied, skipped=skipped, notes=notes)
+
+
+def _apply_inbox_message(store: StateStore, msg) -> bool:
+    """Return True if the message changed local state."""
+    p = msg.payload
+    kind = p.get("kind")
+    if kind == "issue_state":
+        ref = store.external_refs.resolve(GITHUB_PROVIDER, "issue", str(p["issue_number"]))
+        if ref is None:
+            return False
+        store.objects.set_state(ref.object_uid, p.get("state"))
+        return True
+    if kind == "issue_imported":
+        uid = p.get("slug") or f"github-issue-{p['issue_number']}"
+        store.objects.upsert(uid, "work_item", state=p.get("state"),
+                             data={"title": p.get("title")})
+        store.external_refs.link(uid, GITHUB_PROVIDER, "issue", str(p["issue_number"]),
+                                 data={"source": "inbox-import"})
+        return True
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry — routed from `atdd state sync` by the top-level cli.py.
+# --------------------------------------------------------------------------- #
+def run_sync_cli(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="atdd state sync",
+        description="Sync the State Store with GitHub via outbox/inbox (#1184).",
+    )
+    parser.add_argument("--root", default=None, help="Starting directory (default: cwd).")
+    parser.add_argument("--push", action="store_true",
+                        help="Actually push the outbox to GitHub (default: report only).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Report pending work without mutating local or remote state.")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    start = Path(args.root).resolve() if args.root else Path.cwd()
+    resolution = resolve_control_root(start)
+    db_path = init_state_store(start=resolution.control_root)
+
+    conn = connect(db_path)
+    try:
+        store = StateStore(conn)
+        applied = apply_inbox(store, dry_run=args.dry_run)
+        print(f"inbox: {applied.applied} applied, {applied.skipped} skipped (of {applied.pending} pending)")
+        for n in applied.notes:
+            print(f"  - {n}")
+
+        if args.push:
+            pushed = push_outbox(store, GhCliClient(), dry_run=args.dry_run)
+            print(f"outbox: {pushed.pushed} pushed, {pushed.failed} failed (of {pushed.pending} pending)")
+            for e in pushed.errors:
+                print(f"  - {e}")
+            return 1 if pushed.failed else 0
+        pending = len(store.sync.pending_outbox())
+        print(f"outbox: {pending} pending (pass --push to send to GitHub)")
+        return 0
+    finally:
+        conn.close()

--- a/src/atdd/integrations/github/tests/test_state_sync.py
+++ b/src/atdd/integrations/github/tests/test_state_sync.py
@@ -1,0 +1,145 @@
+# URN: test:state-store:github-sync:outbox-push-and-inbox-apply
+# Issue: #1184 (#1168 Phase 5)
+# Phase: GREEN
+# Layer: unit
+# Assertion: behavioral
+"""#1184 — State Store ⇄ GitHub provider sync (outbox push / inbox apply).
+
+Uses a fake GitHubClient (no live `gh`): pushing the outbox dispatches the right
+client ops, records a created issue as an external_ref, and marks messages sent;
+a failing op leaves its message pending. Applying the inbox folds GitHub issue
+state onto the linked work item and imports new issues.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atdd.integrations.github.state_sync import apply_inbox, push_outbox
+from atdd.state.db import connect, init_state_store
+from atdd.state.store import StateStore
+
+
+class FakeGitHubClient:
+    def __init__(self, *, fail_on=None, next_number="500"):
+        self.calls = []
+        self._fail_on = fail_on
+        self._next_number = next_number
+
+    def create_issue(self, title, body, labels):
+        self.calls.append(("create_issue", title, tuple(labels)))
+        if self._fail_on == "create_issue":
+            raise RuntimeError("gh boom")
+        return self._next_number
+
+    def add_label(self, issue_number, label):
+        self.calls.append(("add_label", issue_number, label))
+        if self._fail_on == "add_label":
+            raise RuntimeError("gh boom")
+
+    def add_comment(self, issue_number, body):
+        self.calls.append(("add_comment", issue_number, body))
+
+
+@pytest.fixture()
+def store(tmp_path):
+    db = init_state_store(db_path=tmp_path / ".atdd" / "state" / "state.sqlite")
+    conn = connect(db)
+    try:
+        yield StateStore(conn)
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Outbox push (local → GitHub)
+# --------------------------------------------------------------------------- #
+def test_push_create_issue_records_external_ref(store):
+    store.objects.upsert("wi-1", "work_item", state="INIT")
+    store.sync.enqueue_outbox("github", "create_issue",
+                              {"object_uid": "wi-1", "title": "do it", "labels": ["atdd-issue"]})
+    client = FakeGitHubClient(next_number="777")
+
+    result = push_outbox(store, client)
+
+    assert result.pushed == 1 and result.failed == 0
+    assert ("create_issue", "do it", ("atdd-issue",)) in client.calls
+    ref = store.external_refs.resolve("github", "issue", "777")
+    assert ref is not None and ref.object_uid == "wi-1"
+    assert store.sync.pending_outbox() == []          # marked sent
+
+
+def test_push_dispatches_label_and_comment(store):
+    store.sync.enqueue_outbox("github", "add_label", {"issue_number": 42, "label": "atdd:RED"})
+    store.sync.enqueue_outbox("github", "comment", {"issue_number": 42, "body": "hi"})
+
+    result = push_outbox(store, (client := FakeGitHubClient()))
+
+    assert result.pushed == 2
+    assert ("add_label", "42", "atdd:RED") in client.calls
+    assert ("add_comment", "42", "hi") in client.calls
+
+
+def test_push_failure_leaves_message_pending(store):
+    store.sync.enqueue_outbox("github", "create_issue", {"object_uid": "wi-1", "title": "x"})
+    store.objects.upsert("wi-1", "work_item")
+
+    result = push_outbox(store, FakeGitHubClient(fail_on="create_issue"))
+
+    assert result.pushed == 0 and result.failed == 1 and result.errors
+    assert len(store.sync.pending_outbox()) == 1       # NOT marked sent → retryable
+
+
+def test_push_dry_run_sends_nothing(store):
+    store.sync.enqueue_outbox("github", "comment", {"issue_number": 1, "body": "x"})
+    result = push_outbox(store, (client := FakeGitHubClient()), dry_run=True)
+    assert result.pushed == 0 and client.calls == []
+    assert len(store.sync.pending_outbox()) == 1
+
+
+def test_push_unknown_operation_is_isolated_failure(store):
+    store.sync.enqueue_outbox("github", "frobnicate", {})
+    result = push_outbox(store, FakeGitHubClient())
+    assert result.failed == 1 and "unknown outbox operation" in result.errors[0]
+
+
+# --------------------------------------------------------------------------- #
+# Inbox apply (GitHub → local)
+# --------------------------------------------------------------------------- #
+def test_apply_issue_state_updates_linked_work_item(store):
+    store.objects.upsert("wi-1", "work_item", state="RED")
+    store.external_refs.link("wi-1", "github", "issue", "900")
+    store.sync.enqueue_inbox("github", {"kind": "issue_state", "issue_number": 900, "state": "COMPLETE"})
+
+    result = apply_inbox(store)
+
+    assert result.applied == 1
+    assert store.objects.get("wi-1").state == "COMPLETE"
+    assert store.sync.pending_inbox() == []           # marked processed
+
+
+def test_apply_issue_state_without_local_object_is_skipped(store):
+    store.sync.enqueue_inbox("github", {"kind": "issue_state", "issue_number": 999, "state": "X"})
+    result = apply_inbox(store)
+    assert result.applied == 0 and result.skipped == 1
+
+
+def test_apply_issue_imported_creates_work_item_and_ref(store):
+    store.sync.enqueue_inbox("github", {"kind": "issue_imported", "issue_number": 123,
+                                        "slug": "imported-thing", "title": "T", "state": "INIT"})
+    result = apply_inbox(store)
+    assert result.applied == 1
+    assert store.objects.get("imported-thing").data["title"] == "T"
+    assert store.external_refs.resolve("github", "issue", "123").object_uid == "imported-thing"
+
+
+def test_apply_dry_run_leaves_inbox_pending(store):
+    store.objects.upsert("wi-1", "work_item", state="RED")
+    store.external_refs.link("wi-1", "github", "issue", "900")
+    store.sync.enqueue_inbox("github", {"kind": "issue_state", "issue_number": 900, "state": "GREEN"})
+
+    apply_inbox(store, dry_run=True)
+
+    assert store.objects.get("wi-1").state == "GREEN"   # state change applied...
+    assert len(store.sync.pending_inbox()) == 1         # ...but not marked processed (dry-run)

--- a/tests/architecture/test_layer_imports.py
+++ b/tests/architecture/test_layer_imports.py
@@ -53,6 +53,11 @@ FORBIDDEN_BY_LAYER = {
     "atdd.integrations.github": {
         "atdd.coach", "atdd.train", "atdd.runtime",
     },
+    # ATDD State Store (#1168) is the foundational operational-data layer: it may
+    # be imported by higher layers but must never import them (#1184 hardening).
+    "atdd.state": {
+        "atdd.coach", "atdd.train", "atdd.integrations", "atdd.runtime", "atdd.observer",
+    },
 }
 
 


### PR DESCRIPTION
Phase 5 of the ATDD State Store (#1168): GitHub provider sync via outbox/inbox + external_refs.

State Store (operational truth) <-> GitHub (side-effect truth) bridge in src/atdd/integrations/github/state_sync.py: push_outbox (create_issue/add_label/comment; created issue recorded as external_ref; failed op stays pending), apply_inbox (issue_state folds onto linked work item; issue_imported upserts). `atdd state sync` routed from cli.py so atdd.state stays integrations-free; layer-imports gate hardened to make atdd.state a foundational layer.

All gates green locally (architecture/coder/tester/planner/coach 720). PR opened via REST (GraphQL quota exhausted).

Closes #1184