### PR TITLE
fix(atdd): install build+twine and inject PyPI token in Publish job (interim, atdd-extensions#40)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3536,3 +3536,12 @@ sessions:
   created: '2026-07-01'
   archived: null
   train: 0001-self-compliance-validate
+- id: '1301'
+  slug: install-build-twine-for-pypi-publish
+  file: null
+  issue_number: 1301
+  type: implementation
+  status: INIT
+  created: '2026-07-01'
+  archived: null
+  branch: feat/install-build-twine-for-pypi-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,16 @@ jobs:
       - name: Install atdd (the release-pipeline CLI)
         run: python -m pip install -e .
 
+      # INTERIM (decommission → afokapu/atdd-extensions#40): the extension's
+      # `real_publish` shells to `python -m build` + `python -m twine upload`, but
+      # this Publish job never installed them (Publish run 28501873003:
+      # "No module named build"). Install here as a stopgap. The durable shape is a
+      # single extension release entrypoint that owns its own deps + the upload, so
+      # publish.yml stays thin (Core keeps only the version DECISION). Do not treat
+      # this as correct Core logic — it is release-overfit to remove on migration.
+      - name: Install build + twine (interim — moves into the extension, atdd-extensions#40)
+        run: python -m pip install -U build twine
+
       # Release-bot git identity. GitHub runners carry no default git identity, so
       # the extension's annotated `git tag -a vX` aborts with "empty ident name"
       # (Publish run 28495533869). Set it ONCE here, before the drain step that
@@ -145,6 +155,13 @@ jobs:
         env:
           ATDD_RELEASE_ALLOW_PUBLISH: ${{ secrets.ATDD_RELEASE_ALLOW_PUBLISH }}
           WORKER_DIR: ${{ steps.ext.outputs.worker_dir }}
+          # INTERIM (decommission → afokapu/atdd-extensions#40): the extension's
+          # real_publish uses raw `twine upload`, which cannot consume this repo's
+          # OIDC trusted-publishing. Supply a project-scoped PyPI API token via
+          # standard twine env vars as a stopgap. DECOMMISSION: move the upload
+          # (OIDC-native, or token) into the extension release entrypoint; drop these.
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           set -euo pipefail
           DRY_RUN=true


### PR DESCRIPTION
Part of #1301 (closed manually after merge; workflow hotfix, not a full lifecycle).

Interim hotfix to unblock the **v3.152.0** release. Publish run 28501873003 failed at `python -m build` ("No module named build"); the extension's `real_publish` shells to `python -m build` + `twine upload`, which the Publish job never installed/authenticated.

**Changes (both marked INTERIM in-file → afokapu/atdd-extensions#40):**
- `pip install -U build twine` in the Publish job.
- Inject a project-scoped PyPI token via `TWINE_USERNAME=__token__` / `TWINE_PASSWORD=${{ secrets.PYPI_API_TOKEN }}` on the drain step.

**Decommission target:** move build/tag/upload (deps + creds) into a single extension release entrypoint so publish.yml stays thin (Core keeps only the version DECISION). Tracked in atdd-extensions#40.