### PR TITLE
feat: Carry themes and sequence through create_train (#1401)

### DIFF
--- a/plan/_wagons.yaml
+++ b/plan/_wagons.yaml
@@ -2440,7 +2440,7 @@ wagons:
     to: external
   consume: []
   wmbt:
-    total: 33
+    total: 34
     E001: minimize likelihood of registry-family-template-mismatch — registry.yaml
       declares exactly the 13 canonical families and 22 templates
     E002: minimize likelihood of registry-archetype-divergence — each family archetype.py
@@ -2514,6 +2514,10 @@ wagons:
       legacy validator is classified PLATFORM/RULE-BOUND/ACCEPTANCE-ANCHORED with
       its legacy-validator-map status and required retirement steps, naming the two
       CI catches, before any deletion
+    Y003: minimize likelihood of coverage-loss-on-legacy-validator-sweep-retirement
+      — no rule implementation.ref/validator resolves to a deleted persona-folder
+      validator and every repointed rule binds to an executing convention variant
+      (not an xfail/stub); complements Y001 (map safety) and Y002 (preflight visibility)
   total: 0
   manifest: plan/validate_conventions/_validate_conventions.yaml
   path: plan/validate_conventions/

--- a/plan/author_plan_substrate/E004.yaml
+++ b/plan/author_plan_substrate/E004.yaml
@@ -1,49 +1,150 @@
-urn: "wmbt:author-plan-substrate:E004"
-step: "execute"
-direction: "maximize"
-dimension: "likelihood"
-object_of_control: "train-entry-creation"
-context_clarifier: "when authoring a train, the writer must dedup-insert into plan/_trains.yaml and write plan/_trains/<id>.yaml with stable-sort + atomic write so concurrent inserts stay deterministic"
-lens: "functional.effectiveness"
-statement: "maximize likelihood of schema-valid train-entry-creation when authoring a train into the _trains.yaml registry and plan/_trains/<id>.yaml"
+urn: wmbt:author-plan-substrate:E004
+step: execute
+direction: maximize
+dimension: likelihood
+object_of_control: train-entry-creation
+context_clarifier: when authoring a train, the writer must dedup-insert into plan/_trains.yaml
+  and write plan/_trains/<id>.yaml with stable-sort + atomic write so concurrent inserts
+  stay deterministic
+lens: functional.effectiveness
+statement: maximize likelihood of schema-valid train-entry-creation when authoring
+  a train into the _trains.yaml registry and plan/_trains/<id>.yaml
 acceptances:
-  - identity:
-      urn: "acc:author-plan-substrate:E004-UNIT-001-registry-insert-and-per-train-file"
-      id: "AC-UNIT-001"
-      purpose: "create_train dedup-inserts into _trains.yaml in sorted position and writes the per-train file"
-      phase: "GREEN"
-    harness:
-      type: "unit"
-      category: "backend"
-    given:
-      abstract:
-        - "A valid train input (train_id, wagons) and a temp plan/ home with an existing _trains.yaml"
-    when:
-      abstract: "create_train(input) is called"
-    then:
-      abstract:
-        - "_trains.yaml gains the entry in train_id-sorted position"
-        - "plan/_trains/<id>.yaml is written and validates against the train schema"
-    metadata:
-      author: "atdd:self-compliance"
-      created: "2026-06-18"
-  - identity:
-      urn: "acc:author-plan-substrate:E004-SMOKE-001-cli-creates-valid-train"
-      id: "AC-SMOKE-001"
-      purpose: "Verify `atdd author train` registers a schema-valid train deterministically in a real checkout"
-      phase: "SMOKE"
-    harness:
-      type: "integration"
-      category: "backend"
-    given:
-      abstract:
-        - "A real repo checkout and the installed atdd author CLI"
-    when:
-      abstract: "atdd author train --id <id> --wagon <slug> ... is run"
-    then:
-      abstract:
-        - "_trains.yaml gains the entry and plan/_trains/<id>.yaml appears"
-        - "atdd validate planner accepts the created train without manual fixups"
-    metadata:
-      author: "atdd:self-compliance"
-      created: "2026-06-18"
+- identity:
+    urn: acc:author-plan-substrate:E004-UNIT-001-registry-insert-and-per-train-file
+    id: AC-UNIT-001
+    purpose: create_train dedup-inserts into _trains.yaml in sorted position and writes
+      the per-train file
+    phase: GREEN
+  harness:
+    type: unit
+    category: backend
+  given:
+    abstract:
+    - A valid train input (train_id, wagons) and a temp plan/ home with an existing
+      _trains.yaml
+  when:
+    abstract: create_train(input) is called
+  then:
+    abstract:
+    - _trains.yaml gains the entry in train_id-sorted position
+    - plan/_trains/<id>.yaml is written and validates against the train schema
+  metadata:
+    author: atdd:self-compliance
+    created: '2026-06-18'
+- identity:
+    urn: acc:author-plan-substrate:E004-SMOKE-001-cli-creates-valid-train
+    id: AC-SMOKE-001
+    purpose: Verify `atdd author train` registers a schema-valid train deterministically
+      in a real checkout
+    phase: SMOKE
+  harness:
+    type: integration
+    category: backend
+  given:
+    abstract:
+    - A real repo checkout and the installed atdd author CLI
+  when:
+    abstract: atdd author train --id <id> --wagon <slug> ... is run
+  then:
+    abstract:
+    - _trains.yaml gains the entry and plan/_trains/<id>.yaml appears
+    - atdd validate planner accepts the created train without manual fixups
+  metadata:
+    author: atdd:self-compliance
+    created: '2026-06-18'
+- identity:
+    urn: acc:author-plan-substrate:E004-UNIT-002-carries-schema-required-keys
+    id: AC-UNIT-002
+    purpose: create_train carries every schema-recognized key the spec supplies into
+      plan/_trains/<id>.yaml, so the authored document validates against train.schema.json
+    phase: RED
+  harness:
+    type: unit
+    category: backend
+  given:
+    abstract:
+    - A full train spec carrying themes, sequence, family, primary_wagon, dependencies
+      and acceptances, and a temp plan/ home
+  when:
+    abstract: create_train(spec) is called
+    action: invoke
+  then:
+    abstract:
+    - The written plan/_trains/<id>.yaml carries themes and sequence verbatim from
+      the spec
+    - family, primary_wagon, dependencies and acceptances round-trip when supplied
+      and are absent when omitted
+    - The written document validates against src/atdd/planner/schemas/train.schema.json
+      with zero errors
+    - 'wagons is NOT written into the document (train.schema.json sets additionalProperties:
+      false)'
+    assertions:
+    - type: equals
+    - type: schema
+  signal: {}
+  metadata:
+    wagon: author-plan-substrate
+    feature: author-train
+    author: atdd:self-compliance
+    created: '2026-07-09'
+- identity:
+    urn: acc:author-plan-substrate:E004-UNIT-003-alternate-path-train-carries-sequence
+    id: AC-UNIT-003
+    purpose: 'The per-train document writer is category-agnostic: an alternate-path
+      (02xx) train carries themes and sequence exactly as a nominal (00xx) train does'
+    phase: RED
+  harness:
+    type: unit
+    category: backend
+  given:
+    abstract:
+    - 'Two specs identical but for their train_id category digit: a nominal 0009-*
+      train and an alternate-path 0209-* train'
+  when:
+    abstract: create_train is called for each
+    action: invoke
+  then:
+    abstract:
+    - Both written documents carry themes and sequence verbatim
+    - "The two documents differ only in train_id \u2014 the writer branches on no\
+      \ digit of train_id"
+    assertions:
+    - type: equals
+  signal: {}
+  metadata:
+    wagon: author-plan-substrate
+    feature: author-train
+    author: atdd:self-compliance
+    created: '2026-07-09'
+- identity:
+    urn: acc:author-plan-substrate:E004-UNIT-004-preserves-caller-participants
+    id: AC-UNIT-004
+    purpose: create_train preserves caller-supplied participants verbatim and derives
+      wagon:<w> participants only when the caller omitted participants
+    phase: RED
+  harness:
+    type: unit
+    category: backend
+  given:
+    abstract:
+    - A spec whose participants carry a non-wagon principal (system:atdd-cli) alongside
+      wagon:<w> entries
+    - A second spec that supplies wagons but omits participants entirely
+  when:
+    abstract: create_train is called for each
+    action: invoke
+  then:
+    abstract:
+    - "The first document's participants equal the caller's list verbatim \u2014 system:atdd-cli\
+      \ is not discarded"
+    - The second document's participants are derived as wagon:<w> from wagons, preserving
+      today's fallback
+    assertions:
+    - type: equals
+  signal: {}
+  metadata:
+    wagon: author-plan-substrate
+    feature: author-train
+    author: atdd:self-compliance
+    created: '2026-07-09'

--- a/plan/author_plan_substrate/E004.yaml
+++ b/plan/author_plan_substrate/E004.yaml
@@ -58,7 +58,7 @@ acceptances:
     id: AC-UNIT-002
     purpose: create_train carries every schema-recognized key the spec supplies into
       plan/_trains/<id>.yaml, so the authored document validates against train.schema.json
-    phase: RED
+    phase: GREEN
   harness:
     type: unit
     category: backend
@@ -93,7 +93,7 @@ acceptances:
     id: AC-UNIT-003
     purpose: 'The per-train document writer is category-agnostic: an alternate-path
       (02xx) train carries themes and sequence exactly as a nominal (00xx) train does'
-    phase: RED
+    phase: GREEN
   harness:
     type: unit
     category: backend
@@ -122,7 +122,7 @@ acceptances:
     id: AC-UNIT-004
     purpose: create_train preserves caller-supplied participants verbatim and derives
       wagon:<w> participants only when the caller omitted participants
-    phase: RED
+    phase: GREEN
   harness:
     type: unit
     category: backend

--- a/src/atdd/planner/commands/author.py
+++ b/src/atdd/planner/commands/author.py
@@ -496,9 +496,29 @@ def create_train(spec: dict, *, root: Path | str | None = None) -> Path:
             "train_id": tid,
             "title": spec.get("title", tid),
             "description": spec.get("description", ""),
-            "participants": [f"wagon:{w}" for w in spec.get("wagons", [])],
-            "status": "planned",
         }
+        # `themes` and `sequence` are schema-REQUIRED; `family`, `primary_wagon`,
+        # `dependencies` and `acceptances` are optional. All six are copied verbatim
+        # and only when supplied — inventing a default would write a schema-invalid
+        # value (`themes: []` fails minItems, `family: ""` fails the enum). `wagons`
+        # is deliberately absent: train.schema sets additionalProperties=false and
+        # defines no such property; it belongs to the _trains.yaml registry entry
+        # above, and expresses itself here as the `participants` fallback (#1401).
+        for key in ("themes", "family", "primary_wagon", "dependencies", "sequence",
+                    "acceptances"):
+            if key in spec:
+                train_doc[key] = spec[key]
+
+        # Preserve caller-supplied participants verbatim: train.schema admits
+        # wagon:/user:/system: principals, so deriving from `wagons` unconditionally
+        # would silently discard every non-wagon participant. Derive only as a
+        # fallback, which is what every pre-#1401 caller relied on.
+        participants = spec.get("participants")
+        if not participants:
+            participants = [f"wagon:{w}" for w in spec.get("wagons", [])]
+        train_doc["participants"] = list(participants)
+        train_doc["status"] = "planned"
+
         # Adjacent seam (#1265): carry the optional #1248 interlocking back-ref so a
         # train authored as a route's target self-describes its owning interlocking.
         # Pure traceability — it never alters train linearity (train.schema

--- a/src/atdd/planner/commands/tests/test_e004_unit_002_carries_schema_required_keys.py
+++ b/src/atdd/planner/commands/tests/test_e004_unit_002_carries_schema_required_keys.py
@@ -1,0 +1,104 @@
+# URN: test:author-plan-substrate:author-train:E004-UNIT-002-carries-schema-required-keys
+# Acceptance: acc:author-plan-substrate:E004-UNIT-002-carries-schema-required-keys
+# WMBT: wmbt:author-plan-substrate:E004
+# Phase: RED
+# Layer: unit
+# Assertion: behavioral
+"""E004-UNIT-002 — create_train carries the schema-recognized keys into the per-train doc.
+
+RED: create_train builds train_doc from only five keys and drops `themes` and
+`sequence`, both of which train.schema.json marks REQUIRED. Every train the
+writer authors is therefore schema-invalid.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+from atdd.planner.commands.author import create_train
+
+SCHEMA = Path(__file__).resolve().parents[2] / "schemas" / "train.schema.json"
+
+
+def _full_spec(train_id: str = "0009-demo-train") -> dict:
+    return {
+        "train_id": train_id,
+        "title": "Demo train",
+        "description": "a demo train exercising the writer's carry-through",
+        "themes": ["commons"],
+        "family": "delivery",
+        "primary_wagon": "demo-wagon",
+        "wagons": ["demo-wagon"],
+        "participants": ["wagon:demo-wagon", "system:atdd-cli"],
+        "dependencies": ["train:0001-self-compliance-validate"],
+        "sequence": [
+            {
+                "step": 1,
+                "intent": "author the plan substrate",
+                "from": "wagon:demo-wagon",
+                "to": "system:atdd-cli",
+                "artifact": "commons:manifest",
+            },
+        ],
+    }
+
+
+def _author(tmp_path: Path, spec: dict) -> dict:
+    plan = tmp_path / "plan"
+    (plan / "_trains").mkdir(parents=True)
+    (plan / "_trains.yaml").write_text("trains: {}\n", encoding="utf-8")
+    per_train = create_train(spec, root=tmp_path)
+    return yaml.safe_load(per_train.read_text(encoding="utf-8"))
+
+
+def test_required_keys_round_trip(tmp_path):
+    spec = _full_spec()
+    doc = _author(tmp_path, spec)
+    assert doc["themes"] == spec["themes"]
+    assert doc["sequence"] == spec["sequence"]
+
+
+def test_optional_keys_round_trip_when_supplied(tmp_path):
+    spec = _full_spec()
+    doc = _author(tmp_path, spec)
+    assert doc["family"] == "delivery"
+    assert doc["primary_wagon"] == "demo-wagon"
+    assert doc["dependencies"] == ["train:0001-self-compliance-validate"]
+
+
+def test_optional_keys_absent_when_omitted(tmp_path):
+    spec = _full_spec()
+    for k in ("family", "primary_wagon", "dependencies"):
+        spec.pop(k)
+    doc = _author(tmp_path, spec)
+    for k in ("family", "primary_wagon", "dependencies"):
+        assert k not in doc, f"{k} must not be invented when the caller omitted it"
+
+
+def test_acceptances_round_trip_when_supplied(tmp_path):
+    spec = _full_spec()
+    spec["acceptances"] = [
+        {"identity": {"urn": "acc:demo-wagon:E001-UNIT-001-demo", "id": "AC-UNIT-001",
+                      "purpose": "demo", "phase": "GREEN"}},
+    ]
+    doc = _author(tmp_path, spec)
+    assert doc["acceptances"] == spec["acceptances"]
+
+
+def test_wagons_is_not_written_into_the_document(tmp_path):
+    # train.schema.json sets additionalProperties: false and defines no `wagons`
+    # property — `wagons` belongs to the _trains.yaml registry entry only.
+    doc = _author(tmp_path, _full_spec())
+    assert "wagons" not in doc
+
+
+def test_authored_train_validates_against_train_schema(tmp_path):
+    doc = _author(tmp_path, _full_spec())
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    errors = sorted(jsonschema.Draft7Validator(schema).iter_errors(doc), key=str)
+    assert errors == [], "\n".join(
+        f"{list(e.absolute_path)}: {e.message}" for e in errors
+    )

--- a/src/atdd/planner/commands/tests/test_e004_unit_002_carries_schema_required_keys.py
+++ b/src/atdd/planner/commands/tests/test_e004_unit_002_carries_schema_required_keys.py
@@ -1,7 +1,7 @@
 # URN: test:author-plan-substrate:author-train:E004-UNIT-002-carries-schema-required-keys
 # Acceptance: acc:author-plan-substrate:E004-UNIT-002-carries-schema-required-keys
 # WMBT: wmbt:author-plan-substrate:E004
-# Phase: RED
+# Phase: GREEN
 # Layer: unit
 # Assertion: behavioral
 """E004-UNIT-002 — create_train carries the schema-recognized keys into the per-train doc.

--- a/src/atdd/planner/commands/tests/test_e004_unit_003_alternate_path_train_carries_sequence.py
+++ b/src/atdd/planner/commands/tests/test_e004_unit_003_alternate_path_train_carries_sequence.py
@@ -1,0 +1,74 @@
+# URN: test:author-plan-substrate:author-train:E004-UNIT-003-alternate-path-train-carries-sequence
+# Acceptance: acc:author-plan-substrate:E004-UNIT-003-alternate-path-train-carries-sequence
+# WMBT: wmbt:author-plan-substrate:E004
+# Phase: RED
+# Layer: unit
+# Assertion: behavioral
+"""E004-UNIT-003 — the per-train document writer is category-agnostic.
+
+Train ids are [Theme][Category][Variation]. Category digit 2 = alternate path
+(0201, 0202 …). The document writer must never branch on any digit of the id;
+an alternate-path train carries `themes` / `sequence` exactly as a nominal one.
+
+RED: neither carries them today, so the equality below holds vacuously on the
+missing-key side — the explicit `in doc` assertions are what fail.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from atdd.planner.commands.author import create_train
+
+
+def _spec(train_id: str) -> dict:
+    return {
+        "train_id": train_id,
+        "title": "Category probe",
+        "description": "identical but for the train_id category digit",
+        "themes": ["commons"],
+        "primary_wagon": "demo-wagon",
+        "wagons": ["demo-wagon"],
+        "participants": ["wagon:demo-wagon"],
+        "sequence": [
+            {
+                "step": 1,
+                "intent": "carry the sequence through the writer",
+                "from": "wagon:demo-wagon",
+                "to": "system:atdd-cli",
+                "artifact": "commons:manifest",
+            },
+        ],
+    }
+
+
+def _author(tmp_path: Path, train_id: str) -> dict:
+    plan = tmp_path / "plan"
+    (plan / "_trains").mkdir(parents=True)
+    (plan / "_trains.yaml").write_text("trains: {}\n", encoding="utf-8")
+    per_train = create_train(_spec(train_id), root=tmp_path)
+    return yaml.safe_load(per_train.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    "train_id",
+    [
+        "0009-nominal-probe",     # category 0 — nominal
+        "0209-alternate-probe",   # category 2 — alternate path
+        "0309-exception-probe",   # category 3 — exception
+    ],
+)
+def test_every_category_carries_themes_and_sequence(tmp_path, train_id):
+    doc = _author(tmp_path, train_id)
+    assert doc["themes"] == ["commons"]
+    assert doc["sequence"] == _spec(train_id)["sequence"]
+
+
+def test_nominal_and_alternate_documents_differ_only_by_train_id(tmp_path):
+    nominal = _author(tmp_path / "a", "0009-probe")
+    alternate = _author(tmp_path / "b", "0209-probe")
+    assert nominal.pop("train_id") == "0009-probe"
+    assert alternate.pop("train_id") == "0209-probe"
+    assert nominal == alternate, "the writer must not branch on the category digit"

--- a/src/atdd/planner/commands/tests/test_e004_unit_003_alternate_path_train_carries_sequence.py
+++ b/src/atdd/planner/commands/tests/test_e004_unit_003_alternate_path_train_carries_sequence.py
@@ -1,7 +1,7 @@
 # URN: test:author-plan-substrate:author-train:E004-UNIT-003-alternate-path-train-carries-sequence
 # Acceptance: acc:author-plan-substrate:E004-UNIT-003-alternate-path-train-carries-sequence
 # WMBT: wmbt:author-plan-substrate:E004
-# Phase: RED
+# Phase: GREEN
 # Layer: unit
 # Assertion: behavioral
 """E004-UNIT-003 — the per-train document writer is category-agnostic.

--- a/src/atdd/planner/commands/tests/test_e004_unit_004_preserves_caller_participants.py
+++ b/src/atdd/planner/commands/tests/test_e004_unit_004_preserves_caller_participants.py
@@ -1,0 +1,69 @@
+# URN: test:author-plan-substrate:author-train:E004-UNIT-004-preserves-caller-participants
+# Acceptance: acc:author-plan-substrate:E004-UNIT-004-preserves-caller-participants
+# WMBT: wmbt:author-plan-substrate:E004
+# Phase: RED
+# Layer: unit
+# Assertion: behavioral
+"""E004-UNIT-004 — caller-supplied participants survive the writer.
+
+RED: create_train unconditionally overwrites participants with
+`[f"wagon:{w}" for w in spec["wagons"]]`, silently discarding every
+`system:*` / `user:*` principal the caller passed. train.schema.json admits
+all three prefixes, so the discard is lossy, not normalizing.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from atdd.planner.commands.author import create_train
+
+
+def _author(tmp_path: Path, spec: dict) -> dict:
+    plan = tmp_path / "plan"
+    (plan / "_trains").mkdir(parents=True)
+    (plan / "_trains.yaml").write_text("trains: {}\n", encoding="utf-8")
+    per_train = create_train(spec, root=tmp_path)
+    return yaml.safe_load(per_train.read_text(encoding="utf-8"))
+
+
+def _base(train_id: str = "0009-participants-probe") -> dict:
+    return {
+        "train_id": train_id,
+        "title": "Participants probe",
+        "description": "a train carrying a non-wagon principal",
+        "themes": ["commons"],
+        "wagons": ["demo-wagon"],
+        "sequence": [
+            {
+                "step": 1,
+                "intent": "hand the artifact to the cli",
+                "from": "wagon:demo-wagon",
+                "to": "system:atdd-cli",
+                "artifact": "commons:manifest",
+            },
+        ],
+    }
+
+
+def test_caller_participants_are_preserved_verbatim(tmp_path):
+    spec = _base()
+    spec["participants"] = ["wagon:demo-wagon", "system:atdd-cli", "user:operator"]
+    doc = _author(tmp_path, spec)
+    assert doc["participants"] == ["wagon:demo-wagon", "system:atdd-cli", "user:operator"]
+
+
+def test_non_wagon_principals_are_not_discarded(tmp_path):
+    spec = _base()
+    spec["participants"] = ["wagon:demo-wagon", "system:atdd-cli"]
+    doc = _author(tmp_path, spec)
+    assert "system:atdd-cli" in doc["participants"]
+
+
+def test_participants_derived_from_wagons_when_omitted(tmp_path):
+    # Today's fallback is preserved: no participants supplied -> derive wagon URNs.
+    spec = _base()
+    assert "participants" not in spec
+    doc = _author(tmp_path, spec)
+    assert doc["participants"] == ["wagon:demo-wagon"]

--- a/src/atdd/planner/commands/tests/test_e004_unit_004_preserves_caller_participants.py
+++ b/src/atdd/planner/commands/tests/test_e004_unit_004_preserves_caller_participants.py
@@ -1,7 +1,7 @@
 # URN: test:author-plan-substrate:author-train:E004-UNIT-004-preserves-caller-participants
 # Acceptance: acc:author-plan-substrate:E004-UNIT-004-preserves-caller-participants
 # WMBT: wmbt:author-plan-substrate:E004
-# Phase: RED
+# Phase: GREEN
 # Layer: unit
 # Assertion: behavioral
 """E004-UNIT-004 — caller-supplied participants survive the writer.


### PR DESCRIPTION
Closes #1401

## Issue Metadata

| Field | Value |
|-------|-------|
| Issue | #1401 |
| Type | bug |
| Slug | fix-create-train-drops-themes-and-sequence |
| Train | 0003-author-substrate |
| Labels | atdd-issue, atdd:INIT |

## Risk score breakdown

| Archetype | Severity sum |
|-----------|--------------|
| coder | 0 |
| coach | 0 |
| tester | 0 |
| planner | 0 |
| repo | 0 |
| **total** | **0** |

---
PR created by `atdd pr`.

