### PR TITLE
fix(atdd): atdd plan guidelines returns empty in consumer repos (load_working_context ignores the installed package) (#1275)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3381,7 +3381,7 @@ sessions:
   file: null
   issue_number: 1275
   type: implementation
-  status: RED
+  status: SMOKE
   train: 0001-self-compliance-validate
   created: '2026-06-30'
   archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3376,3 +3376,13 @@ sessions:
   train: 0002-coach-drives-lifecycle
   created: '2026-06-30'
   archived: null
+- id: '1275'
+  slug: plan-guidelines-consumer
+  file: null
+  issue_number: 1275
+  type: implementation
+  status: RED
+  train: 0001-self-compliance-validate
+  created: '2026-06-30'
+  archived: null
+  branch: fix/plan-guidelines-consumer

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3381,7 +3381,7 @@ sessions:
   file: null
   issue_number: 1275
   type: implementation
-  status: SMOKE
+  status: REFACTOR
   train: 0001-self-compliance-validate
   created: '2026-06-30'
   archived: null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atdd"
-version = "3.150.0"
+version = "3.150.1"
 description = "ATDD Platform - Acceptance Test Driven Development toolkit"
 requires-python = ">=3.10"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ exclude = ["atdd.*.validators.fixtures*"]
 "atdd.coach.prompts" = ["**/*.yaml"]
 "atdd.coach.conventions" = ["*.yaml", "nodes/*.yaml"]
 "atdd.coach.overlays" = ["*.md"]
+# #1275: ship the relationship graph so `atdd plan guidelines` can surface
+# protocol-flow edges in consumer repos (graph/ is not a package; the glob
+# reaches into it from the atdd.coach package root).
+"atdd.coach" = ["graph/*.yaml"]
 "atdd.planner.conventions" = ["*.yaml", "nodes/*.yaml"]
 "atdd.planner.schemas" = ["*.json", "author/*.json"]
 "atdd.tester.conventions" = ["*.yaml"]

--- a/src/atdd/planner/commands/plan_context.py
+++ b/src/atdd/planner/commands/plan_context.py
@@ -9,6 +9,12 @@ and presents them; it does not restate them. Stdlib only.
 The decomposition-protocol nodes ship via #761; until that merges, only the
 session-protocol nodes are present — the assembler simply includes whatever
 guideline nodes exist (forward-compatible).
+
+Resolution falls back to the installed package (#1275): the nodes and the
+relationship graph are read from the bundled `atdd` package when the repo has
+no `src/atdd/` tree of its own, so `atdd plan guidelines` works in consumer
+repos and not just the toolkit's own source checkout. Repo-vendored files
+override the package; a missing graph degrades `edges` to `[]`.
 """
 from __future__ import annotations
 

--- a/src/atdd/planner/commands/plan_context.py
+++ b/src/atdd/planner/commands/plan_context.py
@@ -18,23 +18,60 @@ import yaml
 
 _GUIDELINE_PREFIXES = ("planner.plan.", "planner.decomposition.")
 
+# Package-relative fallbacks (#1275). plan_context.py lives at
+# atdd/planner/commands/plan_context.py, so the bundled nodes are two levels up
+# under conventions/nodes, and the relationship graph three levels up under
+# coach/graph. These resolve in any consumer repo that pip-installs atdd, with
+# no src/atdd/ tree of its own. atdd installs unzipped, so __file__ is a real
+# path (no zip-import); importlib.resources is unneeded and graph/ is not a
+# package anyway.
+_PKG_NODES_DIR = Path(__file__).resolve().parent.parent / "conventions" / "nodes"
+_PKG_GRAPH = Path(__file__).resolve().parents[2] / "coach" / "graph" / "relationships.yaml"
 
-def _nodes_dir(root: Path | str) -> Path:
+
+def _repo_nodes_dir(root: Path | str) -> Path:
     return Path(root) / "src" / "atdd" / "planner" / "conventions" / "nodes"
 
 
-def _graph(root: Path | str) -> Path:
+def _repo_graph(root: Path | str) -> Path:
     return Path(root) / "src" / "atdd" / "coach" / "graph" / "relationships.yaml"
+
+
+def _nodes_dirs(root: Path | str) -> list[Path]:
+    """Directories to read guideline nodes from, in ascending precedence: the
+    bundled package nodes are the base; repo-vendored nodes override them. A
+    consumer repo (no src/atdd/) gets the package set; the toolkit's own repo
+    resolves to the same files for both, so it reads them once."""
+    dirs: list[Path] = []
+    if _PKG_NODES_DIR.is_dir():
+        dirs.append(_PKG_NODES_DIR)
+    repo = _repo_nodes_dir(root)
+    if repo.is_dir() and (not dirs or repo.resolve() != _PKG_NODES_DIR.resolve()):
+        dirs.append(repo)
+    return dirs
+
+
+def _graph_path(root: Path | str) -> Path | None:
+    """Repo-vendored relationships.yaml wins; otherwise the bundled package copy;
+    otherwise None (consumer repos without the bundled graph degrade to []
+    edges)."""
+    repo = _repo_graph(root)
+    if repo.is_file():
+        return repo
+    if _PKG_GRAPH.is_file():
+        return _PKG_GRAPH
+    return None
 
 
 def load_working_context(root: Path | str = ".") -> dict:
     """Return the agent's working context:
     {guidelines: {rule_id: {kind, statement, terms[]}}, edges: [{source,target,type,reason}]}.
     Only guideline nodes (session-protocol + decomposition-protocol) and the
-    edges touching them are included."""
+    edges touching them are included. Resolution falls back to the installed
+    package so consumer repos (no src/atdd/ tree) still get the bundled
+    conventions; repo-vendored nodes override the package (#1275)."""
     guidelines: dict = {}
-    nodes_dir = _nodes_dir(root)
-    if nodes_dir.is_dir():
+    for nodes_dir in _nodes_dirs(root):
         for f in sorted(nodes_dir.glob("*.convention.yaml")):
             doc = yaml.safe_load(f.read_text(encoding="utf-8")) or {}
             rid = doc.get("rule_id", "")
@@ -46,8 +83,8 @@ def load_working_context(root: Path | str = ".") -> dict:
                 }
 
     edges: list = []
-    graph = _graph(root)
-    if graph.is_dir() is False and graph.exists():
+    graph = _graph_path(root)
+    if graph is not None:
         g = yaml.safe_load(graph.read_text(encoding="utf-8")) or {}
         for e in (g.get("edges") or []):
             src, tgt = e.get("source_ref"), e.get("target_ref")

--- a/src/atdd/planner/commands/tests/test_plan_working_context_and_worked_example.py
+++ b/src/atdd/planner/commands/tests/test_plan_working_context_and_worked_example.py
@@ -58,6 +58,34 @@ def test_working_context_includes_session_protocol_nodes_and_edges():
                for e in ctx["edges"])
 
 
+def test_working_context_falls_back_to_package_in_consumer_repo(tmp_path):
+    """#1275: a consumer repo (pip-installs atdd, has no src/atdd/ tree) must
+    still receive the bundled convention nodes — load_working_context falls back
+    to the installed package when the repo-vendored path is absent. Today it
+    returns {} and is a silent no-op everywhere except the toolkit's own repo."""
+    assert not (tmp_path / "src" / "atdd").exists()  # a bare consumer repo
+    ctx = load_working_context(tmp_path)
+    g = ctx["guidelines"]
+    for rid in ("planner.plan.session-lifecycle", "planner.plan.confirm-before-author"):
+        assert rid in g, f"{rid} missing — package fallback not wired (consumer repo got empty guidelines)"
+        assert g[rid]["statement"]
+    # the package-relative graph resolves too, so protocol-flow edges are surfaced
+    assert any(e["source"].startswith("planner.plan.") and e["target"].startswith("planner.plan.")
+               for e in ctx["edges"]), "consumer repo got no protocol-flow edges"
+
+
+def test_repo_vendored_nodes_override_package(tmp_path):
+    """#1275: when a repo vendors its own nodes they take precedence over the
+    package (repo-vendored overrides; otherwise package)."""
+    nodes = tmp_path / "src" / "atdd" / "planner" / "conventions" / "nodes"
+    nodes.mkdir(parents=True)
+    (nodes / "planner.plan.session-lifecycle.convention.yaml").write_text(
+        "rule_id: planner.plan.session-lifecycle\nkind: protocol\n"
+        "statement: VENDORED OVERRIDE\nterms: []\n", encoding="utf-8")
+    ctx = load_working_context(tmp_path)
+    assert ctx["guidelines"]["planner.plan.session-lifecycle"]["statement"] == "VENDORED OVERRIDE"
+
+
 def test_guidelines_cli_emits_context():
     env = {"PYTHONPATH": str(_SRC), "PATH": os.environ.get("PATH", ""), "HOME": str(_REPO)}
     r = subprocess.run([sys.executable, "-m", "atdd", "plan", "--root", str(_REPO), "guidelines"],


### PR DESCRIPTION
Closes #1275

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #1275 |
| Type | implementation |
| Slug | plan-guidelines-consumer |
| Train | 0001-self-compliance-validate |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.