### PR TITLE
feat(atdd): Atomize Core Coder Conventions (#1218)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3077,3 +3077,12 @@ sessions:
   created: '2026-06-25'
   archived: null
   branch: feat/atomize-tester-acceptance-violation
+- id: '1218'
+  slug: atomize-coder-shared-nodes
+  file: null
+  issue_number: 1218
+  type: migration
+  status: INIT
+  created: '2026-06-25'
+  archived: null
+  branch: feat/atomize-coder-shared-nodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.135.4"
+version = "3.135.5"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -1854,6 +1854,33 @@ edges:
   strength: important
   target_ref: coder.backend.imports-respect-dependency-allowed
   type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: pure-value tokens are the base of the design-system dependency flow
+  source_ref: coder.design.tokens-are-pure-values
+  strength: important
+  target_ref: coder.design.dependency-flow-tokens-primitives
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the design-system one-way flow is a specialization of the inward dependency-direction principle
+  source_ref: coder.design.dependency-flow-tokens-primitives
+  strength: important
+  target_ref: coder.backend.imports-respect-dependency-allowed
+  type: refines
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: wagons->design_system one-way import is a specialization of the inward dependency-direction principle
+  source_ref: coder.design.wagons-import-from-design
+  strength: important
+  target_ref: coder.backend.imports-respect-dependency-allowed
+  type: refines
 graph_id: atdd.convention.relationships
 kind: relationship_graph
 schema_version: 1.0.0

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -1845,6 +1845,15 @@ edges:
   strength: minor
   target_ref: coder.technology.unapproved-technology-choices-require
   type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: the 4-layer organization is realized by the inward dependency-direction rule
+  source_ref: coder.backend.code-is-organized
+  strength: important
+  target_ref: coder.backend.imports-respect-dependency-allowed
+  type: runs_alongside
 graph_id: atdd.convention.relationships
 kind: relationship_graph
 schema_version: 1.0.0

--- a/src/atdd/coder/conventions/backend.convention.yaml
+++ b/src/atdd/coder/conventions/backend.convention.yaml
@@ -10,23 +10,14 @@ description: "Layer catalog and component suffixes for backend implementation."
 # the testable invariants implied by those structures so the registry walker
 # can reconcile them against validator-emitted Violation rule_ids.
 rules:
-  - id: "coder.backend.code-is-organized"
-    aliases: ["BOUNDARIES-LAYER-001"]
-    severity: 3
-    disposition: documentation-only
-    description: "Backend code is organized into 4 layers: presentation, application, integration, domain"
-    introduced_in: "1.66.0"
+  # coder.backend.code-is-organized and coder.backend.imports-respect-dependency-allowed
+  # (the canonical dependency-direction node) were atomized into single-node files under
+  # conventions/nodes/ (Phase A). The extension-bound component-file-suffix rule stays here.
   - id: "coder.backend.component-file-suffix-matches"
     aliases: ["BOUNDARIES-LAYER-002"]
     severity: 3
     disposition: documentation-only
     description: "Component file suffix matches its layer's component_type catalog (e.g. *_controller.py for presentation.controllers)"
-    introduced_in: "1.66.0"
-  - id: "coder.backend.imports-respect-dependency-allowed"
-    aliases: ["BOUNDARIES-LAYER-003"]
-    severity: 3
-    disposition: documentation-only
-    description: "Imports respect dependency.allowed_edges (presentation→application→domain; integration→application→domain)"
     introduced_in: "1.66.0"
 
 backend:

--- a/src/atdd/coder/conventions/design.convention.yaml
+++ b/src/atdd/coder/conventions/design.convention.yaml
@@ -12,24 +12,10 @@ design_system:
   # grammar. The legacy DS-NN/AP-DS-NN entries below are preserved verbatim
   # — renaming is out of scope (Out-of-Scope per issue #389).
   rules:
-    - id: "coder.design.tokens-are-pure-values"
-      aliases: ["DESIGN-HIERARCHY-001"]
-      severity: 3
-      disposition: documentation-only
-      description: "Tokens are pure values — no widgets, no logic (mirrors principles.DS-01)"
-      introduced_in: "1.66.0"
-    - id: "coder.design.dependency-flow-tokens-primitives"
-      aliases: ["DESIGN-HIERARCHY-002"]
-      severity: 3
-      disposition: documentation-only
-      description: "Dependency flow: tokens ← primitives ← components ← templates (mirrors principles.DS-05)"
-      introduced_in: "1.66.0"
-    - id: "coder.design.wagons-import-from-design"
-      aliases: ["DESIGN-HIERARCHY-003"]
-      severity: 3
-      disposition: documentation-only
-      description: "Wagons import from design_system; design_system never imports from wagons (mirrors principles.DS-06)"
-      introduced_in: "1.66.0"
+    # The 3 stack-neutral design-hierarchy principles (tokens-are-pure-values,
+    # dependency-flow-tokens-primitives, wagons-import-from-design) were atomized into
+    # single-node files under conventions/nodes/ (Phase A). The Flutter-specific
+    # extract/detector rules below stay here for the extension migration.
     - id: "coder.design.extract-to-design-system"
       aliases: ["DESIGN-HIERARCHY-004"]
       severity: 2

--- a/src/atdd/coder/conventions/nodes/coder.backend.code-is-organized.convention.yaml
+++ b/src/atdd/coder/conventions/nodes/coder.backend.code-is-organized.convention.yaml
@@ -1,0 +1,23 @@
+schema_version: 1.0.0
+rule_id: coder.backend.code-is-organized
+kind: rule
+status: active
+name: Backend code is organized into 4 layers
+statement: 'Backend code is organized into 4 layers: presentation, application, integration,
+  domain'
+terms:
+- term_id: layers
+  text: the four backend layers presentation, application, integration, domain
+source:
+  legacy_path: src/atdd/coder/conventions/backend.convention.yaml
+  legacy_section: rules
+  legacy_rule_id: coder.backend.code-is-organized
+  extraction_mode: high_fidelity
+content:
+  summary: 4-layer backend architecture (stack-neutral)
+metadata:
+  severity: 3
+  disposition: documentation-only
+  aliases:
+  - BOUNDARIES-LAYER-001
+  introduced_in: 1.66.0

--- a/src/atdd/coder/conventions/nodes/coder.backend.imports-respect-dependency-allowed.convention.yaml
+++ b/src/atdd/coder/conventions/nodes/coder.backend.imports-respect-dependency-allowed.convention.yaml
@@ -1,0 +1,25 @@
+schema_version: 1.0.0
+rule_id: coder.backend.imports-respect-dependency-allowed
+kind: rule
+status: active
+name: Imports respect the allowed dependency direction
+statement: Imports respect dependency.allowed_edges (presentation->application->domain;
+  integration->application->domain)
+terms:
+- term_id: dependency_direction
+  text: 'the canonical inward dependency rule: outer layers may import inner, never
+    the reverse'
+source:
+  legacy_path: src/atdd/coder/conventions/backend.convention.yaml
+  legacy_section: rules
+  legacy_rule_id: coder.backend.imports-respect-dependency-allowed
+  extraction_mode: high_fidelity
+content:
+  summary: canonical inward dependency-direction principle (SHARED node referenced
+    by commons/composition/train/design)
+metadata:
+  severity: 3
+  disposition: documentation-only
+  aliases:
+  - BOUNDARIES-LAYER-003
+  introduced_in: 1.66.0

--- a/src/atdd/coder/conventions/nodes/coder.design.dependency-flow-tokens-primitives.convention.yaml
+++ b/src/atdd/coder/conventions/nodes/coder.design.dependency-flow-tokens-primitives.convention.yaml
@@ -1,0 +1,23 @@
+schema_version: 1.0.0
+rule_id: coder.design.dependency-flow-tokens-primitives
+kind: rule
+status: active
+name: Design-system dependency flow is one-way
+statement: 'Dependency flow: tokens <- primitives <- components <- templates (mirrors
+  principles.DS-05)'
+terms:
+- term_id: design_flow
+  text: the one-way design-system layering tokens<-primitives<-components<-templates
+source:
+  legacy_path: src/atdd/coder/conventions/design.convention.yaml
+  legacy_section: rules
+  legacy_rule_id: coder.design.dependency-flow-tokens-primitives
+  extraction_mode: high_fidelity
+content:
+  summary: design-system hierarchy principle (stack-neutral)
+metadata:
+  severity: 3
+  disposition: documentation-only
+  aliases:
+  - DESIGN-HIERARCHY-002
+  introduced_in: 1.66.0

--- a/src/atdd/coder/conventions/nodes/coder.design.tokens-are-pure-values.convention.yaml
+++ b/src/atdd/coder/conventions/nodes/coder.design.tokens-are-pure-values.convention.yaml
@@ -1,0 +1,23 @@
+schema_version: 1.0.0
+rule_id: coder.design.tokens-are-pure-values
+kind: rule
+status: active
+name: Design tokens are pure values
+statement: "Tokens are pure values \u2014 no widgets, no logic (mirrors principles.DS-01)"
+terms:
+- term_id: tokens
+  text: 'design tokens: pure values (spacing/radii/motion) carrying no widgets or
+    logic'
+source:
+  legacy_path: src/atdd/coder/conventions/design.convention.yaml
+  legacy_section: rules
+  legacy_rule_id: coder.design.tokens-are-pure-values
+  extraction_mode: high_fidelity
+content:
+  summary: design-system hierarchy principle (stack-neutral)
+metadata:
+  severity: 3
+  disposition: documentation-only
+  aliases:
+  - DESIGN-HIERARCHY-001
+  introduced_in: 1.66.0

--- a/src/atdd/coder/conventions/nodes/coder.design.wagons-import-from-design.convention.yaml
+++ b/src/atdd/coder/conventions/nodes/coder.design.wagons-import-from-design.convention.yaml
@@ -1,0 +1,23 @@
+schema_version: 1.0.0
+rule_id: coder.design.wagons-import-from-design
+kind: rule
+status: active
+name: Wagons import from the design system, never the reverse
+statement: Wagons import from design_system; design_system never imports from wagons
+  (mirrors principles.DS-06)
+terms:
+- term_id: design_boundary
+  text: 'the one-way boundary: wagons depend on design_system, never the reverse'
+source:
+  legacy_path: src/atdd/coder/conventions/design.convention.yaml
+  legacy_section: rules
+  legacy_rule_id: coder.design.wagons-import-from-design
+  extraction_mode: high_fidelity
+content:
+  summary: design-system hierarchy principle (stack-neutral)
+metadata:
+  severity: 3
+  disposition: documentation-only
+  aliases:
+  - DESIGN-HIERARCHY-003
+  introduced_in: 1.66.0


### PR DESCRIPTION
Refs #1218 (atomize core coder) · Refs #1216 (umbrella) — stay OPEN.

## Phase A batch 2 — shared-principle nodes (careful single-thread pass)

Follows batch 1 (#1231, 48 nodes). This batch handles the **shared-principle** clusters
the parallel fan deliberately deferred, demonstrating the "author once, reference by edge"
pattern with no duplicate-representation.

- **`backend`** — authors the **canonical `dependency-direction` node ONCE**
  (`coder.backend.imports-respect-dependency-allowed`) + `code-is-organized` (documentation-only).
  Partial de-monolith: the extension-bound `component-file-suffix` rule stays (keeps a
  `rules:` array — `phase_3a` satisfied).
- **`design`** — 3 documentation-only design-hierarchy principles
  (`tokens-are-pure-values`, `dependency-flow-tokens-primitives`, `wagons-import-from-design`).
  The two dependency-flow principles **`refines`-edge the canonical backend node** rather than
  restating it. Flutter-specific detectors stay in the monolith for Phase B.

5 nodes, authored compliance-by-construction via `atdd author --core`. Verified green
including `fix_hint_completeness` + `phase_3a` (213 passed). Bumped to 3.135.5.

Execution learnings + remaining next-steps are now recorded in #1218 / #1215.
