### PR TITLE
refactor(atdd): Stop mirroring lifecycle transitions to the manifest (#1358)

### DIFF
--- a/src/atdd/coach/commands/issue.py
+++ b/src/atdd/coach/commands/issue.py
@@ -331,33 +331,16 @@ class IssueManager:
             return False
 
     def _update_manifest_status(self, issue_number: int, status: str) -> None:
-        """Record a successful GitHub status transition.
+        """Record a successful GitHub status transition into the State Store.
 
-        #1203 Phase 2: the State Store is authoritative for the work-item phase —
-        this writes the store first, then mirrors the manifest ``sessions`` entry
-        (a compatibility projection, retained until the manifest is fully demoted).
-        A missing manifest or a manifest without a matching session is a no-op for
-        the mirror — transitions for unregistered issues are valid (e.g. issues
-        created outside the atdd CLI) and must not crash the lifecycle.
+        #1270 slice F: the State Store is authoritative for the work-item phase
+        (#1203 Phase 2) and every reader now resolves the phase from it (slices
+        A–E). The former ``.atdd/manifest.yaml`` mirror write is retired — keeping
+        a mirror nothing reads in sync was dead work (and the source of the
+        parallel-session clobber #1270 removes). The manifest survives only as the
+        store's cold-start seed until Slice G.
         """
         self._store_set_status(issue_number, status)
-        if not self.manifest_file.exists():
-            return
-        manifest = self._load_manifest()
-        sessions = manifest.get("sessions") or []
-        mutated = False
-        for entry in sessions:
-            if entry.get("issue_number") == issue_number:
-                entry["status"] = status
-                mutated = True
-        if mutated:
-            self._save_manifest(manifest)
-            self._commit_manifest_change(
-                verb="atdd update --status",
-                message=(
-                    f"chore(coach): mirror issue #{issue_number} status → {status} in manifest"
-                ),
-            )
 
     def _store_work_item_field(
         self, issue_number: int, field: str
@@ -485,36 +468,15 @@ class IssueManager:
     def _update_manifest_fields(
         self, issue_number: int, fields: Dict[str, Any]
     ) -> None:
-        """Record work-item metadata (branch/train/...).
+        """Record work-item metadata (branch/train/...) into the State Store.
 
-        #1203 Phase 2: the State Store is authoritative — this writes the store
-        first (merging into the work item's ``data``), then mirrors the manifest
-        ``sessions`` entry and the ``issues.<n>`` record (a compatibility
-        projection). A missing manifest is a no-op for the mirror — transitions
-        for issues created outside the atdd CLI remain valid.
+        #1270 slice F: the State Store is authoritative (#1203 Phase 2) and every
+        reader resolves metadata from it (slices A–E). The former
+        ``.atdd/manifest.yaml`` mirror write (``sessions`` + ``issues.<n>``) is
+        retired — nothing reads it. The manifest survives only as the store's
+        cold-start seed until Slice G.
         """
         self._store_update_fields(issue_number, fields)
-        if not self.manifest_file.exists():
-            return
-        manifest = self._load_manifest()
-        mutated = False
-        for session in manifest.get("sessions") or []:
-            if session.get("issue_number") == issue_number:
-                session.update(fields)
-                mutated = True
-        issues = manifest.setdefault("issues", {})
-        record = issues.get(str(issue_number))
-        if record is not None:
-            record.update(fields)
-            mutated = True
-        if mutated:
-            self._save_manifest(manifest)
-            self._commit_manifest_change(
-                verb="atdd update",
-                message=(
-                    f"chore(coach): mirror issue #{issue_number} metadata in manifest"
-                ),
-            )
 
     def _slugify(self, text: str) -> str:
         """Convert text to kebab-case slug."""
@@ -1643,21 +1605,11 @@ class IssueManager:
         # the archived date), then mirror the manifest below. Both calls degrade
         # to a logged no-op if the store is unavailable; the GitHub close +
         # manifest record below still apply.
+        # #1270 slice F: the State Store is authoritative for the terminal
+        # COMPLETE/archived state; the manifest mirror write is retired (nothing
+        # reads it — slices A–E). Manifest survives only as the cold-start seed.
         self._store_set_status(issue_number, "COMPLETE")
         self._store_update_fields(issue_number, {"archived": date.today().isoformat()})
-
-        # Update manifest
-        manifest = self._load_manifest()
-        for s in manifest.get("sessions", []):
-            if s.get("issue_number") == issue_number:
-                s["status"] = "COMPLETE"
-                s["archived"] = date.today().isoformat()
-                break
-        self._save_manifest(manifest)
-        self._commit_manifest_change(
-            verb="atdd archive",
-            message=f"chore(coach): archive issue #{issue_number} in manifest",
-        )
 
         total_subs = len(subs) if subs else 0
         print(f"\nArchived #{issue_number}: closed {closed_count} sub-issues, "

--- a/src/atdd/coach/commands/tests/test_e051_unit_001_transition_label_rest_only_no_board_graphql.py
+++ b/src/atdd/coach/commands/tests/test_e051_unit_001_transition_label_rest_only_no_board_graphql.py
@@ -47,7 +47,7 @@ def _setup(tmp_path: Path, status: str = "RED") -> Path:
     (cfg / "manifest.yaml").write_text(
         yaml.safe_dump(
             {
-                "sessions": [{"issue_number": 384, "status": status}],
+                "sessions": [{"issue_number": 384, "slug": "demo", "status": status}],
                 "issues": {"384": {"slug": "demo", "train": "0001-self-compliance-validate"}},
             }
         )
@@ -90,6 +90,7 @@ def test_transition_emits_label_rest_only_no_board_graphql(tmp_path):
     for method in BOARD_METHODS:
         getattr(client, method).assert_not_called()
 
-    manifest = yaml.safe_load((target / ".atdd" / "manifest.yaml").read_text())
-    statuses = {e["issue_number"]: e.get("status") for e in manifest["sessions"]}
-    assert statuses[384] == "GREEN", "manifest remains the local state mirror"
+    # #1270 slice F: the local state mirror is the State Store, not the manifest.
+    from atdd.state.work_item_reader import WorkItemReader
+    with WorkItemReader(control_root=target) as reader:
+        assert reader.status(384) == "GREEN", "the store is the local state mirror"

--- a/src/atdd/coach/commands/tests/test_store_authoritative_writes.py
+++ b/src/atdd/coach/commands/tests/test_store_authoritative_writes.py
@@ -63,12 +63,19 @@ def test_update_status_unregistered_issue_is_noop_not_crash(tmp_path):
     assert mgr._store_set_status(999999, "SMOKE") is False
 
 
-def test_update_status_still_mirrors_manifest(tmp_path):
+def test_update_status_no_longer_mirrors_manifest(tmp_path):
+    """#1270 slice F: the status transition lands in the store only; the manifest
+    mirror write is retired, so the manifest session status is left untouched."""
     mgr = _init_repo(tmp_path)
     mgr._update_manifest_status(1203, "SMOKE")
+    # Store is authoritative → SMOKE.
+    store = _store(tmp_path)
+    ref = store.external_refs.resolve(GITHUB_PROVIDER, "issue", "1203")
+    assert store.objects.get(ref.object_uid).state == "SMOKE"
+    # Manifest is NOT mirrored → still the seeded GREEN.
     doc = yaml.safe_load((tmp_path / ".atdd" / "manifest.yaml").read_text())
     entry = next(s for s in doc["sessions"] if s["issue_number"] == 1203)
-    assert entry["status"] == "SMOKE"
+    assert entry["status"] == "GREEN"
 
 
 def test_update_fields_writes_store_authoritatively(tmp_path):
@@ -89,12 +96,19 @@ def test_update_fields_unregistered_issue_is_noop_not_crash(tmp_path):
     assert mgr._store_update_fields(999999, {"branch": "feat/x"}) is False
 
 
-def test_update_fields_still_mirrors_manifest(tmp_path):
+def test_update_fields_no_longer_mirrors_manifest(tmp_path):
+    """#1270 slice F: metadata lands in the store only; the manifest mirror write
+    is retired, so the manifest session gains no ``branch`` key."""
     mgr = _init_repo(tmp_path)
     mgr._update_manifest_fields(1203, {"branch": "feat/foo"})
+    # Store is authoritative → branch recorded.
+    store = _store(tmp_path)
+    ref = store.external_refs.resolve(GITHUB_PROVIDER, "issue", "1203")
+    assert store.objects.get(ref.object_uid).data["branch"] == "feat/foo"
+    # Manifest is NOT mirrored → no branch key added.
     doc = yaml.safe_load((tmp_path / ".atdd" / "manifest.yaml").read_text())
     entry = next(s for s in doc["sessions"] if s["issue_number"] == 1203)
-    assert entry["branch"] == "feat/foo"
+    assert "branch" not in entry
 
 
 def test_register_issue_creates_store_work_item_and_ref(tmp_path):

--- a/src/atdd/coach/commands/tests/test_transition_side_effects.py
+++ b/src/atdd/coach/commands/tests/test_transition_side_effects.py
@@ -15,6 +15,13 @@ import yaml
 pytestmark = [pytest.mark.platform]
 
 
+def _store_status(tmp_path: Path, issue_number: int):
+    from atdd.state.work_item_reader import WorkItemReader
+
+    with WorkItemReader(control_root=tmp_path) as reader:
+        return reader.status(issue_number)
+
+
 def _write_manifest(tmp_path: Path, issue_number: int, status: str) -> Path:
     atdd_dir = tmp_path / ".atdd"
     atdd_dir.mkdir()
@@ -35,22 +42,28 @@ def _write_manifest(tmp_path: Path, issue_number: int, status: str) -> Path:
     return manifest_path
 
 
-def test_r001_unit_001_update_manifest_status_writes_session_entry(tmp_path):
-    """R001: IssueManager must mirror a GitHub status transition into the local manifest.
+def test_r001_unit_001_update_manifest_status_writes_store_not_manifest(tmp_path):
+    """R001 (#1270 slice F): a status transition is recorded in the State Store;
+    the ``.atdd/manifest.yaml`` mirror write is retired (the store is
+    authoritative — slices A–E migrated every reader to it).
 
-    Currently fails: IssueManager has no helper that updates the session entry's status
-    field, and IssueManager.update() never touches the manifest.
+    Discriminator: the old mirror implementation rewrote the manifest session's
+    status; the store-only implementation leaves the manifest untouched.
     """
     from atdd.coach.commands.issue import IssueManager
 
+    # The manifest seeds the store once via the reader's cold-start auto-import;
+    # the transition then updates the store (authoritative).
     manifest_path = _write_manifest(tmp_path, issue_number=282, status="INIT")
+    original_manifest = manifest_path.read_text()
     manager = IssueManager(target_dir=tmp_path)
 
     manager._update_manifest_status(282, "PLANNED")
 
-    data = yaml.safe_load(manifest_path.read_text())
-    assert data["sessions"][0]["status"] == "PLANNED"
-    assert data["sessions"][0]["issue_number"] == 282
+    # Store is authoritative and updated.
+    assert _store_status(tmp_path, 282) == "PLANNED"
+    # The manifest mirror is NOT written (slice F contract).
+    assert manifest_path.read_text() == original_manifest
 
 
 def test_r001_unit_001_update_manifest_status_is_noop_for_unknown_issue(tmp_path):


### PR DESCRIPTION
## Summary

Slice F of #1270 (decommission the manifest mirror). The State Store is authoritative
for work-item lifecycle state (#1203 Phase 2) and every reader now resolves from it
(slices A–E, all merged). This retires the three recurring **manifest-mirror WRITES** on
lifecycle transitions — keeping a mirror nothing reads in sync was dead work and the source
of the parallel-session clobber #1270 removes.

## Changes

| Site | Change |
|------|--------|
| `issue.py::_update_manifest_status` | store-only (drop the `sessions` mirror write + commit) |
| `issue.py::_update_manifest_fields` | store-only (drop the `sessions`/`issues.<n>` mirror + commit) |
| `issue.py::archive` | store-only terminal COMPLETE/archived (drop the mirror + commit) |

The store-authoritative `_store_*` writes are unchanged. The manifest survives only as the
store's cold-start seed until Slice G.

## What is deliberately NOT here (Slice G)

The issue-**registration** writes (`_register_issue_in_manifest` / `reconcile`) and the
`atdd init` **genesis** (`_create_manifest`) are left in place. They keep the
`test_manifest_write_discipline` invariant satisfied (it asserts ≥1 `_save_manifest` call
exists), and they are removed **together with the file** in Slice G — you cannot delete a
file that genesis recreates. Removing all writers + retiring that validator + deleting the
file + dropping the control-root marker is Slice G, gated on the fresh-clone seeding story
(ext#40).

## Tests

Migrated the four tests that codified the retired mirror to assert the store-only contract
(store updated, manifest untouched): `test_transition_side_effects` R001,
`test_store_authoritative_writes` status/fields (now `*_no_longer_mirrors_manifest`), and
the E051 label-only transition (the local state mirror is the store). `test_manifest_write_discipline`
still passes. Regression-checked against current main (incl. #1346 control-root activation):
44 Slice-E+F tests green; the one `test_build_version_hook` failure is a pre-existing
pipx-venv version-resolver env issue, unrelated.

Refs #1358. Part of #1270 (umbrella stays OPEN).

