### PR TITLE
fix(atdd): must-be-canonical theme validator rejects consumer-repo game-domain themes; contradicts get_theme_map (#1314) (#1317)

### DIFF
--- a/.atdd/config.yaml
+++ b/.atdd/config.yaml
@@ -12,6 +12,19 @@ release:
   tag_prefix: v
 code:
   toolkit: src/atdd
+# Theme taxonomy (#1317). The toolkit self-governs to its own abstraction
+# stack (commons/plan/test/code/coach, #970/#951), so declare it explicitly:
+# `planner.theme.must-be-canonical` resolves the canonical set from
+# get_theme_map(config), and without this block the built-in game-domain
+# DEFAULT_THEME_MAP would make the toolkit accept game themes and reject its
+# own plan/test/code/coach wagons. Digits 5-9 keep the game-domain defaults
+# (get_theme_map merges, it cannot remove digits) but are unused here.
+themes:
+  '0': commons
+  '1': plan
+  '2': test
+  '3': code
+  '4': coach
 sync:
   agents:
   - claude

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -6,7 +6,7 @@ sessions:
   file: null
   issue_number: 1317
   type: implementation
-  status: PLANNED
+  status: RED
   created: '2026-07-02'
   archived: null
   branch: fix/resolve-canonical-theme-from-config

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -6,7 +6,7 @@ sessions:
   file: null
   issue_number: 1317
   type: implementation
-  status: GREEN
+  status: SMOKE
   created: '2026-07-02'
   archived: null
   branch: fix/resolve-canonical-theme-from-config

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -6,7 +6,7 @@ sessions:
   file: null
   issue_number: 1317
   type: implementation
-  status: RED
+  status: GREEN
   created: '2026-07-02'
   archived: null
   branch: fix/resolve-canonical-theme-from-config

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -6,7 +6,7 @@ sessions:
   file: null
   issue_number: 1317
   type: implementation
-  status: INIT
+  status: PLANNED
   created: '2026-07-02'
   archived: null
   branch: fix/resolve-canonical-theme-from-config

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -1,6 +1,15 @@
 version: '2.0'
 created: '2026-05-13'
 sessions:
+- id: '1317'
+  slug: resolve-canonical-theme-from-config
+  file: null
+  issue_number: 1317
+  type: implementation
+  status: INIT
+  created: '2026-07-02'
+  archived: null
+  branch: fix/resolve-canonical-theme-from-config
 - id: '1315'
   slug: single-shared-state-store-per-project
   file: null

--- a/.atdd/manifest.yaml
+++ b/.atdd/manifest.yaml
@@ -10,6 +10,7 @@ sessions:
   created: '2026-07-02'
   archived: null
   branch: fix/resolve-canonical-theme-from-config
+  train: 0002-coach-drives-lifecycle
 - id: '1315'
   slug: single-shared-state-store-per-project
   file: null
@@ -3604,3 +3605,4 @@ sessions:
   archived: null
   branch: refactor/migrate-cli-readers-to-state-store
   train: 0002-coach-drives-lifecycle
+issues: {}

--- a/src/atdd/planner/conventions/nodes/planner.theme.canonical-taxonomy.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.theme.canonical-taxonomy.convention.yaml
@@ -58,4 +58,7 @@ terms:
     - audience
     - monetization
     - partnership
-    note: DEFAULT_THEME_MAP retains them for back-compat resolution only; must-be-canonical rejects them
+    note: 'In the toolkit''s own repo these digits are unused (config declares only 0-4). must-be-canonical
+      no longer hardcodes a reject list (#1317) — a theme is non-canonical iff absent from get_theme_map(config),
+      so it can never both be blessed by the map and rejected. get_theme_map merges and cannot remove digits,
+      so 5-9 keep the game-domain defaults but are unreferenced.'

--- a/src/atdd/planner/conventions/nodes/planner.theme.must-be-canonical.convention.yaml
+++ b/src/atdd/planner/conventions/nodes/planner.theme.must-be-canonical.convention.yaml
@@ -3,8 +3,10 @@ rule_id: planner.theme.must-be-canonical
 kind: rule
 status: active
 name: Theme must be canonical
-statement: 'Every wagon theme: and every train theme-digit MUST resolve to one of the five canonical themes
-  (commons/plan/test/code/coach; digits 0-4); retired (5-9) and undeclared themes are rejected.'
+statement: 'Every wagon theme: and every train theme-digit MUST resolve to a theme in the effective map
+  get_theme_map(config) — built-in defaults + .atdd/config.yaml themes: overrides (#1317). The canonical set
+  is consumer-repo-aware, not a hardcoded five; a theme absent from the effective map is rejected. In the
+  toolkit''s own repo the config declares commons/plan/test/code/coach.'
 implementation:
   type: validator
   ref: test_theme_must_be_canonical::test_every_wagon_theme_is_canonical
@@ -31,13 +33,14 @@ parity:
   reviewed_at: '2026-06-16'
 terms:
 - term_id: canonical_resolution
-  text: a theme/digit resolving to the canonical set.
+  text: a theme/digit resolving to the effective canonical set = values of get_theme_map(config).
   values:
-    allowed:
+    source: get_theme_map(config)  # built-in defaults + .atdd/config.yaml themes: overrides
+    toolkit_repo:  # what the toolkit's own .atdd/config.yaml declares
     - commons
     - plan
     - test
     - code
     - coach
-    digits: 0-4
+    consumer_repo: repo-declared game-domain (or other) themes; resolved per-repo, not hardcoded
 notes: Subsumes the runtime theme-membership check wmbt:govern-lifecycle:E001 (which is otherwise unbound).

--- a/src/atdd/planner/conventions/theme.convention.yaml
+++ b/src/atdd/planner/conventions/theme.convention.yaml
@@ -1,19 +1,23 @@
 version: "1.0"
 name: "Theme Convention"
 description: >-
-  Canonical wagon/train theme taxonomy (issue #970). Collapses the vestigial
-  10-theme game-domain template (commons/mechanic/scenario/match/sensory/player/
-  league/audience/monetization/partnership) down to five canonical themes that
-  describe the ATDD toolkit's own abstraction stack, and binds validators that
-  enforce the set, the commons-vs-coach boundary, URN-prefix alignment, and
-  archetype alignment.
+  Wagon/train theme taxonomy (issue #970; consumer-aware #1317). The ATDD
+  toolkit self-governs to a five-theme abstraction stack (commons/plan/test/
+  code/coach), declared in its own .atdd/config.yaml `themes:` block. The
+  canonical SET a repo enforces is NOT hardcoded: planner.theme.must-be-canonical
+  resolves it from get_theme_map(config) — the effective, consumer-repo-aware map
+  (built-in defaults + .atdd/config.yaml overrides) — so a game/consumer repo
+  governs against its own domain themes. This convention also binds the
+  commons-vs-coach boundary, URN-prefix alignment, and archetype alignment.
 
 # =============================================================================
 # CANONICAL TAXONOMY (5 themes, ordered as an abstraction stack)
 # =============================================================================
 # Digit alignment preserves the existing train-numbering scheme
-# (train.convention.yaml theme_digit): only digits 0-4 are canonical; 5-9 are
-# retired. The digit-0 NAME is the single flip point — see `theme_zero_token`
+# (train.convention.yaml theme_digit). This is the TOOLKIT's own map (digits
+# 0-4); a consumer repo declares its own via .atdd/config.yaml `themes:` and
+# must-be-canonical resolves the effective set from get_theme_map(config)
+# (#1317). The digit-0 NAME is the single flip point — see `theme_zero_token`
 # below and CANONICAL_THEME_0 in
 # src/atdd/planner/validators/_theme_taxonomy.py (one constant, mirrored here).
 taxonomy:
@@ -58,9 +62,14 @@ taxonomy:
 
   retired_digits: ["5", "6", "7", "8", "9"]
   retired_note: >-
-    The legacy game-domain names (sensory/player/league/audience/monetization/
-    partnership) at digits 5-9 are retired. DEFAULT_THEME_MAP retains them for
-    back-compat resolution only; planner.theme.must-be-canonical rejects them.
+    In the TOOLKIT's own repo, digits 5-9 (the legacy game-domain names
+    sensory/player/league/audience/monetization/partnership) are unused — the
+    toolkit config declares only 0-4. must-be-canonical no longer hardcodes a
+    reject list (#1317): a theme is non-canonical iff it is absent from the
+    effective get_theme_map(config), so the validator and get_theme_map can
+    never disagree. get_theme_map merges overrides onto the built-in defaults
+    and cannot remove digits, so 5-9 keep the game-domain defaults but are not
+    referenced by any toolkit wagon.
 
 # =============================================================================
 # COMMONS-vs-COACH BOUNDARY (the one sharp line — bindable)

--- a/src/atdd/planner/validators/_theme_taxonomy.py
+++ b/src/atdd/planner/validators/_theme_taxonomy.py
@@ -17,9 +17,12 @@ import ast
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Mapping, Optional, Tuple
+from typing import Dict, FrozenSet, List, Mapping, Optional, Tuple
 
 import yaml
+
+from atdd.coach.utils.config import load_atdd_config
+from atdd.coach.utils.theme_map import get_theme_map
 
 _log = logging.getLogger(__name__)
 
@@ -32,7 +35,11 @@ _log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 CANONICAL_THEME_0: str = "commons"
 
-#: The five canonical themes, ordered as the abstraction stack (digits 0-4).
+#: The toolkit's OWN abstraction-stack themes (digits 0-4), documentary only.
+#: As of #1317 this tuple is NOT the enforcement source — the canonical set is
+#: resolved per-repo from ``get_theme_map(config)`` (see ``canonical_theme_set``)
+#: so a consumer/game repo governs against its own effective map. It remains as
+#: the value the toolkit's own ``.atdd/config.yaml`` ``themes:`` block declares.
 CANONICAL_THEMES: Tuple[str, ...] = (
     CANONICAL_THEME_0,
     "plan",
@@ -41,8 +48,9 @@ CANONICAL_THEMES: Tuple[str, ...] = (
     "coach",
 )
 
-#: digit -> canonical theme name (the post-#970 replacement for the 10-entry
-#: game-domain DEFAULT_THEME_MAP). Digits 5-9 are retired.
+#: digit -> canonical theme name for the toolkit's own abstraction stack (0-4).
+#: Used by ``resolve_theme_set`` / theme-zero-mandatory as the pinned floor;
+#: the must-be-canonical membership check instead defers to ``get_theme_map``.
 CANONICAL_DIGIT_MAP: Dict[str, str] = {
     "0": CANONICAL_THEME_0,
     "1": "plan",
@@ -58,17 +66,12 @@ ARCHETYPE_THEME_ROOTS: Dict[str, str] = {
     "code": "src/atdd/coder",
 }
 
-RETIRED_THEMES: Tuple[str, ...] = (
-    "mechanic",
-    "scenario",
-    "match",
-    "sensory",
-    "player",
-    "league",
-    "audience",
-    "monetization",
-    "partnership",
-)
+# NOTE (#1317): the former static ``RETIRED_THEMES`` reject list was removed.
+# A theme is "retired"/non-canonical iff it is ABSENT from the effective
+# ``get_theme_map(config)`` — so the validator and get_theme_map can never
+# disagree on the same theme (a name can no longer be both blessed by the map
+# and rejected as retired). Retirement is now purely the complement of the
+# effective map, resolved per-repo.
 
 #: Wagons whose theme correction + URN re-namespacing is deferred to the #951
 #: recompose co-land. The repo-wide boundary/URN checks exclude these so the
@@ -97,9 +100,24 @@ class ThemeViolation:
     path: str
 
 
-def is_canonical_theme(theme: str) -> bool:
-    """Return True iff *theme* is one of the five canonical theme names."""
-    return theme in CANONICAL_THEMES
+def canonical_theme_set(config: Optional[Mapping]) -> FrozenSet[str]:
+    """Return the effective canonical theme set for *config* (#1317).
+
+    Single source of truth = ``get_theme_map(config)``: the built-in defaults
+    merged with the ``.atdd/config.yaml`` ``themes:`` overrides. The canonical
+    set is exactly the set of names that map resolves to, so a consumer/game
+    repo governs against its own effective taxonomy and the validator can never
+    disagree with ``get_theme_map`` on any theme.
+    """
+    return frozenset(get_theme_map(config).values())
+
+
+def is_canonical_theme(theme: str, config: Optional[Mapping] = None) -> bool:
+    """Return True iff *theme* is in the effective canonical set for *config*.
+
+    With no config the built-in defaults are used (``get_theme_map(None)``).
+    """
+    return theme in canonical_theme_set(config)
 
 
 def drop_deferred(violations: List["ThemeViolation"]) -> List["ThemeViolation"]:
@@ -175,17 +193,29 @@ def scan_wagon_themes(repo_root: Path) -> Dict[str, Tuple[str, str]]:
 
 
 def check_must_be_canonical(repo_root: Path) -> List[ThemeViolation]:
-    """Flag every wagon whose ``theme:`` is not in CANONICAL_THEMES."""
+    """Flag every wagon whose ``theme:`` is absent from the effective map.
+
+    #1317: the canonical set is resolved from ``get_theme_map`` applied to the
+    repo's own ``.atdd/config.yaml`` (``canonical_theme_set``), so a game/
+    consumer repo governs against its declared game-domain themes while the
+    toolkit's own repo (whose config declares ``plan/test/code/coach``)
+    continues to reject those game names.
+    """
+    config = load_atdd_config(repo_root)
+    allowed = canonical_theme_set(config)
     viols: List[ThemeViolation] = []
     for data, mf in _iter_wagon_manifests(repo_root):
         theme = data["theme"]
-        if theme not in CANONICAL_THEMES:
+        if theme not in allowed:
             viols.append(
                 ThemeViolation(
                     rule_id="planner.theme.must-be-canonical",
                     wagon=data["wagon"],
                     theme=theme,
-                    detail=f"theme {theme!r} is not one of {CANONICAL_THEMES}",
+                    detail=(
+                        f"theme {theme!r} is not in the effective theme map "
+                        f"{sorted(allowed)} (get_theme_map + .atdd/config.yaml themes)"
+                    ),
                     path=str(mf),
                 )
             )

--- a/src/atdd/planner/validators/test_theme_must_be_canonical.py
+++ b/src/atdd/planner/validators/test_theme_must_be_canonical.py
@@ -1,14 +1,19 @@
 # Acceptance: acc:govern-lifecycle:C002-UNIT-001-non-canonical-theme-is-flagged
 # Acceptance: acc:govern-lifecycle:C002-SMOKE-001-plan-tree-has-no-non-canonical-theme
 # Acceptance: acc:govern-lifecycle:E001-UNIT-001-schema-pattern-accepts-custom-themes
-"""planner.theme.must-be-canonical validator (issue #970).
+"""planner.theme.must-be-canonical validator (issue #970; #1317 config-aware).
 
-Enforces that every wagon ``theme:`` (and, by digit, every train theme) resolves
-to one of the five canonical themes: commons/plan/test/code/coach (digits 0-4).
-The retired game-domain names (digits 5-9) and any undeclared theme are rejected.
+Enforces that every wagon ``theme:`` resolves to a canonical theme. As of #1317
+the canonical set is no longer a hardcoded five — it is the effective,
+consumer-repo-aware theme map ``get_theme_map(load_atdd_config(repo_root))``
+(built-in defaults + ``.atdd/config.yaml`` ``themes:`` overrides). This is the
+single source of truth shared with ``inventory``/``registry``/``sync``, so the
+validator and ``get_theme_map`` can never disagree on the same theme.
 
-This subsumes the runtime theme-membership check described by
-wmbt:govern-lifecycle:E001 (previously unbound — RULEID-0007 gap closed here).
+In the toolkit's OWN repo the config's ``themes:`` block yields
+commons/plan/test/code/coach; in a game/consumer repo it yields the game-domain
+themes. A theme is non-canonical iff it is absent from the effective map — there
+is no separate static reject list to contradict ``get_theme_map`` (#1317).
 
 Rule: planner.theme.must-be-canonical (severity 3)
 Convention: src/atdd/planner/conventions/theme.convention.yaml::rules
@@ -19,12 +24,13 @@ from pathlib import Path
 
 import pytest
 
+from atdd.coach.utils.config import load_atdd_config
 from atdd.coach.utils.repo import find_repo_root
 from atdd.coach.utils.rule_binding import bind_rule
+from atdd.coach.utils.theme_map import get_theme_map
 
 from ._theme_taxonomy import (
-    CANONICAL_THEMES,
-    RETIRED_THEMES,
+    canonical_theme_set,
     check_must_be_canonical,
     is_canonical_theme,
 )
@@ -38,9 +44,32 @@ _RULE = bind_rule("planner.theme.must-be-canonical")
 
 REPO_ROOT = find_repo_root()
 
+# Effective-map fixtures (as written to a tmp repo's .atdd/config.yaml).
+TOOLKIT_THEMES = {0: "commons", 1: "plan", 2: "test", 3: "code", 4: "coach"}
+GAME_THEMES = {
+    0: "commons", 1: "mechanic", 2: "scenario", 3: "match",
+    4: "sensory", 5: "player", 6: "league",
+}
+
+
+def _write_wagon(root: Path, wagon: str, theme: str) -> None:
+    slug = wagon.replace("-", "_")
+    d = root / "plan" / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"_{slug}.yaml").write_text(
+        f'wagon: {wagon}\nurn: "wagon:{wagon}"\ntheme: {theme}\n'
+    )
+
+
+def _write_config(root: Path, themes: dict) -> None:
+    atdd = root / ".atdd"
+    atdd.mkdir(parents=True, exist_ok=True)
+    lines = ["themes:"] + [f"  {k}: {v}" for k, v in themes.items()]
+    (atdd / "config.yaml").write_text("\n".join(lines) + "\n")
+
 
 def test_every_wagon_theme_is_canonical() -> None:
-    """Repo-wide: no wagon declares a non-canonical theme."""
+    """Repo-wide: no wagon declares a theme outside the effective map."""
     violations = check_must_be_canonical(REPO_ROOT)
     assert violations == [], (
         f"[{_RULE_ID}] non-canonical wagon themes:\n"
@@ -48,32 +77,61 @@ def test_every_wagon_theme_is_canonical() -> None:
     )
 
 
-def test_retired_game_theme_is_flagged(tmp_path: Path) -> None:
-    """A wagon declaring a retired game-domain theme is a violation."""
-    wagon_dir = tmp_path / "plan" / "play_match"
-    wagon_dir.mkdir(parents=True)
-    (wagon_dir / "_play_match.yaml").write_text(
-        "wagon: play-match\nurn: \"wagon:play-match\"\ntheme: match\n"
-    )
-    violations = check_must_be_canonical(tmp_path)
-    assert any(v.theme == "match" for v in violations), (
-        "expected the retired 'match' theme to be flagged"
-    )
-
-
-def test_canonical_themes_pass(tmp_path: Path) -> None:
-    """Each of the five canonical themes validates clean."""
-    for theme in CANONICAL_THEMES:
-        wagon_dir = tmp_path / "plan" / f"w_{theme}"
-        wagon_dir.mkdir(parents=True)
-        (wagon_dir / f"_w_{theme}.yaml").write_text(
-            f"wagon: w-{theme}\nurn: \"wagon:w-{theme}\"\ntheme: {theme}\n"
-        )
+def test_game_repo_config_accepts_game_themes(tmp_path: Path) -> None:
+    """Consumer/game repo whose config declares game themes → PASSES for
+    match/mechanic/scenario/league wagons (acceptance #1)."""
+    _write_config(tmp_path, GAME_THEMES)
+    for wagon, theme in (
+        ("run-match", "match"),
+        ("own-territory", "mechanic"),
+        ("curate-content", "scenario"),
+        ("run-league", "league"),
+    ):
+        _write_wagon(tmp_path, wagon, theme)
     assert check_must_be_canonical(tmp_path) == []
 
 
-def test_taxonomy_is_exactly_five() -> None:
-    """Guard: the canonical set is the five themes and excludes game themes."""
-    assert len(CANONICAL_THEMES) == 5
-    assert is_canonical_theme("plan") and not is_canonical_theme("mechanic")
-    assert set(CANONICAL_THEMES).isdisjoint(RETIRED_THEMES)
+def test_toolkit_config_rejects_out_of_map_theme(tmp_path: Path) -> None:
+    """Toolkit-config repo → STILL enforces plan/test/code/coach: a game theme
+    that the config maps away (mechanic → digit 1 = plan) is rejected
+    (acceptance #2)."""
+    _write_config(tmp_path, TOOLKIT_THEMES)
+    _write_wagon(tmp_path, "own-territory", "mechanic")
+    violations = check_must_be_canonical(tmp_path)
+    assert any(v.theme == "mechanic" for v in violations), (
+        "expected 'mechanic' to be rejected under the toolkit themes block"
+    )
+
+
+def test_toolkit_config_accepts_toolkit_themes(tmp_path: Path) -> None:
+    """Under the toolkit themes block, commons/plan/test/code/coach all pass."""
+    _write_config(tmp_path, TOOLKIT_THEMES)
+    for theme in ("commons", "plan", "test", "code", "coach"):
+        _write_wagon(tmp_path, f"w-{theme}", theme)
+    assert check_must_be_canonical(tmp_path) == []
+
+
+@pytest.mark.parametrize(
+    "config",
+    [{"themes": GAME_THEMES}, {"themes": TOOLKIT_THEMES}, {}, None],
+)
+def test_validator_never_disagrees_with_get_theme_map(config) -> None:
+    """acceptance #3: every theme blessed by get_theme_map is canonical, and a
+    theme absent from the effective map is not."""
+    effective = get_theme_map(config)
+    for theme in effective.values():
+        assert is_canonical_theme(theme, config), (
+            f"{theme!r} in get_theme_map but not canonical under {config!r}"
+        )
+    assert set(canonical_theme_set(config)) == set(effective.values())
+    assert not is_canonical_theme("no-such-theme-xyz", config)
+
+
+def test_is_canonical_theme_is_config_aware() -> None:
+    """Same name, opposite verdict under different effective maps."""
+    game = {"themes": GAME_THEMES}
+    toolkit = {"themes": TOOLKIT_THEMES}
+    assert is_canonical_theme("mechanic", game)
+    assert not is_canonical_theme("mechanic", toolkit)
+    assert is_canonical_theme("plan", toolkit)
+    assert not is_canonical_theme("plan", game)


### PR DESCRIPTION
Closes #1317

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #1317 |
| Type | implementation |
| Slug | resolve-canonical-theme-from-config |
| Train | 0002-coach-drives-lifecycle |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.