### PR TITLE
feat(atdd): Atomize Core Coder Conventions (#1218)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3095,3 +3095,12 @@ sessions:
   created: '2026-06-28'
   archived: null
   branch: feat/atomize-coder-careful-pass
+- id: '1218'
+  slug: atomize-coder-synthesize-id
+  file: null
+  issue_number: 1218
+  type: migration
+  status: INIT
+  created: '2026-06-28'
+  archived: null
+  branch: feat/atomize-coder-synthesize-id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.136.0"
+version = "3.137.0"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/atdd/coach/graph/relationships.yaml
+++ b/src/atdd/coach/graph/relationships.yaml
@@ -1917,6 +1917,42 @@ edges:
   strength: important
   target_ref: coder.boundaries.no-cross-wagon-imports
   type: refines
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: domain purity is the inner endpoint of the inward dependency-direction boundary (the domain depends on nothing outward)
+  source_ref: coder.commons.domain-layer-purity
+  strength: important
+  target_ref: coder.backend.imports-respect-dependency-allowed
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: naming the shared layer commons is part of the same layer-organization discipline
+  source_ref: coder.commons.shared-code-named-commons
+  strength: minor
+  target_ref: coder.backend.code-is-organized
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: start_to_start
+  reason: composition completeness is part of organizing a feature into wired layers
+  source_ref: coder.composition.every-file-has-a-consumer
+  strength: minor
+  target_ref: coder.backend.code-is-organized
+  type: runs_alongside
+- confidence: 1.0
+  constraint: mandatory
+  control: internal
+  foundation: finish_to_start
+  reason: the composition root reaching every layer is what makes each source file have a consumer
+  source_ref: coder.composition.root-reaches-all-layers
+  strength: important
+  target_ref: coder.composition.every-file-has-a-consumer
+  type: refines
 graph_id: atdd.convention.relationships
 kind: relationship_graph
 schema_version: 1.0.0

--- a/src/atdd/coder/conventions/commons.convention.yaml
+++ b/src/atdd/coder/conventions/commons.convention.yaml
@@ -105,6 +105,13 @@ structure_patterns:
           - "integration/supabase/"   # Supabase client
         audit: "May import from domain and application"
 
+  # MIGRATED (#1218 careful pass — synthesize-id): the stack-neutral principles below
+  # are now single-node conventions under nodes/:
+  #   "Domain layer purity"  -> coder.commons.domain-layer-purity
+  #   "Consistent naming"     -> coder.commons.shared-code-named-commons
+  #   "Dependency direction"  -> NOT re-authored; it is the canonical
+  #     coder.backend.imports-respect-dependency-allowed (commons refines it via a
+  #     graph edge). The prose is preserved verbatim as migration source.
   common_principles:
     - principle: "Domain layer purity"
       description: "Domain layer has no framework imports in both stacks"

--- a/src/atdd/coder/conventions/composition.convention.yaml
+++ b/src/atdd/coder/conventions/composition.convention.yaml
@@ -10,6 +10,15 @@ scope:
     - "Cross-wagon SharedDependencies dependency injection validation"
     - "Runtime prop-flow analysis"
 
+# MIGRATED (#1218 careful pass — synthesize-id): the stack-neutral composition
+# principles are now single-node conventions under nodes/:
+#   composition.principle            -> coder.composition.every-file-has-a-consumer
+#   composition_root_rule (COMP-0004) -> coder.composition.root-reaches-all-layers
+#   consumer-layer direction (the layer_rules COMP-0001/0002/0003) is NOT re-authored;
+#     it is the canonical coder.backend.imports-respect-dependency-allowed expressed as
+#     consumer layers (commons/composition refine it via graph edges).
+# The per-stack blocks below (repo roots, composition_roots, AST detectors) are
+# preserved verbatim as workspace realization / migration source.
 composition:
   principle: |
     Every implementation file in a source layer should be consumed by at least one

--- a/src/atdd/coder/conventions/nodes/coder.commons.domain-layer-purity.convention.yaml
+++ b/src/atdd/coder/conventions/nodes/coder.commons.domain-layer-purity.convention.yaml
@@ -1,0 +1,27 @@
+schema_version: 1.0.0
+rule_id: coder.commons.domain-layer-purity
+kind: principle
+status: active
+name: Domain layer is framework-pure
+statement: The domain layer MUST contain no framework or third-party library imports
+  in any stack; it depends only on language primitives and its own abstractions, while
+  framework bindings live in the outer (application / integration / presentation)
+  layers.
+terms:
+- term_id: domain_purity
+  text: "the domain layer imports no web/UI/persistence framework \u2014 only language\
+    \ stdlib and in-domain types \u2014 so business logic stays portable and testable\
+    \ without infrastructure"
+source:
+  legacy_path: src/atdd/coder/conventions/commons.convention.yaml
+  legacy_section: structure_patterns.common_principles
+  legacy_rule_id: Domain layer purity
+  extraction_mode: high_fidelity
+content:
+  summary: 'Stack-neutral domain-purity principle. The per-stack framework ban lists
+    (Python: flask/fastapi/django; frontend: preact/react/@tanstack/@maintain-ux/gsap)
+    are workspace realization.'
+metadata:
+  severity: 3
+  disposition: documentation-only
+  introduced_in: 1.66.0

--- a/src/atdd/coder/conventions/nodes/coder.commons.shared-code-named-commons.convention.yaml
+++ b/src/atdd/coder/conventions/nodes/coder.commons.shared-code-named-commons.convention.yaml
@@ -1,0 +1,24 @@
+schema_version: 1.0.0
+rule_id: coder.commons.shared-code-named-commons
+kind: constraint
+status: active
+name: Shared cross-feature code is named commons
+statement: Shared cross-feature code MUST be placed under a module named 'commons'
+  (never 'shared', 'core', or 'lib'), consistently across all stacks, so the shared
+  layer is unambiguous and greppable.
+terms:
+- term_id: commons_naming
+  text: the single canonical name for the cross-feature shared layer is commons; alternatives
+    like shared/core/lib are forbidden to avoid divergent shared roots
+source:
+  legacy_path: src/atdd/coder/conventions/commons.convention.yaml
+  legacy_section: structure_patterns.common_principles
+  legacy_rule_id: Consistent naming
+  extraction_mode: high_fidelity
+content:
+  summary: Stack-neutral naming-consistency constraint for the shared layer; applies
+    to both backend and frontend stacks.
+metadata:
+  severity: 2
+  disposition: documentation-only
+  introduced_in: 1.66.0

--- a/src/atdd/coder/conventions/nodes/coder.composition.every-file-has-a-consumer.convention.yaml
+++ b/src/atdd/coder/conventions/nodes/coder.composition.every-file-has-a-consumer.convention.yaml
@@ -1,0 +1,27 @@
+schema_version: 1.0.0
+rule_id: coder.composition.every-file-has-a-consumer
+kind: principle
+status: active
+name: Every source file has a downstream consumer
+statement: Every implementation file in a source layer MUST be consumed by at least
+  one valid downstream consumer or composition root; candidate consumer layers are
+  filtered to the layers that actually exist, so intentionally partial features are
+  not flagged as unwired.
+terms:
+- term_id: composition_completeness
+  text: "no intra-feature vertical slice is left dangling \u2014 each source file\
+    \ is reached by a consumer in an allowed downstream layer or by the feature composition\
+    \ root"
+source:
+  legacy_path: src/atdd/coder/conventions/composition.convention.yaml
+  legacy_section: composition.principle
+  legacy_rule_id: SPEC-CODER-COMP-0001/0002/0003
+  extraction_mode: high_fidelity
+content:
+  summary: Stack-neutral composition-completeness principle. Per-stack repo roots
+    (web/src, python, supabase/functions), composition-root patterns, and the AST/import
+    detectors (SPEC-CODER-COMP-0001..0004) are workspace realization.
+metadata:
+  severity: 3
+  disposition: documentation-only
+  introduced_in: 1.66.0

--- a/src/atdd/coder/conventions/nodes/coder.composition.root-reaches-all-layers.convention.yaml
+++ b/src/atdd/coder/conventions/nodes/coder.composition.root-reaches-all-layers.convention.yaml
@@ -1,0 +1,26 @@
+schema_version: 1.0.0
+rule_id: coder.composition.root-reaches-all-layers
+kind: principle
+status: active
+name: Composition root reaches every feature layer
+statement: A feature composition root MUST reach every existing feature layer via
+  imports or setter wiring, so no present layer is left unwired by the root.
+terms:
+- term_id: root_completeness
+  text: the feature composition root is the single place that wires the slice; it
+    must touch each layer that exists for the feature (domain/application/integration/presentation)
+    through imports or setter injection
+source:
+  legacy_path: src/atdd/coder/conventions/composition.convention.yaml
+  legacy_section: composition.stacks.python.composition_root_rule
+  legacy_rule_id: SPEC-CODER-COMP-0004
+  extraction_mode: high_fidelity
+content:
+  summary: Stack-neutral root-completeness principle. The python composition.py path
+    and the import/setter AST detection are workspace realization.
+metadata:
+  severity: 3
+  disposition: documentation-only
+  aliases:
+  - SPEC-CODER-COMP-0004
+  introduced_in: 1.66.0


### PR DESCRIPTION
Refs #1218

Careful single-thread pass — cluster 4 (synthesize-id), coder side. Authors core
single-node conventions for the stack-neutral **principle docs** that have no dotted
`rules:` array. Doc-only (no validator-source changes). Full convention-gate set:
398 passed.

## commons.convention.yaml (`common_principles`)

- `coder.commons.domain-layer-purity` — the domain layer imports no framework/library;
  per-stack ban lists (flask/fastapi/django; preact/react/...) are workspace.
- `coder.commons.shared-code-named-commons` — the shared layer is named `commons`
  (never shared/core/lib) across stacks.
- "Dependency direction" is **not** re-authored — it is the canonical
  `coder.backend.imports-respect-dependency-allowed`.

## composition.convention.yaml

- `coder.composition.every-file-has-a-consumer` — composition-completeness principle;
  repo roots + AST detectors (SPEC-CODER-COMP-0001..0004) are workspace.
- `coder.composition.root-reaches-all-layers` — the feature composition root wires every
  existing layer (SPEC-CODER-COMP-0004).
- consumer-layer direction (the layer_rules) is **not** re-authored — same canonical
  dependency-direction node.

commons keeps its `dependency_rules:` (phase-3a special case is respected); both monoliths
keep their prose as migration source with a migration marker. Graph edges added for all 4
new nodes.

Remaining careful-pass clusters (separate PRs): **cluster 2 — mirror collapses**
(logging/security; touches validator source + `scan_scope`, higher risk), and the
**tester side of cluster 4** (contract/artifact + GREEN kernel → #1215).
