### PR TITLE
fix(atdd): graft build_meta_shim into sdist so wheel-from-sdist build works

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3545,3 +3545,12 @@ sessions:
   created: '2026-07-01'
   archived: null
   branch: feat/install-build-twine-for-pypi-publish
+- id: '1310'
+  slug: graft-build-meta-shim-into-sdist
+  file: null
+  issue_number: 1310
+  type: implementation
+  status: INIT
+  created: '2026-07-01'
+  archived: null
+  branch: feat/graft-build-meta-shim-into-sdist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
+# #1172 dynamic-version backend: the in-tree PEP517 build backend must ship in
+# the sdist, else `python -m build`'s wheel-from-sdist step fails with
+# "backend-path entry 'build_meta_shim' does not exist". #1310.
+graft build_meta_shim
+
 recursive-include src/atdd/coach/validators/fixtures *
 recursive-include src/atdd/coder/validators/fixtures *
 recursive-include src/atdd/tester/validators/fixtures *


### PR DESCRIPTION
Part of #1310 (closed manually after merge — no auto-close keyword, to avoid the pre-smoke-close gate).

The first release after #1172 (dynamic-version backend) fails at `python -m build`: the sdist ships without `build_meta_shim/`, so building the wheel from the sdist errors `backend-path entry 'build_meta_shim' does not exist`. Fix: `graft build_meta_shim` in MANIFEST.in.

**Verified locally:** clean-venv `python -m build` now succeeds (sdist+wheel) and the sdist contains `build_meta_shim/`. Unblocks v3.152.0 (Publish run 28528405908 failed here). Refs atdd-extensions#40.