### PR TITLE
refactor(atdd): Migrate Graph Readers To State Store (#1318)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3579,7 +3579,7 @@ sessions:
   file: null
   issue_number: 1318
   type: refactor
-  status: PLANNED
+  status: RED
   created: '2026-07-02'
   archived: null
   branch: refactor/migrate-graph-readers-to-state-store

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3574,3 +3574,11 @@ sessions:
   created: '2026-07-01'
   archived: null
   branch: feat/graft-build-meta-shim-into-sdist
+- id: '1318'
+  slug: migrate-graph-readers-to-state-store
+  file: null
+  issue_number: 1318
+  type: refactor
+  status: INIT
+  created: '2026-07-02'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3582,3 +3582,5 @@ sessions:
   status: INIT
   created: '2026-07-02'
   archived: null
+  branch: refactor/migrate-graph-readers-to-state-store
+  train: 0002-coach-drives-lifecycle

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3579,7 +3579,7 @@ sessions:
   file: null
   issue_number: 1318
   type: refactor
-  status: RED
+  status: GREEN
   created: '2026-07-02'
   archived: null
   branch: refactor/migrate-graph-readers-to-state-store

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3579,7 +3579,7 @@ sessions:
   file: null
   issue_number: 1318
   type: refactor
-  status: GREEN
+  status: SMOKE
   created: '2026-07-02'
   archived: null
   branch: refactor/migrate-graph-readers-to-state-store

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3579,7 +3579,7 @@ sessions:
   file: null
   issue_number: 1318
   type: refactor
-  status: INIT
+  status: PLANNED
   created: '2026-07-02'
   archived: null
   branch: refactor/migrate-graph-readers-to-state-store

--- a/src/atdd/coach/commands/issue_graph.py
+++ b/src/atdd/coach/commands/issue_graph.py
@@ -33,8 +33,38 @@ def _load_yaml(path: Path) -> dict:
         return {}
 
 
+def _store_wagon(issue_number: int, repo_root: Path) -> Optional[str]:
+    """Wagon for *issue_number* from the State Store, or None on any miss."""
+    try:
+        from atdd.state.work_item_reader import WorkItemReader
+
+        with WorkItemReader(control_root=repo_root) as reader:
+            return reader.wagon(issue_number)
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        return None
+
+
+def _store_train(issue_number: int, repo_root: Path) -> Optional[str]:
+    """Train for *issue_number* from the State Store, or None on any miss."""
+    try:
+        from atdd.state.work_item_reader import WorkItemReader
+
+        with WorkItemReader(control_root=repo_root) as reader:
+            return reader.train(issue_number)
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        return None
+
+
 def _wagon_slug_for_issue(issue_number: int, repo_root: Path) -> Optional[str]:
-    """Return the wagon slug for *issue_number* from .atdd/manifest.yaml."""
+    """Return the wagon slug for *issue_number*.
+
+    #1270 slice A: read the wagon from the State Store first (authoritative since
+    #1203), falling back to the ``.atdd/manifest.yaml`` mirror when the store has
+    no wagon for the issue (e.g. a store not yet imported from the manifest).
+    """
+    from_store = _store_wagon(issue_number, repo_root)
+    if from_store:
+        return str(from_store)
     manifest_path = repo_root / ".atdd" / "manifest.yaml"
     if not manifest_path.is_file():
         return None
@@ -315,14 +345,16 @@ def build_issue_architecture_context(
     if not wagon_slug:
         return None
 
-    manifest_path = repo_root / ".atdd" / "manifest.yaml"
-    train_id: Optional[str] = None
-    if manifest_path.is_file():
-        manifest_data = _load_yaml(manifest_path)
-        for session in manifest_data.get("sessions", []):
-            if str(session.get("issue_number", "")) == str(issue_number):
-                train_id = session.get("train") or None
-                break
+    # #1270 slice A: train store-first (authoritative since #1203), manifest fallback.
+    train_id: Optional[str] = _store_train(issue_number, repo_root)
+    if not train_id:
+        manifest_path = repo_root / ".atdd" / "manifest.yaml"
+        if manifest_path.is_file():
+            manifest_data = _load_yaml(manifest_path)
+            for session in manifest_data.get("sessions", []):
+                if str(session.get("issue_number", "")) == str(issue_number):
+                    train_id = session.get("train") or None
+                    break
 
     return build_architecture_context_for_wagon(
         wagon_slug, train_id=train_id, repo_root=repo_root,

--- a/src/atdd/coach/commands/tests/test_issue_graph_store_first.py
+++ b/src/atdd/coach/commands/tests/test_issue_graph_store_first.py
@@ -1,0 +1,99 @@
+# URN: test:govern-lifecycle:issue-graph:store-first-wagon-and-train
+# Issue: #1318 (#1270 slice A — decommission the manifest mirror)
+# Phase: RED
+# Layer: unit
+# Assertion: behavioral
+"""#1270 slice A — the issue-graph context readers read the State Store first.
+
+``issue_graph`` resolves an issue's wagon and train for the spawn-prompt
+architecture context. These reads were manifest-only; #1203 made the store
+authoritative. The discriminating tests seed the store and a *divergent*
+manifest for the same issue and assert the reader returns the **store** value —
+which fails on the old manifest-only implementation and passes once the reader
+is store-first. The manifest fallback is retained for an un-imported store.
+"""
+from __future__ import annotations
+
+import yaml
+
+from atdd.state.db import connect, init_state_store
+from atdd.state.manifest_import import GITHUB_PROVIDER, WORK_ITEM_KIND
+from atdd.state.store import StateStore
+from atdd.coach.commands.issue_graph import (
+    _wagon_slug_for_issue,
+    build_issue_architecture_context,
+)
+
+
+def _seed_store(root, *, slug, issue_number, wagon=None, train=None, status="PLANNED"):
+    """Register one work item (with optional wagon/train) directly in the store."""
+    (root / ".atdd").mkdir(parents=True, exist_ok=True)
+    marker = root / ".atdd" / "config.yaml"
+    if not marker.exists():
+        marker.write_text("version: '1.0'\n", encoding="utf-8")  # Control Root marker
+    db = init_state_store(start=root)
+    conn = connect(db)
+    try:
+        store = StateStore(conn)
+        data = {"issue_number": issue_number}
+        if wagon:
+            data["wagon"] = wagon
+        if train:
+            data["train"] = train
+        store.objects.upsert(slug, WORK_ITEM_KIND, state=status, data=data)
+        store.external_refs.link(
+            slug, GITHUB_PROVIDER, "issue", str(issue_number), data={}
+        )
+    finally:
+        conn.close()
+
+
+def _write_manifest(root, sessions):
+    (root / ".atdd").mkdir(parents=True, exist_ok=True)
+    path = root / ".atdd" / "manifest.yaml"
+    path.write_text(yaml.safe_dump({"version": "2.0", "sessions": sessions}), encoding="utf-8")
+    return path
+
+
+def test_wagon_slug_for_issue_prefers_store_over_divergent_manifest(tmp_path):
+    """Store wagon wins over a different manifest wagon for the same issue."""
+    _seed_store(tmp_path, slug="my-item", issue_number=42, wagon="govern-lifecycle")
+    _write_manifest(
+        tmp_path,
+        [{"issue_number": 42, "slug": "my-item", "wagon": "author-plan-substrate"}],
+    )
+    assert _wagon_slug_for_issue(42, tmp_path) == "govern-lifecycle"
+
+
+def test_wagon_slug_for_issue_falls_back_to_manifest(tmp_path):
+    """With no store wagon, the manifest mirror still resolves the wagon."""
+    # Store holds the issue but no wagon; manifest carries the wagon.
+    _seed_store(tmp_path, slug="x", issue_number=7)
+    _write_manifest(tmp_path, [{"issue_number": 7, "slug": "x", "wagon": "define-plans"}])
+    assert _wagon_slug_for_issue(7, tmp_path) == "define-plans"
+
+
+def test_build_architecture_context_uses_store_train(tmp_path, monkeypatch):
+    """The architecture-context train is read store-first over a divergent manifest."""
+    captured = {}
+
+    def _fake_ctx_for_wagon(wagon_slug, *, train_id=None, repo_root=None):
+        captured["wagon"] = wagon_slug
+        captured["train"] = train_id
+        return "## Architecture context\n"
+
+    monkeypatch.setattr(
+        "atdd.coach.commands.issue_graph.build_architecture_context_for_wagon",
+        _fake_ctx_for_wagon,
+    )
+    _seed_store(
+        tmp_path, slug="ctx-item", issue_number=55,
+        wagon="govern-lifecycle", train="0002-coach-drives-lifecycle",
+    )
+    _write_manifest(
+        tmp_path,
+        [{"issue_number": 55, "slug": "ctx-item", "wagon": "govern-lifecycle",
+          "train": "0001-self-compliance-validate"}],
+    )
+    build_issue_architecture_context(55, repo_root=tmp_path)
+    assert captured["train"] == "0002-coach-drives-lifecycle"  # store, not manifest

--- a/src/atdd/coach/runtime/graph.py
+++ b/src/atdd/coach/runtime/graph.py
@@ -76,9 +76,29 @@ def wagon_deps_transitive(
     return seen
 
 
+def _store_issue_wagon_map(root: Path) -> dict[int, str]:
+    """Issue number → wagon map from the State Store, or {} on any miss."""
+    try:
+        from atdd.state.work_item_reader import WorkItemReader
+
+        with WorkItemReader(control_root=root) as reader:
+            return reader.issue_wagon_map()
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        return {}
+
+
 def issue_wagon_map(repo_root: Optional[Path] = None) -> dict[int, str]:
-    """Map issue number → wagon slug, read from ``.atdd/manifest.yaml``."""
-    path = _repo_root(repo_root) / ".atdd" / "manifest.yaml"
+    """Map issue number → wagon slug.
+
+    #1270 slice A: read from the State Store first (authoritative since #1203),
+    falling back to ``.atdd/manifest.yaml`` when the store yields no wagons (e.g.
+    a store not yet imported from the manifest).
+    """
+    root = _repo_root(repo_root)
+    store_map = _store_issue_wagon_map(root)
+    if store_map:
+        return {number: _wagon_slug(str(wagon)) for number, wagon in store_map.items()}
+    path = root / ".atdd" / "manifest.yaml"
     if not path.is_file():
         return {}
     data = yaml.safe_load(path.read_text()) or {}

--- a/src/atdd/coach/runtime/tests/test_graph_issue_wagon_map_store_first.py
+++ b/src/atdd/coach/runtime/tests/test_graph_issue_wagon_map_store_first.py
@@ -1,0 +1,66 @@
+# URN: test:govern-lifecycle:runtime-graph:store-first-issue-wagon-map
+# Issue: #1318 (#1270 slice A — decommission the manifest mirror)
+# Phase: RED
+# Layer: unit
+# Assertion: behavioral
+"""#1270 slice A — runtime graph ``issue_wagon_map`` reads the State Store first.
+
+``issue_wagon_map`` drives wave planning by mapping issue → wagon. It was
+manifest-only; #1203 made the store authoritative. The discriminating test
+seeds the store and a *divergent* manifest and asserts the store wins — failing
+on the old manifest-only implementation. The manifest fallback is retained when
+the store carries no wagons.
+"""
+from __future__ import annotations
+
+import yaml
+
+from atdd.state.db import connect, init_state_store
+from atdd.state.manifest_import import GITHUB_PROVIDER, WORK_ITEM_KIND
+from atdd.state.store import StateStore
+from atdd.coach.runtime.graph import issue_wagon_map
+
+
+def _seed_store(root, *, slug, issue_number, wagon=None):
+    (root / ".atdd").mkdir(parents=True, exist_ok=True)
+    marker = root / ".atdd" / "config.yaml"
+    if not marker.exists():
+        marker.write_text("version: '1.0'\n", encoding="utf-8")  # Control Root marker
+    db = init_state_store(start=root)
+    conn = connect(db)
+    try:
+        store = StateStore(conn)
+        data = {"issue_number": issue_number}
+        if wagon:
+            data["wagon"] = wagon
+        store.objects.upsert(slug, WORK_ITEM_KIND, state="PLANNED", data=data)
+        store.external_refs.link(
+            slug, GITHUB_PROVIDER, "issue", str(issue_number), data={}
+        )
+    finally:
+        conn.close()
+
+
+def _write_manifest(root, sessions):
+    (root / ".atdd").mkdir(parents=True, exist_ok=True)
+    path = root / ".atdd" / "manifest.yaml"
+    path.write_text(yaml.safe_dump({"version": "2.0", "sessions": sessions}), encoding="utf-8")
+    return path
+
+
+def test_issue_wagon_map_prefers_store_over_divergent_manifest(tmp_path):
+    """The map is built from the store when it carries wagons, not the manifest."""
+    _seed_store(tmp_path, slug="a", issue_number=42, wagon="govern-lifecycle")
+    _write_manifest(
+        tmp_path,
+        [{"issue_number": 42, "slug": "a", "wagon": "author-plan-substrate"}],
+    )
+    assert issue_wagon_map(tmp_path) == {42: "govern-lifecycle"}
+
+
+def test_issue_wagon_map_falls_back_to_manifest_when_store_has_no_wagons(tmp_path):
+    """A store with no wagons (e.g. writer-populated) falls back to the manifest."""
+    # Store holds the issue but no wagon at all → store map empty → manifest wins.
+    _seed_store(tmp_path, slug="b", issue_number=7)
+    _write_manifest(tmp_path, [{"issue_number": 7, "slug": "b", "wagon": "define-plans"}])
+    assert issue_wagon_map(tmp_path) == {7: "define-plans"}

--- a/src/atdd/state/tests/test_work_item_reader.py
+++ b/src/atdd/state/tests/test_work_item_reader.py
@@ -39,6 +39,7 @@ _MANIFEST = {
             "train": "0002",
             "branch": "feat/state-store-authoritative-work-item-lifecycle",
             "feature": "feature:atdd:state-store",
+            "wagon": "govern-lifecycle",
         },
         {
             "id": "900",
@@ -141,3 +142,37 @@ def test_missing_manifest_yields_empty_reads(tmp_path):
         assert r.status(1203) is None
         assert r.train(1203) is None
         assert r.branch(1203) is None
+
+
+# -- #1270 slice A: wagon reads for the graph-context migration ------------- #
+
+
+def test_wagon_reads_from_store(reader):
+    """wagon() returns the stored wagon; None when unrecorded or unregistered."""
+    assert reader.wagon(1203) == "govern-lifecycle"
+    assert reader.wagon(900) is None  # session carries no wagon
+    assert reader.wagon(424242) is None  # unregistered issue
+
+
+def test_issue_wagon_map_holds_only_wagoned_issues(reader):
+    """issue_wagon_map() maps issue → wagon, skipping issues with no wagon."""
+    assert reader.issue_wagon_map() == {1203: "govern-lifecycle"}
+
+
+def test_issue_wagon_map_reads_from_store_not_yaml(reader, tmp_path):
+    """A store-only wagon write is reflected without touching the manifest."""
+    db = tmp_path / ".atdd" / "state" / "state.sqlite"
+    conn = connect(db)
+    try:
+        store = StateStore(conn)
+        obj = store.objects.get("older-thing")
+        store.objects.upsert(
+            "older-thing", obj.kind, state=obj.state,
+            data={**obj.data, "wagon": "author-plan-substrate"},
+        )
+    finally:
+        conn.close()
+    assert reader.issue_wagon_map() == {
+        1203: "govern-lifecycle",
+        900: "author-plan-substrate",
+    }

--- a/src/atdd/state/work_item_reader.py
+++ b/src/atdd/state/work_item_reader.py
@@ -38,6 +38,7 @@ _ISSUE_REF_KIND = "issue"
 #: Work-item ``data`` keys mirrored from the manifest session entry.
 _TRAIN_KEY = "train"
 _BRANCH_KEY = "branch"
+_WAGON_KEY = "wagon"
 
 
 class WorkItemReader:
@@ -130,6 +131,36 @@ class WorkItemReader:
         """The branch recorded for ``issue_number`` (from the work-item ``data``)."""
         obj = self.get(issue_number)
         return obj.data.get(_BRANCH_KEY) if obj is not None else None
+
+    def wagon(self, issue_number: int) -> Optional[str]:
+        """The wagon slug recorded for ``issue_number`` (from the work-item ``data``)."""
+        obj = self.get(issue_number)
+        return obj.data.get(_WAGON_KEY) if obj is not None else None
+
+    def issue_wagon_map(self) -> dict[int, str]:
+        """Map GitHub issue number → wagon slug for every stored work item with a wagon.
+
+        The store-backed analog of scanning the manifest ``sessions`` for
+        ``issue_number``/``wagon`` pairs: enumerate the GitHub ``issue``
+        external-refs and read each linked work item's wagon from its ``data``
+        bag. Items with no wagon (or a non-integer ref) are skipped, so the map
+        holds only issues that actually carry a wagon.
+        """
+        out: dict[int, str] = {}
+        for ref in self._store.external_refs.all():
+            if ref.provider != GITHUB_PROVIDER or ref.ref_kind != _ISSUE_REF_KIND:
+                continue
+            obj = self._store.objects.get(ref.object_uid)
+            if obj is None:
+                continue
+            wagon = obj.data.get(_WAGON_KEY)
+            if not wagon:
+                continue
+            try:
+                out[int(ref.ref_value)] = str(wagon)
+            except (TypeError, ValueError):
+                continue
+        return out
 
     # -- internals ---------------------------------------------------------- #
     def _auto_import_if_empty(self, *, db_path: Optional[Path]) -> None:


### PR DESCRIPTION
Delivers #1318 · Part of #1270 (auto-close removed: #1318 is pre-REFACTOR — see coach.pr.merge-blocks-on-pre-smoke-close)
## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #1318 |
| Type | refactor |
| Slug | migrate-graph-readers-to-state-store |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd-issue, atdd:INIT |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.
