### PR TITLE
refactor(atdd): Migrate Cli Readers To State Store (#1320)

### DIFF
--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3585,3 +3585,11 @@ sessions:
   archived: null
   branch: refactor/migrate-graph-readers-to-state-store
   train: 0002-coach-drives-lifecycle
+- id: '1320'
+  slug: migrate-cli-readers-to-state-store
+  file: null
+  issue_number: 1320
+  type: refactor
+  status: INIT
+  created: '2026-07-02'
+  archived: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3590,7 +3590,7 @@ sessions:
   file: null
   issue_number: 1320
   type: refactor
-  status: PLANNED
+  status: SMOKE
   created: '2026-07-02'
   archived: null
   branch: refactor/migrate-cli-readers-to-state-store

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3590,7 +3590,7 @@ sessions:
   file: null
   issue_number: 1320
   type: refactor
-  status: INIT
+  status: PLANNED
   created: '2026-07-02'
   archived: null
   branch: refactor/migrate-cli-readers-to-state-store

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -3593,3 +3593,5 @@ sessions:
   status: INIT
   created: '2026-07-02'
   archived: null
+  branch: refactor/migrate-cli-readers-to-state-store
+  train: 0002-coach-drives-lifecycle

--- a/src/atdd/coach/commands/branch.py
+++ b/src/atdd/coach/commands/branch.py
@@ -43,6 +43,17 @@ def _rev_count_past_default(worktree_path: Path, default_branch: str) -> Optiona
     return int(out)
 
 
+def _store_session_entry(root, issue_number: int):
+    """Manifest-session-shaped dict for *issue_number* from the State Store, or None."""
+    try:
+        from atdd.state.work_item_reader import WorkItemReader
+
+        with WorkItemReader(control_root=root) as reader:
+            return reader.session_entry(issue_number)
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        return None
+
+
 class BranchManager:
     """Create worktree branches from ATDD issue metadata."""
 
@@ -135,7 +146,13 @@ class BranchManager:
             return yaml.safe_load(f) or {}
 
     def _find_issue(self, issue_number: int):
-        """Find an issue in the manifest by number. Returns the entry or None."""
+        """Find an issue by number — store-first (#1270 slice B), manifest fallback.
+
+        Returns a manifest-``sessions``-shaped entry (``slug``/``type``/...) or None.
+        """
+        entry = _store_session_entry(self.target_dir, issue_number)
+        if entry is not None:
+            return entry
         manifest = self._load_manifest()
         for entry in manifest.get("sessions", []):
             if entry.get("issue_number") == issue_number:

--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -781,22 +781,28 @@ class IssueManager:
 
         Returns the number of sub-issues created, or 1 on a hard error.
         """
-        manifest = self._load_manifest() if self.manifest_file.exists() else {}
-        sessions = manifest.get("sessions") or []
-        entry = next(
-            (s for s in sessions if s.get("issue_number") == issue_number),
-            None,
-        )
-        if entry is None:
-            print(f"Error: Issue #{issue_number} not found in manifest.")
-            return 1
+        # #1270 slice B: read wagon/feature store-first (authoritative since
+        # #1203), falling back to the .atdd/manifest.yaml mirror.
+        wagon = self._store_work_item_field(issue_number, "wagon")
+        feature_urn = self._store_work_item_field(issue_number, "feature")
+        if not wagon or not feature_urn:
+            manifest = self._load_manifest() if self.manifest_file.exists() else {}
+            entry = next(
+                (s for s in (manifest.get("sessions") or [])
+                 if s.get("issue_number") == issue_number),
+                None,
+            )
+            if entry is None and not (wagon or feature_urn):
+                print(f"Error: Issue #{issue_number} not found in store or manifest.")
+                return 1
+            if entry is not None:
+                wagon = wagon or entry.get("wagon")
+                feature_urn = feature_urn or entry.get("feature")
 
-        wagon = entry.get("wagon")
-        feature_urn = entry.get("feature")
         if not wagon or not feature_urn:
             print(
-                f"Error: Issue #{issue_number} session entry missing 'wagon' or "
-                f"'feature' fields. sync_wmbts needs both to resolve plan artifacts."
+                f"Error: Issue #{issue_number} missing 'wagon' or 'feature' fields. "
+                f"sync_wmbts needs both to resolve plan artifacts."
             )
             return 1
 

--- a/src/atdd/coach/commands/issue_lifecycle.py
+++ b/src/atdd/coach/commands/issue_lifecycle.py
@@ -66,6 +66,17 @@ def _check_on_main_branch(repo_root: Path) -> tuple:
 _COMPLIANCE_REQUIRED_STATUSES = {"PLANNED", "RED", "GREEN", "SMOKE", "REFACTOR"}
 
 
+def _store_issue_number_for_slug(root, slug: str):
+    """GitHub issue number linked to *slug* from the State Store, or None."""
+    try:
+        from atdd.state.work_item_reader import WorkItemReader
+
+        with WorkItemReader(control_root=root) as reader:
+            return reader.issue_number_for_slug(slug)
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        return None
+
+
 class IssueLifecycle:
     """Unified issue lifecycle orchestrator."""
 
@@ -611,27 +622,25 @@ class IssueLifecycle:
         if rc != 0:
             return rc
 
-        # Read manifest to find the created issue number by slug
-        manifest_path = self.atdd_config_dir / "manifest.yaml"
-        if not manifest_path.exists():
-            print("Error: manifest.yaml not found after creation.")
-            return 1
-
-        manifest = yaml.safe_load(manifest_path.read_text()) or {}
-        sessions = manifest.get("sessions", [])
-
-        # Find the entry matching our slug (last match in case of duplicates)
+        # Find the created issue number by slug.
         from atdd.coach.commands.issue import IssueManager as _IM
         slugified = _IM(self.target_dir)._slugify(slug)
 
-        issue_number = None
-        for entry in reversed(sessions):
-            if entry.get("slug") == slugified:
-                issue_number = entry.get("issue_number")
-                break
+        # #1270 slice B: resolve slug → issue_number store-first (authoritative
+        # since #1203), falling back to the .atdd/manifest.yaml mirror (last
+        # match wins there, in case of duplicate slugs).
+        issue_number = _store_issue_number_for_slug(self.target_dir, slugified)
+        if issue_number is None:
+            manifest_path = self.atdd_config_dir / "manifest.yaml"
+            if manifest_path.exists():
+                manifest = yaml.safe_load(manifest_path.read_text()) or {}
+                for entry in reversed(manifest.get("sessions", [])):
+                    if entry.get("slug") == slugified:
+                        issue_number = entry.get("issue_number")
+                        break
 
         if not issue_number:
-            print(f"Error: Could not find issue number for slug '{slug}' in manifest.")
+            print(f"Error: Could not find issue number for slug '{slug}'.")
             return 1
 
         # Phase 2: chain to worktree creation (default) or print intent (--no-branch).

--- a/src/atdd/coach/commands/pr.py
+++ b/src/atdd/coach/commands/pr.py
@@ -37,6 +37,28 @@ from atdd.coach.validators._violation import Violation
 logger = logging.getLogger(__name__)
 
 
+def _store_session_entry(root, issue_number: int):
+    """Manifest-session-shaped dict for *issue_number* from the store, or None."""
+    try:
+        from atdd.state.work_item_reader import WorkItemReader
+
+        with WorkItemReader(control_root=root) as reader:
+            return reader.session_entry(issue_number)
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        return None
+
+
+def _store_issue_number_for_slug(root, slug: str):
+    """GitHub issue number linked to *slug* from the store, or None."""
+    try:
+        from atdd.state.work_item_reader import WorkItemReader
+
+        with WorkItemReader(control_root=root) as reader:
+            return reader.issue_number_for_slug(slug)
+    except Exception:  # atdd:suppress(coder.logging.coach-silent-swallow) UNTIL=2026-08-01
+        return None
+
+
 class PRManager:
     """Create pull requests from ATDD issue metadata."""
 
@@ -54,7 +76,10 @@ class PRManager:
             return yaml.safe_load(f) or {}
 
     def _find_issue_in_manifest(self, issue_number: int) -> Optional[dict]:
-        """Find an issue in the manifest by number."""
+        """Find an issue by number — store-first (#1270 slice B), manifest fallback."""
+        entry = _store_session_entry(self.target_dir, issue_number)
+        if entry is not None:
+            return entry
         manifest = self._load_manifest()
         for entry in manifest.get("sessions", []):
             if entry.get("issue_number") == issue_number:
@@ -234,12 +259,20 @@ class PRManager:
         return None
 
     def _resolve_via_manifest(self, pr_data: dict) -> Optional[int]:
-        """Strategy 3: Branch name → manifest slug → issue_number."""
+        """Strategy 3: Branch name → slug → issue_number.
+
+        #1270 slice B: resolves the slug through the State Store first (the
+        authoritative work-item→issue link since #1203), falling back to the
+        ``.atdd/manifest.yaml`` mirror when the store has no match.
+        """
         branch = pr_data.get("headRefName") or ""
         if not branch:
             return None
         # Branch format: prefix/slug → extract slug part
         slug = branch.split("/", 1)[-1] if "/" in branch else branch
+        from_store = _store_issue_number_for_slug(self.target_dir, slug)
+        if from_store is not None:
+            return from_store
         manifest = self._load_manifest()
         for entry in manifest.get("sessions", []):
             if entry.get("slug") == slug:

--- a/src/atdd/coach/commands/tests/test_cli_readers_store_first.py
+++ b/src/atdd/coach/commands/tests/test_cli_readers_store_first.py
@@ -1,0 +1,95 @@
+# URN: test:govern-lifecycle:cli-readers:store-first
+# Issue: #1320 (#1270 slice B — decommission the manifest mirror)
+# Phase: RED
+# Layer: unit
+# Assertion: behavioral
+"""#1270 slice B — the atdd CLI-command readers read the store first.
+
+Discriminating tests seed the store and a DIVERGENT manifest for the same
+issue/slug, then assert the reader returns the STORE value — failing on the
+manifest-only implementations, passing once repointed store-first with manifest
+fallback. Isolated tmp stores; independent of the ambient control-root layout.
+"""
+from __future__ import annotations
+
+import yaml
+
+from atdd.state.db import connect, init_state_store
+from atdd.state.manifest_import import GITHUB_PROVIDER, WORK_ITEM_KIND
+from atdd.state.store import StateStore
+
+
+def _seed(root, *, slug, issue_number, status="PLANNED", **data):
+    (root / ".atdd").mkdir(parents=True, exist_ok=True)
+    marker = root / ".atdd" / "config.yaml"
+    if not marker.exists():
+        marker.write_text("version: '1.0'\n", encoding="utf-8")  # Control Root marker
+    db = init_state_store(start=root)
+    conn = connect(db)
+    try:
+        s = StateStore(conn)
+        s.objects.upsert(slug, WORK_ITEM_KIND, state=status,
+                         data={"issue_number": issue_number, **data})
+        s.external_refs.link(slug, GITHUB_PROVIDER, "issue", str(issue_number), data={})
+    finally:
+        conn.close()
+
+
+def _manifest(root, sessions):
+    (root / ".atdd").mkdir(parents=True, exist_ok=True)
+    (root / ".atdd" / "manifest.yaml").write_text(
+        yaml.safe_dump({"version": "2.0", "sessions": sessions}), encoding="utf-8")
+
+
+# --- pr._resolve_via_manifest (branch slug → issue_number) ----------------- #
+def test_pr_resolve_via_store_over_divergent_manifest(tmp_path):
+    from atdd.coach.commands.pr import PRManager
+    _seed(tmp_path, slug="my-slug", issue_number=42)
+    _manifest(tmp_path, [{"slug": "my-slug", "issue_number": 999}])  # divergent
+    mgr = PRManager(target_dir=tmp_path)
+    assert mgr._resolve_via_manifest({"headRefName": "feat/my-slug"}) == 42
+
+
+def test_pr_resolve_falls_back_to_manifest(tmp_path):
+    """No store link for the slug → manifest mirror still resolves it."""
+    from atdd.coach.commands.pr import PRManager
+    _seed(tmp_path, slug="other", issue_number=1)  # store has a different item
+    _manifest(tmp_path, [{"slug": "only-in-manifest", "issue_number": 77}])
+    mgr = PRManager(target_dir=tmp_path)
+    assert mgr._resolve_via_manifest({"headRefName": "fix/only-in-manifest"}) == 77
+
+
+# --- pr._find_issue_in_manifest (type) ------------------------------------- #
+def test_pr_find_issue_type_from_store(tmp_path):
+    from atdd.coach.commands.pr import PRManager
+    _seed(tmp_path, slug="x", issue_number=7, type="refactor")
+    _manifest(tmp_path, [{"slug": "x", "issue_number": 7, "type": "implementation"}])
+    mgr = PRManager(target_dir=tmp_path)
+    assert (mgr._find_issue_in_manifest(7) or {}).get("type") == "refactor"
+
+
+# --- branch._find_issue (slug + type) -------------------------------------- #
+def test_branch_find_issue_from_store(tmp_path):
+    from atdd.coach.commands.branch import BranchManager
+    _seed(tmp_path, slug="the-slug", issue_number=55, type="refactor")
+    _manifest(tmp_path, [{"slug": "WRONG", "issue_number": 55, "type": "implementation"}])
+    entry = BranchManager(target_dir=tmp_path)._find_issue(55)
+    assert entry is not None
+    assert entry["slug"] == "the-slug"
+    assert entry.get("type") == "refactor"
+
+
+# --- issue.sync_wmbts (wagon + feature) ------------------------------------ #
+def test_sync_wmbts_reads_wagon_feature_from_store(tmp_path):
+    from atdd.coach.commands.issue import IssueManager
+    _seed(tmp_path, slug="w", issue_number=88,
+          wagon="govern-lifecycle", feature="feature:govern-lifecycle:x")
+    _manifest(tmp_path, [{"slug": "w", "issue_number": 88,
+                          "wagon": "author-plan-substrate", "feature": "feature:other:y"}])
+    mgr = IssueManager(tmp_path)
+    captured = {}
+    mgr._discover_wmbts_from_feature = lambda wagon, feature: captured.update(
+        wagon=wagon, feature=feature) or []
+    mgr.sync_wmbts(88)
+    assert captured.get("wagon") == "govern-lifecycle"
+    assert captured.get("feature") == "feature:govern-lifecycle:x"

--- a/src/atdd/state/tests/test_work_item_reader_cli_accessor.py
+++ b/src/atdd/state/tests/test_work_item_reader_cli_accessor.py
@@ -1,0 +1,60 @@
+# URN: test:state-store:work-item-reader:cli-accessor
+# Issue: #1320 (#1270 slice B — decommission the manifest mirror)
+# Phase: RED
+# Layer: unit
+# Assertion: behavioral
+"""#1270 slice B — WorkItemReader accessor extensions for the CLI readers.
+
+Adds feature(), issue_number_for_slug(), session_entry() consumed by the
+pr/branch/issue_lifecycle/sync_wmbts repoints. Isolated tmp-store tests
+(explicit db_path), independent of the ambient control-root layout.
+"""
+from __future__ import annotations
+
+import yaml
+import pytest
+
+from atdd.state.work_item_reader import WorkItemReader
+
+_MANIFEST = {
+    "version": "2.0",
+    "sessions": [
+        {"id": "1203", "slug": "state-store-authoritative", "issue_number": 1203,
+         "type": "implementation", "status": "PLANNED", "train": "0002",
+         "branch": "feat/ssa", "feature": "feature:atdd:state-store",
+         "wagon": "govern-lifecycle", "created": "2026-06-01", "archived": None},
+        {"id": "900", "slug": "older-thing", "issue_number": 900, "type": "refactor",
+         "status": "COMPLETE", "train": "0001", "branch": "fix/older"},
+    ],
+}
+
+
+@pytest.fixture()
+def reader(tmp_path):
+    (tmp_path / ".atdd").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".atdd" / "manifest.yaml").write_text(yaml.safe_dump(_MANIFEST), encoding="utf-8")
+    db = tmp_path / ".atdd" / "state" / "state.sqlite"
+    with WorkItemReader(control_root=tmp_path, db_path=db) as r:
+        yield r
+
+
+def test_feature_reads_from_store(reader):
+    assert reader.feature(1203) == "feature:atdd:state-store"
+    assert reader.feature(900) is None          # no feature recorded
+    assert reader.feature(424242) is None        # unregistered
+
+
+def test_issue_number_for_slug(reader):
+    assert reader.issue_number_for_slug("state-store-authoritative") == 1203
+    assert reader.issue_number_for_slug("older-thing") == 900
+    assert reader.issue_number_for_slug("nope") is None
+
+
+def test_session_entry_reconstructs_manifest_shape(reader):
+    entry = reader.session_entry(1203)
+    assert entry is not None
+    assert entry["slug"] == "state-store-authoritative"   # from uid
+    assert entry["status"] == "PLANNED"                    # from state
+    assert entry["type"] == "implementation"               # from data
+    assert entry["train"] == "0002"
+    assert reader.session_entry(424242) is None

--- a/src/atdd/state/work_item_reader.py
+++ b/src/atdd/state/work_item_reader.py
@@ -39,6 +39,7 @@ _ISSUE_REF_KIND = "issue"
 _TRAIN_KEY = "train"
 _BRANCH_KEY = "branch"
 _WAGON_KEY = "wagon"
+_FEATURE_KEY = "feature"
 
 
 class WorkItemReader:
@@ -161,6 +162,39 @@ class WorkItemReader:
             except (TypeError, ValueError):
                 continue
         return out
+
+    def feature(self, issue_number: int) -> Optional[str]:
+        """The feature URN recorded for ``issue_number`` (from the work-item ``data``)."""
+        obj = self.get(issue_number)
+        return obj.data.get(_FEATURE_KEY) if obj is not None else None
+
+    def issue_number_for_slug(self, slug: str) -> Optional[int]:
+        """Reverse lookup: the GitHub issue number linked to work-item *slug*, or None.
+
+        The store keys work items by slug (the object uid) and links exactly one
+        GitHub ``issue`` external-ref per issue, so this is unambiguous — unlike
+        the manifest scan it replaces, which had to pick the last duplicate slug.
+        """
+        for ref in self._store.external_refs.for_object(slug):
+            if ref.provider == GITHUB_PROVIDER and ref.ref_kind == _ISSUE_REF_KIND:
+                try:
+                    return int(ref.ref_value)
+                except (TypeError, ValueError):
+                    return None
+        return None
+
+    def session_entry(self, issue_number: int) -> Optional[dict]:
+        """Reconstruct the manifest-``sessions``-shaped dict for ``issue_number``.
+
+        Returns ``{**data, "slug": <uid>, "status": <state>}`` — the same shape
+        the manifest carried — so callers that read ``entry["slug"]`` /
+        ``entry.get("type")`` off a manifest session keep working unchanged, now
+        sourced from the store. Returns ``None`` for an unregistered issue.
+        """
+        obj = self.get(issue_number)
+        if obj is None:
+            return None
+        return {**obj.data, "slug": obj.uid, "status": obj.state}
 
     # -- internals ---------------------------------------------------------- #
     def _auto_import_if_empty(self, *, db_path: Optional[Path]) -> None:

--- a/src/atdd/state/work_item_reader.py
+++ b/src/atdd/state/work_item_reader.py
@@ -181,8 +181,8 @@ class WorkItemReader:
                     return int(ref.ref_value)
                 except (TypeError, ValueError):
                     _log.debug(
-                        "non-integer github issue ref_value for slug %r: %r",
-                        slug, ref.ref_value,
+                        "non-integer github issue ref_value; treating slug as unlinked",
+                        extra={"slug": slug, "ref_value": ref.ref_value},
                     )
                     return None
         return None

--- a/src/atdd/state/work_item_reader.py
+++ b/src/atdd/state/work_item_reader.py
@@ -180,6 +180,10 @@ class WorkItemReader:
                 try:
                     return int(ref.ref_value)
                 except (TypeError, ValueError):
+                    _log.debug(
+                        "non-integer github issue ref_value for slug %r: %r",
+                        slug, ref.ref_value,
+                    )
                     return None
         return None
 


### PR DESCRIPTION
Delivers #1320 · Part of #1270 (auto-close removed: partial step; #1320 closes via its lifecycle)
## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #1320 |
| Type | refactor |
| Slug | migrate-cli-readers-to-state-store |
| Train | 0002-coach-drives-lifecycle |
| Labels | atdd-issue, atdd:INIT |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.
