### PR TITLE
feat: Activate extension enforcement in core (bind conventions + run atdd enforce in CI) (#1359)

### DIFF
--- a/.github/workflows/atdd-validate.yml
+++ b/.github/workflows/atdd-validate.yml
@@ -293,6 +293,63 @@ jobs:
       - name: Run incident-defense suite (§9)
         run: PYTHONPATH=src python3 -m pytest tests/incident_defenses/ -v --tb=short
 
+  # Extension-convention enforcement (#1359). Runs `atdd enforce` over the
+  # vendored, committed substrate (.atdd/{extensions,workspaces} + binding.lock).
+  # The convention VERDICT is ADVISORY (non-blocking) — a deliberate ratchet
+  # STAGE: the toolkit does not yet pass 13/25 of its own extension rules (active
+  # core debt, not legacy), so the verdict is surfaced but does not fail the
+  # build. The flip to a BLOCKING gate is a tracked follow-up (decommission #1207
+  # + extract the subagent-orchestration surface out of core). Substrate digest
+  # coherence and the gate wiring ARE blocking (real invariants). train-interlocking
+  # is deferred to #1361 (blocked on #1292/#1345).
+  enforce-extensions:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'issues' ||
+      contains(github.event.issue.labels.*.name, 'atdd-issue') ||
+      contains(github.event.issue.labels.*.name, 'atdd-wmbt')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-atdd-toolkit
+
+      - name: Install dependencies
+        run: pip3 install pytest jsonschema pyyaml tree-sitter tree-sitter-typescript
+
+      # Blocking: the committed vendored substrate must be digest-coherent.
+      # PYTHONDONTWRITEBYTECODE keeps the tree clean — compute_digest hashes .pyc,
+      # so a compiled provider would otherwise drift the digest.
+      - name: Verify extension substrate (blocking)
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: PYTHONPATH=src python3 -m atdd enforce --verify-substrate --repo-root .
+
+      # Advisory (non-blocking) ratchet stage — surfaces the real PASS/FAIL verdict
+      # without failing the build. Do NOT make this blocking until the toolkit's
+      # self-debt is paid (decommission #1207 + orchestration-out-of-core).
+      - name: Enforce extension conventions (ADVISORY — ratchet stage, #1359)
+        continue-on-error: true
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: |
+          echo "::notice::ADVISORY extension enforcement (#1359 ratchet stage) — verdict is non-blocking until the toolkit passes its own rules."
+          # Scope to the toolkit's product code (config `code.toolkit: src/atdd`);
+          # avoids scanning the vendored substrate's own intentional-dirty fixtures.
+          PYTHONPATH=src python3 -m atdd enforce --repo-root . --paths src/atdd || true
+
+      # Blocking: the gate wiring + substrate guards must hold (regression guard).
+      - name: Assert enforce gate wiring
+        run: PYTHONPATH=src python3 -m pytest tests/enforce/ -v --tb=short
+
   # Note: the pre-merge `version-bump` PR check was removed in #462 phase 2.
   # Version is now bumped automatically on main by the bump-on-merge step in
   # `.github/workflows/post-merge-lifecycle.yml` (branch-prefix → semver
@@ -301,7 +358,7 @@ jobs:
   # check that no longer reports.
 
   validate-gate:
-    needs: [validate-planner, validate-tester, validate-coder, validate-coach, validate-conventions, validate-smoke, import-discipline-test, parity-test, incident-defense-test]
+    needs: [validate-planner, validate-tester, validate-coder, validate-coach, validate-conventions, validate-smoke, import-discipline-test, parity-test, incident-defense-test, enforce-extensions]
     runs-on: ubuntu-latest
     if: always()
     permissions:
@@ -317,7 +374,8 @@ jobs:
                         "smoke:${{ needs.validate-smoke.result }}" \
                         "import-discipline:${{ needs.import-discipline-test.result }}" \
                         "parity:${{ needs.parity-test.result }}" \
-                        "incident-defense:${{ needs.incident-defense-test.result }}"; do
+                        "incident-defense:${{ needs.incident-defense-test.result }}" \
+                        "enforce-extensions:${{ needs.enforce-extensions.result }}"; do
             phase="${result%%:*}"
             status="${result##*:}"
             if [ "$status" != "success" ] && [ "$status" != "skipped" ]; then

--- a/src/atdd/enforce/runner.py
+++ b/src/atdd/enforce/runner.py
@@ -149,30 +149,44 @@ def _candidate_roots(substrate_home: Path) -> list[Path]:
 # --------------------------------------------------------------------------- #
 # Provider invocation (the subprocess boundary — V5)
 # --------------------------------------------------------------------------- #
-def _impl_has_report_channel(substrate_home: Path, implementation_id: str) -> bool:
-    """True iff the vendored impl ships a v1.1 report-test channel.
+def _resolve_impls_root(substrate_home: Path, implementation_id: str) -> Optional[Path]:
+    """The impls-root owning ``implementation_id``, iff it ships a v1.1 report channel.
 
     Reads the impl manifest's ``report:`` field and checks the named test file is
     present next to the manifest — the exact runnable-detection the vendored
     ``cli/scan.py`` performs (``_report_test_name`` + ``test_path.is_file()``).
-    Replacing the prior hardcoded ``test_logging_print_report.py`` lets all 26
-    bound detectors run, not just ``coder.logging.print`` (#1238 V1).
+    Replacing the prior hardcoded ``test_logging_print_report.py`` lets all bound
+    detectors run, not just ``coder.logging.print`` (#1238 V1).
+
+    Searches BOTH vendored trees. A workspace package ships the detectors for its
+    own runtime; an EXTENSION may ship its own detectors targeting that workspace's
+    provider contract (the train-interlocking extension does). Searching only
+    ``.atdd/workspaces`` made every extension-shipped detector ``unrunnable`` while
+    enforce still reported PASS — a false green (#1359).
+
+    Returns the root the owning manifest sits under (``…/implementations``), which
+    the caller forwards to the provider CLI as ``--impls-root``; ``None`` when the
+    impl is absent or ships no report channel.
     """
-    ws_root = substrate_home / ".atdd" / "workspaces"
-    if not ws_root.is_dir():
-        return False
-    for manifest in ws_root.rglob("atdd.implementation.yaml"):
-        try:
-            data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
-        except (OSError, yaml.YAMLError):
+    roots = (substrate_home / ".atdd" / "workspaces", substrate_home / ".atdd" / "extensions")
+    for root in roots:
+        if not root.is_dir():
             continue
-        if data.get("implementation_id") != implementation_id:
-            continue
-        report = data.get(_PROVIDER_REPORT_FIELD)
-        if not report:
-            return False
-        return (manifest.parent / str(report)).is_file()
-    return False
+        for manifest in sorted(root.rglob("atdd.implementation.yaml")):
+            try:
+                data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+            except (OSError, yaml.YAMLError):
+                continue
+            if data.get("implementation_id") != implementation_id:
+                continue
+            report = data.get(_PROVIDER_REPORT_FIELD)
+            if not report:
+                return None
+            if not (manifest.parent / str(report)).is_file():
+                return None
+            # cli/scan.py discovers impls as children of the root it is given.
+            return manifest.parent.parent
+    return None
 
 
 def _invoke_provider(
@@ -181,6 +195,7 @@ def _invoke_provider(
     scan_roots: list[str],
     scan_excludes: list[str],
     graph_roots: Optional[list[str]] = None,
+    impls_root: Optional[Path] = None,
 ) -> list[dict]:
     """Subprocess the provider CLI over ``scan_roots``; parse RAW v1.1 JSON.
 
@@ -207,8 +222,13 @@ def _invoke_provider(
         env["ATDD_SCAN_EXCLUDES"] = json.dumps([str(e) for e in scan_excludes])
     if graph_roots:
         env["ATDD_GRAPH_ROOTS"] = json.dumps([str(r) for r in graph_roots])
+    argv = [sys.executable, str(provider.provider_cli_path)]
+    if impls_root is not None:
+        # Without this the provider CLI defaults to its OWN implementations/ dir and
+        # cannot discover a detector shipped by an extension package.
+        argv += ["--impls-root", str(impls_root)]
     proc = subprocess.run(
-        [sys.executable, str(provider.provider_cli_path)],
+        argv,
         env=env,
         capture_output=True,
         text=True,
@@ -310,7 +330,8 @@ def enforce(
 
         # Honest gate: a rule whose vendored impl ships no v1.1 report channel
         # cannot enforce over consumer code yet (workspace generalization, D-1).
-        if not _impl_has_report_channel(substrate_home, impl_id):
+        impls_root = _resolve_impls_root(substrate_home, impl_id)
+        if impls_root is None:
             verdicts.append(
                 RuleVerdict(
                     rule_id,
@@ -340,6 +361,7 @@ def enforce(
             policy.scan_roots,
             policy.scan_excludes,
             policy.graph_roots,
+            impls_root=impls_root,
         )
         # A multi-rule detector emits several rule_ids in one run; judge this
         # bound convention only on its own rule_id's records.
@@ -381,7 +403,7 @@ def conformance(repo_root: Path) -> tuple[bool, str]:
     for conv in bound:
         rule_id = str(conv.get("convention_id"))
         impl_id = str(conv.get("implementation_id") or rule_id)
-        if _impl_has_report_channel(substrate_home, impl_id):
+        if _resolve_impls_root(substrate_home, impl_id) is not None:
             runnable.append(rule_id)
         else:
             unrunnable.append(rule_id)

--- a/src/atdd/planner/commands/author_manifest.py
+++ b/src/atdd/planner/commands/author_manifest.py
@@ -202,10 +202,12 @@ def validate_implementation_manifest(data: dict) -> None:
     Beyond identity (kind/id/targets/contract), enforces the executable-validator
     shape so a validator is compliant *by construction* rather than by copying an
     example: a runnable ``entrypoint``, a v1.1 ``report`` emitter, and a non-empty
-    ``emits_rule_ids`` list (the rule_ids this one detector realizes — a FAMILY
-    detector emits >1, a singleton emits 1). ``realizes_convention`` (the primary
-    node) and ``subtype`` are validated for consistency when present. This is the
-    ``atdd.core.implementation-schema`` every extension declares in ``depends_on``.
+    ``emits_rule_ids`` list (the rule_ids this one detector EMITS — a FAMILY
+    detector emits >1, a singleton emits 1). ``realizes_convention`` names the
+    convention(s) the detector OWNS — one, or the list a family owns — and every
+    owned convention must be one it emits. ``subtype`` is validated when present.
+    This is the ``atdd.core.implementation-schema`` every extension declares in
+    ``depends_on``.
     """
     data = data or {}
     if data.get("kind") != "implementation":
@@ -224,22 +226,39 @@ def validate_implementation_manifest(data: dict) -> None:
             "report, when declared, must be a non-empty path (the runnable v1.1 report-emitter "
             "the provider CLI collects; may equal entrypoint)")
     # The impl must declare the rule_id(s) it realizes — via a non-empty
-    # ``emits_rule_ids`` list (v1.1; a FAMILY detector emits >1 from one run) OR a
-    # single ``realizes_convention`` (v1.0 exit-code mapping). At least one required.
+    # ``emits_rule_ids`` list (v1.1; a FAMILY detector emits >1 from one run) OR
+    # ``realizes_convention`` (v1.0 exit-code mapping). At least one required.
+    # ``realizes_convention`` may be a single convention or the LIST a family owns.
     emits = data.get("emits_rule_ids")
     rc = data.get("realizes_convention")
     has_emits = isinstance(emits, list) and bool(emits)
     if has_emits and not all(isinstance(r, str) and r.strip() for r in emits):
         raise AuthorInputError("emits_rule_ids", "emits_rule_ids entries must be non-empty rule_id strings")
-    has_rc = isinstance(rc, str) and bool(rc.strip())
-    if not has_emits and not has_rc:
+    if isinstance(rc, list):
+        if not rc or not all(isinstance(c, str) and c.strip() for c in rc):
+            raise AuthorInputError(
+                "realizes_convention",
+                "realizes_convention, when a list, must be non-empty convention_id strings")
+        owned = list(rc)
+    elif isinstance(rc, str) and rc.strip():
+        owned = [rc]
+    elif rc is None:
+        owned = []
+    else:
+        raise AuthorInputError(
+            "realizes_convention", "realizes_convention must be a convention_id or a list of them")
+    if not has_emits and not owned:
         raise AuthorInputError(
             "emits_rule_ids",
             "implementation must declare the rule_id(s) it realizes — a non-empty emits_rule_ids "
             "list (v1.1; a FAMILY emits more than one) or realizes_convention (v1.0 single-rule)")
-    if has_emits and has_rc and rc not in emits:
-        raise AuthorInputError(
-            "realizes_convention", f"realizes_convention {rc!r} must be one of emits_rule_ids {emits!r}")
+    # A detector cannot OWN a convention it never EMITS.
+    if has_emits and owned:
+        unemitted = [c for c in owned if c not in emits]
+        if unemitted:
+            raise AuthorInputError(
+                "realizes_convention",
+                f"realizes_convention {unemitted!r} must be among emits_rule_ids {emits!r}")
     sub = data.get("subtype")
     if sub is not None and sub != "validator":
         raise AuthorInputError("subtype", f"implementation subtype must be 'validator' (got {sub!r})")

--- a/src/atdd/planner/commands/tests/test_c006_unit_002_implementation_contract.py
+++ b/src/atdd/planner/commands/tests/test_c006_unit_002_implementation_contract.py
@@ -38,6 +38,29 @@ def test_accepts_v10_realizes_only_manifest():
     validate_implementation_manifest(_m(realizes_convention="coder.x.a"))
 
 
+def test_accepts_family_owning_every_rule_it_emits():
+    # One detector OWNS all the conventions it emits (train-interlocking's shape).
+    validate_implementation_manifest(_m(emits_rule_ids=["coder.x.a", "coder.x.b"],
+                                        realizes_convention=["coder.x.a", "coder.x.b"]))
+
+
+def test_accepts_family_owning_a_subset_of_what_it_emits():
+    # Co-emission: the detector emits coder.x.b but another detector owns it.
+    validate_implementation_manifest(_m(emits_rule_ids=["coder.x.a", "coder.x.b"],
+                                        realizes_convention=["coder.x.a"]))
+
+
+def test_rejects_owning_a_rule_it_never_emits():
+    with pytest.raises(AuthorInputError, match="realizes_convention"):
+        validate_implementation_manifest(_m(emits_rule_ids=["coder.x.a"],
+                                            realizes_convention=["coder.x.a", "coder.x.ghost"]))
+
+
+def test_rejects_empty_realizes_list():
+    with pytest.raises(AuthorInputError, match="realizes_convention"):
+        validate_implementation_manifest(_m(emits_rule_ids=["coder.x.a"], realizes_convention=[]))
+
+
 def _drop_rule_binding(m):
     m.pop("emits_rule_ids", None)
     m.pop("realizes_convention", None)

--- a/src/atdd/substrate/binding/composer.py
+++ b/src/atdd/substrate/binding/composer.py
@@ -5,6 +5,17 @@ Indexes the implementations the enabled, digest-verified packages ship by their
 for a given convention, which admitted implementation (if any) owns its gating.
 Pure data: it consumes ``LoadedPackage`` records (manifests only) and never
 imports or runs an implementation module.
+
+``realizes_convention`` may name ONE convention or a LIST of them: a family
+detector realizes N conventions from a single run (e.g. the train-interlocking
+infrastructure detector owns five ``coder.train.interlocking-*`` rules). Each
+named convention is indexed to that one implementation.
+
+``realizes_convention`` is OWNERSHIP; ``emits_rule_ids`` is CO-EMISSION and is
+deliberately NOT indexed here. A detector may emit a rule_id it does not own —
+``coder.logging.structured`` emits ``coder.logging.print`` alongside its own rule,
+while ``coder.logging.print`` is owned by the dedicated print detector. Indexing
+by ``emits_rule_ids`` would make those two collide.
 """
 from __future__ import annotations
 
@@ -16,23 +27,34 @@ class DuplicateConventionError(BindingError):
     """Two admitted implementations claim to realize the same convention."""
 
 
-def index_by_convention(packages: list[LoadedPackage]) -> dict[str, dict]:
-    """Map ``realizes_convention`` -> implementation record across loaded packages.
+def realized_conventions(implementation: dict) -> list[str]:
+    """The conventions an implementation OWNS, as a list (scalar or list manifest)."""
+    realizes = implementation.get("realizes_convention")
+    if realizes is None:
+        return []
+    if isinstance(realizes, str):
+        return [realizes]
+    return [str(c) for c in realizes]
 
-    Raises ``DuplicateConventionError`` if two admitted implementations realize the
-    same convention (an ambiguous binding the operator must resolve). The record
-    carries the implementation manifest plus the owning package id.
+
+def index_by_convention(packages: list[LoadedPackage]) -> dict[str, dict]:
+    """Map each realized convention -> implementation record across loaded packages.
+
+    One implementation fans out across every convention it realizes. Raises
+    ``DuplicateConventionError`` if two admitted implementations realize the same
+    convention (an ambiguous binding the operator must resolve). The record carries
+    the implementation manifest plus the owning package id.
     """
     index: dict[str, dict] = {}
     for pkg in packages:
         for impl in pkg.implementations:
-            convention = impl["realizes_convention"]
-            if convention in index:
-                prior = index[convention]
-                raise DuplicateConventionError(
-                    f"convention {convention!r} is realized by both "
-                    f"{prior['implementation_id']!r} (package {prior['_package_id']}) and "
-                    f"{impl['implementation_id']!r} (package {pkg.id})"
-                )
-            index[convention] = {**impl, "_package_id": pkg.id}
+            for convention in realized_conventions(impl):
+                if convention in index:
+                    prior = index[convention]
+                    raise DuplicateConventionError(
+                        f"convention {convention!r} is realized by both "
+                        f"{prior['implementation_id']!r} (package {prior['_package_id']}) and "
+                        f"{impl['implementation_id']!r} (package {pkg.id})"
+                    )
+                index[convention] = {**impl, "_package_id": pkg.id}
     return index

--- a/src/atdd/substrate/binding/lock_loader.py
+++ b/src/atdd/substrate/binding/lock_loader.py
@@ -86,7 +86,12 @@ def _discover_implementations(pkg_dir: Path) -> list[dict]:
             continue
         if data.get("kind") != "implementation":
             continue
-        if data.get("implementation_id") and data.get("realizes_convention"):
+        # A manifest binds rules either by OWNERSHIP (realizes_convention) or, for a
+        # family detector authored against the v1.1 schema, by emits_rule_ids alone.
+        # Requiring realizes_convention silently dropped the latter.
+        if data.get("implementation_id") and (
+            data.get("realizes_convention") or data.get("emits_rule_ids")
+        ):
             data["_manifest_path"] = str(mp)
             impls.append(data)
     return impls

--- a/src/atdd/substrate/binding/resolver.py
+++ b/src/atdd/substrate/binding/resolver.py
@@ -20,18 +20,23 @@ GREEN targets:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Union
 
 from atdd.substrate.binding import ContractMismatchError, ProviderNotFoundError
 
 
 @dataclass
 class WorkspaceBinding:
-    """A resolved, contract-compatible implementation->provider binding."""
+    """A resolved, contract-compatible implementation->provider binding.
+
+    ``realizes_convention`` mirrors the manifest: one convention, or the list a
+    family detector realizes from a single run.
+    """
 
     implementation_id: str
     workspace_id: str
     contract_version: str
-    realizes_convention: str
+    realizes_convention: Union[str, list[str]]
 
 
 def _parse_semver(version: str) -> tuple[int, int, int]:

--- a/src/atdd/substrate/binding/tests/test_l001_unit_002_family_fans_out_to_conventions.py
+++ b/src/atdd/substrate/binding/tests/test_l001_unit_002_family_fans_out_to_conventions.py
@@ -1,0 +1,107 @@
+# URN: test:bind-substrate-runtime:substrate-binding:L001-UNIT-002-family-fans-out-to-conventions
+# Acceptance: acc:bind-substrate-runtime:L001-UNIT-002-family-fans-out-to-conventions
+# WMBT: wmbt:bind-substrate-runtime:L001
+# Phase: GREEN
+# Layer: unit
+# Assertion: behavioral
+"""L001-UNIT-002 — one implementation may realize N conventions.
+
+A FAMILY detector declares ``realizes_convention`` as a list and owns every
+convention in it; the composer fans the single implementation out across all of
+them. Ownership collisions are still refused, per convention.
+
+``emits_rule_ids`` is CO-EMISSION, not ownership, and must never be indexed: a
+detector may emit a rule_id another detector owns.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from atdd.substrate import installer
+from atdd.substrate.binding import composer, lock_loader
+
+
+def _install_family(
+    project_root: Path,
+    ext_id: str,
+    *,
+    realizes: str,
+    emits: str = "",
+) -> None:
+    """Install an extension whose one implementation declares ``realizes``/``emits`` verbatim."""
+    version = "0.1.0"
+    dest = installer.install_path(project_root, "extension", ext_id, version)
+    impl_dir = dest / "implementations" / "family"
+    impl_dir.mkdir(parents=True, exist_ok=True)
+    (dest / "atdd.extension.yaml").write_text(
+        f"schema_version: '1.0.0'\nextension_id: {ext_id}\nkind: extension\nversion: '{version}'\n",
+        encoding="utf-8",
+    )
+    (impl_dir / "atdd.implementation.yaml").write_text(
+        "schema_version: '1.1.0'\n"
+        "kind: implementation\n"
+        f"implementation_id: {ext_id}.family.impl\n"
+        "targets_workspace: atdd.workspace.python-pytest\n"
+        "contract_version: '1.0.0'\n"
+        f"realizes_convention: {realizes}\n"
+        f"{emits}"
+        "entrypoint: family.py\n",
+        encoding="utf-8",
+    )
+    installer.upsert_lock_entry(
+        project_root,
+        {
+            "id": ext_id,
+            "kind": "extension",
+            "version": version,
+            "digest": installer.compute_digest(dest),
+            "installed_path": str(dest.relative_to(project_root)),
+            "enabled": True,
+        },
+    )
+
+
+def test_list_valued_realizes_fans_one_impl_out_to_every_convention(tmp_path: Path) -> None:
+    _install_family(tmp_path, "acme.extension.family", realizes="[conv.a, conv.b, conv.c]")
+
+    index = composer.index_by_convention(lock_loader.load_enabled_packages(tmp_path))
+
+    assert set(index) == {"conv.a", "conv.b", "conv.c"}
+    for convention in ("conv.a", "conv.b", "conv.c"):
+        assert index[convention]["implementation_id"] == "acme.extension.family.family.impl"
+
+
+def test_scalar_realizes_still_indexes_one_convention(tmp_path: Path) -> None:
+    _install_family(tmp_path, "acme.extension.single", realizes="conv.only")
+
+    index = composer.index_by_convention(lock_loader.load_enabled_packages(tmp_path))
+
+    assert set(index) == {"conv.only"}
+
+
+def test_two_families_overlapping_on_one_convention_are_refused(tmp_path: Path) -> None:
+    _install_family(tmp_path, "acme.extension.left", realizes="[conv.a, conv.shared]")
+    _install_family(tmp_path, "acme.extension.right", realizes="[conv.shared, conv.z]")
+
+    loaded = lock_loader.load_enabled_packages(tmp_path)
+
+    with pytest.raises(composer.DuplicateConventionError, match="conv.shared"):
+        composer.index_by_convention(loaded)
+
+
+def test_emitted_but_unowned_rule_id_is_not_indexed(tmp_path: Path) -> None:
+    """Co-emission must not create a binding — otherwise two detectors that both
+    emit the same rule_id would collide even though only one owns it."""
+    _install_family(
+        tmp_path,
+        "acme.extension.emitter",
+        realizes="conv.owned",
+        emits="emits_rule_ids: [conv.owned, conv.borrowed]\n",
+    )
+
+    index = composer.index_by_convention(lock_loader.load_enabled_packages(tmp_path))
+
+    assert set(index) == {"conv.owned"}
+    assert "conv.borrowed" not in index

--- a/tests/enforce/test_advisory_enforce_gate.py
+++ b/tests/enforce/test_advisory_enforce_gate.py
@@ -1,0 +1,114 @@
+"""Advisory extension-enforcement gate (#1359).
+
+Guards the MECHANISM #1359 activates against the vendored, committed substrate:
+
+  * the canonical ``.atdd/binding.lock.yaml`` binds a real (non-no-op) coder/tester
+    set, and train-interlocking is DEFERRED (#1361, blocked on #1292/#1345) — an
+    unresolvable bind would break ``--verify-substrate`` and the gate;
+  * ``atdd enforce --verify-substrate`` passes against the committed vendored tree
+    (digest coherence — a real, blocking invariant);
+  * CI wires ``atdd enforce`` and runs its VERDICT as an ADVISORY (non-blocking)
+    ratchet stage — the toolkit does not yet pass its own extension rules, so a FAIL
+    verdict must not break the build. The flip to a BLOCKING gate is a tracked
+    follow-up (decommission #1207 + extract orchestration out of core).
+
+These are fast + dependency-light (no tree-sitter): the heavy convention verdict is
+produced by the advisory CI step itself, visible in the CI log, not re-run here.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "atdd-validate.yml"
+BINDING_LOCK = REPO_ROOT / ".atdd" / "binding.lock.yaml"
+
+
+def _run_enforce(*args: str) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "PYTHONDONTWRITEBYTECODE": "1",  # keep the vendored tree's digest stable
+        "PYTHONPATH": str(REPO_ROOT / "src"),
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "atdd", "enforce", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _enforce_run_steps() -> list[tuple[str, dict, str]]:
+    """Every workflow step whose ``run`` invokes ``atdd enforce`` — (job, step, run)."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8")) or {}
+    steps: list[tuple[str, dict, str]] = []
+    for job_name, job in (workflow.get("jobs") or {}).items():
+        for step in job.get("steps", []) or []:
+            run = step.get("run") or ""
+            if "atdd enforce" in run:
+                steps.append((job_name, step, run))
+    return steps
+
+
+def test_binding_lock_binds_runnable_set_without_train_interlocking():
+    """GT-001: the canonical lock binds a non-empty coder/tester set; train-interlocking omitted (#1361)."""
+    assert BINDING_LOCK.is_file(), f"canonical binding.lock missing at {BINDING_LOCK}"
+    lock = yaml.safe_load(BINDING_LOCK.read_text(encoding="utf-8")) or {}
+    bound = [c for c in lock.get("conventions", []) if c.get("disposition") == "bound"]
+    assert bound, "binding.lock has no bound conventions — enforce would be a silent no-op"
+    ids = {c["convention_id"] for c in bound}
+    assert any(i.startswith(("coder.", "tester.")) for i in ids), (
+        f"expected coder/tester bound conventions, got: {sorted(ids)}"
+    )
+    # train-interlocking is deferred to #1361 (blocked on #1292/#1345): the core
+    # composer cannot yet compose its list-valued realizes_convention, and an
+    # unresolvable bound entry would fail --verify-substrate and break the gate.
+    assert not any("interlocking" in i for i in ids), (
+        "train-interlocking must NOT be bound here — deferred to #1361 (#1292/#1345)"
+    )
+
+
+def test_verify_substrate_passes_against_vendored_tree():
+    """GT-002: the committed vendored substrate is digest-coherent (blocking invariant)."""
+    proc = _run_enforce("--verify-substrate", "--repo-root", str(REPO_ROOT))
+    assert proc.returncode == 0, (
+        f"`atdd enforce --verify-substrate` FAILED (exit {proc.returncode}):\n"
+        f"{proc.stdout}\n{proc.stderr}"
+    )
+    assert "verify-substrate: PASS" in proc.stdout, proc.stdout
+
+
+def test_ci_runs_enforce_verify_substrate():
+    """CI must guard substrate coherence with `atdd enforce --verify-substrate`."""
+    steps = _enforce_run_steps()
+    assert any("--verify-substrate" in run for _, _, run in steps), (
+        "no CI step runs `atdd enforce --verify-substrate` in atdd-validate.yml"
+    )
+
+
+def test_ci_enforce_verdict_is_advisory():
+    """GT-900 mechanism: the `atdd enforce` VERDICT step is advisory (non-blocking ratchet stage).
+
+    A verdict step is any `atdd enforce` invocation that is NOT `--verify-substrate`.
+    It must be non-blocking (``continue-on-error: true`` or ``|| true``) so the
+    toolkit's current self-debt (13/25 rules) does not break the build — this is an
+    explicit ratchet stage, not the destination (#1359).
+    """
+    verdict_steps = [
+        (job, step, run)
+        for job, step, run in _enforce_run_steps()
+        if "--verify-substrate" not in run
+    ]
+    assert verdict_steps, "CI must run the `atdd enforce` verdict (a non --verify-substrate invocation)"
+    for job, step, run in verdict_steps:
+        advisory = step.get("continue-on-error") is True or "|| true" in run
+        assert advisory, (
+            f"the `atdd enforce` verdict step in job {job!r} must be ADVISORY "
+            f"(continue-on-error: true or `|| true`) — #1359 ratchet stage"
+        )

--- a/tests/enforce/test_extension_shipped_detector_runs.py
+++ b/tests/enforce/test_extension_shipped_detector_runs.py
@@ -1,0 +1,138 @@
+"""An EXTENSION-shipped detector must be runnable by `atdd enforce` (#1359).
+
+A workspace package ships the detectors for its own runtime, but an extension may
+ship its own detectors targeting that workspace's provider contract. Before this
+guard the runner discovered implementations only under ``.atdd/workspaces``, so
+every extension-shipped detector was reported ``unrunnable`` while the aggregate
+verdict still printed PASS — a false green.
+
+These tests build a minimal real substrate in a tmp_path (a workspace provider
+whose ``cli/scan.py`` is the real subprocess boundary, plus an extension shipping
+one detector) and drive the real ``enforce`` runner over it. No mocks: the
+detector is discovered, subprocessed, and its RAW v1.1 records become a verdict.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from atdd.enforce.runner import _resolve_impls_root, enforce
+
+# A stand-in provider CLI honouring the real contract: discover the impl under
+# --impls-root, run its report channel, print RAW v1.1 JSON to stdout.
+_PROVIDER_CLI = '''\
+import argparse, json, os, sys
+from pathlib import Path
+ap = argparse.ArgumentParser()
+ap.add_argument("--impl", default=os.environ.get("ATDD_IMPL_ID"))
+ap.add_argument("--impls-root", default=str(Path(__file__).resolve().parent.parent / "implementations"))
+ap.add_argument("scan_roots", nargs="*")
+args = ap.parse_args()
+root = Path(args.impls_root)
+manifest = next((m for m in root.rglob("atdd.implementation.yaml")
+                 if args.impl in m.read_text()), None)
+if manifest is None:
+    print(f"provider-cli: impl {args.impl!r} not discoverable under {root}", file=sys.stderr)
+    sys.exit(2)
+roots = json.loads(os.environ.get("ATDD_SCAN_ROOTS", "[]"))
+violations = [
+    {"rule_id": "acme.rule.owned", "file": f"{r}/bad.py", "line": 1, "col": 0,
+     "evidence": "injected", "source_line": "x = 1"}
+    for r in roots
+]
+json.dump(violations, sys.stdout)
+'''
+
+_CONVENTION = """\
+schema_version: '1.0.0'
+kind: convention
+convention_id: acme.rule.owned
+metadata:
+  severity: 2
+  disposition: strict
+"""
+
+
+def _build_substrate(tmp_path: Path, *, detector_in_extension: bool) -> Path:
+    """Vendor a workspace provider + one detector, then bind it in binding.lock."""
+    atdd = tmp_path / ".atdd"
+    ws = atdd / "workspaces" / "atdd.workspace.python-pytest" / "0.1.0"
+    (ws / "cli").mkdir(parents=True)
+    (ws / "cli" / "scan.py").write_text(_PROVIDER_CLI, encoding="utf-8")
+    (ws / "atdd.workspace.yaml").write_text(
+        "schema_version: '1.0.0'\nkind: workspace\n"
+        "workspace_id: atdd.workspace.python-pytest\ncontract_version: '1.1.0'\n",
+        encoding="utf-8",
+    )
+
+    ext = atdd / "extensions" / "acme.extension.rules" / "0.1.0"
+    (ext / "conventions").mkdir(parents=True)
+    (ext / "conventions" / "acme.rule.owned.convention.yaml").write_text(_CONVENTION, encoding="utf-8")
+
+    home = ext if detector_in_extension else ws
+    impl = home / "implementations" / "owned_detector"
+    impl.mkdir(parents=True)
+    (impl / "atdd.implementation.yaml").write_text(
+        "schema_version: '1.1.0'\nkind: implementation\n"
+        "implementation_id: acme.rule.owned.impl\n"
+        "targets_workspace: atdd.workspace.python-pytest\n"
+        "contract_version: '1.1.0'\n"
+        "realizes_convention: acme.rule.owned\n"
+        "entrypoint: detect.py\nreport: test_owned_report.py\n",
+        encoding="utf-8",
+    )
+    (impl / "test_owned_report.py").write_text("", encoding="utf-8")
+
+    (atdd / "binding.lock.yaml").write_text(
+        "schema_version: 1.0.0\nconventions:\n"
+        "- convention_id: acme.rule.owned\n  disposition: bound\n"
+        "  implementation_id: acme.rule.owned.impl\n"
+        "  workspace_id: atdd.workspace.python-pytest\n  contract_version: 1.1.0\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "consumer").mkdir()
+    (tmp_path / "consumer" / "bad.py").write_text("x = 1\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_extension_shipped_detector_resolves_to_its_own_impls_root(tmp_path: Path) -> None:
+    root = _build_substrate(tmp_path, detector_in_extension=True)
+
+    impls_root = _resolve_impls_root(root, "acme.rule.owned.impl")
+
+    assert impls_root is not None, "an extension-shipped detector must be discoverable"
+    assert impls_root == root / ".atdd" / "extensions" / "acme.extension.rules" / "0.1.0" / "implementations"
+
+
+def test_extension_shipped_detector_produces_a_real_fail_not_a_false_green(tmp_path: Path) -> None:
+    root = _build_substrate(tmp_path, detector_in_extension=True)
+
+    result = enforce(root, path_override=["consumer"])
+
+    statuses = {v.rule_id: v.status for v in result.verdicts}
+    assert statuses == {"acme.rule.owned": "fail"}, "the injected violation must surface as FAIL"
+    assert result.exit_code == 1
+    assert not result.passed
+
+
+def test_workspace_shipped_detector_still_resolves(tmp_path: Path) -> None:
+    """Regression: forwarding --impls-root must not break the workspace's own detectors."""
+    root = _build_substrate(tmp_path, detector_in_extension=False)
+
+    result = enforce(root, path_override=["consumer"])
+
+    assert [v.status for v in result.verdicts] == ["fail"]
+
+
+def test_absent_implementation_is_unrunnable_not_silently_passing(tmp_path: Path) -> None:
+    root = _build_substrate(tmp_path, detector_in_extension=True)
+    (root / ".atdd" / "binding.lock.yaml").write_text(
+        "schema_version: 1.0.0\nconventions:\n"
+        "- convention_id: acme.rule.owned\n  disposition: bound\n"
+        "  implementation_id: acme.rule.ghost.impl\n"
+        "  workspace_id: atdd.workspace.python-pytest\n  contract_version: 1.1.0\n",
+        encoding="utf-8",
+    )
+
+    result = enforce(root, path_override=["consumer"])
+
+    assert [v.status for v in result.verdicts] == ["unrunnable"]


### PR DESCRIPTION
Part of #1359

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #1359 |
| Type | implementation |
| Slug | activate-extension-enforcement-in-core-bind-conventions-run-atdd-enforce-in-ci |
| Labels | atdd-issue, atdd:INIT |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.